### PR TITLE
remove auto-namespace creation. Fixes  https://github.com/tilt-dev/tilt/issues/3349

### DIFF
--- a/internal/tiltfile/files.go
+++ b/internal/tiltfile/files.go
@@ -227,26 +227,11 @@ func (s *tiltfileState) helm(thread *starlark.Thread, fn *starlark.Builtin, args
 			return nil, err
 		}
 
-		var haveYAMLForNamespace bool
 		for i, e := range parsed {
-			if e.GVK().Kind == "Namespace" && e.Name() == namespace {
-				// Chart already has YAML for the --namespace passed, we don't need to insert it
-				haveYAMLForNamespace = true
-				continue
-			}
 			parsed[i] = e.WithNamespace(namespace)
 		}
 
-		var entities []k8s.K8sEntity
-		if !haveYAMLForNamespace {
-			// User is relying on Helm to create the namespace, which it does independent
-			// of the YAML it generates, so we need to make sure the new namespace is included
-			// in the YAML.
-			entities = []k8s.K8sEntity{k8s.NewNamespaceEntity(namespace)}
-		}
-		entities = append(entities, parsed...)
-
-		yaml, err = k8s.SerializeSpecYAML(entities)
+		yaml, err = k8s.SerializeSpecYAML(parsed)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/tiltfile/helm_test.go
+++ b/internal/tiltfile/helm_test.go
@@ -23,7 +23,7 @@ k8s_yaml(yml)
 
 	f.load()
 
-	m := f.assertNextManifestUnresourced("garnet",
+	m := f.assertNextManifestUnresourced(
 		// A service and ingress with the same name
 		"rose-quartz-helloworld-chart",
 		"rose-quartz-helloworld-chart")
@@ -63,7 +63,7 @@ func TestHelmUnknownVersion(t *testing.T) {
 }
 
 const fileRequirementsYAML = `dependencies:
-  - name: foobar 
+  - name: foobar
     version: 1.0.1
     repository: file://./foobar`
 

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -1236,7 +1236,7 @@ k8s_yaml(yml)
 
 	f.load()
 
-	m := f.assertNextManifestUnresourced("garnet", "rose-quartz-helloworld-chart")
+	m := f.assertNextManifestUnresourced("rose-quartz-helloworld-chart")
 	yaml := m.K8sTarget().YAML
 	assert.Contains(t, yaml, "release: rose-quartz")
 	assert.Contains(t, yaml, "namespace: garnet")
@@ -1247,7 +1247,7 @@ k8s_yaml(yml)
 	require.NoError(t, err)
 
 	names := k8s.UniqueNames(entities, 2)
-	expectedNames := []string{"garnet:namespace", "rose-quartz-helloworld-chart:service"}
+	expectedNames := []string{"rose-quartz-helloworld-chart:service"}
 	assert.ElementsMatch(t, expectedNames, names)
 
 	f.assertConfigFiles("./helm/", "./dev/helm/values-dev.yaml", ".tiltignore", "Tiltfile")
@@ -1304,7 +1304,7 @@ k8s_yaml(yml)
 
 	f.load()
 
-	f.assertNextManifestUnresourced("foobarbaz", "not-the-one-specified-in-flag", "rose-quartz-helloworld-chart")
+	f.assertNextManifestUnresourced("not-the-one-specified-in-flag", "rose-quartz-helloworld-chart")
 }
 
 func TestHelmInvalidDirectory(t *testing.T) {


### PR DESCRIPTION
Hello @maiamcc, @jazzdan,

Please review the following commits I made in branch nicks/ch7045/namespace:

cfa92e2cbb8e9c266c255dabc394e38076bcd74b (2020-05-18 18:43:00 -0400)
remove auto-namespace creation. Fixes  https://github.com/tilt-dev/tilt/issues/3349
helm3 has moved away from this behavior, and in retrospect, it seems
to create more problems than it solves

As a work-around, people should create a new namespace
themselves if that's what they want.

This is basically a revert of https://github.com/tilt-dev/tilt/pull/2418

I also considered adding some sort of EnsureNamespace
primitive in K8sTarget, which might be more generally useful,
but was worried it added a lot of complexity and made this
harder to implement as a tilt extension.

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics