### PR TITLE
bump the timeout on watchTestFixture, 10ms isn't enough time if there's a gc pause

### DIFF
--- a/internal/k8s/watch_test.go
+++ b/internal/k8s/watch_test.go
@@ -398,8 +398,8 @@ func (tf *watchTestFixture) assertPods(expectedOutput []runtime.Object, ch <-cha
 			if ok {
 				observedPods = append(observedPods, pod)
 			}
-		case <-time.After(10 * time.Millisecond):
-			// if we haven't seen any events for 10ms, assume we're done
+		case <-time.After(200 * time.Millisecond):
+			// if we haven't seen any events for 200ms, assume we're done
 			done = true
 		}
 	}
@@ -425,7 +425,7 @@ func (tf *watchTestFixture) assertServices(expectedOutput []runtime.Object, ch <
 			} else {
 				observedServices = append(observedServices, pod)
 			}
-		case <-time.After(10 * time.Millisecond):
+		case <-time.After(200 * time.Millisecond):
 			// if we haven't seen any events for 10ms, assume we're done
 			done = true
 		}
@@ -452,7 +452,7 @@ func (tf *watchTestFixture) assertEvents(expectedOutput []runtime.Object, ch <-c
 			} else {
 				observedEvents = append(observedEvents, event)
 			}
-		case <-time.After(10 * time.Millisecond):
+		case <-time.After(200 * time.Millisecond):
 			// if we haven't seen any events for 10ms, assume we're done
 			// ideally we'd always be exiting from ch closing, but it's not currently clear how to do that via informer
 			done = true


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/pods:

c152ca266d311422eb55a8d848b9c55f5e661e7a (2020-05-26 19:27:11 -0400)
bump the timeout on watchTestFixture, 10ms isn't enough time if there's a gc pause

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics