### PR TITLE
prompt: handle logs during the init sequence properly

### DIFF
--- a/internal/cli/ci.go
+++ b/internal/cli/ci.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/tilt-dev/tilt/internal/analytics"
 	"github.com/tilt-dev/tilt/internal/cloud"
+	"github.com/tilt-dev/tilt/internal/hud/prompt"
 	"github.com/tilt-dev/tilt/internal/store"
 	"github.com/tilt-dev/tilt/pkg/logger"
 )
@@ -59,7 +60,11 @@ func (c *ciCmd) run(ctx context.Context, args []string) error {
 	deferred := logger.NewDeferredLogger(ctx)
 	ctx = redirectLogs(ctx, deferred)
 
-	logOutput(fmt.Sprintf("Starting Tilt (%s)…", buildStamp()))
+	webHost := provideWebHost()
+	webURL, _ := provideWebURL(webHost, provideWebPort())
+	startLine := prompt.StartStatusLine(webURL, webHost)
+	log.Print(startLine)
+	log.Print(buildStamp())
 
 	if ok, reason := analytics.IsAnalyticsDisabledFromEnv(); ok {
 		log.Printf("Tilt analytics disabled: %s", reason)

--- a/internal/cli/wire.go
+++ b/internal/cli/wire.go
@@ -157,6 +157,7 @@ type CmdUpDeps struct {
 	Token        token.Token
 	CloudAddress cloudurl.Address
 	Store        *store.Store
+	Prompt       *prompt.TerminalPrompt
 }
 
 func wireCmdCI(ctx context.Context, analytics *analytics.TiltAnalytics) (CmdCIDeps, error) {

--- a/internal/cli/wire_gen.go
+++ b/internal/cli/wire_gen.go
@@ -276,6 +276,7 @@ func wireCmdUp(ctx context.Context, analytics3 *analytics.TiltAnalytics, cmdTags
 		Token:        tokenToken,
 		CloudAddress: address,
 		Store:        storeStore,
+		Prompt:       terminalPrompt,
 	}
 	return cmdUpDeps, nil
 }
@@ -652,6 +653,7 @@ type CmdUpDeps struct {
 	Token        token.Token
 	CloudAddress cloudurl.Address
 	Store        *store.Store
+	Prompt       *prompt.TerminalPrompt
 }
 
 type CmdCIDeps struct {

--- a/internal/hud/prompt/prompt_test.go
+++ b/internal/hud/prompt/prompt_test.go
@@ -1,6 +1,7 @@
 package prompt
 
 import (
+	"bytes"
 	"context"
 	"net/url"
 	"reflect"
@@ -54,6 +55,18 @@ func TestOpenHUD(t *testing.T) {
 
 	action := f.st.WaitForAction(t, reflect.TypeOf(SwitchTerminalModeAction{}))
 	assert.Equal(t, SwitchTerminalModeAction{Mode: store.TerminalModeHUD}, action)
+}
+
+func TestInitOutput(t *testing.T) {
+	f := newFixture()
+	defer f.TearDown()
+
+	f.prompt.SetInitOutput(bytes.NewBuffer([]byte("this is a warning\n")))
+	f.prompt.OnChange(f.ctx, f.st)
+
+	assert.Contains(t, f.out.String(), `this is a warning
+
+(space) to open the browser`)
 }
 
 type fixture struct {

--- a/pkg/logger/deferred.go
+++ b/pkg/logger/deferred.go
@@ -1,6 +1,7 @@
 package logger
 
 import (
+	"bytes"
 	"context"
 	"sync"
 )
@@ -29,6 +30,18 @@ func NewDeferredLogger(ctx context.Context) *DeferredLogger {
 	})
 	dLogger.Logger = fLogger
 	return dLogger
+}
+
+func (dl *DeferredLogger) CopyBuffered(lvl Level) *bytes.Buffer {
+	dl.mu.Lock()
+	defer dl.mu.Unlock()
+
+	buf := bytes.NewBuffer(nil)
+	logger := NewLogger(lvl, buf)
+	for _, entry := range dl.entries {
+		logger.Write(entry.level, entry.b)
+	}
+	return buf
 }
 
 // Set the output logger, and send all the buffered output to the new logger.


### PR DESCRIPTION
Hello @landism, @jazzdan,

Please review the following commits I made in branch nicks/ch7729/output:

5cd0783840165bdfdd03ad1a3de583701b8f92e9 (2020-06-16 12:16:36 -0400)
prompt: handle logs during the init sequence properly

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics