### PR TITLE
local: fix shutdown sequence to handle delayed exit and log correctly

### DIFF
--- a/internal/engine/local/controller.go
+++ b/internal/engine/local/controller.go
@@ -140,10 +140,9 @@ func (c *Controller) start(ctx context.Context, spec ServeSpec, st store.RStore)
 	ctx, proc.cancelFunc = context.WithCancel(ctx)
 
 	w := LocalServeLogActionWriter{
-		store:               st,
-		manifestName:        spec.ManifestName,
-		procNum:             proc.procNum,
-		stillHasSameProcNum: proc.stillHasSameProcNum(),
+		store:        st,
+		manifestName: spec.ManifestName,
+		procNum:      proc.procNum,
 	}
 	ctx = logger.CtxWithLogHandler(ctx, w)
 
@@ -212,17 +211,12 @@ func (p *currentProcess) currentProcNum() int {
 }
 
 type LocalServeLogActionWriter struct {
-	store               store.RStore
-	manifestName        model.ManifestName
-	stillHasSameProcNum func() bool
-	procNum             int
+	store        store.RStore
+	manifestName model.ManifestName
+	procNum      int
 }
 
 func (w LocalServeLogActionWriter) Write(level logger.Level, fields logger.Fields, p []byte) error {
-	if !w.stillHasSameProcNum() {
-		return nil
-	}
-
 	w.store.Dispatch(store.NewLogAction(w.manifestName, SpanIDForServeLog(w.procNum), level, fields, p))
 	return nil
 }

--- a/internal/engine/local/controller_test.go
+++ b/internal/engine/local/controller_test.go
@@ -43,15 +43,9 @@ func TestUpdate(t *testing.T) {
 		}
 		return a.ManifestName == "foo" && a.Status == model.RuntimeStatusError
 	})
-	f.assertNoAction("log for cancel", func(action store.Action) bool {
-		a, ok := action.(store.LogAction)
-		if !ok {
-			return false
-		}
-		return a.ManifestName() == "foo" && strings.Contains(string(a.Message()), "cmd true canceled")
-	})
 	f.fe.RequireNoKnownProcess(t, "true")
 	f.assertLogMessage("foo", "Starting cmd false")
