### PR TITLE
tiltfile: explicitly mark non-workload manifests as such so we can handle them differently in the UI

### DIFF
--- a/internal/hud/webview/analytics_nudge.go
+++ b/internal/hud/webview/analytics_nudge.go
@@ -18,7 +18,7 @@ func NeedsNudge(st store.EngineState) bool {
 	}
 
 	for _, targ := range manifestTargs {
-		if targ.Manifest.IsNonWorkloadYAMLManifest() {
+		if targ.Manifest.NonWorkloadManifest() {
 			continue
 		}
 

--- a/internal/hud/webview/analytics_nudge.go
+++ b/internal/hud/webview/analytics_nudge.go
@@ -18,7 +18,7 @@ func NeedsNudge(st store.EngineState) bool {
 	}
 
 	for _, targ := range manifestTargs {
-		if targ.Manifest.IsUnresourcedYAMLManifest() {
+		if targ.Manifest.IsNonWorkloadYAMLManifest() {
 			continue
 		}
 

--- a/internal/hud/webview/convert.go
+++ b/internal/hud/webview/convert.go
@@ -215,7 +215,7 @@ func tiltfileResourceProtoView(s store.EngineState) (*proto_webview.Resource, er
 func protoPopulateResourceInfoView(mt *store.ManifestTarget, r *proto_webview.Resource) error {
 	r.RuntimeStatus = string(model.RuntimeStatusNotApplicable)
 
-	if mt.Manifest.IsUnresourcedYAMLManifest() {
+	if mt.Manifest.IsNonWorkloadYAMLManifest() {
 		r.YamlResourceInfo = &proto_webview.YAMLResourceInfo{
 			K8SResources: mt.Manifest.K8sTarget().DisplayNames,
 		}

--- a/internal/hud/webview/convert.go
+++ b/internal/hud/webview/convert.go
@@ -215,7 +215,7 @@ func tiltfileResourceProtoView(s store.EngineState) (*proto_webview.Resource, er
 func protoPopulateResourceInfoView(mt *store.ManifestTarget, r *proto_webview.Resource) error {
 	r.RuntimeStatus = string(model.RuntimeStatusNotApplicable)
 
-	if mt.Manifest.IsNonWorkloadYAMLManifest() {
+	if mt.Manifest.NonWorkloadManifest() {
 		r.YamlResourceInfo = &proto_webview.YAMLResourceInfo{
 			K8SResources: mt.Manifest.K8sTarget().DisplayNames,
 		}

--- a/internal/k8s/target.go
+++ b/internal/k8s/target.go
@@ -17,7 +17,7 @@ func MustTarget(name model.TargetName, yaml string) model.K8sTarget {
 	if err != nil {
 		panic(fmt.Errorf("MustTarget: %v", err))
 	}
-	target, err := NewTarget(name, entities, nil, nil, nil, nil)
+	target, err := NewTarget(name, entities, nil, nil, nil, nil, false)
 	if err != nil {
 		panic(fmt.Errorf("MustTarget: %v", err))
 	}
@@ -30,7 +30,8 @@ func NewTarget(
 	portForwards []model.PortForward,
 	extraPodSelectors []labels.Selector,
 	dependencyIDs []model.TargetID,
-	refInjectCounts map[string]int) (model.K8sTarget, error) {
+	refInjectCounts map[string]int,
+	nonWorkload bool) (model.K8sTarget, error) {
 	sorted := SortedEntities(entities)
 	yaml, err := SerializeSpecYAML(sorted)
 	if err != nil {
@@ -53,11 +54,12 @@ func NewTarget(
 		ExtraPodSelectors: extraPodSelectors,
 		DisplayNames:      displayNames,
 		ObjectRefs:        objectRefs,
+		NonWorkload:       nonWorkload,
 	}.WithDependencyIDs(dependencyIDs).WithRefInjectCounts(refInjectCounts), nil
 }
 
 func NewK8sOnlyManifest(name model.ManifestName, entities []K8sEntity) (model.Manifest, error) {
-	kTarget, err := NewTarget(name.TargetName(), entities, nil, nil, nil, nil)
+	kTarget, err := NewTarget(name.TargetName(), entities, nil, nil, nil, nil, false)
 	if err != nil {
 		return model.Manifest{}, err
 	}

--- a/internal/k8s/target.go
+++ b/internal/k8s/target.go
@@ -59,7 +59,7 @@ func NewTarget(
 }
 
 func NewK8sOnlyManifest(name model.ManifestName, entities []K8sEntity) (model.Manifest, error) {
-	kTarget, err := NewTarget(name.TargetName(), entities, nil, nil, nil, nil, false)
+	kTarget, err := NewTarget(name.TargetName(), entities, nil, nil, nil, nil, true)
 	if err != nil {
 		return model.Manifest{}, err
 	}

--- a/internal/k8s/target_test.go
+++ b/internal/k8s/target_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestNewTargetSortsK8sEntities(t *testing.T) {
 	entities := MustParseYAMLFromString(t, testyaml.OutOfOrderYaml)
-	targ, err := NewTarget("foo", entities, nil, nil, nil, nil)
+	targ, err := NewTarget("foo", entities, nil, nil, nil, nil, false)
 	require.NoError(t, err)
 
 	expectedKindOrder := []string{"PersistentVolume", "PersistentVolumeClaim", "ConfigMap", "Service", "StatefulSet", "Job", "Pod"}

--- a/internal/store/engine_state.go
+++ b/internal/store/engine_state.go
@@ -732,7 +732,7 @@ func resourceInfoView(mt *ManifestTarget) view.ResourceInfoView {
 		runStatus = mt.State.RuntimeState.RuntimeStatus()
 	}
 
-	if mt.Manifest.IsNonWorkloadYAMLManifest() {
+	if mt.Manifest.NonWorkloadManifest() {
 		return view.YAMLResourceInfo{
 			K8sResources: mt.Manifest.K8sTarget().DisplayNames,
 		}

--- a/internal/store/engine_state.go
+++ b/internal/store/engine_state.go
@@ -732,7 +732,7 @@ func resourceInfoView(mt *ManifestTarget) view.ResourceInfoView {
 		runStatus = mt.State.RuntimeState.RuntimeStatus()
 	}
 
-	if mt.Manifest.IsUnresourcedYAMLManifest() {
+	if mt.Manifest.IsNonWorkloadYAMLManifest() {
 		return view.YAMLResourceInfo{
 			K8sResources: mt.Manifest.K8sTarget().DisplayNames,
 		}

--- a/internal/store/engine_state_test.go
+++ b/internal/store/engine_state_test.go
@@ -101,6 +101,25 @@ func TestStateToViewUnresourcedYAMLManifest(t *testing.T) {
 	assert.Equal(t, expectedInfo, r.ResourceInfo)
 }
 
+func TestStateToViewNonWorkloadYAMLManifest(t *testing.T) {
+	es, err := k8s.ParseYAMLFromString(testyaml.SecretYaml)
+	require.NoError(t, err)
+	m, err := k8s.NewK8sOnlyManifest(model.ManifestName("foo"), es)
+	require.NoError(t, err)
+	state := newState([]model.Manifest{m})
+	v := StateToView(*state, &sync.RWMutex{})
+
+	assert.Equal(t, 2, len(v.Resources))
+
+	r, _ := v.Resource(m.Name)
+	assert.Equal(t, nil, r.LastBuild().Error)
+
+	expectedInfo := view.YAMLResourceInfo{
+		K8sResources: []string{"mysecret:secret"},
+	}
+	assert.Equal(t, expectedInfo, r.ResourceInfo)
+}
+
 func TestMostRecentPod(t *testing.T) {
 	podA := Pod{PodID: "pod-a", StartedAt: time.Now()}
 	podB := Pod{PodID: "pod-b", StartedAt: time.Now().Add(time.Minute)}

--- a/internal/tiltfile/k8s.go
+++ b/internal/tiltfile/k8s.go
@@ -52,6 +52,8 @@ type k8sResource struct {
 	triggerMode triggerMode
 
 	resourceDeps []string
+
+	nonWorkload bool
 }
 
 const deprecatedResourceAssemblyV1Warning = "This Tiltfile is using k8s resource assembly version 1, which has been " +

--- a/internal/tiltfile/tiltfile_state.go
+++ b/internal/tiltfile/tiltfile_state.go
@@ -628,6 +628,7 @@ func (s *tiltfileState) assembleK8sV2() error {
 			if err != nil {
 				return err
 			}
+			r.nonWorkload = true
 			s.k8sByName[opts.newName] = r
 		}
 		if r, ok := s.k8sByName[workload]; ok {
@@ -1039,7 +1040,7 @@ func (s *tiltfileState) translateK8s(resources []*k8sResource) ([]model.Manifest
 		}
 
 		k8sTarget, err := k8s.NewTarget(mn.TargetName(), r.entities, s.defaultedPortForwards(r.portForwards),
-			r.extraPodSelectors, r.dependencyIDs, r.imageRefMap)
+			r.extraPodSelectors, r.dependencyIDs, r.imageRefMap, r.nonWorkload)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -4494,7 +4494,7 @@ k8s_resource('foo', objects=['bar', 'baz:namespace:default'])
 
 	f.load()
 
-	f.assertNextManifest("foo", deployment("foo"), k8sObject("bar", "Secret"), k8sObject("baz", "Namespace"))
+	f.assertNextManifest("foo", deployment("foo"), k8sObject("bar", "Secret"), k8sObject("baz", "Namespace"), nonWorkload(false))
 	f.assertNoMoreManifests()
 }
 
@@ -4858,7 +4858,7 @@ k8s_resource(new_name='foo', objects=['bar', 'baz:namespace:default'])
 
 	f.load()
 
-	f.assertNextManifest("foo", k8sObject("bar", "Secret"), k8sObject("baz", "Namespace"))
+	f.assertNextManifest("foo", k8sObject("bar", "Secret"), k8sObject("baz", "Namespace"), nonWorkload(true))
 	f.assertNoMoreManifests()
 }
 
@@ -5323,6 +5323,8 @@ func (f *fixture) assertNextManifest(name model.ManifestName, opts ...interface{
 			if !found {
 				f.t.Fatalf("deployment %v not found in yaml %q", opt.name, yaml)
 			}
+		case nonWorkloadHelper:
+			assert.Equal(f.t, opt.nonWorkload, m.K8sTarget().NonWorkload)
 		case namespaceHelper:
 			yaml := m.K8sTarget().YAML
 			found := false
@@ -5558,6 +5560,14 @@ func deployment(name string, opts ...interface{}) deploymentHelper {
 		}
 	}
 	return r
+}
+
+type nonWorkloadHelper struct {
+	nonWorkload bool
+}
+
+func nonWorkload(nonWorkload bool) nonWorkloadHelper {
+	return nonWorkloadHelper{nonWorkload: nonWorkload}
 }
 
 type serviceHelper struct {

--- a/pkg/model/k8s_target.go
+++ b/pkg/model/k8s_target.go
@@ -24,6 +24,10 @@ type K8sTarget struct {
 	// for easy access. This should duplicate what's specified in the YAML.
 	ObjectRefs []v1.ObjectReference
 
+	// NonWorkload indicates whether or not a given K8sTarget was
+	// determined to have workloads at assembly time during Tiltfile execution
+	NonWorkload bool
+
 	dependencyIDs []TargetID
 
 	// Map configRef -> number of times we (expect to) inject it.

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -113,10 +113,6 @@ func (m Manifest) IsK8s() bool {
 }
 
 func (m Manifest) IsNonWorkloadYAMLManifest() bool {
-	if m.Name == UnresourcedYAMLManifestName {
-		return true
-	}
-
 	k8sTarget, ok := m.deployTarget.(K8sTarget)
 	if !ok {
 		return false

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -112,12 +112,11 @@ func (m Manifest) IsK8s() bool {
 	return ok
 }
 
-func (m Manifest) IsNonWorkloadYAMLManifest() bool {
-	k8sTarget, ok := m.deployTarget.(K8sTarget)
-	if !ok {
-		return false
+func (m Manifest) NonWorkloadManifest() bool {
+	if k8sTarget, ok := m.deployTarget.(K8sTarget); ok {
+		return k8sTarget.NonWorkload
 	}
-	return k8sTarget.NonWorkload
+	return false
 }
 
 func (m Manifest) DeployTarget() TargetSpec {

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -112,8 +112,16 @@ func (m Manifest) IsK8s() bool {
 	return ok
 }
 
-func (m Manifest) IsUnresourcedYAMLManifest() bool {
-	return m.Name == UnresourcedYAMLManifestName
+func (m Manifest) IsNonWorkloadYAMLManifest() bool {
+	if m.Name == UnresourcedYAMLManifestName {
+		return true
+	}
+
+	k8sTarget, ok := m.deployTarget.(K8sTarget)
+	if !ok {
+		return false
+	}
+	return k8sTarget.NonWorkload
 }
 
 func (m Manifest) DeployTarget() TargetSpec {


### PR DESCRIPTION
…ifest