### PR TITLE
k8s: improve jsonpath api to allow both extraction and injection

### DIFF
--- a/internal/k8s/image.go
+++ b/internal/k8s/image.go
@@ -274,15 +274,18 @@ func (e K8sEntity) FindImages(imageJSONPaths []JSONPath, envVarImages []containe
 
 	// also look for images in any json paths that were specified for this entity
 	for _, path := range imageJSONPaths {
-		image, err := path.Execute(obj)
+		images, err := path.FindStrings(obj)
 		if err != nil {
 			return nil, errors.Wrapf(err, "error applying json path '%s'", path)
 		}
-		ref, err := container.ParseNamed(image)
-		if err != nil {
-			return nil, errors.Wrapf(err, "error parsing image '%s' at json path '%s'", image, path)
+
+		for _, image := range images {
+			ref, err := container.ParseNamed(image)
+			if err != nil {
+				return nil, errors.Wrapf(err, "error parsing image '%s' at json path '%s'", image, path)
+			}
+			result = append(result, ref)
 		}
-		result = append(result, ref)
 	}
 
 	envVars, err := extractEnvVars(&obj)

--- a/internal/k8s/json_path.go
+++ b/internal/k8s/json_path.go
@@ -1,17 +1,16 @@
 package k8s
 
 import (
-	"bytes"
-	"strings"
+	"fmt"
+	"reflect"
 
 	"k8s.io/client-go/util/jsonpath"
 )
 
-// This is just a wrapper around k8s jsonpath, mostly because k8s jsonpath doesn't produce errors containing
-// the problematic path
-// (and as long as we're here, deal with some of its other annoyances, like taking a "name" that doesn't do anything,
-// and having a separate "Parse" step to make an instance actually useful, and making you use an io.Writer, and
-// wrapping string results in quotes)
+// A wrapper around JSONPath with utility functions for
+// locating particular types we need (like strings).
+//
+// Improves the error message to include the problematic path.
 type JSONPath struct {
 	jp   *jsonpath.JSONPath
 	path string
@@ -27,17 +26,42 @@ func NewJSONPath(s string) (JSONPath, error) {
 	return JSONPath{jp, s}, nil
 }
 
-// Gets the value at the specified path
-// NB: currently strips away surrounding quotes, which the underlying parser includes in its return value
-// If, at some point, we want to distinguish between, e.g., ints and strings by the presence of quotes, this
-// will need to be revisited.
-func (jp JSONPath) Execute(obj interface{}) (string, error) {
-	buf := &bytes.Buffer{}
-	err := jp.jp.Execute(buf, obj)
+// Extract all the strings from the given object.
+// Returns an error if the object at the specified path isn't a string.
+func (jp JSONPath) FindStrings(obj interface{}) ([]string, error) {
+	result := []string{}
+	err := jp.VisitStrings(obj, func(match reflect.Value) error {
+		result = append(result, match.String())
+		return nil
+	})
 	if err != nil {
-		return "", err
+		return nil, err
 	}
-	return strings.Trim(buf.String(), "\""), nil
+	return result, nil
+}
+
+// Visit all the strings from the given object.
+// Returns an error if the object at the specified path isn't a string.
+func (jp JSONPath) VisitStrings(obj interface{}, visit func(val reflect.Value) error) error {
+	matches, err := jp.jp.FindResults(obj)
+	if err != nil {
+		return fmt.Errorf("Matching strings (json_path=%q): %v", jp.path, err)
+	}
+
+	for _, matchSet := range matches {
+		for _, match := range matchSet {
+			if match.Kind() != reflect.String {
+				return fmt.Errorf("May only match strings (json_path=%q)\nGot Type: %s.\nGot Value: %s",
+					jp.path, match.Type(), match)
+			}
+
+			err := visit(match)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }
 
 func (jp JSONPath) String() string {

--- a/internal/k8s/json_path_test.go
+++ b/internal/k8s/json_path_test.go
@@ -1,0 +1,50 @@
+package k8s
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/tilt-dev/tilt/internal/k8s/testyaml"
+)
+
+func TestJSONPathOneMatch(t *testing.T) {
+	entities := MustParseYAMLFromString(t, testyaml.SanchoYAML)
+	deployment := entities[0]
+	path, err := NewJSONPath("{.spec.template.spec.containers[].image}")
+	assert.NoError(t, err)
+	result, err := path.FindStrings(deployment.Obj)
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"gcr.io/some-project-162817/sancho"}, result)
+}
+
+func TestJSONPathReplace(t *testing.T) {
+	entities := MustParseYAMLFromString(t, testyaml.SanchoYAML)
+	deployment := entities[0]
+	path, err := NewJSONPath("{.spec.template.spec.containers[].image}")
+	assert.NoError(t, err)
+
+	err = path.VisitStrings(deployment.Obj, func(val reflect.Value) error {
+		val.SetString("injected-image")
+		return nil
+	})
+	assert.NoError(t, err)
+
+	result, err := path.FindStrings(deployment.Obj)
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"injected-image"}, result)
+}
+
+func TestJSONPathMultipleMatches(t *testing.T) {
+	entities := MustParseYAMLFromString(t, testyaml.SanchoSidecarYAML)
+	deployment := entities[0]
+	path, err := NewJSONPath("{.spec.template.spec.containers[*].image}")
+	assert.NoError(t, err)
+	result, err := path.FindStrings(deployment.Obj)
+	assert.NoError(t, err)
+	assert.Equal(t, []string{
+		"gcr.io/some-project-162817/sancho",
+		"gcr.io/some-project-162817/sancho-sidecar",
+	}, result)
+}

--- a/internal/k8s/testyaml/testyaml.go
+++ b/internal/k8s/testyaml/testyaml.go
@@ -61,7 +61,7 @@ const BlorgBackendAmbiguousYAML = `
 apiVersion: v1
 kind: Service
 metadata:
-  name: blorg 
+  name: blorg
   labels:
     app: blorg
     owner: nick
@@ -81,7 +81,7 @@ spec:
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: blorg 
+  name: blorg
 spec:
   selector:
     matchLabels:
@@ -91,7 +91,7 @@ spec:
       tier: backend
   template:
     metadata:
-      name: blorg 
+      name: blorg
       labels:
         app: blorg
         owner: nick


### PR DESCRIPTION
Hello @landism, @maiamcc,

Please review the following commits I made in branch nicks/jsonpath:

959fe4cbe63fe59cf11e102addaa5899af6c8667 (2020-06-18 11:23:00 -0400)
k8s: improve jsonpath api to allow both extraction and injection

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics