### PR TITLE
hud/server: enable websocket compression

### DIFF
--- a/internal/hud/server/websocket.go
+++ b/internal/hud/server/websocket.go
@@ -22,8 +22,9 @@ import (
 )
 
 var upgrader = websocket.Upgrader{
-	ReadBufferSize:  1024,
-	WriteBufferSize: 1024,
+	ReadBufferSize:    1024,
+	WriteBufferSize:   1024,
+	EnableCompression: true,
 }
 
 type WebsocketSubscriber struct {


### PR DESCRIPTION
May help with situations where Tilt is being run on a remote server and
the web UI is running on a local laptop resulting in the websocket
messages being sent over the Internet like in #3359.

Currently seeing if there is a measurable performance impact here, but I figure if it's a wash, then we might as well enable this. WDYT?