### PR TITLE
engine: shut down log streaming when the container shuts down, to avoid internal k8s error messages about missing containers

### DIFF
--- a/internal/engine/reader.go
+++ b/internal/engine/reader.go
@@ -1,0 +1,30 @@
+package engine
+
+import (
+	"context"
+	"io"
+)
+
+// A reader that will stop returning data after its context has been canceled.
+//
+// If any data is read from the underlying stream after the cancel happens, throw the data out.
+type HardCancelReader struct {
+	ctx    context.Context
+	reader io.Reader
+}
+
+func NewHardCancelReader(ctx context.Context, reader io.Reader) HardCancelReader {
+	return HardCancelReader{ctx: ctx, reader: reader}
+}
+
+func (r HardCancelReader) Read(b []byte) (int, error) {
+	err := r.ctx.Err()
+	if err != nil {
+		return 0, err
+	}
+	n, err := r.reader.Read(b)
+	if r.ctx.Err() != nil {
+		return 0, r.ctx.Err()
+	}
+	return n, err
+}


### PR DESCRIPTION
Hello @landism,

Please review the following commits I made in branch nicks/ch751/logs:

860a7e7901a4ef260c7a414b69164cf07061d53d (2018-11-30 12:23:28 -0500)
engine: shut down log streaming when the container shuts down, to avoid internal k8s error messages about missing containers