### PR TITLE
Added Deprecate Property to Watch Flag (Issue  #3256) 

### DIFF
--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -12,6 +12,9 @@ import (
 	"github.com/mattn/go-isatty"
 	"github.com/opentracing/opentracing-go"
 	"github.com/spf13/cobra"
+	"golang.org/x/sync/errgroup"
+	"k8s.io/klog"
+
 	"github.com/tilt-dev/tilt/internal/analytics"
 	"github.com/tilt-dev/tilt/internal/cloud"
 	engineanalytics "github.com/tilt-dev/tilt/internal/engine/analytics"
@@ -24,8 +27,6 @@ import (
 	"github.com/tilt-dev/tilt/pkg/logger"
 	"github.com/tilt-dev/tilt/pkg/model"
 	"github.com/tilt-dev/tilt/web"
-	"golang.org/x/sync/errgroup"
-	"k8s.io/klog"
 )
 
 const DefaultWebHost = "localhost"

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -100,6 +100,8 @@ local resources--i.e. those using serve_cmd--are terminated when you exit Tilt.
 		c.hudFlagExplicitlySet = cmd.Flag("hud").Changed
 	}
 
+	cmd.Flag("watch").Deprecated = "it will be removed in future releases."
+
 	return cmd
 }
 

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -142,7 +142,7 @@ func (c *upCmd) run(ctx context.Context, args []string) error {
 
 	//if --watch was set, warn user about deprecation
 	if c.watchFlagExplicitlySet {
-		logOutput("Flag --watch has been deprecated, it will be removed in future releases.")
+		logger.Get(ctx).Warnf("Flag --watch has been deprecated, it will be removed in future releases.")
 	}
 
 	if ok, reason := analytics.IsAnalyticsDisabledFromEnv(); ok {

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -12,9 +12,6 @@ import (
 	"github.com/mattn/go-isatty"
 	"github.com/opentracing/opentracing-go"
 	"github.com/spf13/cobra"
-	"golang.org/x/sync/errgroup"
-	"k8s.io/klog"
-
 	"github.com/tilt-dev/tilt/internal/analytics"
 	"github.com/tilt-dev/tilt/internal/cloud"
 	engineanalytics "github.com/tilt-dev/tilt/internal/engine/analytics"
@@ -27,6 +24,8 @@ import (
 	"github.com/tilt-dev/tilt/pkg/logger"
 	"github.com/tilt-dev/tilt/pkg/model"
 	"github.com/tilt-dev/tilt/web"
+	"golang.org/x/sync/errgroup"
+	"k8s.io/klog"
 )
 
 const DefaultWebHost = "localhost"
@@ -101,15 +100,9 @@ local resources--i.e. those using serve_cmd--are terminated when you exit Tilt.
 
 	cmd.PreRun = func(cmd *cobra.Command, args []string) {
 		c.hudFlagExplicitlySet = cmd.Flag("hud").Changed
+		c.watchFlagExplicitlySet = cmd.Flag("watch").Changed
 	}
 
-	//since the --watch flag isn't really useful and has been made obselete by tilt ci, print a deprecation warning.
-	cmd.Flag("watch").Deprecated = "it will be removed in future releases."
-	//if a deprecation message exists, then watch was explicitly set by the user, so mark the watchFlagExplicitlySet var as true for
-	//logging the message on the web UI and TUI
-	if len(cmd.Flag("watch").Deprecated) > 0 {
-		c.watchFlagExplicitlySet = true
-	}
 	return cmd
 }
 


### PR DESCRIPTION
Fixes  #3256

I've added the deprecate property to the watch flag. The result of doing so is as follows: 

When "--watch" is used:
![depracated-terminal](https://user-images.githubusercontent.com/35721712/84379145-61d6e800-abf6-11ea-8a33-8a5810d9f677.png)

When there's no "--watch" included:
![nowatch](https://user-images.githubusercontent.com/35721712/84379246-8b900f00-abf6-11ea-89eb-a343adfc3048.png)
