### PR TITLE
tiltfile: add a period= parameter to experimental_telemetry_cmd

### DIFF
--- a/internal/engine/telemetry/controller.go
+++ b/internal/engine/telemetry/controller.go
@@ -30,13 +30,16 @@ func NewController(clock build.Clock, spans tracer.SpanSource) *Controller {
 	}
 }
 
-var period = 60 * time.Second
-
 func (t *Controller) OnChange(ctx context.Context, st store.RStore) {
 	state := st.RLockState()
 	ts := state.TelemetrySettings
 	tc := ts.Cmd
 	st.RUnlockState()
+
+	period := ts.Period
+	if period == 0 {
+		period = model.DefaultTelemetryPeriod
+	}
 
 	if tc.Empty() || !t.lastRunAt.Add(period).Before(t.clock.Now()) {
 		return

--- a/internal/tiltfile/telemetry/telemetry.go
+++ b/internal/tiltfile/telemetry/telemetry.go
@@ -18,7 +18,9 @@ func NewExtension() Extension {
 }
 
 func (e Extension) NewState() interface{} {
-	return model.TelemetrySettings{}
+	return model.TelemetrySettings{
+		Period: model.DefaultTelemetryPeriod,
+	}
 }
 
 func (Extension) OnStart(env *starkit.Environment) error {
@@ -27,9 +29,11 @@ func (Extension) OnStart(env *starkit.Environment) error {
 
 func setTelemetryCmd(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	var cmdVal, cmdBatVal starlark.Value
+	var period value.Duration
 	err := starkit.UnpackArgs(thread, fn.Name(), args, kwargs,
 		"cmd", &cmdVal,
-		"cmd_bat?", &cmdBatVal)
+		"cmd_bat?", &cmdBatVal,
+		"period?", &period)
 	if err != nil {
 		return starlark.None, err
 	}
@@ -50,6 +54,9 @@ func setTelemetryCmd(thread *starlark.Thread, fn *starlark.Builtin, args starlar
 
 		settings.Cmd = cmd
 		settings.Workdir = filepath.Dir(starkit.CurrentExecPath(thread))
+		if !period.IsZero() {
+			settings.Period = period.AsDuration()
+		}
 
 		return settings, nil
 	})

--- a/internal/tiltfile/telemetry/telemetry_test.go
+++ b/internal/tiltfile/telemetry/telemetry_test.go
@@ -2,6 +2,7 @@ package telemetry
 
 import (
 	"testing"
+	"time"
 
 	"github.com/tilt-dev/tilt/pkg/model"
 
@@ -18,6 +19,17 @@ func TestTelemetryCmdString(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.Equal(t, model.ToHostCmd("foo.sh"), MustState(result).Cmd)
+	assert.Equal(t, model.DefaultTelemetryPeriod, MustState(result).Period)
+}
+
+func TestTelemetryPeriod(t *testing.T) {
+	f := newFixture(t)
+	defer f.TearDown()
+	f.File("Tiltfile", "experimental_telemetry_cmd('foo.sh', period='5s')")
+
+	result, err := f.ExecFile("Tiltfile")
+	assert.NoError(t, err)
+	assert.Equal(t, 5*time.Second, MustState(result).Period)
 }
 
 func TestTelemetryCmdArray(t *testing.T) {

--- a/internal/tiltfile/value/duration.go
+++ b/internal/tiltfile/value/duration.go
@@ -1,0 +1,34 @@
+package value
+
+import (
+	"fmt"
+	"time"
+
+	"go.starlark.net/starlark"
+)
+
+// Parse duration constants from starlark.
+type Duration time.Duration
+
+func (d Duration) IsZero() bool {
+	return d.AsDuration() == 0
+}
+
+func (d Duration) AsDuration() time.Duration {
+	return time.Duration(d)
+}
+
+func (d *Duration) Unpack(v starlark.Value) error {
+	s, ok := starlark.AsString(v)
+	if !ok {
+		return fmt.Errorf("Expected string. Got: %s", v.Type())
+	}
+
+	dur, err := time.ParseDuration(s)
+	if err != nil {
+		return err
+	}
+
+	*d = Duration(dur)
+	return nil
+}

--- a/pkg/model/telemetry_settings.go
+++ b/pkg/model/telemetry_settings.go
@@ -1,6 +1,13 @@
 package model
 
+import "time"
+
+const DefaultTelemetryPeriod = 60 * time.Second
+
 type TelemetrySettings struct {
 	Cmd     Cmd
 	Workdir string // directory from which this Cmd should be run
+
+	// How often to send the trace data.
+	Period time.Duration
 }


### PR DESCRIPTION
Hello @jazzdan,

Please review the following commits I made in branch nicks/opentelemetry:

453fbb4d4142da11e341584ae78d17f7246bb559 (2020-06-22 12:02:03 -0400)
tiltfile: add a period= parameter to experimental_telemetry_cmd

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics