### PR TITLE
tiltfile/engine: k8s upsert timeout settable from tiltfile [ch6947]

### DIFF
--- a/internal/engine/image_build_and_deployer.go
+++ b/internal/engine/image_build_and_deployer.go
@@ -242,7 +242,11 @@ func (ibd *ImageBuildAndDeployer) deploy(ctx context.Context, st store.RStore, p
 		l.Infof("→ %s", displayName)
 	}
 
-	deployed, err := ibd.k8sClient.Upsert(ctx, newK8sEntities)
+	state := st.RLockState()
+	us := state.UpdateSettings
+	st.RUnlockState()
+
+	deployed, err := ibd.k8sClient.Upsert(ctx, newK8sEntities, us.K8sUpsertTimeout())
 	if err != nil {
 		return nil, err
 	}

--- a/internal/engine/image_build_and_deployer_test.go
+++ b/internal/engine/image_build_and_deployer_test.go
@@ -336,6 +336,26 @@ ENTRYPOINT /go/bin/sancho
 	testutils.AssertFileInTar(t, tar.NewReader(f.docker.BuildOptions.Context), expected)
 }
 
+func TestK8sUpsertTimeout(t *testing.T) {
+	f := newIBDFixture(t, k8s.EnvGKE)
+	defer f.TearDown()
+
+	timeout := 123 * time.Second
+
+	state := f.st.LockMutableStateForTesting()
+	state.UpdateSettings = state.UpdateSettings.WithK8sUpsertTimeout(123 * time.Second)
+	f.st.UnlockMutableState()
+
+	manifest := NewSanchoDockerBuildManifest(f)
+
+	_, err := f.ibd.BuildAndDeploy(f.ctx, f.st, buildTargets(manifest), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, f.k8s.UpsertTimeout, timeout)
+}
+
 func TestKINDLoad(t *testing.T) {
 	f := newIBDFixture(t, k8s.EnvKIND6)
 	defer f.TearDown()

--- a/internal/k8s/exploding_client.go
+++ b/internal/k8s/exploding_client.go
@@ -21,7 +21,7 @@ type explodingClient struct {
 	err error
 }
 
-func (ec *explodingClient) Upsert(ctx context.Context, entities []K8sEntity) ([]K8sEntity, error) {
+func (ec *explodingClient) Upsert(ctx context.Context, entities []K8sEntity, timeout time.Duration) ([]K8sEntity, error) {
 	return nil, errors.Wrap(ec.err, "could not set up k8s client")
 }
 

--- a/internal/k8s/fake_client.go
+++ b/internal/k8s/fake_client.go
@@ -59,6 +59,7 @@ type FakeK8sClient struct {
 
 	UpsertError      error
 	LastUpsertResult []K8sEntity
+	UpsertTimeout    time.Duration
 
 	Runtime    container.Runtime
 	Registry   container.Registry
@@ -204,7 +205,7 @@ func (c *FakeK8sClient) ConnectedToCluster(ctx context.Context) error {
 	return nil
 }
 
-func (c *FakeK8sClient) Upsert(ctx context.Context, entities []K8sEntity) ([]K8sEntity, error) {
+func (c *FakeK8sClient) Upsert(ctx context.Context, entities []K8sEntity, timeout time.Duration) ([]K8sEntity, error) {
 	if c.UpsertError != nil {
 		return nil, c.UpsertError
 	}
@@ -226,6 +227,7 @@ func (c *FakeK8sClient) Upsert(ctx context.Context, entities []K8sEntity) ([]K8s
 	}
 
 	c.LastUpsertResult = result
+	c.UpsertTimeout = timeout
 	return result, nil
 }
 

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -4418,6 +4418,17 @@ func TestK8sUpsertTimeout(t *testing.T) {
 	}
 }
 
+func TestUpdateSettingsOnlyCallableOnce(t *testing.T) {
+
+	f := newFixture(t)
+	defer f.TearDown()
+
+	f.file("Tiltfile", `update_settings(max_parallel_updates=123)
+update_settings(k8s_upsert_timeout_secs=456)`)
+
+	f.loadErrString("'update_settings' can only be called once")
+}
+
 // recursion is disabled by default in Starlark. Make sure we've enabled it for Tiltfiles.
 func TestRecursionEnabled(t *testing.T) {
 	f := newFixture(t)

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -4341,7 +4341,7 @@ func TestMaxParallelUpdates(t *testing.T) {
 		{
 			name:                "NaN error",
 			tiltfile:            "update_settings(max_parallel_updates='boop')",
-			expectErrorContains: "got string, want int",
+			expectErrorContains: "got starlark.String, want int",
 		},
 		{
 			name:                "must be positive int",
@@ -4392,7 +4392,7 @@ func TestK8sUpsertTimeout(t *testing.T) {
 		{
 			name:                "NaN error",
 			tiltfile:            "update_settings(k8s_upsert_timeout_secs='boop')",
-			expectErrorContains: "got string, want int",
+			expectErrorContains: "got starlark.String, want int",
 		},
 		{
 			name:                "must be positive int",
@@ -4418,15 +4418,16 @@ func TestK8sUpsertTimeout(t *testing.T) {
 	}
 }
 
-func TestUpdateSettingsOnlyCallableOnce(t *testing.T) {
-
+func TestUpdateSettingsCalledTwice(t *testing.T) {
 	f := newFixture(t)
 	defer f.TearDown()
 
 	f.file("Tiltfile", `update_settings(max_parallel_updates=123)
 update_settings(k8s_upsert_timeout_secs=456)`)
 
-	f.loadErrString("'update_settings' can only be called once")
+	f.load()
+	assert.Equal(t, 123, f.loadResult.UpdateSettings.MaxParallelUpdates(), "expected vs. actual MaxParallelUpdates")
+	assert.Equal(t, 456*time.Second, f.loadResult.UpdateSettings.K8sUpsertTimeout(), "expected vs. actual k8sUpsertTimeout")
 }
 
 // recursion is disabled by default in Starlark. Make sure we've enabled it for Tiltfiles.

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -4318,20 +4318,25 @@ local_resource('e', 'echo e')
 
 func TestMaxParallelUpdates(t *testing.T) {
 	for _, tc := range []struct {
-		name                  string
-		tiltfile              string
-		expectErrorContains   string
-		expectedMaxBuildSlots int
+		name                       string
+		tiltfile                   string
+		expectErrorContains        string
+		expectedMaxParallelUpdates int
 	}{
 		{
-			name:                  "default max parallel updates",
-			tiltfile:              "print('hello world')",
-			expectedMaxBuildSlots: model.DefaultMaxParallelUpdates,
+			name:                       "default value if func not called",
+			tiltfile:                   "print('hello world')",
+			expectedMaxParallelUpdates: model.DefaultMaxParallelUpdates,
 		},
 		{
-			name:                  "set max parallel updates",
-			tiltfile:              "update_settings(max_parallel_updates=42)",
-			expectedMaxBuildSlots: 42,
+			name:                       "default value if arg not specified",
+			tiltfile:                   "update_settings(k8s_upsert_timeout_secs=123)",
+			expectedMaxParallelUpdates: model.DefaultMaxParallelUpdates,
+		},
+		{
+			name:                       "set max parallel updates",
+			tiltfile:                   "update_settings(max_parallel_updates=42)",
+			expectedMaxParallelUpdates: 42,
 		},
 		{
 			name:                "NaN error",
@@ -4342,14 +4347,6 @@ func TestMaxParallelUpdates(t *testing.T) {
 			name:                "must be positive int",
 			tiltfile:            "update_settings(max_parallel_updates=-1)",
 			expectErrorContains: "must be >= 1",
-		},
-		{
-			// as more settings are configurable from this func, max_parallel_updates
-			// won't be a required arg and instead we should test that it gets
-			// set to the approprirate default; but for now, it IS required.
-			name:                "max_parallel_updates is required arg",
-			tiltfile:            "update_settings()",
-			expectErrorContains: "missing argument for max_parallel_updates",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -4365,7 +4362,58 @@ func TestMaxParallelUpdates(t *testing.T) {
 
 			f.load()
 			actualBuildSlots := f.loadResult.UpdateSettings.MaxParallelUpdates()
-			assert.Equal(t, tc.expectedMaxBuildSlots, actualBuildSlots, "expected vs. actual maxParallelUpdates")
+			assert.Equal(t, tc.expectedMaxParallelUpdates, actualBuildSlots, "expected vs. actual maxParallelUpdates")
+		})
+	}
+}
+
+func TestK8sUpsertTimeout(t *testing.T) {
+	for _, tc := range []struct {
+		name                string
+		tiltfile            string
+		expectErrorContains string
+		expectedTimeout     time.Duration
+	}{
+		{
+			name:            "default value if func not called",
+			tiltfile:        "print('hello world')",
+			expectedTimeout: model.DefaultK8sUpsertTimeout,
+		},
+		{
+			name:            "default value if arg not specified",
+			tiltfile:        "update_settings(max_parallel_updates=123)",
+			expectedTimeout: model.DefaultK8sUpsertTimeout,
+		},
+		{
+			name:            "set max parallel updates",
+			tiltfile:        "update_settings(k8s_upsert_timeout_secs=42)",
+			expectedTimeout: 42 * time.Second,
+		},
+		{
+			name:                "NaN error",
+			tiltfile:            "update_settings(k8s_upsert_timeout_secs='boop')",
+			expectErrorContains: "got string, want int",
+		},
+		{
+			name:                "must be positive int",
+			tiltfile:            "update_settings(k8s_upsert_timeout_secs=-1)",
+			expectErrorContains: "minimum k8s upsert timeout is 1s",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newFixture(t)
+			defer f.TearDown()
+
+			f.file("Tiltfile", tc.tiltfile)
+
+			if tc.expectErrorContains != "" {
+				f.loadErrString(tc.expectErrorContains)
+				return
+			}
+
+			f.load()
+			actualTimeout := f.loadResult.UpdateSettings.K8sUpsertTimeout()
+			assert.Equal(t, tc.expectedTimeout, actualTimeout, "expected vs. actual k8sUpsertTimeout")
 		})
 	}
 }

--- a/internal/tiltfile/updatesettings/update_settings.go
+++ b/internal/tiltfile/updatesettings/update_settings.go
@@ -5,8 +5,9 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"github.com/tilt-dev/tilt/pkg/model"
 	"go.starlark.net/starlark"
+
+	"github.com/tilt-dev/tilt/pkg/model"
 
 	"github.com/tilt-dev/tilt/internal/tiltfile/starkit"
 )

--- a/internal/tiltfile/updatesettings/update_settings.go
+++ b/internal/tiltfile/updatesettings/update_settings.go
@@ -4,18 +4,15 @@ import (
 	"fmt"
 	"time"
 
-	"go.starlark.net/starlark"
-	"go.starlark.net/syntax"
-
+	"github.com/pkg/errors"
 	"github.com/tilt-dev/tilt/pkg/model"
+	"go.starlark.net/starlark"
 
 	"github.com/tilt-dev/tilt/internal/tiltfile/starkit"
 )
 
 // Implements functions for dealing with update settings.
-type Extension struct {
-	callPosition syntax.Position
-}
+type Extension struct{}
 
 func NewExtension() Extension {
 	return Extension{}
@@ -30,37 +27,54 @@ func (e Extension) OnStart(env *starkit.Environment) error {
 }
 
 func (e *Extension) updateSettings(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-	if e.callPosition.IsValid() {
-		return starlark.None, fmt.Errorf(
-			"'update_settings' can only be called once. It was already called at %s", e.callPosition.String())
-	}
-	e.callPosition = thread.CallFrame(1).Pos
-
-	maxParallelUpdates := model.DefaultMaxParallelUpdates
-	k8sUpsertTimeoutSecs := int(model.DefaultK8sUpsertTimeout / time.Second)
-
+	var maxParallelUpdates, k8sUpsertTimeoutSecs starlark.Value
 	if err := starkit.UnpackArgs(thread, fn.Name(), args, kwargs,
 		"max_parallel_updates?", &maxParallelUpdates,
 		"k8s_upsert_timeout_secs?", &k8sUpsertTimeoutSecs); err != nil {
 		return nil, err
 	}
 
-	if maxParallelUpdates < 1 {
+	mpu, mpuPassed, err := valueToInt(maxParallelUpdates)
+	if err != nil {
+		return nil, errors.Wrap(err, "update_settings: for parameter \"max_parallel_updates\"")
+	}
+	if mpuPassed && mpu < 1 {
 		return nil, fmt.Errorf("max number of parallel updates must be >= 1(got: %d)",
 			maxParallelUpdates)
 	}
-	if k8sUpsertTimeoutSecs < 1 {
+
+	kuts, kutsPassed, err := valueToInt(k8sUpsertTimeoutSecs)
+	if err != nil {
+		return nil, errors.Wrap(err, "update_settings: for parameter \"k8s_upsert_timeout_secs\"")
+	}
+	if kutsPassed && kuts < 1 {
 		return nil, fmt.Errorf("minimum k8s upsert timeout is 1s; got %ds",
 			k8sUpsertTimeoutSecs)
 	}
 
-	err := starkit.SetState(thread, func(settings model.UpdateSettings) model.UpdateSettings {
-		settings = settings.WithMaxParallelUpdates(maxParallelUpdates)
-		settings = settings.WithK8sUpsertTimeout(time.Duration(k8sUpsertTimeoutSecs) * time.Second)
+	err = starkit.SetState(thread, func(settings model.UpdateSettings) model.UpdateSettings {
+		if mpuPassed {
+			settings = settings.WithMaxParallelUpdates(mpu)
+		}
+		if kutsPassed {
+			settings = settings.WithK8sUpsertTimeout(time.Duration(kuts) * time.Second)
+		}
 		return settings
 	})
 
 	return starlark.None, err
+}
+
+func valueToInt(v starlark.Value) (val int, wasPassed bool, err error) {
+	switch x := v.(type) {
+	case nil:
+		return 0, false, nil
+	case starlark.Int:
+		val, err := starlark.AsInt32(x)
+		return val, true, err
+	default:
+		return 0, true, fmt.Errorf("got %T, want int", x)
+	}
 }
 
 var _ starkit.StatefulExtension = Extension{}

--- a/internal/tiltfile/updatesettings/update_settings.go
+++ b/internal/tiltfile/updatesettings/update_settings.go
@@ -68,7 +68,7 @@ func (e *Extension) updateSettings(thread *starlark.Thread, fn *starlark.Builtin
 
 func valueToInt(v starlark.Value) (val int, wasPassed bool, err error) {
 	switch x := v.(type) {
-	case nil:
+	case nil, starlark.NoneType:
 		return 0, false, nil
 	case starlark.Int:
 		val, err := starlark.AsInt32(x)

--- a/pkg/model/update_settings.go
+++ b/pkg/model/update_settings.go
@@ -1,9 +1,15 @@
 package model
 
-var DefaultMaxParallelUpdates = 3
+import "time"
+
+const (
+	DefaultMaxParallelUpdates = 3
+	DefaultK8sUpsertTimeout   = 15 * time.Second
+)
 
 type UpdateSettings struct {
-	maxParallelUpdates int // max number of updates to run concurrently
+	maxParallelUpdates int           // max number of updates to run concurrently
+	k8sUpsertTimeout   time.Duration // timeout for k8s upsert operations
 }
 
 func (us UpdateSettings) MaxParallelUpdates() int {
@@ -23,6 +29,26 @@ func (us UpdateSettings) WithMaxParallelUpdates(n int) UpdateSettings {
 	return us
 }
 
+func (us UpdateSettings) K8sUpsertTimeout() time.Duration {
+	// Min. value is 1s
+	if us.k8sUpsertTimeout < time.Second {
+		return time.Second
+	}
+	return us.k8sUpsertTimeout
+}
+
+func (us UpdateSettings) WithK8sUpsertTimeout(timeout time.Duration) UpdateSettings {
+	// Min. value is 1s
+	if us.k8sUpsertTimeout < time.Second {
+		timeout = time.Second
+	}
+	us.k8sUpsertTimeout = timeout
+	return us
+}
+
 func DefaultUpdateSettings() UpdateSettings {
-	return UpdateSettings{maxParallelUpdates: DefaultMaxParallelUpdates}
+	return UpdateSettings{
+		maxParallelUpdates: DefaultMaxParallelUpdates,
+		k8sUpsertTimeout:   DefaultK8sUpsertTimeout,
+	}
 }

--- a/pkg/model/update_settings.go
+++ b/pkg/model/update_settings.go
@@ -4,7 +4,7 @@ import "time"
 
 const (
 	DefaultMaxParallelUpdates = 3
-	DefaultK8sUpsertTimeout   = 15 * time.Second
+	DefaultK8sUpsertTimeout   = 30 * time.Second
 )
 
 type UpdateSettings struct {


### PR DESCRIPTION
Hello @landism, @nicks,

Please review the following commits I made in branch maiamcc/configure-timeout:

e6860bad300cbca51f5660c827d8ba9350dddd63 (2020-05-14 16:18:00 -0400)
tiltfile/engine: expose update_settings.k8s_upsert_timeout_secs

0b9a9f192146471807ca21b024560ac520f33d2c (2020-05-13 18:15:53 -0400)
store: keep the whole UpdateSettings on EngineState, not just MaxParallelBuilds

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics