### PR TITLE
tiltfile: obsolesce multipleContainersPerPod flag, validate live updates better

### DIFF
--- a/internal/feature/flags.go
+++ b/internal/feature/flags.go
@@ -38,7 +38,7 @@ type Defaults map[string]Value
 var MainDefaults = Defaults{
 	MultipleContainersPerPod: Value{
 		Enabled: true,
-		Status:  Active,
+		Status:  Obsolete,
 	},
 	Events: Value{
 		Enabled: true,

--- a/internal/tiltfile/tiltfile_state.go
+++ b/internal/tiltfile/tiltfile_state.go
@@ -222,7 +222,7 @@ to your Tiltfile. Otherwise, switch k8s contexts and restart Tilt.`, kubeContext
 		}
 	}
 
-	err = s.validateLiveUpdates(manifests)
+	err = s.validateLiveUpdatesForManifests(manifests)
 	if err != nil {
 		return nil, result, err
 	}
@@ -1131,7 +1131,7 @@ func (s *tiltfileState) defaultedPortForwards(pfs []model.PortForward) []model.P
 	return result
 }
 
-func (s *tiltfileState) validateLiveUpdates(manifests []model.Manifest) error {
+func (s *tiltfileState) validateLiveUpdatesForManifests(manifests []model.Manifest) error {
 	for _, m := range manifests {
 		err := s.validateLiveUpdatesForManifest(m)
 		if err != nil {

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -5015,11 +5015,10 @@ type fixture struct {
 func (f *fixture) newTiltfileLoader() TiltfileLoader {
 	dcc := dockercompose.NewDockerComposeClient(docker.LocalEnv{})
 	features := feature.Defaults{
-		"testflag_disabled":              feature.Value{Enabled: false},
-		"testflag_enabled":               feature.Value{Enabled: true},
-		"obsoleteflag":                   feature.Value{Status: feature.Obsolete, Enabled: true},
-		feature.MultipleContainersPerPod: feature.Value{Enabled: false},
-		feature.Snapshots:                feature.Value{Enabled: true},
+		"testflag_disabled": feature.Value{Enabled: false},
+		"testflag_enabled":  feature.Value{Enabled: true},
+		"obsoleteflag":      feature.Value{Status: feature.Obsolete, Enabled: true},
+		feature.Snapshots:   feature.Value{Enabled: true},
 	}
 
 	k8sContextExt := k8scontext.NewExtension(f.k8sContext, f.k8sEnv)


### PR DESCRIPTION
Hello @jazzdan, @landism,

Please review the following commits I made in branch maiamcc/obsolesce-multiple-containers-flag:

1d6489f1e54221b7aad27167ea76e035bb2a35ae (2020-06-16 17:56:01 -0400)
tiltfile: obsolesce multipleContainersPerPod flag, validate live updates better

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics