### PR TITLE
engine: k8sTargets should have buildState too. Fixes https://github.com/tilt-dev/tilt/issues/3454

### DIFF
--- a/internal/engine/buildcontroller.go
+++ b/internal/engine/buildcontroller.go
@@ -165,10 +165,6 @@ func buildStateSet(ctx context.Context, manifest model.Manifest, specs []model.T
 
 	for _, spec := range specs {
 		id := spec.ID()
-		if id.Type != model.TargetTypeImage && id.Type != model.TargetTypeDockerCompose && id.Type != model.TargetTypeLocal {
-			continue
-		}
-
 		status := ms.BuildStatus(id)
 		var filesChanged []string
 		for file := range status.PendingFileChanges {
@@ -210,8 +206,8 @@ func buildStateSet(ctx context.Context, manifest model.Manifest, specs []model.T
 	isLiveUpdateEligibleTrigger := reason.HasTrigger() &&
 		reason.Has(model.BuildReasonFlagChangedFiles) &&
 		manifest.TriggerMode != model.TriggerModeAuto
-	isImageBuildTrigger := reason.HasTrigger() && !isLiveUpdateEligibleTrigger
-	if isImageBuildTrigger {
+	isFullBuildTrigger := reason.HasTrigger() && !isLiveUpdateEligibleTrigger
+	if isFullBuildTrigger {
 		for k, v := range result {
 			result[k] = v.WithFullBuildTriggered(true)
 		}

--- a/internal/engine/docker_compose_build_and_deployer.go
+++ b/internal/engine/docker_compose_build_and_deployer.go
@@ -90,7 +90,7 @@ func (bd *DockerComposeBuildAndDeployer) BuildAndDeploy(ctx context.Context, st 
 		ps.StartPipelineStep(ctx, "Loading cached images")
 		for _, result := range reused {
 			ref := store.LocalImageRefFromBuildResult(result)
-			logger.Get(ctx).Infof("- %s", container.FamiliarString(ref))
+			ps.Printf(ctx, "- %s", container.FamiliarString(ref))
 		}
 		ps.EndPipelineStep(ctx)
 	}

--- a/internal/engine/image_build_and_deployer.go
+++ b/internal/engine/image_build_and_deployer.go
@@ -142,7 +142,7 @@ func (ibd *ImageBuildAndDeployer) BuildAndDeploy(ctx context.Context, st store.R
 
 	if hasDeleteStep {
 		ps.StartPipelineStep(ctx, "Force update")
-		err = ibd.delete(ctx, kTarget)
+		err = ibd.delete(ps.AttachLogger(ctx), kTarget)
 		if err != nil {
 			return store.BuildResultSet{}, buildcontrol.WrapDontFallBackError(err)
 		}
@@ -153,7 +153,7 @@ func (ibd *ImageBuildAndDeployer) BuildAndDeploy(ctx context.Context, st store.R
 		ps.StartPipelineStep(ctx, "Loading cached images")
 		for _, result := range reused {
 			ref := store.LocalImageRefFromBuildResult(result)
-			logger.Get(ctx).Infof("- %s", container.FamiliarString(ref))
+			ps.Printf(ctx, "- %s", container.FamiliarString(ref))
 		}
 		ps.EndPipelineStep(ctx)
 	}

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -152,14 +152,26 @@ func (c buildAndDeployCall) local() model.LocalTarget {
 	return model.LocalTarget{}
 }
 
-func (c buildAndDeployCall) oneState() store.BuildState {
-	if len(c.state) != 1 {
+func (c buildAndDeployCall) dcState() store.BuildState {
+	return c.state[c.dc().ID()]
+}
+
+func (c buildAndDeployCall) k8sState() store.BuildState {
+	return c.state[c.k8s().ID()]
+}
+
+func (c buildAndDeployCall) oneImageState() store.BuildState {
+	imageStates := make([]store.BuildState, 0)
+	for k, v := range c.state {
+		if k.Type == model.TargetTypeImage {
+			imageStates = append(imageStates, v)
+		}
+	}
+
+	if len(imageStates) != 1 {
 		panic(fmt.Sprintf("More than one state: %v", c.state))
 	}
-	for _, v := range c.state {
-		return v
-	}
-	panic("space/time has unraveled, sorry")
+	return imageStates[0]
 }
 
 type fakeBuildAndDeployer struct {
@@ -475,16 +487,16 @@ func TestUpper_UpWatchFileChange(t *testing.T) {
 	f.timerMaker.MaxTimerLock.Lock()
 	call := f.nextCallComplete()
 	assert.Equal(t, manifest.ImageTargetAt(0), call.firstImgTarg())
-	assert.Equal(t, []string{}, call.oneState().FilesChanged())
+	assert.Equal(t, []string{}, call.oneImageState().FilesChanged())
 
 	fileRelPath := "fdas"
 	f.fsWatcher.Events <- watch.NewFileEvent(f.JoinPath(fileRelPath))
 
 	call = f.nextCallComplete()
 	assert.Equal(t, manifest.ImageTargetAt(0), call.firstImgTarg())
-	assert.Equal(t, "gcr.io/some-project-162817/sancho:tilt-1", call.oneState().LastLocalImageAsString())
+	assert.Equal(t, "gcr.io/some-project-162817/sancho:tilt-1", call.oneImageState().LastLocalImageAsString())
 	fileAbsPath := f.JoinPath(fileRelPath)
-	assert.Equal(t, []string{fileAbsPath}, call.oneState().FilesChanged())
+	assert.Equal(t, []string{fileAbsPath}, call.oneImageState().FilesChanged())
 
 	f.withManifestState("foobar", func(ms store.ManifestState) {
 		assert.True(t, ms.LastBuild().Reason.Has(model.BuildReasonFlagChangedFiles))
@@ -505,7 +517,7 @@ func TestUpper_UpWatchCoalescedFileChanges(t *testing.T) {
 	f.timerMaker.MaxTimerLock.Lock()
 	call := f.nextCall()
 	assert.Equal(t, manifest.ImageTargetAt(0), call.firstImgTarg())
-	assert.Equal(t, []string{}, call.oneState().FilesChanged())
+	assert.Equal(t, []string{}, call.oneImageState().FilesChanged())
 
 	f.timerMaker.RestTimerLock.Lock()
 	fileRelPaths := []string{"fdas", "giueheh"}
@@ -522,7 +534,7 @@ func TestUpper_UpWatchCoalescedFileChanges(t *testing.T) {
 	for _, fileRelPath := range fileRelPaths {
 		fileAbsPaths = append(fileAbsPaths, f.JoinPath(fileRelPath))
 	}
-	assert.Equal(t, fileAbsPaths, call.oneState().FilesChanged())
+	assert.Equal(t, fileAbsPaths, call.oneImageState().FilesChanged())
 
 	err := f.Stop()
 	assert.NoError(t, err)
@@ -538,7 +550,7 @@ func TestUpper_UpWatchCoalescedFileChangesHitMaxTimeout(t *testing.T) {
 
 	call := f.nextCall()
 	assert.Equal(t, manifest.ImageTargetAt(0), call.firstImgTarg())
-	assert.Equal(t, []string{}, call.oneState().FilesChanged())
+	assert.Equal(t, []string{}, call.oneImageState().FilesChanged())
 
 	f.timerMaker.MaxTimerLock.Lock()
 	f.timerMaker.RestTimerLock.Lock()
@@ -556,7 +568,7 @@ func TestUpper_UpWatchCoalescedFileChangesHitMaxTimeout(t *testing.T) {
 	for _, fileRelPath := range fileRelPaths {
 		fileAbsPaths = append(fileAbsPaths, f.JoinPath(fileRelPath))
 	}
-	assert.Equal(t, fileAbsPaths, call.oneState().FilesChanged())
+	assert.Equal(t, fileAbsPaths, call.oneImageState().FilesChanged())
 
 	err := f.Stop()
 	assert.NoError(t, err)
@@ -573,13 +585,13 @@ func TestFirstBuildFailsWhileWatching(t *testing.T) {
 	f.Start([]model.Manifest{manifest})
 
 	call := f.nextCall()
-	assert.True(t, call.oneState().IsEmpty())
+	assert.True(t, call.oneImageState().IsEmpty())
 
 	f.fsWatcher.Events <- watch.NewFileEvent(f.JoinPath("a.go"))
 
 	call = f.nextCall()
-	assert.True(t, call.oneState().IsEmpty())
-	assert.Equal(t, []string{f.JoinPath("a.go")}, call.oneState().FilesChanged())
+	assert.True(t, call.oneImageState().IsEmpty())
+	assert.Equal(t, []string{f.JoinPath("a.go")}, call.oneImageState().FilesChanged())
 
 	err := f.Stop()
 	assert.NoError(t, err)
@@ -595,7 +607,7 @@ func TestFirstBuildCancelsWhileWatching(t *testing.T) {
 	f.Start([]model.Manifest{manifest})
 
 	call := f.nextCall()
-	assert.True(t, call.oneState().IsEmpty())
+	assert.True(t, call.oneImageState().IsEmpty())
 
 	err := f.Stop()
 	assert.NoError(t, err)
@@ -641,23 +653,23 @@ func TestRebuildWithChangedFiles(t *testing.T) {
 	f.Start([]model.Manifest{manifest})
 
 	call := f.nextCallComplete("first build")
-	assert.True(t, call.oneState().IsEmpty())
+	assert.True(t, call.oneImageState().IsEmpty())
 
 	// Simulate a change to a.go that makes the build fail.
 	f.SetNextBuildFailure(errors.New("build failed"))
 	f.fsWatcher.Events <- watch.NewFileEvent(f.JoinPath("a.go"))
 
 	call = f.nextCallComplete("failed build from a.go change")
-	assert.Equal(t, "gcr.io/some-project-162817/sancho:tilt-1", call.oneState().LastLocalImageAsString())
-	assert.Equal(t, []string{f.JoinPath("a.go")}, call.oneState().FilesChanged())
+	assert.Equal(t, "gcr.io/some-project-162817/sancho:tilt-1", call.oneImageState().LastLocalImageAsString())
+	assert.Equal(t, []string{f.JoinPath("a.go")}, call.oneImageState().FilesChanged())
 
 	// Simulate a change to b.go
 	f.fsWatcher.Events <- watch.NewFileEvent(f.JoinPath("b.go"))
 
 	// The next build should only treat b.go as changed.
 	call = f.nextCallComplete("build on last successful result")
-	assert.Equal(t, []string{f.JoinPath("b.go")}, call.oneState().FilesChanged())
-	assert.Equal(t, "gcr.io/some-project-162817/sancho:tilt-1", call.oneState().LastLocalImageAsString())
+	assert.Equal(t, []string{f.JoinPath("b.go")}, call.oneImageState().FilesChanged())
+	assert.Equal(t, "gcr.io/some-project-162817/sancho:tilt-1", call.oneImageState().LastLocalImageAsString())
 
 	err := f.Stop()
 	assert.NoError(t, err)
@@ -672,18 +684,18 @@ func TestThreeBuilds(t *testing.T) {
 	f.Start([]model.Manifest{manifest})
 
 	call := f.nextCallComplete("first build")
-	assert.True(t, call.oneState().IsEmpty())
+	assert.True(t, call.oneImageState().IsEmpty())
 
 	f.fsWatcher.Events <- watch.NewFileEvent(f.JoinPath("a.go"))
 
 	call = f.nextCallComplete("second build")
-	assert.Equal(t, []string{f.JoinPath("a.go")}, call.oneState().FilesChanged())
+	assert.Equal(t, []string{f.JoinPath("a.go")}, call.oneImageState().FilesChanged())
 
 	// Simulate a change to b.go
 	f.fsWatcher.Events <- watch.NewFileEvent(f.JoinPath("b.go"))
 
 	call = f.nextCallComplete("third build")
-	assert.Equal(t, []string{f.JoinPath("b.go")}, call.oneState().FilesChanged())
+	assert.Equal(t, []string{f.JoinPath("b.go")}, call.oneImageState().FilesChanged())
 
 	f.withManifestState("fe", func(ms store.ManifestState) {
 		assert.Equal(t, 2, len(ms.BuildHistory))
@@ -702,7 +714,7 @@ func TestRebuildWithSpuriousChangedFiles(t *testing.T) {
 	f.Start([]model.Manifest{manifest})
 
 	call := f.nextCall()
-	assert.True(t, call.oneState().IsEmpty())
+	assert.True(t, call.oneImageState().IsEmpty())
 
 	// Simulate a change to .#a.go that's a broken symlink.
 	realPath := filepath.Join(f.Path(), "a.go")
@@ -717,7 +729,7 @@ func TestRebuildWithSpuriousChangedFiles(t *testing.T) {
 	f.fsWatcher.Events <- watch.NewFileEvent(realPath)
 
 	call = f.nextCall()
-	assert.Equal(t, []string{realPath}, call.oneState().FilesChanged())
+	assert.Equal(t, []string{realPath}, call.oneImageState().FilesChanged())
 
 	err := f.Stop()
 	assert.NoError(t, err)
@@ -749,7 +761,7 @@ k8s_yaml('snack.yaml')
 
 	// Since the manifest changed, we cleared the previous build state to force an image build
 	// (i.e. check that we called BuildAndDeploy with no pre-existing state)
-	assert.False(t, call.oneState().HasLastSuccessfulResult())
+	assert.False(t, call.oneImageState().HasLastSuccessfulResult())
 
 	f.fsWatcher.Events <- watch.NewFileEvent(f.JoinPath("random_file.go"))
 
@@ -758,7 +770,7 @@ k8s_yaml('snack.yaml')
 	assert.Equal(t, "FROM iron/go:dev", call.firstImgTarg().DockerBuildInfo().Dockerfile)
 
 	// Unchanged manifest --> we do NOT clear the build state
-	assert.True(t, call.oneState().HasLastSuccessfulResult())
+	assert.True(t, call.oneImageState().HasLastSuccessfulResult())
 
 	err := f.Stop()
 	assert.NoError(t, err)
@@ -814,10 +826,10 @@ k8s_resource('doggos', new_name='quux')
 	call = f.nextCall("changed config file --> new manifest")
 
 	assert.Equal(t, "baz", string(call.k8s().Name))
-	assert.ElementsMatch(t, []string{}, call.oneState().FilesChanged())
+	assert.ElementsMatch(t, []string{}, call.oneImageState().FilesChanged())
 
 	// Since the manifest changed, we cleared the previous build state to force an image build
-	assert.False(t, call.oneState().HasLastSuccessfulResult())
+	assert.False(t, call.oneImageState().HasLastSuccessfulResult())
 
 	// Importantly the other manifest, quux, is _not_ called -- the DF change didn't affect its manifest
 	err := f.Stop()
@@ -863,7 +875,7 @@ k8s_resource('doggos', new_name='quux')  # rename "doggos" --> "quux"
 	// Expect a build of quux, the new resource
 	call = f.nextCall("changed config file --> new manifest")
 	assert.Equal(t, "quux", string(call.k8s().Name))
-	assert.ElementsMatch(t, []string{}, call.oneState().FilesChanged())
+	assert.ElementsMatch(t, []string{}, call.oneImageState().FilesChanged())
 
 	err := f.Stop()
 	assert.Nil(t, err)
@@ -903,8 +915,8 @@ k8s_yaml('snack.yaml')`)
 	assert.Equal(t, "snack", string(call.k8s().Name))
 	assert.ElementsMatch(t, []string{
 		f.JoinPath("src/main.go"),
-	}, call.oneState().FilesChanged())
-	assert.True(t, call.oneState().HasLastSuccessfulResult(), "Unchanged manifest --> we do NOT clear the build state")
+	}, call.oneImageState().FilesChanged())
+	assert.True(t, call.oneImageState().HasLastSuccessfulResult(), "Unchanged manifest --> we do NOT clear the build state")
 
 	err := f.Stop()
 	assert.Nil(t, err)
@@ -982,7 +994,7 @@ k8s_yaml('snack.yaml')
 	f.WriteConfigFiles("Tiltfile", tiltfileWithCmd("changed"))
 
 	call := f.nextCall("fixed broken config and rebuilt manifest")
-	assert.False(t, call.oneState().HasLastSuccessfulResult(),
+	assert.False(t, call.oneImageState().HasLastSuccessfulResult(),
 		"expected this call to have NO image (since we should have cleared it to force an image build)")
 
 	f.WaitUntil("tiltfile error cleared", func(state store.EngineState) bool {
@@ -1067,7 +1079,7 @@ k8s_yaml('snack.yaml')`
 	f.WriteConfigFiles("Tiltfile", triggerAutoTiltfile)
 
 	call := f.nextCall("manifest updated b/c it's now TriggerModeAuto")
-	assert.True(t, call.oneState().HasLastSuccessfulResult(),
+	assert.True(t, call.oneImageState().HasLastSuccessfulResult(),
 		"we did NOT clear the build state (b/c a change to Manifest.TriggerMode does NOT invalidate the build")
 	f.WaitUntilManifest("triggerMode has changed on manifest", "snack", func(mt store.ManifestTarget) bool {
 		return mt.Manifest.TriggerMode == model.TriggerModeAuto
@@ -1195,7 +1207,7 @@ go build ./...
 	f.Start([]model.Manifest{manifest})
 
 	call := f.nextCallComplete("first build")
-	assert.True(t, call.oneState().IsEmpty())
+	assert.True(t, call.oneImageState().IsEmpty())
 
 	// Simulate a change to main.go
 	mainPath := filepath.Join(f.Path(), "main.go")
@@ -1203,7 +1215,7 @@ go build ./...
 
 	// Check that this triggered a rebuild.
 	call = f.nextCallComplete("rebuild triggered")
-	assert.Equal(t, []string{mainPath}, call.oneState().FilesChanged())
+	assert.Equal(t, []string{mainPath}, call.oneImageState().FilesChanged())
 
 	err := f.Stop()
 	assert.NoError(t, err)
@@ -1218,7 +1230,7 @@ func TestHudUpdated(t *testing.T) {
 
 	f.Start([]model.Manifest{manifest})
 	call := f.nextCall()
-	assert.True(t, call.oneState().IsEmpty())
+	assert.True(t, call.oneImageState().IsEmpty())
 
 	f.WaitUntilHUD("hud update", func(v view.View) bool {
 		return len(v.Resources) == 2
@@ -1248,7 +1260,7 @@ func TestDisabledHudUpdated(t *testing.T) {
 
 	f.Start([]model.Manifest{manifest})
 	call := f.nextCall()
-	assert.True(t, call.oneState().IsEmpty())
+	assert.True(t, call.oneImageState().IsEmpty())
 
 	// Make sure we're done logging stuff, then grab # processed bytes
 	time.Sleep(5 * time.Millisecond)
@@ -1279,7 +1291,7 @@ func TestPodEvent(t *testing.T) {
 	f.Start([]model.Manifest{manifest})
 
 	call := f.nextCall()
-	assert.True(t, call.oneState().IsEmpty())
+	assert.True(t, call.oneImageState().IsEmpty())
 
 	pod := podbuilder.New(f.T(), manifest).
 		WithPhase("CrashLoopBackOff").
@@ -1305,7 +1317,7 @@ func TestPodResetRestartsAction(t *testing.T) {
 	f.Start([]model.Manifest{manifest})
 
 	call := f.nextCall()
-	assert.True(t, call.oneState().IsEmpty())
+	assert.True(t, call.oneImageState().IsEmpty())
 
 	pb := podbuilder.New(f.T(), manifest)
 	f.podEvent(pb.Build(), manifest.Name)
@@ -1368,7 +1380,7 @@ func TestPodEventOrdering(t *testing.T) {
 			f.Start([]model.Manifest{manifest})
 
 			call := f.nextCall()
-			assert.True(t, call.oneState().IsEmpty())
+			assert.True(t, call.oneImageState().IsEmpty())
 			f.WaitUntilManifestState("uid deployed", "fe", func(ms store.ManifestState) bool {
 				return ms.K8sRuntimeState().DeployedUIDSet.Contains(uidNow)
 			})
@@ -1659,7 +1671,7 @@ func TestPodEventUpdateByTimestamp(t *testing.T) {
 	f.Start([]model.Manifest{manifest})
 
 	call := f.nextCall()
-	assert.True(t, call.oneState().IsEmpty())
+	assert.True(t, call.oneImageState().IsEmpty())
 
 	firstCreationTime := f.Now()
 	pod := podbuilder.New(f.T(), manifest).
@@ -1696,7 +1708,7 @@ func TestPodEventDeleted(t *testing.T) {
 	f.Start([]model.Manifest{manifest})
 
 	call := f.nextCallComplete()
-	assert.True(t, call.oneState().IsEmpty())
+	assert.True(t, call.oneImageState().IsEmpty())
 
 	creationTime := f.Now()
 	pb := podbuilder.New(f.T(), manifest).
@@ -1728,7 +1740,7 @@ func TestPodEventUpdateByPodName(t *testing.T) {
 	f.Start([]model.Manifest{manifest})
 
 	call := f.nextCallComplete()
-	assert.True(t, call.oneState().IsEmpty())
+	assert.True(t, call.oneImageState().IsEmpty())
 
 	creationTime := f.Now()
 	pb := podbuilder.New(f.T(), manifest).
@@ -1765,7 +1777,7 @@ func TestPodEventIgnoreOlderPod(t *testing.T) {
 	f.Start([]model.Manifest{manifest})
 
 	call := f.nextCall()
-	assert.True(t, call.oneState().IsEmpty())
+	assert.True(t, call.oneImageState().IsEmpty())
 
 	creationTime := f.Now()
 	pod := podbuilder.New(f.T(), manifest).
@@ -2148,7 +2160,7 @@ func TestUpperBuildImmediatelyAfterCrashRebuild(t *testing.T) {
 
 	call := f.nextCall()
 	assert.Equal(t, manifest.ImageTargetAt(0), call.firstImgTarg())
-	assert.Equal(t, []string{}, call.oneState().FilesChanged())
+	assert.Equal(t, []string{}, call.oneImageState().FilesChanged())
 	f.waitForCompletedBuildCount(1)
 
 	f.b.nextLiveUpdateContainerIDs = []container.ID{podbuilder.FakeContainerID()}
@@ -2157,7 +2169,7 @@ func TestUpperBuildImmediatelyAfterCrashRebuild(t *testing.T) {
 	f.fsWatcher.Events <- watch.NewFileEvent(f.JoinPath("main.go"))
 
 	call = f.nextCall()
-	assert.Equal(t, pod.Name, call.oneState().OneContainerInfo().PodID.String())
+	assert.Equal(t, pod.Name, call.oneImageState().OneContainerInfo().PodID.String())
 	f.waitForCompletedBuildCount(2)
 	f.withManifestState("fe", func(ms store.ManifestState) {
 		assert.Equal(t, model.BuildReasonFlagChangedFiles, ms.LastBuild().Reason)
@@ -2170,7 +2182,7 @@ func TestUpperBuildImmediatelyAfterCrashRebuild(t *testing.T) {
 		WithContainerID("funnyContainerID").
 		Build(), manifest.Name)
 	call = f.nextCall()
-	assert.True(t, call.oneState().OneContainerInfo().Empty())
+	assert.True(t, call.oneImageState().OneContainerInfo().Empty())
 	f.waitForCompletedBuildCount(3)
 
 	f.withManifestState("fe", func(ms store.ManifestState) {
@@ -2183,7 +2195,7 @@ func TestUpperBuildImmediatelyAfterCrashRebuild(t *testing.T) {
 	// at this point we have not received a pod event for pod that was started by the crash-rebuild,
 	// so any known pod info would have to be invalid to use for a build and this BuildState should
 	// not have any ContainerInfo
-	assert.True(t, call.oneState().OneContainerInfo().Empty())
+	assert.True(t, call.oneImageState().OneContainerInfo().Empty())
 
 	err := f.Stop()
 	assert.NoError(t, err)
@@ -2480,11 +2492,11 @@ func TestDockerComposeUp(t *testing.T) {
 
 	f.Start([]model.Manifest{redis, server})
 	call := f.nextCall()
-	assert.True(t, call.oneState().IsEmpty())
+	assert.True(t, call.dcState().IsEmpty())
 	assert.False(t, call.dc().ID().Empty())
 	assert.Equal(t, redis.DockerComposeTarget().ID(), call.dc().ID())
 	call = f.nextCall()
-	assert.True(t, call.oneState().IsEmpty())
+	assert.True(t, call.dcState().IsEmpty())
 	assert.False(t, call.dc().ID().Empty())
 	assert.Equal(t, server.DockerComposeTarget().ID(), call.dc().ID())
 }
@@ -2497,12 +2509,12 @@ func TestDockerComposeRedeployFromFileChange(t *testing.T) {
 
 	// Initial build
 	call := f.nextCall()
-	assert.True(t, call.oneState().IsEmpty())
+	assert.True(t, call.dcState().IsEmpty())
 
 	// Change a file -- should trigger build
 	f.fsWatcher.Events <- watch.NewFileEvent(f.JoinPath("package.json"))
 	call = f.nextCall()
-	assert.Equal(t, []string{f.JoinPath("package.json")}, call.oneState().FilesChanged())
+	assert.Equal(t, []string{f.JoinPath("package.json")}, call.dcState().FilesChanged())
 }
 
 // TODO(maia): TestDockerComposeEditConfigFiles once DC manifests load faster (http://bit.ly/2RBX4g5)


### PR DESCRIPTION
Hello @maiamcc, @landism,

Please review the following commits I made in branch nicks/ch7688:

5c458ebb7bdffefbb02ce841e24816202953431c (2020-06-12 15:30:10 -0400)
engine: k8sTargets should have buildState too. Fixes https://github.com/tilt-dev/tilt/issues/3454
It's bothered me so much that k8s targets don't have build state and
now I finally have an excuse to fix it!!!

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics