### PR TITLE
logstore: ratchet down the logstore max a bit for now

### DIFF
--- a/pkg/model/logstore/logstore.go
+++ b/pkg/model/logstore/logstore.go
@@ -13,11 +13,13 @@ import (
 	"github.com/tilt-dev/tilt/pkg/webview"
 )
 
-// All parts of Tilt should display logs incrementally,
-// so there's no longer a CPU usage reason why logs can't grow unbounded.
+// All parts of Tilt should display logs incrementally.
 //
-// We currently cap logs just to prevent heap usage from blowing up unbounded.
-const defaultMaxLogLengthInBytes = 20 * 1000 * 1000
+// But the initial page load loads all the existing logs.
+// https://github.com/tilt-dev/tilt/issues/3359
+//
+// Until that issue is fixed, we cap the logs at about 1MB.
+const defaultMaxLogLengthInBytes = 1000 * 1000
 
 const newlineByte = byte('\n')
 


### PR DESCRIPTION
Hello @landism,

Please review the following commits I made in branch nicks/ch7111/logs:

2665954fef31dc92edb7dc9259f545d624bfb8ef (2020-05-21 18:33:14 -0400)
logstore: ratchet down the logstore max a bit for now

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics