### PR TITLE
cli: consolidate how we set port and host. Fixes https://github.com/windmilleng/tilt/issues/3332

### DIFF
--- a/internal/cli/ci.go
+++ b/internal/cli/ci.go
@@ -39,7 +39,8 @@ While Tilt is running, you can view the UI at %s:%d
 `, DefaultWebHost, DefaultWebPort),
 	}
 
-	addWebServerFlags(cmd)
+	addStartServerFlags(cmd)
+	addDevServerFlags(cmd)
 	addTiltfileFlag(cmd, &c.fileName)
 
 	cmd.Flags().BoolVar(&logActionsFlag, "logactions", false, "log all actions and state changes")

--- a/internal/cli/dump.go
+++ b/internal/cli/dump.go
@@ -48,7 +48,7 @@ and may change frequently.
 		Run:  dumpWebview,
 		Args: cobra.NoArgs,
 	}
-	cmd.Flags().IntVar(&webPort, "port", DefaultWebPort, "Port for the Tilt HTTP server")
+	addConnectServerFlags(cmd)
 	return cmd
 }
 
@@ -69,7 +69,7 @@ Excludes logs.
 		Run:  dumpEngine,
 		Args: cobra.NoArgs,
 	}
-	cmd.Flags().IntVar(&webPort, "port", DefaultWebPort, "Port for the Tilt HTTP server")
+	addConnectServerFlags(cmd)
 	return cmd
 }
 
@@ -88,7 +88,7 @@ and may change frequently.
 		Run:  dumpLogStore,
 		Args: cobra.NoArgs,
 	}
-	cmd.Flags().IntVar(&webPort, "port", DefaultWebPort, "Port for the Tilt HTTP server")
+	addConnectServerFlags(cmd)
 	return cmd
 }
 
@@ -135,7 +135,7 @@ func (c *dumpCliDocsCmd) run(cmd *cobra.Command, args []string) {
 }
 
 func dumpWebview(cmd *cobra.Command, args []string) {
-	body := apiGet(webPort, "view")
+	body := apiGet("view")
 
 	err := dumpJSON(body)
 	if err != nil {
@@ -144,7 +144,7 @@ func dumpWebview(cmd *cobra.Command, args []string) {
 }
 
 func dumpEngine(cmd *cobra.Command, args []string) {
-	body := apiGet(webPort, "dump/engine")
+	body := apiGet("dump/engine")
 	defer func() {
 		_ = body.Close()
 	}()
@@ -166,7 +166,7 @@ func dumpEngine(cmd *cobra.Command, args []string) {
 }
 
 func dumpLogStore(cmd *cobra.Command, args []string) {
-	body := apiGet(webPort, "dump/engine")
+	body := apiGet("dump/engine")
 	defer func() {
 		_ = body.Close()
 	}()

--- a/internal/cli/flags.go
+++ b/internal/cli/flags.go
@@ -13,13 +13,19 @@ func addTiltfileFlag(cmd *cobra.Command, s *string) {
 	cmd.Flags().StringVarP(s, "file", "f", tiltfile.FileName, "Path to Tiltfile")
 }
 
-func addWebPortFlag(cmd *cobra.Command) {
-	cmd.Flags().IntVar(&webPort, "port", DefaultWebPort, "Port for the Tilt HTTP server. Set to 0 to disable.")
+// For commands that talk to the web server.
+func addConnectServerFlags(cmd *cobra.Command) {
+	cmd.Flags().IntVar(&webPort, "port", DefaultWebPort, "Port for the Tilt HTTP server. Only necessary if you started Tilt with --port.")
+	cmd.Flags().StringVar(&webHost, "host", DefaultWebHost, "Host for the Tilt HTTP server. Only necessary if you started Tilt with --host.")
 }
 
-func addWebServerFlags(cmd *cobra.Command) {
-	addWebPortFlag(cmd)
+// For commands that start a web server.
+func addStartServerFlags(cmd *cobra.Command) {
+	cmd.Flags().IntVar(&webPort, "port", DefaultWebPort, "Port for the Tilt HTTP server. Set to 0 to disable.")
 	cmd.Flags().StringVar(&webHost, "host", DefaultWebHost, "Host for the Tilt HTTP server and default host for any port-forwards. Set to 0.0.0.0 to listen on all interfaces.")
+}
+
+func addDevServerFlags(cmd *cobra.Command) {
 	cmd.Flags().IntVar(&webDevPort, "webdev-port", DefaultWebDevPort, "Port for the Tilt Dev Webpack server. Only applies when using --web-mode=local")
 	cmd.Flags().Var(&webModeFlag, "web-mode", "Values: local, prod. Controls whether to use prod assets or a local dev server")
 }

--- a/internal/cli/trigger.go
+++ b/internal/cli/trigger.go
@@ -21,7 +21,7 @@ Otherwise, this command will force a full rebuild.
 		Args: cobra.ExactArgs(1),
 		Run:  triggerUpdate,
 	}
-	cmd.Flags().IntVar(&webPort, "port", DefaultWebPort, "Port for the Tilt HTTP server")
+	addConnectServerFlags(cmd)
 	return cmd
 }
 
@@ -32,7 +32,7 @@ func triggerUpdate(cmd *cobra.Command, args []string) {
 	//   like a lot of code to move over (to avoid import cycles) for one call.
 	payload := []byte(fmt.Sprintf(`{"manifest_names":[%q], "build_reason": %d}`, resource, model.BuildReasonFlagTriggerCLI))
 
-	body := apiPostJson(webPort, "trigger", payload)
+	body := apiPostJson("trigger", payload)
 	_ = body.Close()
 
 	fmt.Printf("Successfully triggered update for resource: %q\n", resource)

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -84,7 +84,8 @@ local resources--i.e. those using serve_cmd--are terminated when you exit Tilt.
 	cmd.Flags().StringVar(&c.traceTags, "traceTags", "", "tags to add to spans for easy querying, of the form: key1=val1,key2=val2")
 	cmd.Flags().BoolVar(&c.hud, "hud", true, "If true, tilt will open in HUD mode.")
 	cmd.Flags().BoolVar(&logActionsFlag, "logactions", false, "log all actions and state changes")
-	addWebServerFlags(cmd)
+	addStartServerFlags(cmd)
+	addDevServerFlags(cmd)
 	addTiltfileFlag(cmd, &c.fileName)
 	cmd.Flags().Lookup("logactions").Hidden = true
 	cmd.Flags().BoolVar(&noBrowser, "no-browser", false, "If true, web UI will not open on startup.")

--- a/internal/cli/utils.go
+++ b/internal/cli/utils.go
@@ -10,13 +10,17 @@ import (
 	"strings"
 )
 
-func apiURL(webPort int, path string) string {
-	path = strings.TrimLeft(path, "/")
-	return fmt.Sprintf("http://localhost:%d/api/%s", webPort, path)
+func apiHost() string {
+	return fmt.Sprintf("%s:%d", webHost, webPort)
 }
 
-func apiGet(webPort int, path string) (body io.ReadCloser) {
-	url := apiURL(webPort, path)
+func apiURL(path string) string {
+	path = strings.TrimLeft(path, "/")
+	return fmt.Sprintf("http://%s:%d/api/%s", webHost, webPort, path)
+}
+
+func apiGet(path string) (body io.ReadCloser) {
+	url := apiURL(path)
 	res, err := http.Get(url)
 	if err != nil {
 		cmdFail(fmt.Errorf("Could not connect to Tilt at %s: %v", url, err))
@@ -28,8 +32,8 @@ func apiGet(webPort int, path string) (body io.ReadCloser) {
 	return res.Body
 }
 
-func apiPostJson(webPort int, path string, payload []byte) (body io.ReadCloser) {
-	url := apiURL(webPort, path)
+func apiPostJson(path string, payload []byte) (body io.ReadCloser) {
+	url := apiURL(path)
 	res, err := http.Post(url, "application/json", bytes.NewBuffer(payload))
 	if err != nil {
 		cmdFail(fmt.Errorf("Could not connect to Tilt at %s: %v", url, err))


### PR DESCRIPTION
Hello @maiamcc,

Please review the following commits I made in branch nicks/ch7016:

f75c6a297f559ed016411376da721a6ea109511a (2020-05-14 18:49:56 -0400)
cli: consolidate how we set port and host. Fixes https://github.com/windmilleng/tilt/issues/3332

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics