### PR TITLE
engine: print out results from previous builds

### DIFF
--- a/internal/engine/buildcontrol/target_queue.go
+++ b/internal/engine/buildcontrol/target_queue.go
@@ -104,6 +104,19 @@ func (q *TargetQueue) NewResults() store.BuildResultSet {
 	return newResults
 }
 
+// Reused results that were not built with the current queue.
+//
+// Used for printing out which builds are cached from previous builds.
+func (q *TargetQueue) ReusedResults() store.BuildResultSet {
+	reusedResults := store.BuildResultSet{}
+	for id, result := range q.results {
+		if !q.isBuilding(id) {
+			reusedResults[id] = result
+		}
+	}
+	return reusedResults
+}
+
 // All results for targets in the current queue.
 func (q *TargetQueue) AllResults() store.BuildResultSet {
 	allResults := store.BuildResultSet{}


### PR DESCRIPTION
Hello @maiamcc, @landism,

Please review the following commits I made in branch nicks/reused:

69a316d8f664ef5d7040ba396d4521b4cb511118 (2020-05-27 15:21:27 -0400)
engine: print out results from previous builds

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics