### PR TITLE
tiltfie: now legal for loaded/included files to call load/include [ch7329 ch7828]

### DIFF
--- a/internal/tiltfile/tiltextension/extension.go
+++ b/internal/tiltfile/tiltextension/extension.go
@@ -6,7 +6,6 @@ package tiltextension
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"strings"
 
@@ -45,12 +44,6 @@ func (e *Extension) LocalPath(t *starlark.Thread, arg string) (string, error) {
 	}
 	if !strings.HasPrefix(arg, extensionPrefix) {
 		return "", nil
-	}
-
-	loadIsHappeningInTopLevel := t.CallStackDepth() == 1
-
-	if !loadIsHappeningInTopLevel {
-		return "", fmt.Errorf("extensions cannot be loaded from `load`ed Tiltfiles")
 	}
 
 	moduleName := strings.TrimPrefix(arg, extensionPrefix)


### PR DESCRIPTION
Hello @nicks, @landism,

Please review the following commits I made in branch maiamcc/non-root-extensions:

90e43b7c97c4a985ae8c7f9735dd540547d07f54 (2020-06-19 17:07:55 -0400)
tiltfie: now legal for loaded/included files to call load/include [ch7329 ch7828]

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics