### PR TITLE
engine: remove last build state from the target queue build handlers

### DIFF
--- a/internal/engine/buildcontrol/target_queue_test.go
+++ b/internal/engine/buildcontrol/target_queue_test.go
@@ -29,7 +29,7 @@ func TestTargetQueue_Simple(t *testing.T) {
 	f.run(targets, buildStateSet)
 
 	expectedCalls := map[model.TargetID]fakeBuildHandlerCall{
-		t1.ID(): newFakeBuildHandlerCall(t1, s1, 1, []store.BuildResult{}),
+		t1.ID(): newFakeBuildHandlerCall(t1, 1, []store.BuildResult{}),
 	}
 	assert.Equal(t, expectedCalls, f.handler.calls)
 }
@@ -50,7 +50,7 @@ func TestTargetQueue_DepsBuilt(t *testing.T) {
 
 	f.run(targets, buildStateSet)
 
-	barCall := newFakeBuildHandlerCall(barTarget, s2, 1, []store.BuildResult{
+	barCall := newFakeBuildHandlerCall(barTarget, 1, []store.BuildResult{
 		store.NewImageBuildResultSingleRef(fooTarget.ID(), store.LocalImageRefFromBuildResult(s1.LastSuccessfulResult)),
 	})
 
@@ -79,9 +79,9 @@ func TestTargetQueue_DepsUnbuilt(t *testing.T) {
 
 	f.run(targets, buildStateSet)
 
-	fooCall := newFakeBuildHandlerCall(fooTarget, s1, 1, []store.BuildResult{})
+	fooCall := newFakeBuildHandlerCall(fooTarget, 1, []store.BuildResult{})
 	// bar's dep is dirty, so bar should not get its old state
-	barCall := newFakeBuildHandlerCall(barTarget, store.BuildState{}, 2, []store.BuildResult{fooCall.result})
+	barCall := newFakeBuildHandlerCall(barTarget, 2, []store.BuildResult{fooCall.result})
 
 	expectedCalls := map[model.TargetID]fakeBuildHandlerCall{
 		fooTarget.ID(): fooCall,
@@ -107,7 +107,7 @@ func TestTargetQueue_IncrementalBuild(t *testing.T) {
 
 	f.run(targets, buildStateSet)
 
-	fooCall := newFakeBuildHandlerCall(fooTarget, s1, 1, []store.BuildResult{})
+	fooCall := newFakeBuildHandlerCall(fooTarget, 1, []store.BuildResult{})
 
 	expectedCalls := map[model.TargetID]fakeBuildHandlerCall{
 		fooTarget.ID(): fooCall,
@@ -154,8 +154,8 @@ func TestTargetQueue_DepsBuiltButReaped(t *testing.T) {
 
 	f.run(targets, buildStateSet)
 
-	fooCall := newFakeBuildHandlerCall(fooTarget, s1, 1, []store.BuildResult{})
-	barCall := newFakeBuildHandlerCall(barTarget, s2, 2, []store.BuildResult{
+	fooCall := newFakeBuildHandlerCall(fooTarget, 1, []store.BuildResult{})
+	barCall := newFakeBuildHandlerCall(barTarget, 2, []store.BuildResult{
 		store.NewImageBuildResultSingleRef(fooTarget.ID(), store.LocalImageRefFromBuildResult(fooCall.result)),
 	})
 
@@ -167,10 +167,9 @@ func TestTargetQueue_DepsBuiltButReaped(t *testing.T) {
 	assert.Equal(t, expectedCalls, f.handler.calls)
 }
 
-func newFakeBuildHandlerCall(target model.ImageTarget, state store.BuildState, num int, depResults []store.BuildResult) fakeBuildHandlerCall {
+func newFakeBuildHandlerCall(target model.ImageTarget, num int, depResults []store.BuildResult) fakeBuildHandlerCall {
 	return fakeBuildHandlerCall{
 		target: target,
-		state:  state,
 		result: store.NewImageBuildResultSingleRef(
 			target.ID(),
 			container.MustParseNamedTagged(fmt.Sprintf("%s:%d", target.Refs.ConfigurationRef.String(), num)),
@@ -181,7 +180,6 @@ func newFakeBuildHandlerCall(target model.ImageTarget, state store.BuildState, n
 
 type fakeBuildHandlerCall struct {
 	target     model.TargetSpec
-	state      store.BuildState
 	depResults []store.BuildResult
 	result     store.BuildResult
 }
@@ -197,12 +195,12 @@ func newFakeBuildHandler() *fakeBuildHandler {
 	}
 }
 
-func (fbh *fakeBuildHandler) handle(target model.TargetSpec, state store.BuildState, depResults []store.BuildResult) (store.BuildResult, error) {
+func (fbh *fakeBuildHandler) handle(target model.TargetSpec, depResults []store.BuildResult) (store.BuildResult, error) {
 	iTarget := target.(model.ImageTarget)
 	fbh.buildNum++
 	namedTagged := container.MustParseNamedTagged(fmt.Sprintf("%s:%d", iTarget.Refs.ConfigurationRef, fbh.buildNum))
 	result := store.NewImageBuildResultSingleRef(target.ID(), namedTagged)
-	fbh.calls[target.ID()] = fakeBuildHandlerCall{target, state, depResults, result}
+	fbh.calls[target.ID()] = fakeBuildHandlerCall{target, depResults, result}
 	return result, nil
 }
 

--- a/internal/engine/docker_compose_build_and_deployer.go
+++ b/internal/engine/docker_compose_build_and_deployer.go
@@ -80,7 +80,7 @@ func (bd *DockerComposeBuildAndDeployer) BuildAndDeploy(ctx context.Context, st 
 	defer func() { ps.End(ctx, err) }()
 
 	iTargetMap := model.ImageTargetsByID(iTargets)
-	err = q.RunBuilds(func(target model.TargetSpec, state store.BuildState, depResults []store.BuildResult) (store.BuildResult, error) {
+	err = q.RunBuilds(func(target model.TargetSpec, depResults []store.BuildResult) (store.BuildResult, error) {
 		iTarget, ok := target.(model.ImageTarget)
 		if !ok {
 			return nil, fmt.Errorf("Not an image target: %T", target)
@@ -96,7 +96,7 @@ func (bd *DockerComposeBuildAndDeployer) BuildAndDeploy(ctx context.Context, st 
 		// NOTE(maia): we assume that this func takes one DC target and up to one image target
 		// corresponding to that service. If this func ever supports specs for more than one
 		// service at once, we'll have to match up image build results to DC target by ref.
-		refs, err := bd.ib.Build(ctx, iTarget, currentState[iTarget.ID()], ps)
+		refs, err := bd.ib.Build(ctx, iTarget, ps)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/engine/image_build_and_deployer.go
+++ b/internal/engine/image_build_and_deployer.go
@@ -132,7 +132,7 @@ func (ibd *ImageBuildAndDeployer) BuildAndDeploy(ctx context.Context, st store.R
 	var anyLiveUpdate bool
 
 	iTargetMap := model.ImageTargetsByID(iTargets)
-	err = q.RunBuilds(func(target model.TargetSpec, state store.BuildState, depResults []store.BuildResult) (store.BuildResult, error) {
+	err = q.RunBuilds(func(target model.TargetSpec, depResults []store.BuildResult) (store.BuildResult, error) {
 		iTarget, ok := target.(model.ImageTarget)
 		if !ok {
 			return nil, fmt.Errorf("Not an image target: %T", target)
@@ -143,7 +143,7 @@ func (ibd *ImageBuildAndDeployer) BuildAndDeploy(ctx context.Context, st store.R
 			return nil, err
 		}
 
-		refs, err := ibd.ib.Build(ctx, iTarget, state, ps)
+		refs, err := ibd.ib.Build(ctx, iTarget, ps)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/engine/image_builder.go
+++ b/internal/engine/image_builder.go
@@ -8,7 +8,6 @@ import (
 	"github.com/tilt-dev/tilt/internal/container"
 	"github.com/tilt-dev/tilt/internal/engine/buildcontrol"
 	"github.com/tilt-dev/tilt/internal/ignore"
-	"github.com/tilt-dev/tilt/internal/store"
 	"github.com/tilt-dev/tilt/pkg/model"
 )
 
@@ -26,7 +25,7 @@ func NewImageBuilder(db build.DockerBuilder, custb build.CustomBuilder, updateMo
 	}
 }
 
-func (icb *imageBuilder) Build(ctx context.Context, iTarget model.ImageTarget, state store.BuildState,
+func (icb *imageBuilder) Build(ctx context.Context, iTarget model.ImageTarget,
 	ps *build.PipelineState) (refs container.TaggedRefs, err error) {
 	userFacingRefName := container.FamiliarString(iTarget.Refs.ConfigurationRef)
 


### PR DESCRIPTION
Hello @maiamcc, @landism,

Please review the following commits I made in branch nicks/targetqueue:

fda20bb722c9c41ad2efa61498f35120ed24c247 (2020-05-22 16:39:54 -0400)
engine: remove last build state from the target queue build handlers

3e08017f81e2e60c842169d580acbfa8f3660562 (2020-05-22 16:14:48 -0400)
build: rename a bunch of types to make more sense (the new names should be uncontroversial and were already in a todo)

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics