### PR TITLE
tiltfile: use RealPath when reading the Tiltfile

### DIFF
--- a/internal/tiltfile/tiltfile.go
+++ b/internal/tiltfile/tiltfile.go
@@ -15,6 +15,7 @@ import (
 	"github.com/google/skylark/resolve"
 	"github.com/windmilleng/tilt/internal/kustomize"
 	"github.com/windmilleng/tilt/internal/model"
+	"github.com/windmilleng/tilt/internal/ospath"
 )
 
 const FileName = "Tiltfile"
@@ -314,7 +315,7 @@ func Load(filename string, out io.Writer) (*Tiltfile, error) {
 		},
 	}
 
-	filename, err := filepath.Abs(filename)
+	filename, err := ospath.RealAbs(filename)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Hello @jazzdan,

Please review the following commits I made in branch nicks/ch635/symlink:

a0150cdec542388fa5036cdf86f6e25182dde371 (2018-10-19 11:24:02 -0400)
tiltfile: use RealPath when reading the Tiltfile