### PR TITLE
tiltfile: default helm release name to 'tilt'. Fixes https://github.com/tilt-dev/tilt/issues/3370

### DIFF
--- a/internal/tiltfile/files.go
+++ b/internal/tiltfile/files.go
@@ -177,17 +177,18 @@ func (s *tiltfileState) helm(thread *starlark.Thread, fn *starlark.Builtin, args
 
 	var cmd []string
 
+	if name == "" {
+		// Use 'chart' as the release name, so that the release name is stable
+		// across Tiltfile loads.
+		// This looks like what helm does.
+		// https://github.com/helm/helm/blob/e672a42efae30d45ddd642a26557dcdbf5a9f5f0/pkg/action/install.go#L562
+		name = "chart"
+	}
+
 	if version == helmV3 {
-		if name != "" {
-			cmd = []string{"helm", "template", name, localPath}
-		} else {
-			cmd = []string{"helm", "template", localPath, "--generate-name"}
-		}
+		cmd = []string{"helm", "template", name, localPath}
 	} else {
-		cmd = []string{"helm", "template", localPath}
-		if name != "" {
-			cmd = append(cmd, "--name", name)
-		}
+		cmd = []string{"helm", "template", localPath, "--name", name}
 	}
 
 	if namespace != "" {

--- a/internal/tiltfile/helm_test.go
+++ b/internal/tiltfile/helm_test.go
@@ -4,6 +4,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tilt-dev/tilt/internal/tiltfile/testdata"
 )
 
 func TestHelmSetArgs(t *testing.T) {
@@ -93,4 +96,32 @@ func TestSubchartRemoteDependencies(t *testing.T) {
 	}
 
 	assert.Empty(t, actual)
+}
+
+func TestHelmReleaseName(t *testing.T) {
+	f := newFixture(t)
+	defer f.TearDown()
+
+	f.file("helm/Chart.yaml", `apiVersion: v1
+description: grafana chart
+name: grafana
+version: 0.1.0`)
+
+	f.file("helm/values.yaml", testdata.GrafanaHelmValues)
+	f.file("helm/templates/_helpers.tpl", testdata.GrafanaHelmHelpers)
+	f.file("helm/templates/service-account.yaml", testdata.GrafanaHelmServiceAccount)
+
+	f.file("Tiltfile", `
+k8s_yaml(helm('./helm'))
+`)
+
+	f.load()
+
+	manifests := f.loadResult.Manifests
+	require.Equal(t, 1, len(manifests))
+
+	m := manifests[0]
+	yaml := m.K8sTarget().YAML
+	assert.NotContains(t, yaml, "RELEASE-NAME")
+	assert.Contains(t, yaml, "name: chart-grafana")
 }

--- a/internal/tiltfile/testdata/grafana.go
+++ b/internal/tiltfile/testdata/grafana.go
@@ -1,0 +1,91 @@
+package testdata
+
+var GrafanaHelmValues = `
+serviceAccount:
+  create: true
+  name:
+  nameTest:
+`
+
+var GrafanaHelmHelpers = `{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "grafana.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "grafana.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "grafana.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account
+*/}}
+{{- define "grafana.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "grafana.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{- define "grafana.serviceAccountNameTest" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (print (include "grafana.fullname" .) "-test") .Values.serviceAccount.nameTest }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.nameTest }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Allow the release namespace to be overridden for multi-namespace deployments in combined charts
+*/}}
+{{- define "grafana.namespace" -}}
+  {{- if .Values.namespaceOverride -}}
+    {{- .Values.namespaceOverride -}}
+  {{- else -}}
+    {{- .Release.Namespace -}}
+  {{- end -}}
+{{- end -}}
+
+`
+
+var GrafanaHelmServiceAccount = `{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: {{ template "grafana.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+{{- with .Values.serviceAccount.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+  name: {{ template "grafana.serviceAccountName" . }}
+  namespace: {{ template "grafana.namespace" . }}
+{{- end }}
+`

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -1215,7 +1215,7 @@ k8s_yaml(yml)
 
 	f.load()
 
-	f.assertNextManifestUnresourced("release-name-helloworld-chart")
+	f.assertNextManifestUnresourced("chart-helloworld-chart")
 	f.assertConfigFiles(
 		"Tiltfile",
 		".tiltignore",
@@ -1334,7 +1334,7 @@ k8s_yaml(yml)
 
 	f.load()
 
-	f.assertNextManifestUnresourced("release-name-helloworld-chart")
+	f.assertNextManifestUnresourced("chart-helloworld-chart")
 	f.assertConfigFiles(
 		"Tiltfile",
 		".tiltignore",
@@ -3220,7 +3220,7 @@ k8s_yaml(yml)
 
 	f.load()
 
-	f.assertNextManifestUnresourced("release-name-helloworld-chart")
+	f.assertNextManifestUnresourced("chart-helloworld-chart")
 	f.assertConfigFiles(
 		"Tiltfile",
 		".tiltignore",
@@ -3255,7 +3255,7 @@ k8s_yaml(yml)
 `)
 
 	f.load()
-	f.assertNextManifest("release-name-nginx-ingress-controller")
+	f.assertNextManifest("chart-nginx-ingress-controller")
 }
 
 func TestK8sContext(t *testing.T) {


### PR DESCRIPTION
Hello @jazzdan,

Please review the following commits I made in branch nicks/ch7120:

9019d5b21aff073142276147d14c51922bea91f6 (2020-05-22 18:54:50 -0400)
tiltfile: default helm release name to 'tilt'. Fixes https://github.com/tilt-dev/tilt/issues/3370

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics