### PR TITLE
tilt: fix change list truncation

### DIFF
--- a/internal/engine/changed_file_list.go
+++ b/internal/engine/changed_file_list.go
@@ -18,5 +18,5 @@ func formatFileChangeList(changedFiles []string) string {
 		changedPathsToPrint = changedFiles
 	}
 
-	return fmt.Sprintf("%v", ospath.TryAsCwdChildren(changedFiles))
+	return fmt.Sprintf("%v", ospath.TryAsCwdChildren(changedPathsToPrint))
 }

--- a/internal/engine/changed_file_list_test.go
+++ b/internal/engine/changed_file_list_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestFormatChangedFileListTruncates(t *testing.T) {
 	actual := formatFileChangeList([]string{"a", "b", "c", "d", "e", "f"})
-	expected := "[a b c d e f]"
+	expected := "[a b c d e ...]"
 	require.Equal(t, expected, actual)
 }
 


### PR DESCRIPTION
when the user changes files and tilt kicks off a build, it prints which files changed to trigger the build

expected: the list of files is truncated after 5
observed: the list of files is not truncated

This was a silly bug introduced in #2041 