### PR TITLE
engine: move the portforwardcontroller into its own package

### DIFF
--- a/internal/cli/wire.go
+++ b/internal/cli/wire.go
@@ -31,6 +31,7 @@ import (
 	"github.com/tilt-dev/tilt/internal/engine/k8srollout"
 	"github.com/tilt-dev/tilt/internal/engine/k8swatch"
 	"github.com/tilt-dev/tilt/internal/engine/local"
+	"github.com/tilt-dev/tilt/internal/engine/portforward"
 	"github.com/tilt-dev/tilt/internal/engine/runtimelog"
 	"github.com/tilt-dev/tilt/internal/engine/telemetry"
 	"github.com/tilt-dev/tilt/internal/feature"
@@ -72,7 +73,7 @@ var BaseWireSet = wire.NewSet(
 	clockwork.NewRealClock,
 	engine.DeployerWireSet,
 	runtimelog.NewPodLogManager,
-	engine.NewPortForwardController,
+	portforward.NewController,
 	engine.NewBuildController,
 	local.ProvideExecer,
 	local.NewController,

--- a/internal/engine/pod.go
+++ b/internal/engine/pod.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/tilt-dev/tilt/internal/container"
 	"github.com/tilt-dev/tilt/internal/engine/k8swatch"
+	"github.com/tilt-dev/tilt/internal/engine/portforward"
 	"github.com/tilt-dev/tilt/internal/engine/runtimelog"
 	"github.com/tilt-dev/tilt/internal/k8s"
 	"github.com/tilt-dev/tilt/internal/store"
@@ -80,7 +81,7 @@ func handlePodChangeAction(ctx context.Context, state *store.EngineState, action
 		ms.RuntimeState = runtime
 	}
 
-	fwdsValid := portForwardsAreValid(manifest, *podInfo)
+	fwdsValid := portforward.PortForwardsAreValid(manifest, *podInfo)
 	if !fwdsValid {
 		logger.Get(ctx).Warnf(
 			"Resource %s is using port forwards, but no container ports on pod %s",

--- a/internal/engine/portforward/controller_test.go
+++ b/internal/engine/portforward/controller_test.go
@@ -1,4 +1,4 @@
-package engine
+package portforward
 
 import (
 	"context"
@@ -251,7 +251,7 @@ type plcFixture struct {
 	cancel func()
 	kCli   *k8s.FakeK8sClient
 	st     *store.TestingStore
-	plc    *PortForwardController
+	plc    *Controller
 	out    *bufsync.ThreadSafeBuffer
 }
 
@@ -259,7 +259,7 @@ func newPLCFixture(t *testing.T) *plcFixture {
 	f := tempdir.NewTempDirFixture(t)
 	st := store.NewTestingStore()
 	kCli := k8s.NewFakeK8sClient()
-	plc := NewPortForwardController(kCli)
+	plc := NewController(kCli)
 
 	out := bufsync.NewThreadSafeBuffer()
 	l := logger.NewLogger(logger.DebugLvl, out)

--- a/internal/engine/subscribers.go
+++ b/internal/engine/subscribers.go
@@ -12,6 +12,7 @@ import (
 	"github.com/tilt-dev/tilt/internal/engine/k8srollout"
 	"github.com/tilt-dev/tilt/internal/engine/k8swatch"
 	"github.com/tilt-dev/tilt/internal/engine/local"
+	"github.com/tilt-dev/tilt/internal/engine/portforward"
 	"github.com/tilt-dev/tilt/internal/engine/runtimelog"
 	"github.com/tilt-dev/tilt/internal/engine/telemetry"
 	"github.com/tilt-dev/tilt/internal/hud"
@@ -24,7 +25,7 @@ func ProvideSubscribers(
 	pw *k8swatch.PodWatcher,
 	sw *k8swatch.ServiceWatcher,
 	plm *runtimelog.PodLogManager,
-	pfc *PortForwardController,
+	pfc *portforward.Controller,
 	fwm *fswatch.WatchManager,
 	bc *BuildController,
 	cc *configs.ConfigsController,

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -45,6 +45,7 @@ import (
 	"github.com/tilt-dev/tilt/internal/engine/k8srollout"
 	"github.com/tilt-dev/tilt/internal/engine/k8swatch"
 	"github.com/tilt-dev/tilt/internal/engine/local"
+	"github.com/tilt-dev/tilt/internal/engine/portforward"
 	"github.com/tilt-dev/tilt/internal/engine/runtimelog"
 	"github.com/tilt-dev/tilt/internal/engine/telemetry"
 	"github.com/tilt-dev/tilt/internal/feature"
@@ -3471,7 +3472,7 @@ func newTestFixtureWithHud(t *testing.T, h hud.HeadsUpDisplay) *testFixture {
 	clock := clockwork.NewRealClock()
 	env := k8s.EnvDockerDesktop
 	fwm := fswatch.NewWatchManager(watcher.NewSub, timerMaker.Maker())
-	pfc := NewPortForwardController(kCli)
+	pfc := portforward.NewController(kCli)
 	au := engineanalytics.NewAnalyticsUpdater(ta, engineanalytics.CmdTags{})
 	ar := engineanalytics.ProvideAnalyticsReporter(ta, st, kCli, env)
 	fakeDcc := dockercompose.NewFakeDockerComposeClient(t, ctx)


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/pf:

6f2cb831f23297b1ac1190b01a83b667c391cfa1 (2020-05-21 16:45:03 -0400)
engine: move the portforwardcontroller into its own package

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics