### PR TITLE
tiltfile: add support for two docker_compose calls in the same tiltfile

### DIFF
--- a/internal/tiltfile/tiltfile_docker_compose_test.go
+++ b/internal/tiltfile/tiltfile_docker_compose_test.go
@@ -39,6 +39,16 @@ volumes:
   bar: {}
   baz: {}`
 
+const barServiceConfig = `version: '3'
+services:
+  bar:
+    image: bar-image
+    expose:
+      - "3000"
+    depends_on:
+      - foo
+`
+
 const twoServiceConfig = `version: '3'
 services:
   foo:
@@ -147,19 +157,41 @@ services:
 	f.assertConfigFiles(expectedConfFiles...)
 }
 
-func TestMultipleDockerComposeNotSupported(t *testing.T) {
+func TestMultipleDockerComposeDifferentDirsNotSupported(t *testing.T) {
 	f := newFixture(t)
 	defer f.TearDown()
 
 	f.dockerfile(filepath.Join("foo", "Dockerfile"))
 	f.file("docker-compose1.yml", simpleConfig)
-	f.file("docker-compose2.yml", simpleConfig)
 
-	tf := `docker_compose('docker-compose1.yml')
+	f.dockerfile(filepath.Join("subdir", "foo", "Dockerfile"))
+	f.file(filepath.Join("subdir", "Tiltfile"), `docker_compose('docker-compose2.yml')`)
+	f.file(filepath.Join("subdir", "docker-compose2.yml"), simpleConfig)
+
+	tf := `
+include('./subdir/Tiltfile')
+docker_compose('docker-compose1.yml')`
+	f.file("Tiltfile", tf)
+
+	f.loadErrString("Cannot load docker-compose files from two different Tiltfiles")
+}
+
+func TestMultipleDockerComposeSameDir(t *testing.T) {
+	f := newFixture(t)
+	defer f.TearDown()
+
+	f.dockerfile(filepath.Join("foo", "Dockerfile"))
+	f.file("docker-compose1.yml", simpleConfig)
+	f.file("docker-compose2.yml", barServiceConfig)
+
+	tf := `
+docker_compose('docker-compose1.yml')
 docker_compose('docker-compose2.yml')`
 	f.file("Tiltfile", tf)
 
-	f.loadErrString("already have a docker-compose resource declared")
+	f.load()
+
+	assert.Equal(t, 2, len(f.loadResult.Manifests))
 }
 
 func TestDockerComposeAndK8sNotSupported(t *testing.T) {


### PR DESCRIPTION
Hello @maiamcc, @jazzdan,

Please review the following commits I made in branch nicks/ch7144:

db0ea97f0b8d2d043073254ec64e5251435b19a2 (2020-05-26 17:42:18 -0400)
tiltfile: add support for two docker_compose calls in the same tiltfile

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics