### PR TITLE
engine: remove LastSuccessfulResult

### DIFF
--- a/internal/engine/buildcontrol/target_queue.go
+++ b/internal/engine/buildcontrol/target_queue.go
@@ -58,8 +58,8 @@ func NewImageTargetQueue(ctx context.Context, iTargets []model.ImageTarget, stat
 		id := target.ID()
 		if state[id].NeedsImageBuild() {
 			needsOwnBuild[id] = true
-		} else if state[id].LastSuccessfulResult != nil {
-			image := store.LocalImageRefFromBuildResult(state[id].LastSuccessfulResult)
+		} else if state[id].LastResult != nil {
+			image := store.LocalImageRefFromBuildResult(state[id].LastResult)
 			exists, err := imageExists(ctx, image)
 			if err != nil {
 				return nil, errors.Wrapf(err, "error looking up whether last image built for %s exists", image.String())
@@ -150,7 +150,7 @@ func (q *TargetQueue) backfillExistingResults() error {
 		id := target.ID()
 		if !q.isBuilding(id) {
 			// We can re-use results from the previous build.
-			lastResult := q.state[id].LastSuccessfulResult
+			lastResult := q.state[id].LastResult
 			image := store.LocalImageRefFromBuildResult(lastResult)
 			if image == nil {
 				return fmt.Errorf("Internal error: build marked clean but last result not found: %+v", q.state[id])

--- a/internal/engine/buildcontrol/target_queue_test.go
+++ b/internal/engine/buildcontrol/target_queue_test.go
@@ -38,7 +38,7 @@ func TestTargetQueue_DepsBuilt(t *testing.T) {
 	f := newTargetQueueFixture(t)
 
 	fooTarget := model.MustNewImageTarget(container.MustParseSelector("foo"))
-	s1 := store.BuildState{LastSuccessfulResult: store.NewImageBuildResultSingleRef(fooTarget.ID(), container.MustParseNamedTagged("foo:1234"))}
+	s1 := store.BuildState{LastResult: store.NewImageBuildResultSingleRef(fooTarget.ID(), container.MustParseNamedTagged("foo:1234"))}
 	barTarget := model.MustNewImageTarget(container.MustParseSelector("bar")).WithDependencyIDs([]model.TargetID{fooTarget.ID()})
 	s2 := store.BuildState{}
 
@@ -51,7 +51,7 @@ func TestTargetQueue_DepsBuilt(t *testing.T) {
 	f.run(targets, buildStateSet)
 
 	barCall := newFakeBuildHandlerCall(barTarget, 1, []store.BuildResult{
-		store.NewImageBuildResultSingleRef(fooTarget.ID(), store.LocalImageRefFromBuildResult(s1.LastSuccessfulResult)),
+		store.NewImageBuildResultSingleRef(fooTarget.ID(), store.LocalImageRefFromBuildResult(s1.LastResult)),
 	})
 
 	// foo has a valid last result, so only bar gets rebuilt
@@ -67,7 +67,7 @@ func TestTargetQueue_DepsUnbuilt(t *testing.T) {
 	fooTarget := model.MustNewImageTarget(container.MustParseSelector("foo"))
 	s1 := store.BuildState{}
 	barTarget := model.MustNewImageTarget(container.MustParseSelector("bar")).WithDependencyIDs([]model.TargetID{fooTarget.ID()})
-	var s2 = store.BuildState{LastSuccessfulResult: store.NewImageBuildResultSingleRef(
+	var s2 = store.BuildState{LastResult: store.NewImageBuildResultSingleRef(
 		barTarget.ID(),
 		container.MustParseNamedTagged("bar:54321"),
 	)}
@@ -95,7 +95,7 @@ func TestTargetQueue_IncrementalBuild(t *testing.T) {
 
 	fooTarget := model.MustNewImageTarget(container.MustParseSelector("foo"))
 	s1 := store.BuildState{
-		LastSuccessfulResult: store.NewImageBuildResultSingleRef(
+		LastResult: store.NewImageBuildResultSingleRef(
 			fooTarget.ID(),
 			container.MustParseNamedTagged("foo:1234"),
 		),
@@ -120,7 +120,7 @@ func TestTargetQueue_CachedBuild(t *testing.T) {
 
 	fooTarget := model.MustNewImageTarget(container.MustParseSelector("foo"))
 	s1 := store.BuildState{
-		LastSuccessfulResult: store.NewImageBuildResultSingleRef(
+		LastResult: store.NewImageBuildResultSingleRef(
 			fooTarget.ID(),
 			container.MustParseNamedTagged("foo:1234"),
 		),
@@ -140,7 +140,7 @@ func TestTargetQueue_DepsBuiltButReaped(t *testing.T) {
 	f := newTargetQueueFixture(t)
 
 	fooTarget := model.MustNewImageTarget(container.MustParseSelector("foo"))
-	s1 := store.BuildState{LastSuccessfulResult: store.NewImageBuildResultSingleRef(fooTarget.ID(), container.MustParseNamedTagged("foo:1234"))}
+	s1 := store.BuildState{LastResult: store.NewImageBuildResultSingleRef(fooTarget.ID(), container.MustParseNamedTagged("foo:1234"))}
 	barTarget := model.MustNewImageTarget(container.MustParseSelector("bar")).WithDependencyIDs([]model.TargetID{fooTarget.ID()})
 	s2 := store.BuildState{}
 
@@ -150,7 +150,7 @@ func TestTargetQueue_DepsBuiltButReaped(t *testing.T) {
 		barTarget.ID(): s2,
 	}
 
-	f.setMissingImage(store.LocalImageRefFromBuildResult(s1.LastSuccessfulResult))
+	f.setMissingImage(store.LocalImageRefFromBuildResult(s1.LastResult))
 
 	f.run(targets, buildStateSet)
 

--- a/internal/engine/buildcontroller.go
+++ b/internal/engine/buildcontroller.go
@@ -177,7 +177,7 @@ func buildStateSet(ctx context.Context, manifest model.Manifest, specs []model.T
 			depsChanged = append(depsChanged, dep)
 		}
 
-		buildState := store.NewBuildState(status.LastSuccessfulResult, filesChanged, depsChanged)
+		buildState := store.NewBuildState(status.LastResult, filesChanged, depsChanged)
 
 		// Pass along the container when we can update containers in-place.
 		//

--- a/internal/engine/live_update_build_and_deployer_test.go
+++ b/internal/engine/live_update_build_and_deployer_test.go
@@ -35,9 +35,9 @@ var TestContainerInfo = store.ContainerInfo{
 }
 
 var TestBuildState = store.BuildState{
-	LastSuccessfulResult: alreadyBuilt,
-	FilesChangedSet:      map[string]bool{"foo.py": true},
-	RunningContainers:    []store.ContainerInfo{TestContainerInfo},
+	LastResult:        alreadyBuilt,
+	FilesChangedSet:   map[string]bool{"foo.py": true},
+	RunningContainers: []store.ContainerInfo{TestContainerInfo},
 }
 
 func TestBuildAndDeployBoilsSteps(t *testing.T) {
@@ -155,9 +155,9 @@ func TestUpdateMultipleRunningContainers(t *testing.T) {
 
 	cInfos := []store.ContainerInfo{cInfo1, cInfo2}
 	state := store.BuildState{
-		LastSuccessfulResult: alreadyBuilt,
-		FilesChangedSet:      map[string]bool{"foo.py": true},
-		RunningContainers:    cInfos,
+		LastResult:        alreadyBuilt,
+		FilesChangedSet:   map[string]bool{"foo.py": true},
+		RunningContainers: cInfos,
 	}
 
 	paths := []build.PathMapping{
@@ -206,9 +206,9 @@ func TestErrorStopsSubsequentContainerUpdates(t *testing.T) {
 
 	cInfos := []store.ContainerInfo{cInfo1, cInfo2}
 	state := store.BuildState{
-		LastSuccessfulResult: alreadyBuilt,
-		FilesChangedSet:      map[string]bool{"foo.py": true},
-		RunningContainers:    cInfos,
+		LastResult:        alreadyBuilt,
+		FilesChangedSet:   map[string]bool{"foo.py": true},
+		RunningContainers: cInfos,
 	}
 
 	f.cu.SetUpdateErr(fmt.Errorf("👀"))
@@ -237,9 +237,9 @@ func TestUpdateMultipleContainersWithSameTarArchive(t *testing.T) {
 
 	cInfos := []store.ContainerInfo{cInfo1, cInfo2}
 	state := store.BuildState{
-		LastSuccessfulResult: alreadyBuilt,
-		FilesChangedSet:      map[string]bool{"foo.py": true},
-		RunningContainers:    cInfos,
+		LastResult:        alreadyBuilt,
+		FilesChangedSet:   map[string]bool{"foo.py": true},
+		RunningContainers: cInfos,
 	}
 
 	// Write files so we know whether to cp to or rm from container
@@ -287,9 +287,9 @@ func TestUpdateMultipleContainersWithSameTarArchiveOnRunStepFailure(t *testing.T
 
 	cInfos := []store.ContainerInfo{cInfo1, cInfo2}
 	state := store.BuildState{
-		LastSuccessfulResult: alreadyBuilt,
-		FilesChangedSet:      map[string]bool{"foo.py": true},
-		RunningContainers:    cInfos,
+		LastResult:        alreadyBuilt,
+		FilesChangedSet:   map[string]bool{"foo.py": true},
+		RunningContainers: cInfos,
 	}
 
 	// Write files so we know whether to cp to or rm from container
@@ -332,9 +332,9 @@ func TestSkipLiveUpdateIfForceUpdate(t *testing.T) {
 	}
 
 	state := store.BuildState{
-		LastSuccessfulResult: alreadyBuilt,
-		RunningContainers:    []store.ContainerInfo{cInfo},
-		FullBuildTriggered:   true, // should make us skip LiveUpdate
+		LastResult:         alreadyBuilt,
+		RunningContainers:  []store.ContainerInfo{cInfo},
+		FullBuildTriggered: true, // should make us skip LiveUpdate
 	}
 
 	stateSet := store.BuildStateSet{m.ImageTargetAt(0).ID(): state}

--- a/internal/engine/live_update_state_tree.go
+++ b/internal/engine/live_update_state_tree.go
@@ -19,7 +19,7 @@ type liveUpdateStateTree struct {
 func (t liveUpdateStateTree) createResultSet() store.BuildResultSet {
 	iTargetID := t.iTarget.ID()
 	state := t.iTargetState
-	res := state.LastSuccessfulResult
+	res := state.LastResult
 
 	liveUpdatedContainerIDs := []container.ID{}
 	for _, c := range state.RunningContainers {

--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -249,10 +249,6 @@ func handleBuildResults(engineState *store.EngineState,
 
 	if isBuildSuccess {
 		ms.LastSuccessfulDeployTime = br.FinishTime
-
-		for id, result := range results {
-			ms.MutableBuildStatus(id).LastSuccessfulResult = result
-		}
 	}
 }
 

--- a/internal/store/engine_state.go
+++ b/internal/store/engine_state.go
@@ -308,8 +308,7 @@ type BuildStatus struct {
 	// This map is mutable.
 	PendingFileChanges map[string]time.Time
 
-	LastSuccessfulResult BuildResult
-	LastResult           BuildResult
+	LastResult BuildResult
 
 	// Stores the times that dependencies were marked dirty, so we can prioritize
 	// the oldest one first.
@@ -338,7 +337,7 @@ func newBuildStatus() *BuildStatus {
 func (s BuildStatus) IsEmpty() bool {
 	return len(s.PendingFileChanges) == 0 &&
 		len(s.PendingDependencyChanges) == 0 &&
-		s.LastSuccessfulResult == nil
+		s.LastResult == nil
 }
 
 type ManifestState struct {


### PR DESCRIPTION
Hello @maiamcc,

Please review the following commits I made in branch nicks/lastresult:

2af94cc3d4a3b705c6fda5360a1afb2e0ecc4b3f (2020-06-16 18:49:40 -0400)
engine: remove LastSuccessfulResult
The fundamental problem is that, by definition, all concrete BuildResult objects
represent success. If an image build fails, we return a nil BuildResult.

The notion of "BuildResult" gets slippery when we talk about live update.
If the in-container RUN step failed, the live-updater returns a valid BuildResult
(containing the container id) AND an error. In some contexts, we want to
treat that as a success (because the container is still live and can get future
live udpates), but in other cases (like error reporting), we want to report
this as an error.

Better to just get rid of the concept of "SuccessfulResult" completely,
and be more precise about what we want.

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics