### PR TITLE
k8s: print local registry as part of 'tilt doctor', and add support for new kind registry annotation

### DIFF
--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -11,6 +11,7 @@ import (
 	wmanalytics "github.com/tilt-dev/wmclient/pkg/analytics"
 
 	"github.com/tilt-dev/tilt/internal/analytics"
+	"github.com/tilt-dev/tilt/pkg/logger"
 )
 
 type doctorCmd struct {
@@ -118,6 +119,9 @@ func (c *doctorCmd) run(ctx context.Context, args []string) error {
 	kVersion, err := wireK8sVersion(ctx)
 	printField("Version", kVersion, err)
 
+	registryDisplay, err := clusterLocalRegistryDisplay(ctx)
+	printField("Cluster Local Registry", registryDisplay, err)
+
 	fmt.Println("---")
 	fmt.Println("Thanks for seeing the Tilt Doctor!")
 	fmt.Println("Please send the info above when filing bug reports. 💗")
@@ -144,6 +148,21 @@ func (c *doctorCmd) run(ctx context.Context, args []string) error {
 	fmt.Printf("- Repo: %s\n", gitRepoHash)
 
 	return nil
+}
+
+func clusterLocalRegistryDisplay(ctx context.Context) (string, error) {
+	kClient, err := wireK8sClient(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	// blackhole any warnings
+	newCtx := logger.WithLogger(ctx, logger.NewDeferredLogger(ctx))
+	registry := kClient.LocalRegistry(newCtx)
+	if registry.Empty() {
+		return "none", nil
+	}
+	return fmt.Sprintf("%+v", registry), nil
 }
 
 func printField(name string, v interface{}, err error) {

--- a/internal/cli/wire.go
+++ b/internal/cli/wire.go
@@ -209,6 +209,15 @@ func wireRuntime(ctx context.Context) (container.Runtime, error) {
 	return "", nil
 }
 
+func wireK8sClient(ctx context.Context) (k8s.Client, error) {
+	wire.Build(
+		K8sWireSet,
+		provideKubectlLogLevel,
+		k8s.ProvideMinikubeClient,
+	)
+	return nil, nil
+}
+
 func wireK8sVersion(ctx context.Context) (*version.Info, error) {
 	wire.Build(K8sWireSet)
 	return nil, nil


### PR DESCRIPTION
Hello @maiamcc,

Please review the following commits I made in branch nicks/kind:

f1159e9ccd44f5eb0d91600eec063a4113bd214b (2020-05-15 17:11:58 -0400)
k8s: print local registry as part of 'tilt doctor', and add support for new kind registry annotation

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics