### PR TITLE
web: fix fallback log styling when there are debug logs

### DIFF
--- a/web/src/LogPaneLine.scss
+++ b/web/src/LogPaneLine.scss
@@ -20,11 +20,15 @@
   }
   &.is-buildEvent-fallback {
     background-color: $color-gray-darker;
-
-    // A lil' trick so bottom margin only appears after the last element
-    margin-top: -$spacing-unit * 0.5;
-    margin-bottom: $spacing-unit * 0.5;
   }
+}
+
+.LogPaneLine.is-buildEvent-init + .LogPaneLine.is-buildEvent-fallback,
+.LogPaneLine.is-buildEvent-fallback + .LogPaneLine.is-buildEvent-fallback {
+
+  // A lil' trick so bottom margin only appears after the last element
+  margin-top: -$spacing-unit * 0.5;
+  margin-bottom: $spacing-unit * 0.5;
 }
 
 .logLinePrefix {


### PR DESCRIPTION
Hello @jazzdan, @hyu,

Please review the following commits I made in branch nicks/ch7547:

0dd5abbb56d7c63d899ad448c5523367b78000e8 (2020-06-12 14:42:30 -0400)
web: fix fallback log styling when there are debug logs

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics