### PR TITLE
k8s: properly route portforward output to debug logs. Fixes https://github.com/tilt-dev/tilt/issues/3355

### DIFF
--- a/internal/k8s/portforward.go
+++ b/internal/k8s/portforward.go
@@ -13,7 +13,6 @@ import (
 	"k8s.io/client-go/transport/spdy"
 
 	"github.com/tilt-dev/tilt/internal/k8s/portforward"
-	"github.com/tilt-dev/tilt/pkg/logger"
 
 	"github.com/pkg/errors"
 )
@@ -32,6 +31,14 @@ type PortForwarder interface {
 	// Returns when the port-forwarder sees an unrecoverable error or
 	// when the context passed at creation is canceled.
 	ForwardPorts() error
+
+	// TODO(nick): If the port forwarder has any problems connecting to the pod,
+	// it just logs those as debug logs. I'm not sure that logs are the right API
+	// for this -- there are lots of cases (e.g., where you're deliberately
+	// restarting the pod) where it's ok if it drops the connection.
+	//
+	// I suspect what we actually need is a healthcheck/status field for the
+	// portforwarder that's exposed as part of the engine.
 }
 
 type portForwarder struct {
@@ -99,7 +106,6 @@ func (c portForwardClient) CreatePortForwarder(ctx context.Context, namespace Na
 		return nil, errors.Wrap(err, "error creating dialer")
 	}
 
-	stopChan := make(chan struct{}, 1)
 	readyChan := make(chan struct{}, 1)
 
 	ports := []string{fmt.Sprintf("%d:%d", localPort, remotePort)}
@@ -107,31 +113,23 @@ func (c portForwardClient) CreatePortForwarder(ctx context.Context, namespace Na
 	var pf *portforward.PortForwarder
 	if host == "" {
 		pf, err = portforward.New(
+			ctx,
 			dialer,
 			ports,
-			stopChan,
-			readyChan,
-			logger.Get(ctx).Writer(logger.DebugLvl),
-			logger.Get(ctx).Writer(logger.DebugLvl))
+			readyChan)
 	} else {
 		addresses := []string{host}
 		pf, err = portforward.NewOnAddresses(
+			ctx,
 			dialer,
 			addresses,
 			ports,
-			stopChan,
-			readyChan,
-			logger.Get(ctx).Writer(logger.DebugLvl),
-			logger.Get(ctx).Writer(logger.DebugLvl))
+			readyChan)
 	}
 	if err != nil {
 		return nil, errors.Wrap(err, "error forwarding port")
 	}
 
-	go func() {
-		<-ctx.Done()
-		close(stopChan)
-	}()
 	return portForwarder{
 		PortForwarder: pf,
 		localPort:     localPort,


### PR DESCRIPTION
Hello @jazzdan, @landism,

Please review the following commits I made in branch nicks/ch7097/portforward:

08faa087c464ed530c1766f6d6ba05ef5bd580ea (2020-05-21 17:59:26 -0400)
k8s: properly route portforward output to debug logs. Fixes https://github.com/tilt-dev/tilt/issues/3355

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics