### PR TITLE
web: fix alignment/truncation of the manifest name

### DIFF
--- a/web/src/LogPaneLine.scss
+++ b/web/src/LogPaneLine.scss
@@ -35,10 +35,8 @@
   color: $color-gray-lightest;
   padding-left: $spacing-unit * 0.5;
   padding-right: $spacing-unit * 0.5;
-  display: flex;
-  align-items: center;
-  justify-content: right;
-  flex-shrink: 0;
+  text-align: right;
+  
   // Truncate long text:
   text-overflow: ellipsis;
   overflow: hidden;
@@ -48,6 +46,9 @@
     // Border shouldn't add height:
     margin-top: -$logLine-separator-height;
     border-top: $logLine-separator-height solid $color-gray;
+  }
+  .LogPaneLine.is-buildEvent-init > & {
+    visibility: hidden;
   }
 }
 


### PR DESCRIPTION
Hello @jazzdan, @hyu,

Please review the following commits I made in branch nicks/ch7387:

3e4e85ade3633981eaeda1b13811880bc8caf6ca (2020-06-04 18:06:42 -0400)
web: fix alignment/truncation of the manifest name
This works more consistently across Chrome/Firefox

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics