### PR TITLE
tiltfile config: use pflag

### DIFF
--- a/internal/tiltfile/config/bool.go
+++ b/internal/tiltfile/config/bool.go
@@ -24,6 +24,10 @@ func (s *boolSetting) IsSet() bool {
 	return s.isSet
 }
 
+func (s *boolSetting) Type() string {
+	return "bool"
+}
+
 func (s *boolSetting) setFromInterface(i interface{}) error {
 	if i == nil {
 		return nil
@@ -54,8 +58,4 @@ func (s *boolSetting) Set(v string) error {
 
 func (s *boolSetting) String() string {
 	return strconv.FormatBool(s.value)
-}
-
-func (s *boolSetting) IsBoolFlag() bool {
-	return true
 }

--- a/internal/tiltfile/config/config_def.go
+++ b/internal/tiltfile/config/config_def.go
@@ -2,12 +2,12 @@ package config
 
 import (
 	"bytes"
-	"flag"
 	"fmt"
 	"os"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
+	flag "github.com/spf13/pflag"
 	"go.starlark.net/starlark"
 
 	"github.com/windmilleng/tilt/internal/tiltfile/starkit"
@@ -104,10 +104,16 @@ func (cd ConfigDef) parseArgs(args []string) (ret configMap, output string, err 
 			continue
 		}
 		fs.Var(ret[name], name, def.usage)
+		// for bools, make "--foo" equal to "--foo true"
+		if _, ok := ret[name].(*boolSetting); ok {
+			fs.Lookup(name).NoOptDefVal = "true"
+		}
 	}
 
 	err = fs.Parse(args)
 	if err != nil {
+		_, _ = fmt.Fprintf(w, "Error parsing tiltfile config args: %v\nUsage:\n", err)
+		fs.PrintDefaults()
 		return nil, w.String(), err
 	}
 

--- a/internal/tiltfile/config/config_test.go
+++ b/internal/tiltfile/config/config_test.go
@@ -101,7 +101,7 @@ func TestParseKeyword(t *testing.T) {
 	foo := strings.Split("republic dominican cuba caribbean greenland el salvador too", " ")
 	var args []string
 	for _, s := range foo {
-		args = append(args, []string{"-foo", s}...)
+		args = append(args, []string{"--foo", s}...)
 	}
 
 	f := NewFixture(t, model.NewUserConfigState(args))
@@ -120,7 +120,7 @@ print(cfg['foo'])
 }
 
 func TestParsePositionalAndMultipleInterspersedKeyword(t *testing.T) {
-	args := []string{"-bar", "puerto rico", "-baz", "colombia", "-bar", "venezuela", "-baz", "honduras", "-baz", "guyana", "and", "still"}
+	args := []string{"--bar", "puerto rico", "--baz", "colombia", "--bar", "venezuela", "--baz", "honduras", "--baz", "guyana", "and", "still"}
 	f := NewFixture(t, model.NewUserConfigState(args))
 	defer f.TearDown()
 
@@ -140,6 +140,26 @@ print("baz:", cfg['baz'])
 	require.Contains(t, f.PrintOutput(), `foo: ["and", "still"]`)
 	require.Contains(t, f.PrintOutput(), `bar: ["puerto rico", "venezuela"]`)
 	require.Contains(t, f.PrintOutput(), `baz: ["colombia", "honduras", "guyana"]`)
+}
+
+func TestParseKeywordAfterPositional(t *testing.T) {
+	args := []string{"--bar", "puerto rico", "colombia"}
+	f := NewFixture(t, model.NewUserConfigState(args))
+	defer f.TearDown()
+
+	f.File("Tiltfile", `
+config.define_string_list('foo', args=True)
+config.define_string('bar')
+cfg = config.parse()
+print("foo:", cfg['foo'])
+print("bar:", cfg['bar'])
+`)
+
+	_, err := f.ExecFile("Tiltfile")
+	require.NoError(t, err)
+
+	require.Contains(t, f.PrintOutput(), `foo: ["colombia"]`)
+	require.Contains(t, f.PrintOutput(), `bar: puerto rico`)
 }
 
 func TestMultiplePositionalDefs(t *testing.T) {
@@ -171,7 +191,7 @@ config.define_string_list('foo')
 }
 
 func TestUndefinedArg(t *testing.T) {
-	f := NewFixture(t, model.NewUserConfigState([]string{"-bar", "hello"}))
+	f := NewFixture(t, model.NewUserConfigState([]string{"--bar", "hello"}))
 	defer f.TearDown()
 
 	f.File("Tiltfile", `
@@ -181,7 +201,7 @@ config.parse()
 
 	_, err := f.ExecFile("Tiltfile")
 	require.Error(t, err)
-	require.Equal(t, "flag provided but not defined: -bar", err.Error())
+	require.Equal(t, "unknown flag: --bar", err.Error())
 }
 
 func TestUnprovidedArg(t *testing.T) {
@@ -226,7 +246,7 @@ cfg = config.parse()
 }
 
 func TestUsage(t *testing.T) {
-	f := NewFixture(t, model.NewUserConfigState([]string{"-bar", "hello"}))
+	f := NewFixture(t, model.NewUserConfigState([]string{"--bar", "hello"}))
 	defer f.TearDown()
 
 	f.File("Tiltfile", `
@@ -236,7 +256,7 @@ config.parse()
 
 	_, err := f.ExecFile("Tiltfile")
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "flag provided but not defined: -bar")
+	require.Contains(t, err.Error(), "unknown flag: --bar")
 	require.Contains(t, f.PrintOutput(), "Usage:")
 	require.Contains(t, f.PrintOutput(), "what can I foo for you today")
 }
@@ -269,7 +289,7 @@ func TestSettingsFromConfigAndArgs(t *testing.T) {
 	}{
 		{
 			name:   "args only",
-			args:   []string{"-a", "1", "-a", "2", "-b", "3", "-a", "4", "5", "6"},
+			args:   []string{"--a", "1", "--a", "2", "--b", "3", "--a", "4", "5", "6"},
 			config: nil,
 			expected: map[string][]string{
 				"a": {"1", "2", "4"},
@@ -291,7 +311,7 @@ func TestSettingsFromConfigAndArgs(t *testing.T) {
 		},
 		{
 			name: "args trump config",
-			args: []string{"-a", "1", "-a", "2", "-a", "4", "5", "6"},
+			args: []string{"--a", "1", "--a", "2", "--a", "4", "5", "6"},
 			config: map[string][]string{
 				"b": {"7", "8"},
 				"c": {"9"},
@@ -485,7 +505,7 @@ func TestTypes(t *testing.T) {
 		newTypeTestCase("string defined multiple times", "config.define_string('foo')").withArgs("--foo bar --foo baz").withExpectedError("string settings can only be specified once"),
 		newTypeTestCase("invalid string from config", "config.define_string('foo')").withConfigFile(`{"foo": 5}`).withExpectedError("expected string, found float64"),
 
-		newTypeTestCase("bool from args", "config.define_bool('foo')").withArgs("--foo").withExpectedVal("True"),
+		newTypeTestCase("bool from args w/ implicit value", "config.define_bool('foo')").withArgs("--foo").withExpectedVal("True"),
 		newTypeTestCase("bool from config", "config.define_bool('foo')").withConfigFile(`{"foo": true}`).withExpectedVal("True"),
 		newTypeTestCase("bool defined multiple times", "config.define_bool('foo')").withArgs("--foo --foo").withExpectedError("bool settings can only be specified once"),
 		newTypeTestCase("invalid bool from config", "config.define_bool('foo')").withConfigFile(`{"foo": 5}`).withExpectedError("expected bool, found float64"),

--- a/internal/tiltfile/config/string.go
+++ b/internal/tiltfile/config/string.go
@@ -1,9 +1,9 @@
 package config
 
 import (
-	"flag"
 	"fmt"
 
+	flag "github.com/spf13/pflag"
 	"go.starlark.net/starlark"
 )
 
@@ -21,6 +21,10 @@ func (s *stringSetting) starlark() starlark.Value {
 
 func (s *stringSetting) IsSet() bool {
 	return s.isSet
+}
+
+func (s *stringSetting) Type() string {
+	return "string"
 }
 
 func (s *stringSetting) setFromInterface(i interface{}) error {

--- a/internal/tiltfile/config/string_list.go
+++ b/internal/tiltfile/config/string_list.go
@@ -1,10 +1,10 @@
 package config
 
 import (
-	"flag"
 	"fmt"
 	"strings"
 
+	flag "github.com/spf13/pflag"
 	"go.starlark.net/starlark"
 
 	"github.com/windmilleng/tilt/internal/tiltfile/value"
@@ -24,6 +24,10 @@ func (s *stringList) starlark() starlark.Value {
 
 func (s *stringList) IsSet() bool {
 	return s.isSet
+}
+
+func (s *stringList) Type() string {
+	return "list[string]"
 }
 
 func (s *stringList) setFromInterface(i interface{}) error {


### PR DESCRIPTION
Fixes #3360

### Problem

In a Tiltfile's `config.parse()`, as soon as it encounters any non-positional arguments, all remaining arguments are treated as non-positional

#### repro
in Tiltfile:
```
config.define_string('foo')
config.define_string_list('bar', args=True)
cfg = config.parse()
```
on cmd line:
`tilt up -- a --foo b`

#### expected
`cfg['foo'] == 'b'` and `cfg['bar'] == ['a']`

#### observed
`cfg['foo'] is undefined and `cfg['bar'] == ['a', '--foo', 'b']`

### Solution
Use [`pflag`](https://github.com/spf13/pflag) instead of golang's `flag`. Further discussion [here](https://github.com/tilt-dev/tilt/issues/3360#issuecomment-632236155).

### Result
1. tiltfile config parsing is consistent with the "main" tilt parsing (i.e., the cobra stuff that happens in `cmd` - cobra uses pflag), and most (AFAIK) unix tools.
2. this is a breaking change in that go's `flag.Parse()` accepts `-foo bar` *or* `--foo bar` to set `foo`, but pflag requires two dashes (i.e., `--foo`). I think this is fine: 1. if you run it with `-foo`, you get an error and usage output that says `--foo`, so it's a clear path to remedying 2. all our docs use two dashes, so this only breaks undocumented behavior.
3. This is a breaking change in that it's fixing the bug report and anyone who relies on the old behavior will be broken. This is more potentially controversial.