+	f.assertLogMessage("foo", "cmd true canceled")
 }
 
 func TestFailure(t *testing.T) {

--- a/internal/engine/local/execer.go
+++ b/internal/engine/local/execer.go
@@ -17,6 +17,8 @@ import (
 	"github.com/tilt-dev/tilt/pkg/procutil"
 )
 
+var DefaultGracePeriod = 30 * time.Second
+
 type Execer interface {
 	Start(ctx context.Context, cmd model.Cmd, w io.Writer, statusCh chan statusAndMetadata, spanID model.LogSpanID) chan struct{}
 }
@@ -115,22 +117,28 @@ func ProvideExecer() Execer {
 	return NewProcessExecer()
 }
 
-type processExecer struct{}
+type processExecer struct {
+	gracePeriod time.Duration
+}
 
 func NewProcessExecer() *processExecer {
-	return &processExecer{}
+	return &processExecer{
+		gracePeriod: DefaultGracePeriod,
+	}
 }
 
 func (e *processExecer) Start(ctx context.Context, cmd model.Cmd, w io.Writer, statusCh chan statusAndMetadata, spanID model.LogSpanID) chan struct{} {
 	doneCh := make(chan struct{})
 
-	go processRun(ctx, cmd, w, statusCh, doneCh, spanID)
+	go func() {
+		e.processRun(ctx, cmd, w, statusCh, spanID)
+		close(doneCh)
+	}()
 
 	return doneCh
 }
 
-func processRun(ctx context.Context, cmd model.Cmd, w io.Writer, statusCh chan statusAndMetadata, doneCh chan struct{}, spanID model.LogSpanID) {
-	defer close(doneCh)
+func (e *processExecer) processRun(ctx context.Context, cmd model.Cmd, w io.Writer, statusCh chan statusAndMetadata, spanID model.LogSpanID) {
 	defer close(statusCh)
 
 	logger.Get(ctx).Infof("Running serve cmd: %s", cmd.String())
@@ -151,13 +159,14 @@ func processRun(ctx context.Context, cmd model.Cmd, w io.Writer, statusCh chan s
 	statusCh <- statusAndMetadata{status: Running, pid: c.Process.Pid, spanID: spanID}
 
 	// This is to prevent this goroutine from blocking, since we know there's only going to be one result
-	errCh := make(chan error, 1)
+	processExitCh := make(chan error, 1)
 	go func() {
-		errCh <- c.Wait()
+		processExitCh <- c.Wait()
+		close(processExitCh)
 	}()
 
 	select {
-	case err := <-errCh:
+	case err := <-processExitCh:
 		if err == nil {
 			logger.Get(ctx).Errorf("%s exited with exit code 0", cmd.String())
 		} else if ee, ok := err.(*exec.ExitError); ok {
@@ -167,22 +176,46 @@ func processRun(ctx context.Context, cmd model.Cmd, w io.Writer, statusCh chan s
 		}
 		statusCh <- statusAndMetadata{status: Error, spanID: spanID}
 	case <-ctx.Done():
-		logger.Get(ctx).Debugf("About to gracefully shut down process %d", c.Process.Pid)
-		err := procutil.GracefullyShutdownProcess(c.Process)
-		if err != nil {
-			logger.Get(ctx).Debugf("Unable to gracefully kill process %d, sending SIGKILL to the process group", c.Process.Pid)
-			procutil.KillProcessGroup(c)
-		} else {
-			// wait and then send SIGKILL to the process group, unless the command finished
-			select {
-			// we wait 30 seconds to give the process enough time to finish doing any cleanup.
-			// this is the same timeout that Kubernetes uses
-			// TODO(dmiller): make this configurable via the Tiltfile
-			case <-time.After(30 * time.Second):
-				procutil.KillProcessGroup(c)
-			case <-doneCh:
-			}
-		}
+		e.killProcess(ctx, c, processExitCh)
 		statusCh <- statusAndMetadata{status: Done, spanID: spanID}
+	}
+}
+
+func (e *processExecer) killProcess(ctx context.Context, c *exec.Cmd, processExitCh chan error) {
+	logger.Get(ctx).Debugf("About to gracefully shut down process %d", c.Process.Pid)
+	err := procutil.GracefullyShutdownProcess(c.Process)
+	if err != nil {
+		logger.Get(ctx).Debugf("Unable to gracefully kill process %d, sending SIGKILL to the process group: %v", c.Process.Pid, err)
+		procutil.KillProcessGroup(c)
+		return
+	}
+
+	// we wait 30 seconds to give the process enough time to finish doing any cleanup.
+	// this is the same timeout that Kubernetes uses
+	// TODO(dmiller): make this configurable via the Tiltfile
+	infoCh := time.After(e.gracePeriod / 20)
+	moreInfoCh := time.After(e.gracePeriod / 3)
+	finalCh := time.After(e.gracePeriod)
+
+	select {
+	case <-infoCh:
+		logger.Get(ctx).Infof("Waiting %s for process to exit... (pid: %d)", e.gracePeriod, c.Process.Pid)
+	case <-processExitCh:
+		return
+	}
+
+	select {
+	case <-moreInfoCh:
+		logger.Get(ctx).Infof("Still waiting on exit... (pid: %d)", c.Process.Pid)
+	case <-processExitCh:
+		return
+	}
+
+	select {
+	case <-finalCh:
+		logger.Get(ctx).Infof("Time is up! Sending %d a kill signal", c.Process.Pid)
+		procutil.KillProcessGroup(c)
+	case <-processExitCh:
+		return
 	}
 }

--- a/internal/engine/local/execer_test.go
+++ b/internal/engine/local/execer_test.go
@@ -35,11 +35,36 @@ func TestSleep(t *testing.T) {
 	}
 	f.start(cmd)
 
-	f.waitForStatusAndNoError(Running)
+	f.waitForStatus(Running)
 
 	time.Sleep(time.Second)
 
 	f.assertCmdSucceeds()
+}
+
+func TestShutdownOnCancel(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("no bash on windows")
+	}
+	f := newProcessExecFixture(t)
+	defer f.tearDown()
+
+	cmd := `
+function cleanup()
+{
+  echo "cleanup time!"
+  exit 1
+}
+
+trap cleanup EXIT
+sleep 100
+`
+	f.start(cmd)
+	f.cancel()
+
+	time.Sleep(time.Second)
+	f.waitForStatus(Done)
+	f.assertLogContains("cleanup time")
 }
 
 func TestPrintsLogs(t *testing.T) {
@@ -69,7 +94,7 @@ func TestStopsGrandchildren(t *testing.T) {
 	defer f.tearDown()
 
 	f.start("bash -c '(for i in $(seq 1 20); do echo loop$i; sleep 1; done)'")
-	f.waitForStatusAndNoError(Running)
+	f.waitForStatus(Running)
 
 	// wait until there's log output
 	timeout := time.After(time.Second)
@@ -86,7 +111,7 @@ func TestStopsGrandchildren(t *testing.T) {
 
 	// cancel the context
 	f.cancel()
-	f.waitForStatusAndNoError(Done)
+	f.waitForStatus(Done)
 }
 
 func TestHandlesProcessThatFailsToStart(t *testing.T) {
@@ -109,6 +134,7 @@ type processExecFixture struct {
 
 func newProcessExecFixture(t *testing.T) *processExecFixture {
 	execer := NewProcessExecer()
+	execer.gracePeriod = time.Second
 	testWriter := bufsync.NewThreadSafeBuffer()
 	ctx, _, _ := testutils.ForkedCtxAndAnalyticsForTest(testWriter)
 	ctx, cancel := context.WithCancel(ctx)
@@ -139,11 +165,12 @@ func (f *processExecFixture) start(cmd string) {
 }
 
 func (f *processExecFixture) assertCmdSucceeds() {
-	f.waitForError()
+	f.waitForStatus(Error)
 	f.assertLogContains("exited with exit code 0")
 }
 
-func (f *processExecFixture) waitForStatusAndNoError(expectedStatus status) {
+func (f *processExecFixture) waitForStatus(expectedStatus status) {
+	deadlineCh := time.After(2 * time.Second)
 	for {
 		select {
 		case sm, ok := <-f.statusCh:
@@ -153,11 +180,15 @@ func (f *processExecFixture) waitForStatusAndNoError(expectedStatus status) {
 			if expectedStatus == sm.status {
 				return
 			}
-			if expectedStatus == Error {
-				f.t.Error("Unexpected Error sm")
+			if sm.status == Error {
+				f.t.Error("Unexpected Error")
 				return
 			}
-		case <-time.After(35 * time.Second):
+			if sm.status == Done {
+				f.t.Error("Unexpected Done")
+				return
+			}
+		case <-deadlineCh:
 			f.t.Fatal("Timed out waiting for cmd sm")
 		}
 	}
@@ -168,14 +199,5 @@ func (f *processExecFixture) assertLogContains(s string) {
 }
 
 func (f *processExecFixture) waitForError() {
-	for {
-		select {
-		case sm := <-f.statusCh:
-			if sm.status == Error {
-				return
-			}
-		case <-time.After(10 * time.Second):
-			f.t.Fatal("Timed out waiting for error")
-		}
-	}
+	f.waitForStatus(Error)
 }


### PR DESCRIPTION
Hello @jazzdan, @landism,

Please review the following commits I made in branch nicks/ch7815/local:

257f34aa62103c9bbb9263262e91f26efaabeb14 (2020-06-19 10:08:33 -0400)
local: fix shutdown sequence to handle delayed exit and log correctly Fixes https://github.com/tilt-dev/tilt/issues/3479 Fixes https://github.com/tilt-dev/tilt/issues/3443

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics