### PR TITLE
engine: partial roll forward of https://github.com/tilt-dev/tilt/pull/3505

### DIFF
--- a/internal/engine/build_and_deployer_test.go
+++ b/internal/engine/build_and_deployer_test.go
@@ -665,7 +665,7 @@ func TestContainerBuildMultiStage(t *testing.T) {
 	// the second does not --> second target needs build
 	iTargetID := targets[0].ID()
 	firstResult := store.NewImageBuildResultSingleRef(iTargetID, container.MustParseNamedTagged("sancho-base:tilt-prebuilt"))
-	bs[iTargetID] = store.NewBuildState(firstResult, nil)
+	bs[iTargetID] = store.NewBuildState(firstResult, nil, nil)
 
 	result, err := f.bd.BuildAndDeploy(f.ctx, f.st, targets, bs)
 	if err != nil {
@@ -838,9 +838,9 @@ func TestOneLiveUpdateOneDockerBuildDoesImageBuild(t *testing.T) {
 		WithImageTargets(sanchoTarg, sidecarTarg).
 		Build()
 	changed := f.WriteFile("a.txt", "a")
-	sanchoState := store.NewBuildState(store.NewImageBuildResultSingleRef(sanchoTarg.ID(), sanchoRef), []string{changed}).
+	sanchoState := store.NewBuildState(store.NewImageBuildResultSingleRef(sanchoTarg.ID(), sanchoRef), []string{changed}, nil).
 		WithRunningContainers([]store.ContainerInfo{sanchoCInfo})
-	sidecarState := store.NewBuildState(store.NewImageBuildResultSingleRef(sidecarTarg.ID(), sidecarRef), []string{changed})
+	sidecarState := store.NewBuildState(store.NewImageBuildResultSingleRef(sidecarTarg.ID(), sidecarRef), []string{changed}, nil)
 
 	bs := store.BuildStateSet{sanchoTarg.ID(): sanchoState, sidecarTarg.ID(): sidecarState}
 
@@ -986,9 +986,9 @@ func multiImageLiveUpdateManifestAndBuildState(f *bdFixture) (model.Manifest, st
 		Build()
 
 	changed := f.WriteFile("a.txt", "a")
-	sanchoState := store.NewBuildState(store.NewImageBuildResultSingleRef(sanchoTarg.ID(), sanchoRef), []string{changed}).
+	sanchoState := store.NewBuildState(store.NewImageBuildResultSingleRef(sanchoTarg.ID(), sanchoRef), []string{changed}, nil).
 		WithRunningContainers([]store.ContainerInfo{sanchoCInfo})
-	sidecarState := store.NewBuildState(store.NewImageBuildResultSingleRef(sidecarTarg.ID(), sidecarRef), []string{changed}).
+	sidecarState := store.NewBuildState(store.NewImageBuildResultSingleRef(sidecarTarg.ID(), sidecarRef), []string{changed}, nil).
 		WithRunningContainers([]store.ContainerInfo{sidecarCInfo})
 
 	bs := store.BuildStateSet{sanchoTarg.ID(): sanchoState, sidecarTarg.ID(): sidecarState}
@@ -1117,7 +1117,7 @@ func (f *bdFixture) createBuildStateSet(manifest model.Manifest, changedFiles []
 			}
 		}
 
-		state := store.NewBuildState(alreadyBuilt, filesChangingImage)
+		state := store.NewBuildState(alreadyBuilt, filesChangingImage, nil)
 		if manifest.IsImageDeployed(iTarget) {
 			state = state.WithRunningContainers([]store.ContainerInfo{testContainerInfo})
 		}
@@ -1135,7 +1135,7 @@ func (f *bdFixture) createBuildStateSet(manifest model.Manifest, changedFiles []
 func resultToStateSet(resultSet store.BuildResultSet, files []string, cInfo store.ContainerInfo) store.BuildStateSet {
 	stateSet := store.BuildStateSet{}
 	for id, result := range resultSet {
-		state := store.NewBuildState(result, files).WithRunningContainers([]store.ContainerInfo{cInfo})
+		state := store.NewBuildState(result, files, nil).WithRunningContainers([]store.ContainerInfo{cInfo})
 		stateSet[id] = state
 	}
 	return stateSet

--- a/internal/engine/buildcontrol/build_control.go
+++ b/internal/engine/buildcontrol/build_control.go
@@ -92,6 +92,9 @@ func RemoveTargetsWithBuildingComponents(mts []*store.ManifestTarget) []*store.M
 	for _, mt := range mts {
 		if mt.State.IsBuilding() {
 			building[mt.Manifest.ID()] = true
+
+			// TODO(nick): This logic isn't quite right.  A manifest can re-use image
+			// results from another manifest's build.
 			for _, spec := range mt.Manifest.TargetSpecs() {
 				building[spec.ID()] = true
 			}
@@ -219,8 +222,9 @@ func IsBuildingLocalTarget(state store.EngineState) bool {
 }
 
 // Go through all the manifests, and check:
-// 1) all pending file changes, and
-// 2) all pending manifest changes
+// 1) all pending file changes
+// 2) all pending dependency changes (where an image has been rebuilt by another manifest), and
+// 3) all pending manifest changes
 // The earliest one is the one we want.
 //
 // If no targets are pending, return nil

--- a/internal/engine/buildcontroller.go
+++ b/internal/engine/buildcontroller.go
@@ -172,7 +172,12 @@ func buildStateSet(ctx context.Context, manifest model.Manifest, specs []model.T
 		}
 		sort.Strings(filesChanged)
 
-		buildState := store.NewBuildState(status.LastSuccessfulResult, filesChanged)
+		var depsChanged []model.TargetID
+		for dep := range status.PendingDependencyChanges {
+			depsChanged = append(depsChanged, dep)
+		}
+
+		buildState := store.NewBuildState(status.LastSuccessfulResult, filesChanged, depsChanged)
 
 		// Pass along the container when we can update containers in-place.
 		//

--- a/internal/engine/docker_compose_build_and_deployer_test.go
+++ b/internal/engine/docker_compose_build_and_deployer_test.go
@@ -144,7 +144,7 @@ func TestMultiStageDockerComposeWithOnlyOneDirtyImage(t *testing.T) {
 
 	iTargetID := manifest.ImageTargets[0].ID()
 	result := store.NewImageBuildResultSingleRef(iTargetID, container.MustParseNamedTagged("sancho-base:tilt-prebuilt"))
-	state := store.NewBuildState(result, nil)
+	state := store.NewBuildState(result, nil, nil)
 	stateSet := store.BuildStateSet{iTargetID: state}
 	f.dCli.ImageListCount = 1
 	_, err := f.dcbad.BuildAndDeploy(f.ctx, f.st, buildTargets(manifest), stateSet)

--- a/internal/engine/extractors.go
+++ b/internal/engine/extractors.go
@@ -52,6 +52,10 @@ func extractImageTargetsForLiveUpdates(specs []model.TargetSpec, stateSet store.
 			return nil, buildcontrol.SilentRedirectToNextBuilderf("Force update (triggered manually, not automatically, with no dirty files)")
 		}
 
+		if len(state.DepsChangedSet) > 0 {
+			return nil, buildcontrol.SilentRedirectToNextBuilderf("Pending dependencies")
+		}
+
 		hasFileChangesIDs, err := hasFileChangesTree(g, iTarget, stateSet)
 		if err != nil {
 			return nil, errors.Wrap(err, "extractImageTargetsForLiveUpdates")

--- a/internal/engine/image_build_and_deployer_test.go
+++ b/internal/engine/image_build_and_deployer_test.go
@@ -169,7 +169,7 @@ func TestImageIsClean(t *testing.T) {
 	result1 := store.NewImageBuildResultSingleRef(iTargetID1, container.MustParseNamedTagged("sancho-base:tilt-prebuilt1"))
 
 	stateSet := store.BuildStateSet{
-		iTargetID1: store.NewBuildState(result1, []string{}),
+		iTargetID1: store.NewBuildState(result1, []string{}, nil),
 	}
 	_, err := f.ibd.BuildAndDeploy(f.ctx, f.st, buildTargets(manifest), stateSet)
 	if err != nil {
@@ -193,7 +193,7 @@ func TestImageIsDirtyAfterContainerBuild(t *testing.T) {
 		[]container.ID{container.ID("12345")})
 
 	stateSet := store.BuildStateSet{
-		iTargetID1: store.NewBuildState(result1, []string{}),
+		iTargetID1: store.NewBuildState(result1, []string{}, nil),
 	}
 	_, err := f.ibd.BuildAndDeploy(f.ctx, f.st, buildTargets(manifest), stateSet)
 	if err != nil {
@@ -292,8 +292,8 @@ func TestMultiStageDockerBuildWithFirstImageDirty(t *testing.T) {
 	newFile := f.WriteFile("sancho-base/message.txt", "message")
 
 	stateSet := store.BuildStateSet{
-		iTargetID1: store.NewBuildState(result1, []string{newFile}),
-		iTargetID2: store.NewBuildState(result2, nil),
+		iTargetID1: store.NewBuildState(result1, []string{newFile}, nil),
+		iTargetID2: store.NewBuildState(result2, nil, nil),
 	}
 	_, err := f.ibd.BuildAndDeploy(f.ctx, f.st, buildTargets(manifest), stateSet)
 	if err != nil {
@@ -328,8 +328,8 @@ func TestMultiStageDockerBuildWithSecondImageDirty(t *testing.T) {
 	newFile := f.WriteFile("sancho/message.txt", "message")
 
 	stateSet := store.BuildStateSet{
-		iTargetID1: store.NewBuildState(result1, nil),
-		iTargetID2: store.NewBuildState(result2, []string{newFile}),
+		iTargetID1: store.NewBuildState(result1, nil, nil),
+		iTargetID2: store.NewBuildState(result2, []string{newFile}, nil),
 	}
 	_, err := f.ibd.BuildAndDeploy(f.ctx, f.st, buildTargets(manifest), stateSet)
 	if err != nil {
@@ -926,7 +926,7 @@ func (f *ibdFixture) TearDown() {
 func (f *ibdFixture) resultsToNextState(results store.BuildResultSet) store.BuildStateSet {
 	stateSet := store.BuildStateSet{}
 	for id, result := range results {
-		stateSet[id] = store.NewBuildState(result, nil)
+		stateSet[id] = store.NewBuildState(result, nil, nil)
 	}
 	return stateSet
 }

--- a/internal/store/build_result.go
+++ b/internal/store/build_result.go
@@ -275,6 +275,9 @@ type BuildState struct {
 	// This must be liberal: it's ok if this has too many files, but not ok if it has too few.
 	FilesChangedSet map[string]bool
 
+	// Dependencies changed since the last result was built
+	DepsChangedSet map[model.TargetID]bool
+
 	// There are three kinds of triggers:
 	//
 	// 1) If a resource is in trigger_mode=TRIGGER_MODE_AUTO, then the resource auto-builds.
@@ -297,14 +300,19 @@ type BuildState struct {
 	RunningContainerError error
 }
 
-func NewBuildState(result BuildResult, files []string) BuildState {
+func NewBuildState(result BuildResult, files []string, pendingDeps []model.TargetID) BuildState {
 	set := make(map[string]bool, len(files))
 	for _, f := range files {
 		set[f] = true
 	}
+	depsSet := make(map[model.TargetID]bool, len(pendingDeps))
+	for _, d := range pendingDeps {
+		depsSet[d] = true
+	}
 	return BuildState{
 		LastSuccessfulResult: result,
 		FilesChangedSet:      set,
+		DepsChangedSet:       depsSet,
 	}
 }
 
@@ -366,7 +374,10 @@ func (b BuildState) HasLastSuccessfulResult() bool {
 func (b BuildState) NeedsImageBuild() bool {
 	lastBuildWasImgBuild := b.LastSuccessfulResult != nil &&
 		b.LastSuccessfulResult.BuildType() == model.BuildTypeImage
-	return !lastBuildWasImgBuild || len(b.FilesChangedSet) > 0 || b.FullBuildTriggered
+	return !lastBuildWasImgBuild ||
+		len(b.FilesChangedSet) > 0 ||
+		len(b.DepsChangedSet) > 0 ||
+		b.FullBuildTriggered
 }
 
 type BuildStateSet map[model.TargetID]BuildState

--- a/pkg/model/build_reason.go
+++ b/pkg/model/build_reason.go
@@ -21,6 +21,14 @@ const (
 
 	// An external process called `tilt args`
 	BuildReasonFlagTiltfileArgs
+
+	// Suppose you have
+	// manifestA with imageA depending on imageCommon
+	// manifestB with imageB depending on imageCommon
+	//
+	// Building manifestA will mark imageB
+	// with changed dependencies.
+	BuildReasonFlagChangedDeps
 )
 
 func (r BuildReason) With(flag BuildReason) BuildReason {
@@ -53,6 +61,7 @@ var translations = map[BuildReason]string{
 	BuildReasonFlagTriggerCLI:     "CLI Trigger",
 	BuildReasonFlagTriggerUnknown: "Unknown Trigger",
 	BuildReasonFlagTiltfileArgs:   "Tilt Args",
+	BuildReasonFlagChangedDeps:    "Dependency Updated",
 }
 
 var triggerBuildReasons = []BuildReason{
@@ -68,6 +77,7 @@ var allBuildReasons = []BuildReason{
 	BuildReasonFlagCrash,
 	BuildReasonFlagTriggerWeb,
 	BuildReasonFlagTriggerCLI,
+	BuildReasonFlagChangedDeps,
 	BuildReasonFlagTriggerUnknown,
 	BuildReasonFlagTiltfileArgs,
 }

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -141,6 +141,15 @@ func (m Manifest) WithTriggerMode(mode TriggerMode) Manifest {
 	return m
 }
 
+func (m Manifest) TargetIDSet() map[TargetID]bool {
+	result := make(map[TargetID]bool)
+	specs := m.TargetSpecs()
+	for _, spec := range specs {
+		result[spec.ID()] = true
+	}
+	return result
+}
+
 func (m Manifest) TargetSpecs() []TargetSpec {
 	result := []TargetSpec{}
 	for _, t := range m.ImageTargets {


### PR DESCRIPTION
Hello @landism,

Please review the following commits I made in branch nicks/depchange:

201e1e055898672da2b4a5fad64bbc5307f24be0 (2020-06-24 16:06:55 -0400)
engine: partial roll forward of ee10a5081bb258073aca30950ca7c5abd89c22bb
Adds the fields to the data model for recording dependency changes,
but doesn't yet propagate those changes.

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics