### PR TITLE
tiltfile: os.path.exists should not watch directories recursively. Fixes https://github.com/tilt-dev/tilt/issues/3387

### DIFF
--- a/internal/store/engine_state.go
+++ b/internal/store/engine_state.go
@@ -69,8 +69,12 @@ type EngineState struct {
 	// All logs in Tilt, stored in a structured format.
 	LogStore *logstore.LogStore `testdiff:"ignore"`
 
-	TiltfilePath             string
-	ConfigFiles              []string
+	TiltfilePath string
+
+	// TODO(nick): This should be called "ConfigPaths", not "ConfigFiles",
+	// because this could refer to directories that are watched recursively.
+	ConfigFiles []string
+
 	TiltIgnoreContents       string
 	PendingConfigFileChanges map[string]time.Time
 

--- a/internal/tiltfile/config/config.go
+++ b/internal/tiltfile/config/config.go
@@ -117,7 +117,7 @@ func (e *Extension) parse(thread *starlark.Thread, fn *starlark.Builtin, args st
 
 	userConfigPath := filepath.Join(wd, UserConfigFileName)
 
-	err = io.RecordReadFile(thread, userConfigPath)
+	err = io.RecordReadPath(thread, io.WatchFileOnly, userConfigPath)
 	if err != nil {
 		return starlark.None, err
 	}

--- a/internal/tiltfile/config/config_test.go
+++ b/internal/tiltfile/config/config_test.go
@@ -442,7 +442,7 @@ cfg = config.parse()`)
 
 	rs, err := io.GetState(result)
 	require.NoError(t, err)
-	require.Contains(t, rs.Files, f.JoinPath(UserConfigFileName))
+	require.Contains(t, rs.Paths, f.JoinPath(UserConfigFileName))
 }
 
 func NewFixture(tb testing.TB, userConfigState model.UserConfigState) *starkit.Fixture {

--- a/internal/tiltfile/encoding/json_test.go
+++ b/internal/tiltfile/encoding/json_test.go
@@ -55,7 +55,7 @@ test()
 
 	rs, err := io.GetState(result)
 	require.NoError(t, err)
-	require.Contains(t, rs.Files, f.JoinPath("options.json"))
+	require.Contains(t, rs.Paths, f.JoinPath("options.json"))
 }
 
 func TestJSONDoesNotExist(t *testing.T) {
@@ -70,7 +70,7 @@ func TestJSONDoesNotExist(t *testing.T) {
 
 	rs, err := io.GetState(result)
 	require.NoError(t, err)
-	require.Contains(t, rs.Files, f.JoinPath("dne.json"))
+	require.Contains(t, rs.Paths, f.JoinPath("dne.json"))
 }
 
 func TestMalformedJSON(t *testing.T) {
@@ -88,7 +88,7 @@ func TestMalformedJSON(t *testing.T) {
 
 	rs, err := io.GetState(result)
 	require.NoError(t, err)
-	require.Contains(t, rs.Files, f.JoinPath("options.json"))
+	require.Contains(t, rs.Paths, f.JoinPath("options.json"))
 }
 
 func TestDecodeJSON(t *testing.T) {

--- a/internal/tiltfile/encoding/yaml_test.go
+++ b/internal/tiltfile/encoding/yaml_test.go
@@ -46,7 +46,7 @@ assert.equals(expected, observed)
 
 	rs, err := io.GetState(result)
 	require.NoError(t, err)
-	require.Contains(t, rs.Files, f.JoinPath("options.yaml"))
+	require.Contains(t, rs.Paths, f.JoinPath("options.yaml"))
 }
 
 func TestReadYAMLDefaultValue(t *testing.T) {
@@ -97,7 +97,7 @@ func TestYAMLDoesNotExist(t *testing.T) {
 
 	rs, err := io.GetState(result)
 	require.NoError(t, err)
-	require.Contains(t, rs.Files, f.JoinPath("dne.yaml"))
+	require.Contains(t, rs.Paths, f.JoinPath("dne.yaml"))
 }
 
 func TestMalformedYAML(t *testing.T) {
@@ -122,7 +122,7 @@ key5: 3
 
 	rs, err := io.GetState(result)
 	require.NoError(t, err)
-	require.Contains(t, rs.Files, f.JoinPath("options.yaml"))
+	require.Contains(t, rs.Paths, f.JoinPath("options.yaml"))
 
 }
 

--- a/internal/tiltfile/files.go
+++ b/internal/tiltfile/files.go
@@ -108,7 +108,7 @@ func (s *tiltfileState) kustomize(thread *starlark.Thread, fn *starlark.Builtin,
 		return nil, fmt.Errorf("internal error: %v", err)
 	}
 	for _, d := range deps {
-		err := tiltfile_io.RecordReadFile(thread, d)
+		err := tiltfile_io.RecordReadPath(thread, tiltfile_io.WatchRecursive, d)
 		if err != nil {
 			return nil, err
 		}
@@ -164,7 +164,7 @@ func (s *tiltfileState) helm(thread *starlark.Thread, fn *starlark.Builtin, args
 		return nil, err
 	}
 	for _, d := range deps {
-		err = tiltfile_io.RecordReadFile(thread, starkit.AbsPath(thread, d))
+		err = tiltfile_io.RecordReadPath(thread, tiltfile_io.WatchRecursive, starkit.AbsPath(thread, d))
 		if err != nil {
 			return nil, err
 		}
@@ -196,7 +196,7 @@ func (s *tiltfileState) helm(thread *starlark.Thread, fn *starlark.Builtin, args
 	}
 	for _, valueFile := range valueFiles {
 		cmd = append(cmd, "--values", valueFile)
-		err := tiltfile_io.RecordReadFile(thread, starkit.AbsPath(thread, valueFile))
+		err := tiltfile_io.RecordReadPath(thread, tiltfile_io.WatchFileOnly, starkit.AbsPath(thread, valueFile))
 		if err != nil {
 			return nil, err
 		}
@@ -212,7 +212,7 @@ func (s *tiltfileState) helm(thread *starlark.Thread, fn *starlark.Builtin, args
 		return nil, err
 	}
 
-	err = tiltfile_io.RecordReadFile(thread, localPath)
+	err = tiltfile_io.RecordReadPath(thread, tiltfile_io.WatchRecursive, localPath)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/tiltfile/io/io.go
+++ b/internal/tiltfile/io/io.go
@@ -14,6 +14,16 @@ import (
 	"github.com/tilt-dev/tilt/internal/tiltfile/value"
 )
 
+type WatchType int
+
+const (
+	// If it's a file, only watch the file. If it's a directory, don't watch at all.
+	WatchFileOnly WatchType = iota
+
+	// If it's a file, only watch the file. If it's a directory, watch it recursively.
+	WatchRecursive
+)
+
 type Extension struct{}
 
 func NewExtension() Extension {
@@ -49,7 +59,7 @@ func (Extension) OnStart(e *starkit.Environment) error {
 }
 
 func (Extension) OnExec(t *starlark.Thread, tiltfilePath string) error {
-	return RecordReadFile(t, tiltfilePath)
+	return RecordReadPath(t, WatchFileOnly, tiltfilePath)
 }
 
 func readFile(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
@@ -98,7 +108,7 @@ func watchFile(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tupl
 		return nil, fmt.Errorf("invalid type for paths: %v", err)
 	}
 
-	err = RecordReadFile(thread, p)
+	err = RecordReadPath(thread, WatchRecursive, p)
 	if err != nil {
 		return nil, err
 	}
@@ -119,9 +129,13 @@ func listdir(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple,
 		return nil, fmt.Errorf("Argument 0 (paths): %v", err)
 	}
 
-	err = RecordReadFile(thread, localPath)
-	if err != nil {
-		return nil, err
+	// We currently don't watch the directory only, because Tilt doesn't have any
+	// way to watch a directory without watching it recursively.
+	if recursive {
+		err = RecordReadPath(thread, WatchRecursive, localPath)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	var files []string
@@ -158,22 +172,56 @@ func blob(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kw
 	return NewBlob(input.GoString(), "Tiltfile blob() call"), nil
 }
 
-// Track all the files read while loading
+// Track all the paths read while loading
 type ReadState struct {
-	Files []string
+	Paths []string
 }
 
 func ReadFile(thread *starlark.Thread, p string) ([]byte, error) {
-	err := RecordReadFile(thread, p)
+	err := RecordReadPath(thread, WatchFileOnly, p)
 	if err != nil {
 		return nil, err
 	}
 	return ioutil.ReadFile(p)
 }
 
-func RecordReadFile(t *starlark.Thread, files ...string) error {
+func RecordReadPath(t *starlark.Thread, wt WatchType, files ...string) error {
+	toWatch := make([]string, 0, len(files))
+	for _, f := range files {
+		switch wt {
+		case WatchRecursive:
+			toWatch = append(toWatch, f)
+
+		case WatchFileOnly:
+			info, err := os.Lstat(f)
+			shouldWatch := false
+			if os.IsNotExist(err) {
+				// If a file does not exist, we should watch the space
+				// to see if the file does appear.
+				shouldWatch = true
+			} else if err != nil {
+				// If we got a permission denied error, we should stop.
+				return err
+			} else if !info.IsDir() {
+				// Tilt only knows how to do recursive watches. If we read a directory
+				// during Tiltfile execution, we'd rather not watch the directory at all
+				// rather than overwatch and over-trigger Tiltfile reloads.
+				//
+				// https://github.com/tilt-dev/tilt/issues/3387
+				shouldWatch = true
+			}
+
+			if shouldWatch {
+				toWatch = append(toWatch, f)
+			}
+
+		default:
+			return fmt.Errorf("Unknown watch type: %v", t)
+		}
+	}
+
 	err := starkit.SetState(t, func(s ReadState) ReadState {
-		s.Files = sliceutils.AppendWithoutDupes(s.Files, files...)
+		s.Paths = sliceutils.AppendWithoutDupes(s.Paths, toWatch...)
 		return s
 	})
 	return errors.Wrap(err, "error recording read file")

--- a/internal/tiltfile/os/os.go
+++ b/internal/tiltfile/os/os.go
@@ -198,7 +198,7 @@ func exists(t *starlark.Thread, path string) (starlark.Value, error) {
 
 	_, err := os.Stat(absPath)
 	if os.IsNotExist(err) {
-		err := io.RecordReadFile(t, absPath)
+		err := io.RecordReadPath(t, io.WatchFileOnly, absPath)
 		if err != nil {
 			return nil, err
 		}
@@ -210,7 +210,7 @@ func exists(t *starlark.Thread, path string) (starlark.Value, error) {
 		return starlark.Bool(false), nil
 	}
 
-	err = io.RecordReadFile(t, absPath)
+	err = io.RecordReadPath(t, io.WatchFileOnly, absPath)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/tiltfile/starkit/fixture.go
+++ b/internal/tiltfile/starkit/fixture.go
@@ -80,7 +80,11 @@ func (f *Fixture) JoinPath(elem ...string) string {
 }
 
 func (f *Fixture) File(name, contents string) {
-	fullPath := filepath.Join(f.path, name)
+	fullPath := name
+	if !filepath.IsAbs(fullPath) {
+		fullPath = filepath.Join(f.path, name)
+	}
+
 	if f.useRealFS {
 		dir := filepath.Dir(fullPath)
 		err := os.MkdirAll(dir, os.FileMode(0755))

--- a/internal/tiltfile/tiltfile.go
+++ b/internal/tiltfile/tiltfile.go
@@ -179,7 +179,7 @@ func (tfl tiltfileLoader) Load(ctx context.Context, filename string, userConfigS
 	s.secretSettings = ss
 
 	ioState, _ := io.GetState(result)
-	tlr.ConfigFiles = sliceutils.AppendWithoutDupes(ioState.Files, s.postExecReadFiles...)
+	tlr.ConfigFiles = sliceutils.AppendWithoutDupes(ioState.Paths, s.postExecReadFiles...)
 
 	dps, _ := dockerprune.GetState(result)
 	tlr.DockerPruneSettings = dps

--- a/internal/tiltfile/tiltfile_state.go
+++ b/internal/tiltfile/tiltfile_state.go
@@ -369,7 +369,7 @@ func (s *tiltfileState) OnBuiltinCall(name string, fn *starlark.Builtin) {
 }
 
 func (s *tiltfileState) OnExec(t *starlark.Thread, tiltfilePath string) error {
-	return io.RecordReadFile(t, tiltIgnorePath(tiltfilePath))
+	return io.RecordReadPath(t, io.WatchFileOnly, tiltIgnorePath(tiltfilePath))
 }
 
 // wrap a builtin such that it's only allowed to run when we have a known safe k8s context

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -1840,7 +1840,7 @@ func TestDir(t *testing.T) {
 
 	f.load("foo", "bar")
 	f.assertNumManifests(2)
-	f.assertConfigFiles("Tiltfile", ".tiltignore", "config/foo.yaml", "config/bar.yaml", "config")
+	f.assertConfigFiles("Tiltfile", ".tiltignore", "config/foo.yaml", "config/bar.yaml")
 }
 
 func TestDirRecursive(t *testing.T) {


### PR DESCRIPTION
Hello @landism,

Please review the following commits I made in branch nicks/ch7235:

fb35e62ffbade35cb7bbb2d103e0b50bc9f38b3f (2020-05-29 14:33:03 -0400)
tiltfile: os.path.exists should not watch directories recursively. Fixes https://github.com/tilt-dev/tilt/issues/3387

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics