### PR TITLE
engine: better handling for image builds in multiple manifests. Fixes https://github.com/windmilleng/tilt/issues/2992

### DIFF
--- a/internal/engine/build_and_deployer_test.go
+++ b/internal/engine/build_and_deployer_test.go
@@ -665,7 +665,7 @@ func TestContainerBuildMultiStage(t *testing.T) {
 	// the second does not --> second target needs build
 	iTargetID := targets[0].ID()
 	firstResult := store.NewImageBuildResultSingleRef(iTargetID, container.MustParseNamedTagged("sancho-base:tilt-prebuilt"))
-	bs[iTargetID] = store.NewBuildState(firstResult, nil)
+	bs[iTargetID] = store.NewBuildState(firstResult, nil, nil)
 
 	result, err := f.bd.BuildAndDeploy(f.ctx, f.st, targets, bs)
 	if err != nil {
@@ -838,9 +838,9 @@ func TestOneLiveUpdateOneDockerBuildDoesImageBuild(t *testing.T) {
 		WithImageTargets(sanchoTarg, sidecarTarg).
 		Build()
 	changed := f.WriteFile("a.txt", "a")
-	sanchoState := store.NewBuildState(store.NewImageBuildResultSingleRef(sanchoTarg.ID(), sanchoRef), []string{changed}).
+	sanchoState := store.NewBuildState(store.NewImageBuildResultSingleRef(sanchoTarg.ID(), sanchoRef), []string{changed}, nil).
 		WithRunningContainers([]store.ContainerInfo{sanchoCInfo})
-	sidecarState := store.NewBuildState(store.NewImageBuildResultSingleRef(sidecarTarg.ID(), sidecarRef), []string{changed})
+	sidecarState := store.NewBuildState(store.NewImageBuildResultSingleRef(sidecarTarg.ID(), sidecarRef), []string{changed}, nil)
 
 	bs := store.BuildStateSet{sanchoTarg.ID(): sanchoState, sidecarTarg.ID(): sidecarState}
 
@@ -986,9 +986,9 @@ func multiImageLiveUpdateManifestAndBuildState(f *bdFixture) (model.Manifest, st
 		Build()
 
 	changed := f.WriteFile("a.txt", "a")
-	sanchoState := store.NewBuildState(store.NewImageBuildResultSingleRef(sanchoTarg.ID(), sanchoRef), []string{changed}).
+	sanchoState := store.NewBuildState(store.NewImageBuildResultSingleRef(sanchoTarg.ID(), sanchoRef), []string{changed}, nil).
 		WithRunningContainers([]store.ContainerInfo{sanchoCInfo})
-	sidecarState := store.NewBuildState(store.NewImageBuildResultSingleRef(sidecarTarg.ID(), sidecarRef), []string{changed}).
+	sidecarState := store.NewBuildState(store.NewImageBuildResultSingleRef(sidecarTarg.ID(), sidecarRef), []string{changed}, nil).
 		WithRunningContainers([]store.ContainerInfo{sidecarCInfo})
 
 	bs := store.BuildStateSet{sanchoTarg.ID(): sanchoState, sidecarTarg.ID(): sidecarState}
@@ -1117,7 +1117,7 @@ func (f *bdFixture) createBuildStateSet(manifest model.Manifest, changedFiles []
 			}
 		}
 
-		state := store.NewBuildState(alreadyBuilt, filesChangingImage)
+		state := store.NewBuildState(alreadyBuilt, filesChangingImage, nil)
 		if manifest.IsImageDeployed(iTarget) {
 			state = state.WithRunningContainers([]store.ContainerInfo{testContainerInfo})
 		}
@@ -1135,7 +1135,7 @@ func (f *bdFixture) createBuildStateSet(manifest model.Manifest, changedFiles []
 func resultToStateSet(resultSet store.BuildResultSet, files []string, cInfo store.ContainerInfo) store.BuildStateSet {
 	stateSet := store.BuildStateSet{}
 	for id, result := range resultSet {
-		state := store.NewBuildState(result, files).WithRunningContainers([]store.ContainerInfo{cInfo})
+		state := store.NewBuildState(result, files, nil).WithRunningContainers([]store.ContainerInfo{cInfo})
 		stateSet[id] = state
 	}
 	return stateSet

--- a/internal/engine/buildcontrol/build_control.go
+++ b/internal/engine/buildcontrol/build_control.go
@@ -92,6 +92,9 @@ func RemoveTargetsWithBuildingComponents(mts []*store.ManifestTarget) []*store.M
 	for _, mt := range mts {
 		if mt.State.IsBuilding() {
 			building[mt.Manifest.ID()] = true
+
+			// TODO(nick): This logic isn't quite right.  A manifest can re-use image
+			// results from another manifest's build.
 			for _, spec := range mt.Manifest.TargetSpecs() {
 				building[spec.ID()] = true
 			}
@@ -219,8 +222,9 @@ func IsBuildingLocalTarget(state store.EngineState) bool {
 }
 
 // Go through all the manifests, and check:
-// 1) all pending file changes, and
-// 2) all pending manifest changes
+// 1) all pending file changes
+// 2) all pending dependency changes (where an image has been rebuilt by another manifest), and
+// 3) all pending manifest changes
 // The earliest one is the one we want.
 //
 // If no targets are pending, return nil

--- a/internal/engine/buildcontroller.go
+++ b/internal/engine/buildcontroller.go
@@ -172,7 +172,12 @@ func buildStateSet(ctx context.Context, manifest model.Manifest, specs []model.T
 		}
 		sort.Strings(filesChanged)
 
-		buildState := store.NewBuildState(status.LastSuccessfulResult, filesChanged)
+		var depsChanged []model.TargetID
+		for dep := range status.PendingDependencyChanges {
+			depsChanged = append(depsChanged, dep)
+		}
+
+		buildState := store.NewBuildState(status.LastSuccessfulResult, filesChanged, depsChanged)
 
 		// Pass along the container when we can update containers in-place.
 		//

--- a/internal/engine/buildcontroller_test.go
+++ b/internal/engine/buildcontroller_test.go
@@ -1267,6 +1267,106 @@ func TestErrorHandlingWithMultipleBuilds(t *testing.T) {
 	f.assertAllBuildsConsumed()
 }
 
+func TestManifestsWithSameTwoImages(t *testing.T) {
+	f := newTestFixture(t)
+	m1, m2 := NewManifestsWithSameTwoImages(f)
+	f.Start([]model.Manifest{m1, m2})
+
+	f.waitForCompletedBuildCount(2)
+
+	call := f.nextCall("m1 build1")
+	assert.Equal(t, m1.K8sTarget(), call.k8s())
+
+	call = f.nextCall("m2 build1")
+	assert.Equal(t, m2.K8sTarget(), call.k8s())
+
+	aPath := f.JoinPath("common", "a.txt")
+	f.fsWatcher.Events <- watch.NewFileEvent(aPath)
+
+	f.waitForCompletedBuildCount(4)
+
+	// Make sure that both builds are triggered, and that they
+	// are triggered in a particular order.
+	call = f.nextCall("m1 build2")
+	assert.Equal(t, m1.K8sTarget(), call.k8s())
+
+	state := call.state[m1.ImageTargets[0].ID()]
+	assert.Equal(t, map[string]bool{aPath: true}, state.FilesChangedSet)
+
+	// Make sure that when the second build is trigged, we did the bookkeeping
+	// correctly around marking the first and second image built and only deploying
+	// the k8s resources.
+	call = f.nextCall("m2 build2")
+	assert.Equal(t, m2.K8sTarget(), call.k8s())
+
+	id := m2.ImageTargets[0].ID()
+	result := f.b.resultsByID[id]
+	assert.Equal(t, store.NewBuildState(result, nil, nil), call.state[id])
+
+	id = m2.ImageTargets[1].ID()
+	result = f.b.resultsByID[id]
+	assert.Equal(t, store.NewBuildState(result, nil, nil), call.state[id])
+
+	err := f.Stop()
+	assert.NoError(t, err)
+	f.assertAllBuildsConsumed()
+}
+
+func TestManifestsWithTwoCommonAncestors(t *testing.T) {
+	f := newTestFixture(t)
+	m1, m2 := NewManifestsWithTwoCommonAncestors(f)
+	f.Start([]model.Manifest{m1, m2})
+
+	f.waitForCompletedBuildCount(2)
+
+	call := f.nextCall("m1 build1")
+	assert.Equal(t, m1.K8sTarget(), call.k8s())
+
+	call = f.nextCall("m2 build1")
+	assert.Equal(t, m2.K8sTarget(), call.k8s())
+
+	aPath := f.JoinPath("base", "a.txt")
+	f.fsWatcher.Events <- watch.NewFileEvent(aPath)
+
+	f.waitForCompletedBuildCount(4)
+
+	// Make sure that both builds are triggered, and that they
+	// are triggered in a particular order.
+	call = f.nextCall("m1 build2")
+	assert.Equal(t, m1.K8sTarget(), call.k8s())
+
+	state := call.state[m1.ImageTargets[0].ID()]
+	assert.Equal(t, map[string]bool{aPath: true}, state.FilesChangedSet)
+
+	// Make sure that when the second build is triggered, we did the bookkeeping
+	// correctly around marking the first and second image built, and only
+	// rebuilding the third image and k8s deploy.
+	call = f.nextCall("m2 build2")
+	assert.Equal(t, m2.K8sTarget(), call.k8s())
+
+	id := m2.ImageTargets[0].ID()
+	result := f.b.resultsByID[id]
+	assert.Equal(t,
+		store.NewBuildState(result, nil, nil),
+		call.state[id])
+
+	id = m2.ImageTargets[1].ID()
+	result = f.b.resultsByID[id]
+	assert.Equal(t,
+		store.NewBuildState(result, nil, nil),
+		call.state[id])
+
+	id = m2.ImageTargets[2].ID()
+	result = f.b.resultsByID[id]
+	assert.Equal(t,
+		store.NewBuildState(result, nil, []model.TargetID{m2.ImageTargets[1].ID()}),
+		call.state[id])
+
+	err := f.Stop()
+	assert.NoError(t, err)
+	f.assertAllBuildsConsumed()
+}
+
 func (f *testFixture) waitUntilManifestBuilding(name model.ManifestName) {
 	msg := fmt.Sprintf("manifest %q is building", name)
 	f.WaitUntilManifestState(msg, name, func(ms store.ManifestState) bool {

--- a/internal/engine/docker_compose_build_and_deployer_test.go
+++ b/internal/engine/docker_compose_build_and_deployer_test.go
@@ -144,7 +144,7 @@ func TestMultiStageDockerComposeWithOnlyOneDirtyImage(t *testing.T) {
 
 	iTargetID := manifest.ImageTargets[0].ID()
 	result := store.NewImageBuildResultSingleRef(iTargetID, container.MustParseNamedTagged("sancho-base:tilt-prebuilt"))
-	state := store.NewBuildState(result, nil)
+	state := store.NewBuildState(result, nil, nil)
 	stateSet := store.BuildStateSet{iTargetID: state}
 	f.dCli.ImageListCount = 1
 	_, err := f.dcbad.BuildAndDeploy(f.ctx, f.st, buildTargets(manifest), stateSet)

--- a/internal/engine/extractors.go
+++ b/internal/engine/extractors.go
@@ -52,6 +52,10 @@ func extractImageTargetsForLiveUpdates(specs []model.TargetSpec, stateSet store.
 			return nil, buildcontrol.SilentRedirectToNextBuilderf("Force update (triggered manually, not automatically, with no dirty files)")
 		}
 
+		if len(state.DepsChangedSet) > 0 {
+			return nil, buildcontrol.SilentRedirectToNextBuilderf("Pending dependencies")
+		}
+
 		hasFileChangesIDs, err := hasFileChangesTree(g, iTarget, stateSet)
 		if err != nil {
 			return nil, errors.Wrap(err, "extractImageTargetsForLiveUpdates")

--- a/internal/engine/image_build_and_deployer_test.go
+++ b/internal/engine/image_build_and_deployer_test.go
@@ -169,7 +169,7 @@ func TestImageIsClean(t *testing.T) {
 	result1 := store.NewImageBuildResultSingleRef(iTargetID1, container.MustParseNamedTagged("sancho-base:tilt-prebuilt1"))
 
 	stateSet := store.BuildStateSet{
-		iTargetID1: store.NewBuildState(result1, []string{}),
+		iTargetID1: store.NewBuildState(result1, []string{}, nil),
 	}
 	_, err := f.ibd.BuildAndDeploy(f.ctx, f.st, buildTargets(manifest), stateSet)
 	if err != nil {
@@ -193,7 +193,7 @@ func TestImageIsDirtyAfterContainerBuild(t *testing.T) {
 		[]container.ID{container.ID("12345")})
 
 	stateSet := store.BuildStateSet{
-		iTargetID1: store.NewBuildState(result1, []string{}),
+		iTargetID1: store.NewBuildState(result1, []string{}, nil),
 	}
 	_, err := f.ibd.BuildAndDeploy(f.ctx, f.st, buildTargets(manifest), stateSet)
 	if err != nil {
@@ -292,8 +292,8 @@ func TestMultiStageDockerBuildWithFirstImageDirty(t *testing.T) {
 	newFile := f.WriteFile("sancho-base/message.txt", "message")
 
 	stateSet := store.BuildStateSet{
-		iTargetID1: store.NewBuildState(result1, []string{newFile}),
-		iTargetID2: store.NewBuildState(result2, nil),
+		iTargetID1: store.NewBuildState(result1, []string{newFile}, nil),
+		iTargetID2: store.NewBuildState(result2, nil, nil),
 	}
 	_, err := f.ibd.BuildAndDeploy(f.ctx, f.st, buildTargets(manifest), stateSet)
 	if err != nil {
@@ -328,8 +328,8 @@ func TestMultiStageDockerBuildWithSecondImageDirty(t *testing.T) {
 	newFile := f.WriteFile("sancho/message.txt", "message")
 
 	stateSet := store.BuildStateSet{
-		iTargetID1: store.NewBuildState(result1, nil),
-		iTargetID2: store.NewBuildState(result2, []string{newFile}),
+		iTargetID1: store.NewBuildState(result1, nil, nil),
+		iTargetID2: store.NewBuildState(result2, []string{newFile}, nil),
 	}
 	_, err := f.ibd.BuildAndDeploy(f.ctx, f.st, buildTargets(manifest), stateSet)
 	if err != nil {
@@ -926,7 +926,7 @@ func (f *ibdFixture) TearDown() {
 func (f *ibdFixture) resultsToNextState(results store.BuildResultSet) store.BuildStateSet {
 	stateSet := store.BuildStateSet{}
 	for id, result := range results {
-		stateSet[id] = store.NewBuildState(result, nil)
+		stateSet[id] = store.NewBuildState(result, nil, nil)
 	}
 	return stateSet
 }

--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -224,6 +224,94 @@ func handleBuildStarted(ctx context.Context, state *store.EngineState, action bu
 	removeFromTriggerQueue(state, mn)
 }
 
+func updateBuildStatus(status *store.BuildStatus, br model.BuildRecord, result store.BuildResult, isBuildSuccess bool) {
+	// Record the result
+	status.LastResult = result
+
+	// Remove pending file changes that were consumed by this build.
+	for file, modTime := range status.PendingFileChanges {
+		if store.BeforeOrEqual(modTime, br.StartTime) {
+			delete(status.PendingFileChanges, file)
+		}
+	}
+
+	// Remove pending dependency changes that were consumed by this build.
+	for id, modTime := range status.PendingDependencyChanges {
+		if store.BeforeOrEqual(modTime, br.StartTime) {
+			delete(status.PendingDependencyChanges, id)
+		}
+	}
+
+	// If the whole build succeeded, mark all of the images in the
+	// build as successful.
+	//
+	// This has a minor bug: if one of the images in a set failed, but another one
+	// succeeded, this doesn't mark any of them as successful. We should fix this,
+	// though personally, I (Nick) think LastSuccessfulResult has problematic
+	// semantics to begin with, and it might make sense to replace it entirely.
+	if isBuildSuccess {
+		status.LastSuccessfulResult = result
+	}
+}
+
+// When a Manifest build finishes, update the BuildStatus for all applicable
+// targets in the engine state.
+func handleBuildResults(engineState *store.EngineState,
+	mt *store.ManifestTarget, br model.BuildRecord, results store.BuildResultSet) {
+	isBuildSuccess := br.Error == nil
+
+	// Update all the build statuses for the current manifest.
+	for _, target := range mt.Manifest.TargetSpecs() {
+		status := mt.State.MutableBuildStatus(target.ID())
+		updateBuildStatus(status, br, results[target.ID()], isBuildSuccess)
+	}
+
+	// Update build statuses for duplicated image targets in other manifests.
+	// This ensures that those images targets aren't redundantly rebuilt.
+	engineState.ForEachMutableBuildStatusInResults(results, func(id model.TargetID, result store.BuildResult, mn model.ManifestName, status *store.BuildStatus) {
+		if mt.Manifest.Name == mn {
+			return
+		}
+
+		// We can only reuse image update, not live-updates or other kinds of
+		// deploys.
+		_, isImageResult := result.(store.ImageBuildResult)
+		if !isImageResult {
+			return
+		}
+
+		updateBuildStatus(status, br, result, isBuildSuccess)
+	})
+
+	// Suppose we built manifestA, which contains imageA depending on imageCommon.
+	//
+	// We also have manifestB, which contains imageB depending on imageCommon.
+	//
+	// We need to mark imageB as dirty, because it was not built in the manifestA
+	// build but its dependency was built.
+	//
+	// Note that this logic also applies to deploy targets depending on image
+	// targets. If we built manifestA, which contains imageX and deploy target
+	// k8sA, and manifestB contains imageX and deploy target k8sB, we need to mark
+	// target k8sB as dirty so that Tilt actually deploys the changes to imageX.
+	engineState.ForEachMutableBuildStatusDependingOn(results, func(id, reverseDepID model.TargetID, mn model.ManifestName, reverseDepStatus *store.BuildStatus) {
+		if mn == mt.Manifest.Name {
+			// We're only worried about manifests that we didn't just build.
+			return
+		}
+
+		_, ok := results[reverseDepID]
+		if ok {
+			// The reverseDep is fresh (i.e. was just built)! Skip it.
+			return
+		}
+
+		// This target was not built, but one of its dependencies was
+		// built, so we have to mark the target for rebuild.
+		reverseDepStatus.PendingDependencyChanges[id] = br.StartTime
+	})
+}
+
 func handleBuildCompleted(ctx context.Context, engineState *store.EngineState, cb buildcontrol.BuildCompleteAction) {
 	defer func() {
 		delete(engineState.CurrentlyBuilding, cb.ManifestName)
@@ -256,18 +344,7 @@ func handleBuildCompleted(ctx context.Context, engineState *store.EngineState, c
 	ms.CurrentBuild = model.BuildRecord{}
 	ms.NeedsRebuildFromCrash = false
 
-	for id, result := range cb.Result {
-		ms.MutableBuildStatus(id).LastResult = result
-	}
-
-	// Remove pending file changes that were consumed by this build.
-	for _, status := range ms.BuildStatuses {
-		for file, modTime := range status.PendingFileChanges {
-			if store.BeforeOrEqual(modTime, bs.StartTime) {
-				delete(status.PendingFileChanges, file)
-			}
-		}
-	}
+	handleBuildResults(engineState, mt, bs, cb.Result)
 
 	if !ms.PendingManifestChange.IsZero() &&
 		store.BeforeOrEqual(ms.PendingManifestChange, bs.StartTime) {
@@ -281,10 +358,6 @@ func handleBuildCompleted(ctx context.Context, engineState *store.EngineState, c
 		}
 	} else {
 		ms.LastSuccessfulDeployTime = cb.FinishTime
-
-		for id, result := range cb.Result {
-			ms.MutableBuildStatus(id).LastSuccessfulResult = result
-		}
 
 		for _, pod := range ms.K8sRuntimeState().Pods {
 			// Reset the baseline, so that we don't show restarts

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -2807,8 +2807,10 @@ func TestWatchManifestsWithCommonAncestor(t *testing.T) {
 	call = f.nextCall("m2 build1")
 	assert.Equal(t, m2.K8sTarget(), call.k8s())
 
-	f.WriteFile("common/a.txt", "hello world")
-	f.fsWatcher.Events <- watch.NewFileEvent(f.JoinPath("common/a.txt"))
+	f.WriteFile(filepath.Join("common", "a.txt"), "hello world")
+
+	aPath := f.JoinPath("common", "a.txt")
+	f.fsWatcher.Events <- watch.NewFileEvent(aPath)
 
 	f.waitForCompletedBuildCount(4)
 
@@ -2817,9 +2819,28 @@ func TestWatchManifestsWithCommonAncestor(t *testing.T) {
 	call = f.nextCall("m1 build2")
 	assert.Equal(t, m1.K8sTarget(), call.k8s())
 
+	state := call.state[m1.ImageTargets[0].ID()]
+	assert.Equal(t, map[string]bool{aPath: true}, state.FilesChangedSet)
+
+	// Make sure that when the second build is triggeredd, we did the bookkeeping
+	// correctly around reusing the image and propagating DepsChanged when
+	// we deploy the second k8s target.
 	call = f.nextCall("m2 build2")
 	assert.Equal(t, m2.K8sTarget(), call.k8s())
 
+	id := m2.ImageTargets[0].ID()
+	result := f.b.resultsByID[id]
+	assert.Equal(t, store.NewBuildState(result, nil, nil), call.state[id])
+
+	id = m2.ImageTargets[1].ID()
+	result = f.b.resultsByID[id]
+	assert.Equal(t,
+		store.NewBuildState(result, nil, []model.TargetID{m2.ImageTargets[0].ID()}),
+		call.state[id])
+
+	err := f.Stop()
+	assert.NoError(t, err)
+	f.assertAllBuildsConsumed()
 }
 
 func TestConfigChangeThatChangesManifestIsIncludedInManifestsChangedFile(t *testing.T) {

--- a/internal/store/build_result.go
+++ b/internal/store/build_result.go
@@ -275,6 +275,9 @@ type BuildState struct {
 	// This must be liberal: it's ok if this has too many files, but not ok if it has too few.
 	FilesChangedSet map[string]bool
 
+	// Dependencies changed since the last result was built
+	DepsChangedSet map[model.TargetID]bool
+
 	// There are three kinds of triggers:
 	//
 	// 1) If a resource is in trigger_mode=TRIGGER_MODE_AUTO, then the resource auto-builds.
@@ -297,14 +300,19 @@ type BuildState struct {
 	RunningContainerError error
 }
 
-func NewBuildState(result BuildResult, files []string) BuildState {
+func NewBuildState(result BuildResult, files []string, pendingDeps []model.TargetID) BuildState {
 	set := make(map[string]bool, len(files))
 	for _, f := range files {
 		set[f] = true
 	}
+	depsSet := make(map[model.TargetID]bool, len(pendingDeps))
+	for _, d := range pendingDeps {
+		depsSet[d] = true
+	}
 	return BuildState{
 		LastSuccessfulResult: result,
 		FilesChangedSet:      set,
+		DepsChangedSet:       depsSet,
 	}
 }
 

--- a/internal/store/engine_state.go
+++ b/internal/store/engine_state.go
@@ -158,6 +158,7 @@ func (e *EngineState) IsCurrentlyBuilding(name model.ManifestName) bool {
 	return e.CurrentlyBuilding[name]
 }
 
+// Find the first build status. Only suitable for testing.
 func (e *EngineState) BuildStatus(id model.TargetID) BuildStatus {
 	mns := e.ManifestNamesForTargetID(id)
 	for _, mn := range mns {
@@ -168,6 +169,46 @@ func (e *EngineState) BuildStatus(id model.TargetID) BuildStatus {
 		}
 	}
 	return BuildStatus{}
+
+}
+
+// Visit all the matching BuildStatuses for these results.
+//
+// Long-term, the EngineState should have TargetSpec and one TargetStatus for
+// each TargetID. But in the current system, we may duplicate an image across
+// multiple manifests.
+func (e *EngineState) ForEachMutableBuildStatusInResults(results BuildResultSet,
+	visitor func(id model.TargetID, result BuildResult, mn model.ManifestName, bs *BuildStatus)) {
+	for id, result := range results {
+		for _, mt := range e.Targets() {
+			for _, target := range mt.Manifest.TargetSpecs() {
+				if id == target.ID() {
+					visitor(id, result, mt.Manifest.Name, mt.State.MutableBuildStatus(id))
+				}
+			}
+		}
+	}
+}
+
+// Visit all the BuildStatuses for Targets depending on these results.
+//
+// A future graph API might just have a GetReverseDepsOn(id).  But we don't
+// currently store them this way. We batch the results together to avoid too
+// many redundant loops (more for readability/debuggability than speed).
+func (e *EngineState) ForEachMutableBuildStatusDependingOn(results BuildResultSet,
+	visitor func(id, reverseDepID model.TargetID, mn model.ManifestName, reverseDepStatus *BuildStatus)) {
+	for _, mt := range e.Targets() {
+		for _, target := range mt.Manifest.TargetSpecs() {
+			reverseDepID := target.ID()
+			for _, depID := range target.DependencyIDs() {
+				_, inResults := results[depID]
+				if inResults {
+					status := mt.State.MutableBuildStatus(reverseDepID)
+					visitor(depID, reverseDepID, mt.Manifest.Name, status)
+				}
+			}
+		}
+	}
 }
 
 func (e *EngineState) AvailableBuildSlots() int {
@@ -308,11 +349,28 @@ type BuildStatus struct {
 
 	LastSuccessfulResult BuildResult
 	LastResult           BuildResult
+
+	// Stores the times that dependencies were marked dirty, so we can prioritize
+	// the oldest one first.
+	//
+	// Long-term, we want to process all dependencies as a build graph rather than
+	// a list of manifests. Specifically, we'll build one Target at a time.  Once
+	// the build completes, we'll look at all the targets that depend on it, and
+	// mark PendingDependencyChanges to indicate that they need a rebuild.
+	//
+	// Short-term, we only use this for cases where two manifests share a common
+	// image. This only handles cross-manifest dependencies.
+	//
+	// This approach allows us to start working on the bookkeeping and
+	// dependency-tracking in the short-term, without having to switch over to a
+	// full dependency graph in one swoop.
+	PendingDependencyChanges map[model.TargetID]time.Time
 }
 
 func newBuildStatus() *BuildStatus {
 	return &BuildStatus{
-		PendingFileChanges: make(map[string]time.Time),
+		PendingFileChanges:       make(map[string]time.Time),
+		PendingDependencyChanges: make(map[model.TargetID]time.Time),
 	}
 }
 
@@ -541,6 +599,13 @@ func (ms *ManifestState) HasPendingChangesBeforeOrEqual(highWaterMark time.Time)
 
 	for _, status := range ms.BuildStatuses {
 		for _, t := range status.PendingFileChanges {
+			if !t.IsZero() && BeforeOrEqual(t, earliest) {
+				ok = true
+				earliest = t
+			}
+		}
+
+		for _, t := range status.PendingDependencyChanges {
 			if !t.IsZero() && BeforeOrEqual(t, earliest) {
 				ok = true
 				earliest = t

--- a/pkg/model/build_reason.go
+++ b/pkg/model/build_reason.go
@@ -21,6 +21,14 @@ const (
 
 	// An external process called `tilt args`
 	BuildReasonFlagTiltfileArgs
+
+	// Suppose you have
+	// manifestA with imageA depending on imageCommon
+	// manifestB with imageB depending on imageCommon
+	//
+	// Building manifestA will mark imageB
+	// with changed dependencies.
+	BuildReasonFlagChangedDep
 )
 
 func (r BuildReason) With(flag BuildReason) BuildReason {
@@ -53,6 +61,7 @@ var translations = map[BuildReason]string{
 	BuildReasonFlagTriggerCLI:     "CLI Trigger",
 	BuildReasonFlagTriggerUnknown: "Unknown Trigger",
 	BuildReasonFlagTiltfileArgs:   "Tilt Args",
+	BuildReasonFlagChangedDep:     "Image Updated",
 }
 
 var triggerBuildReasons = []BuildReason{
@@ -68,6 +77,7 @@ var allBuildReasons = []BuildReason{
 	BuildReasonFlagCrash,
 	BuildReasonFlagTriggerWeb,
 	BuildReasonFlagTriggerCLI,
+	BuildReasonFlagChangedDep,
 	BuildReasonFlagTriggerUnknown,
 	BuildReasonFlagTiltfileArgs,
 }

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -141,6 +141,15 @@ func (m Manifest) WithTriggerMode(mode TriggerMode) Manifest {
 	return m
 }
 
+func (m Manifest) TargetIDSet() map[TargetID]bool {
+	result := make(map[TargetID]bool)
+	specs := m.TargetSpecs()
+	for _, spec := range specs {
+		result[spec.ID()] = true
+	}
+	return result
+}
+
 func (m Manifest) TargetSpecs() []TargetSpec {
 	result := []TargetSpec{}
 	for _, t := range m.ImageTargets {


### PR DESCRIPTION
Hello @landism, @maiamcc,

Please review the following commits I made in branch nicks/ch6738:

c9950540c7fc011d2d348b89b250e99d1ba8215b (2020-05-21 11:07:44 -0400)
engine: better handling for image builds in multiple manifests. Fixes https://github.com/windmilleng/tilt/issues/2992

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics