### PR TITLE
web: fix componentWillMount deprecation warning

### DIFF
--- a/web/src/HUD.tsx
+++ b/web/src/HUD.tsx
@@ -67,13 +67,18 @@ class HUD extends Component<HudProps, HudState> {
   constructor(props: HudProps) {
     super(props)
 
+    incr("ui.web.init", { ua: window.navigator.userAgent })
+
     this.pathBuilder = new PathBuilder(
       window.location.host,
       window.location.pathname
     )
     this.controller = new AppController(this.pathBuilder.getDataUrl(), this)
     this.history = props.history
-    this.unlisten = () => {}
+    this.unlisten = this.history.listen((location, _) => {
+      let tags = { type: pathToTag(location.pathname) }
+      incr("ui.web.navigation", tags)
+    })
 
     this.state = {
       Message: "",
@@ -104,14 +109,6 @@ class HUD extends Component<HudProps, HudState> {
     }
 
     this.toggleSidebar = this.toggleSidebar.bind(this)
-  }
-
-  componentWillMount() {
-    incr("ui.web.init", { ua: window.navigator.userAgent })
-    this.unlisten = this.history.listen((location, _) => {
-      let tags = { type: pathToTag(location.pathname) }
-      incr("ui.web.navigation", tags)
-    })
   }
 
   componentDidMount() {


### PR DESCRIPTION
`componentWillMount` is being moved in to a future version of React.
We can replace our usage of it by just moving things in to the constructor
so I just did that.