### PR TITLE
tiltfile: Throw Error When local_resource() defined multiple times

### DIFF
--- a/internal/engine/buildcontroller_test.go
+++ b/internal/engine/buildcontroller_test.go
@@ -606,7 +606,6 @@ func TestBuildControllerManualTriggerWithFileChangesSinceLastSuccessfulBuildButB
 		return true
 	})
 }
-
 func TestBuildQueueOrdering(t *testing.T) {
 	f := newTestFixture(t)
 	defer f.TearDown()

--- a/internal/k8s/names.go
+++ b/internal/k8s/names.go
@@ -21,6 +21,7 @@ func UniqueNames(es []K8sEntity, minComponents int) []string {
 	// for each entity, take the shortest name that is uniquely wanted by that entity
 	for i, e := range es {
 		names := potentialNames(e, minComponents)
+
 		for _, name := range names {
 			if counts[name] == 1 {
 				ret[i] = name

--- a/internal/k8s/names.go
+++ b/internal/k8s/names.go
@@ -23,7 +23,6 @@ func UniqueNames(es []K8sEntity, minComponents int) []string {
 		names := potentialNames(e, minComponents)
 		for _, name := range names {
 			if counts[name] == 1 {
-				fmt.Println(name)
 				ret[i] = name
 				break
 			}

--- a/internal/k8s/names.go
+++ b/internal/k8s/names.go
@@ -23,6 +23,7 @@ func UniqueNames(es []K8sEntity, minComponents int) []string {
 		names := potentialNames(e, minComponents)
 		for _, name := range names {
 			if counts[name] == 1 {
+				fmt.Println(name)
 				ret[i] = name
 				break
 			}

--- a/internal/tiltfile/local_resource.go
+++ b/internal/tiltfile/local_resource.go
@@ -96,6 +96,11 @@ func (s *tiltfileState) localResource(thread *starlark.Thread, fn *starlark.Buil
 		resourceDeps: resourceDeps,
 		ignores:      ignores,
 	}
+	for _, elem := range s.localResources {
+		if elem.name == res.name {
+			return starlark.None, fmt.Errorf("Local resource %s has been defined multiple times", res.name)
+		}
+	}
 	s.localResources = append(s.localResources, res)
 
 	return starlark.None, nil

--- a/internal/tiltfile/local_resource.go
+++ b/internal/tiltfile/local_resource.go
@@ -96,6 +96,8 @@ func (s *tiltfileState) localResource(thread *starlark.Thread, fn *starlark.Buil
 		resourceDeps: resourceDeps,
 		ignores:      ignores,
 	}
+
+	//check for duplicate resources by name and throw error if found
 	for _, elem := range s.localResources {
 		if elem.name == res.name {
 			return starlark.None, fmt.Errorf("Local resource %s has been defined multiple times", res.name)

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -1178,6 +1178,20 @@ k8s_yaml(blob(''))
 	f.loadErrString("Empty or Invalid YAML Resource Detected")
 }
 
+func TestDuplicateLocalResources(t *testing.T) {
+	f := newFixture(t)
+	defer f.TearDown()
+
+	f.setupFoo()
+
+	f.file("Tiltfile", `
+local_resource('foo', 'echo foo')
+local_resource('foo', 'echo foo')
+`)
+
+	f.loadErrString("Local resource foo has been defined multiple times")
+}
+
 // These tests are for behavior that we specifically enabled in Starlark
 // in the init() function
 func TestTopLevelIfStatement(t *testing.T) {


### PR DESCRIPTION
Hello @nicks @landism 

Please review the following commit in this pull request which attempts to solve the issue posed in Issue #2919 

f971dc4e933fbeb181d79ad6c8c9956e72369025 fixed local resouce duplication? 

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics