### PR TITLE
engine: build and deployers should return results for targets they built, and

### DIFF
--- a/internal/engine/build_and_deployer.go
+++ b/internal/engine/build_and_deployer.go
@@ -18,11 +18,15 @@ import (
 
 type BuildAndDeployer interface {
 	// BuildAndDeploy builds and deployed the specified target specs.
-	//
-	// Returns a BuildResult that expresses the outputs(s) of the build.
+
+	// Returns a BuildResultSet containing output (build result and associated
+	// file changes) for each target built in this call. The BuildResultSet only
+	// contains results for newly built targets--if a target was clean and didn't
+	// need to be built, it doesn't appear in the result set.
 	//
 	// BuildResult can be used to construct a set of BuildStates, which contain
-	// the last successful builds of each target and the files changed since that build.
+	// the last successful builds of each target and the files changed since that
+	// build.
 	BuildAndDeploy(ctx context.Context, st store.RStore, specs []model.TargetSpec, currentState store.BuildStateSet) (store.BuildResultSet, error)
 }
 


### PR DESCRIPTION
Hello @landism, @maiamcc,

Please review the following commits I made in branch nicks/noop:

a935df30053134965d80e454c480059308eb50b1 (2020-05-22 18:03:01 -0400)
engine: build and deployers should return results for targets they built, and not return results for targets they didn't build.
This should make https://github.com/tilt-dev/tilt/pull/3362
much simpler and easy to reason about.

Also adds test harnesses for different build graph configurations.

4fb88080da67e01cb8b18675d12965c1bf92ae8e (2020-05-22 16:40:23 -0400)
engine: remove last build state from the target queue build handlers

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics