### PR TITLE
windows: use gotestsum in ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,6 +81,8 @@ jobs:
       # Check to make sure Windows binaries compile
       - run: go install -mod vendor ./cmd/tilt
       - run: make shorttestsum
+      - store_test_results:
+          path: test-results
 
   build-integration:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,10 +76,11 @@ jobs:
     steps:
       - run: choco install make kustomize kubernetes-helm docker-compose
       - run: choco update golang
+      - run: go get -u gotest.tools/gotestsum
       - checkout
       # Check to make sure Windows binaries compile
       - run: go install -mod vendor ./cmd/tilt
-      - run: make shorttest
+      - run: make shorttestsum
 
   build-integration:
     docker:

--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,12 @@ shorttest:
 	go test -mod vendor -p $(GO_PARALLEL_JOBS) -tags skipcontainertests,skipdockercomposetests -timeout 60s ./...
 
 shorttestsum:
+ifneq ($(CIRCLECI),true)
 	gotestsum -- -mod vendor -p $(GO_PARALLEL_JOBS) -tags skipcontainertests,skipdockercomposetests -timeout 60s ./...
+else
+	mkdir -p test-results
+	gotestsum --format standard-quiet --junitfile test-results/unit-tests.xml -- ./... -mod vendor -count 1 -p $(GO_PARALLEL_JOBS) -tags skipcontainertests,skipdockercomposetests -timeout 60s
+endif
 
 integration:
 ifneq ($(CIRCLECI),true)

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -2870,10 +2870,6 @@ func TestK8sResourceEmptyWorkloadSpecifier(t *testing.T) {
 	f := newFixture(t)
 	defer f.TearDown()
 
-	if runtime.GOOS == "windows" {
-		t.Fatal("this test is failing to test gotestsum!")
-	}
-
 	f.setupFoo()
 
 	f.file("Tiltfile", `

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -2870,6 +2870,8 @@ func TestK8sResourceEmptyWorkloadSpecifier(t *testing.T) {
 	f := newFixture(t)
 	defer f.TearDown()
 
+	t.Fatal("this test is failing to test gotestsum!")
+
 	f.setupFoo()
 
 	f.file("Tiltfile", `

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -2870,7 +2870,9 @@ func TestK8sResourceEmptyWorkloadSpecifier(t *testing.T) {
 	f := newFixture(t)
 	defer f.TearDown()
 
-	t.Fatal("this test is failing to test gotestsum!")
+	if runtime.GOOS == "windows" {
+		t.Fatal("this test is failing to test gotestsum!")
+	}
 
 	f.setupFoo()
 


### PR DESCRIPTION
sample result w/ failures https://circleci.com/gh/tilt-dev/tilt/40825

Installing gotestsum added 35 seconds to the windows build, for a total of 7m54s.