### PR TITLE
tiltfile: remove k8s resource assembly v1

### DIFF
--- a/integration/imagetags/Tiltfile
+++ b/integration/imagetags/Tiltfile
@@ -1,6 +1,4 @@
 
-k8s_resource_assembly_version(2)
-
 include('../Tiltfile')
 
 repo = 'gcr.io/windmill-test-containers'

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -806,7 +806,6 @@ k8s_resource('snack', new_name='baz')  # rename "snack" --> "baz"
 
 	// Now add a second resource
 	f.WriteConfigFiles("Tiltfile", `
-k8s_resource_assembly_version(2)
 docker_build("gcr.io/windmill-public-containers/servantes/snack", "./snack", dockerfile="Dockerfile1")
 docker_build("gcr.io/windmill-public-containers/servantes/doggos", "./doggos", dockerfile="Dockerfile2")
 

--- a/internal/tiltfile/k8s.go
+++ b/internal/tiltfile/k8s.go
@@ -296,14 +296,7 @@ func (s *tiltfileState) k8sResourceV1(thread *starlark.Thread, fn *starlark.Buil
 }
 
 func (s *tiltfileState) k8sResource(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-	switch s.k8sResourceAssemblyVersion {
-	case 1:
-		return s.k8sResourceV1(thread, fn, args, kwargs)
-	case 2:
-		return s.k8sResourceV2(thread, fn, args, kwargs)
-	default:
-		return starlark.None, fmt.Errorf("invalid k8s resource assembly version: %v", s.k8sResourceAssemblyVersion)
-	}
+	return s.k8sResourceV2(thread, fn, args, kwargs)
 }
 
 // v1 syntax:

--- a/internal/tiltfile/k8s.go
+++ b/internal/tiltfile/k8s.go
@@ -866,33 +866,6 @@ func (s *tiltfileState) imageJSONPaths(e k8s.K8sEntity) []k8s.JSONPath {
 	return ret
 }
 
-func (s *tiltfileState) k8sResourceAssemblyVersionFn(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-	var version int
-	if err := s.unpackArgs(fn.Name(), args, kwargs,
-		"version", &version,
-	); err != nil {
-		return nil, err
-	}
-
-	if len(s.k8sUnresourced) > 0 || len(s.k8s) > 0 || len(s.k8sResourceOptions) > 0 {
-		return starlark.None, fmt.Errorf("%s can only be called before introducing any k8s resources", fn.Name())
-	}
-
-	if version < 1 || version > 2 {
-		return starlark.None, fmt.Errorf("invalid %s %d. Must be 1 or 2.", fn.Name(), version)
-	}
-
-	if version == 1 && !s.warnedDeprecatedResourceAssembly {
-		s.logger.Warnf("%s", deprecatedResourceAssemblyV1Warning)
-		s.warnedDeprecatedResourceAssembly = true
-	}
-
-	s.k8sResourceAssemblyVersion = version
-	s.k8sResourceAssemblyVersionReason = k8sResourceAssemblyVersionReasonExplicit
-
-	return starlark.None, nil
-}
-
 func (s *tiltfileState) calculateResourceNames(workloads []k8s.K8sEntity) ([]string, error) {
 	if s.workloadToResourceFunction.fn != nil {
 		names, err := s.workloadToResourceFunctionNames(workloads)

--- a/internal/tiltfile/tiltfile_state.go
+++ b/internal/tiltfile/tiltfile_state.go
@@ -69,9 +69,7 @@ type tiltfileState struct {
 	// objects of these types are considered workloads, whether or not they have an image
 	workloadTypes []k8sObjectSelector
 
-	k8sResourceAssemblyVersion       int
-	k8sResourceAssemblyVersionReason k8sResourceAssemblyVersionReason
-	workloadToResourceFunction       workloadToResourceFunction
+	workloadToResourceFunction workloadToResourceFunction
 
 	// for assembly
 	usedImages map[string]bool
@@ -102,15 +100,6 @@ type tiltfileState struct {
 	postExecReadFiles                []string
 }
 
-type k8sResourceAssemblyVersionReason int
-
-const (
-	// assembly version is just at the default; the user hasn't set anything
-	k8sResourceAssemblyVersionReasonDefault k8sResourceAssemblyVersionReason = iota
-	// the user has explicit set the assembly version
-	k8sResourceAssemblyVersionReasonExplicit
-)
-
 func newTiltfileState(
 	ctx context.Context,
 	dcCli dockercompose.DockerComposeClient,
@@ -119,24 +108,23 @@ func newTiltfileState(
 	localRegistry container.Registry,
 	features feature.FeatureSet) *tiltfileState {
 	return &tiltfileState{
-		ctx:                        ctx,
-		dcCli:                      dcCli,
-		webHost:                    webHost,
-		k8sContextExt:              k8sContextExt,
-		localRegistry:              localRegistry,
-		buildIndex:                 newBuildIndex(),
-		k8sByName:                  make(map[string]*k8sResource),
-		k8sImageJSONPaths:          make(map[k8sObjectSelector][]k8s.JSONPath),
-		usedImages:                 make(map[string]bool),
-		logger:                     logger.Get(ctx),
-		builtinCallCounts:          make(map[string]int),
-		builtinArgCounts:           make(map[string]map[string]int),
-		unconsumedLiveUpdateSteps:  make(map[string]liveUpdateStep),
-		k8sResourceAssemblyVersion: 2,
-		k8sResourceOptions:         make(map[string]k8sResourceOptions),
-		localResources:             []localResource{},
-		triggerMode:                TriggerModeAuto,
-		features:                   features,
+		ctx:                       ctx,
+		dcCli:                     dcCli,
+		webHost:                   webHost,
+		k8sContextExt:             k8sContextExt,
+		localRegistry:             localRegistry,
+		buildIndex:                newBuildIndex(),
+		k8sByName:                 make(map[string]*k8sResource),
+		k8sImageJSONPaths:         make(map[k8sObjectSelector][]k8s.JSONPath),
+		usedImages:                make(map[string]bool),
+		logger:                    logger.Get(ctx),
+		builtinCallCounts:         make(map[string]int),
+		builtinArgCounts:          make(map[string]map[string]int),
+		unconsumedLiveUpdateSteps: make(map[string]liveUpdateStep),
+		k8sResourceOptions:        make(map[string]k8sResourceOptions),
+		localResources:            []localResource{},
+		triggerMode:               TriggerModeAuto,
+		features:                  features,
 	}
 }
 

--- a/internal/tiltfile/tiltfile_state.go
+++ b/internal/tiltfile/tiltfile_state.go
@@ -254,7 +254,6 @@ const (
 	dcResourceN    = "dc_resource"
 
 	// k8s functions
-	k8sResourceAssemblyVersionN = "k8s_resource_assembly_version"
 	k8sYamlN                    = "k8s_yaml"
 	filterYamlN                 = "filter_yaml"
 	k8sResourceN                = "k8s_resource"
@@ -434,7 +433,6 @@ func (s *tiltfileState) OnStart(e *starkit.Environment) error {
 		{defaultRegistryN, s.defaultRegistry},
 		{dockerComposeN, s.dockerCompose},
 		{dcResourceN, s.dcResource},
-		{k8sResourceAssemblyVersionN, s.k8sResourceAssemblyVersionFn},
 		{k8sYamlN, s.k8sYaml},
 		{filterYamlN, s.filterYaml},
 		{k8sResourceN, s.k8sResource},
@@ -495,12 +493,7 @@ func (s *tiltfileState) assemble() (resourceSet, []k8s.K8sEntity, error) {
 		return resourceSet{}, nil, err
 	}
 
-	switch s.k8sResourceAssemblyVersion {
-	case 1:
-		err = s.assembleK8sV1()
-	case 2:
-		err = s.assembleK8sV2()
-	}
+	err = s.assembleK8s()
 	if err != nil {
 		return resourceSet{}, nil, err
 	}
@@ -568,27 +561,7 @@ func (s *tiltfileState) assembleDC() error {
 	return nil
 }
 
-func (s *tiltfileState) assembleK8sV1() error {
-	err := s.assembleK8sWithImages()
-	if err != nil {
-		return err
-	}
-
-	err = s.assembleK8sUnresourced()
-	if err != nil {
-		return err
-	}
-
-	for _, r := range s.k8s {
-		if err := s.validateK8s(r); err != nil {
-			return err
-		}
-	}
-	return nil
-
-}
-
-func (s *tiltfileState) assembleK8sV2() error {
+func (s *tiltfileState) assembleK8s() error {
 	err := s.assembleK8sByWorkload()
 	if err != nil {
 		return err


### PR DESCRIPTION
We don't have to merge this now, just was in the code and thought that I might as well queue up the PR for when we decide to delete it.