### PR TITLE
k8s: factor out an interface for extracting/injecting images

### DIFF
--- a/internal/k8s/entity.go
+++ b/internal/k8s/entity.go
@@ -334,8 +334,8 @@ func Filter(entities []K8sEntity, test func(e K8sEntity) (bool, error)) (passing
 	return passing, rest, nil
 }
 
-func FilterByImage(entities []K8sEntity, img container.RefSelector, imageJSONPaths func(K8sEntity) []JSONPath, inEnvVars bool) (passing, rest []K8sEntity, err error) {
-	return Filter(entities, func(e K8sEntity) (bool, error) { return e.HasImage(img, imageJSONPaths(e), inEnvVars) })
+func FilterByImage(entities []K8sEntity, img container.RefSelector, locators []ImageLocator, inEnvVars bool) (passing, rest []K8sEntity, err error) {
+	return Filter(entities, func(e K8sEntity) (bool, error) { return e.HasImage(img, locators, inEnvVars) })
 }
 
 func FilterBySelectorMatchesLabels(entities []K8sEntity, labels map[string]string) (passing, rest []K8sEntity, err error) {

--- a/internal/k8s/image_test.go
+++ b/internal/k8s/image_test.go
@@ -279,15 +279,17 @@ func TestEntityHasImage(t *testing.T) {
 
 	img = container.MustParseTaggedSelector("docker.io/bitnami/minideb:latest")
 	e := entities[0]
-	jp, err := NewJSONPath("{.spec.validation.openAPIV3Schema.properties.spec.properties.image}")
-	if err != nil {
-		t.Fatal(err)
-	}
-	imageJSONPaths := []JSONPath{jp}
-	match, err = e.HasImage(img, imageJSONPaths, false)
-	if err != nil {
-		t.Fatal(err)
-	}
+	selector, err := NewPartialMatchObjectSelector("", "", "projects.example.martin-helmich.de", "")
+	require.NoError(t, err)
+
+	jp, err := NewJSONPathImageLocator(
+		selector,
+		"{.spec.validation.openAPIV3Schema.properties.spec.properties.image}")
+	require.NoError(t, err)
+
+	match, err = e.HasImage(img, []ImageLocator{jp}, false)
+	require.NoError(t, err)
+
 	assert.True(t, match, "CRD yaml should match image %s", img.String())
 
 	entities, err = ParseYAMLFromString(testyaml.SanchoImageInEnvYAML)

--- a/internal/k8s/locator.go
+++ b/internal/k8s/locator.go
@@ -1,0 +1,75 @@
+package k8s
+
+import (
+	"github.com/docker/distribution/reference"
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/tilt-dev/tilt/internal/container"
+)
+
+type ImageLocator interface {
+	// Find all the images in this entity.
+	Extract(e K8sEntity) ([]reference.Named, error)
+
+	// Matches the type of this entity.
+	MatchesType(e K8sEntity) bool
+
+	// Find all the images in this entity that match the given selector,
+	// and replace them with the injected ref.
+	//
+	// Returns a new entity with the injected ref.  Returns a boolean indicated
+	// whether there was at least one successful injection.
+	//Inject(e K8sEntity, selector container.RefSelector, injectRef reference.Named) (K8sEntity, bool, error)
+}
+
+type JSONPathImageLocator struct {
+	selector ObjectSelector
+	path     JSONPath
+}
+
+func NewJSONPathImageLocator(selector ObjectSelector, path string) (*JSONPathImageLocator, error) {
+	p, err := NewJSONPath(path)
+	if err != nil {
+		return nil, err
+	}
+	return &JSONPathImageLocator{
+		selector: selector,
+		path:     p,
+	}, nil
+}
+
+func (l *JSONPathImageLocator) MatchesType(e K8sEntity) bool {
+	return l.selector.Matches(e)
+}
+
+func (l *JSONPathImageLocator) Extract(e K8sEntity) ([]reference.Named, error) {
+	if !l.selector.Matches(e) {
+		return nil, nil
+	}
+
+	var obj interface{}
+	if u, ok := e.Obj.(runtime.Unstructured); ok {
+		obj = u.UnstructuredContent()
+	} else {
+		obj = e.Obj
+	}
+
+	// also look for images in any json paths that were specified for this entity
+	images, err := l.path.FindStrings(obj)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]reference.Named, 0, len(images))
+	for _, image := range images {
+		ref, err := container.ParseNamed(image)
+		if err != nil {
+			return nil, errors.Wrapf(err, "error parsing image '%s' at json path '%s'", image, l.path)
+		}
+		result = append(result, ref)
+	}
+	return result, nil
+}
+
+var _ ImageLocator = &JSONPathImageLocator{}

--- a/internal/k8s/object_selector.go
+++ b/internal/k8s/object_selector.go
@@ -1,0 +1,111 @@
+package k8s
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/pkg/errors"
+)
+
+// A selector matches an entity if all non-empty selector fields match the corresponding entity fields
+type ObjectSelector struct {
+	apiVersion       *regexp.Regexp
+	apiVersionString string
+	kind             *regexp.Regexp
+	kindString       string
+
+	// TODO(dmiller): do something like this instead https://github.com/tilt-dev/tilt/blob/c2b2df88de3777eed5f1bb9f54b5c555707c8b42/internal/container/selector.go#L9
+	name            *regexp.Regexp
+	nameString      string
+	namespace       *regexp.Regexp
+	namespaceString string
+}
+
+// TODO(dmiller): this function and newPartialMatchK8sObjectSelector
+// should be written in to a form that can be used like this
+// x := re{pattern: name, ignoreCase: true, fullMatch: true}
+// x.compile()
+// rather than passing around and mutating regex strings
+
+// Creates a new ObjectSelector
+// If an arg is an empty string it will become an empty regex that matches all input
+// Otherwise the arg must match the input exactly
+func NewFullmatchCaseInsensitiveObjectSelector(apiVersion string, kind string, name string, namespace string) (ObjectSelector, error) {
+	ret := ObjectSelector{apiVersionString: apiVersion, kindString: kind, nameString: name, namespaceString: namespace}
+	var err error
+
+	ret.apiVersion, err = regexp.Compile(exactOrEmptyRegex(apiVersion))
+	if err != nil {
+		return ObjectSelector{}, errors.Wrap(err, "error parsing apiVersion regexp")
+	}
+
+	ret.kind, err = regexp.Compile(exactOrEmptyRegex(kind))
+	if err != nil {
+		return ObjectSelector{}, errors.Wrap(err, "error parsing kind regexp")
+	}
+
+	ret.name, err = regexp.Compile(exactOrEmptyRegex(name))
+	if err != nil {
+		return ObjectSelector{}, errors.Wrap(err, "error parsing name regexp")
+	}
+
+	ret.namespace, err = regexp.Compile(exactOrEmptyRegex(namespace))
+	if err != nil {
+		return ObjectSelector{}, errors.Wrap(err, "error parsing namespace regexp")
+	}
+
+	return ret, nil
+}
+
+func makeCaseInsensitive(s string) string {
+	if s == "" {
+		return s
+	} else {
+		return "(?i)" + s
+	}
+}
+
+func exactOrEmptyRegex(s string) string {
+	if s != "" {
+		s = fmt.Sprintf("^%s$", makeCaseInsensitive(regexp.QuoteMeta(s)))
+	}
+	return s
+}
+
+// Creates a new ObjectSelector
+// If an arg is an empty string, it will become an empty regex that matches all input
+// Otherwise the arg will match input from the beginning (prefix matching)
+func NewPartialMatchObjectSelector(apiVersion string, kind string, name string, namespace string) (ObjectSelector, error) {
+	ret := ObjectSelector{apiVersionString: apiVersion, kindString: kind, nameString: name, namespaceString: namespace}
+	var err error
+
+	ret.apiVersion, err = regexp.Compile(makeCaseInsensitive(apiVersion))
+	if err != nil {
+		return ObjectSelector{}, errors.Wrap(err, "error parsing apiVersion regexp")
+	}
+
+	ret.kind, err = regexp.Compile(makeCaseInsensitive(kind))
+	if err != nil {
+		return ObjectSelector{}, errors.Wrap(err, "error parsing kind regexp")
+	}
+
+	ret.name, err = regexp.Compile(makeCaseInsensitive(name))
+	if err != nil {
+		return ObjectSelector{}, errors.Wrap(err, "error parsing name regexp")
+	}
+
+	ret.namespace, err = regexp.Compile(makeCaseInsensitive(namespace))
+	if err != nil {
+		return ObjectSelector{}, errors.Wrap(err, "error parsing namespace regexp")
+	}
+
+	return ret, nil
+}
+
+func (k ObjectSelector) Matches(e K8sEntity) bool {
+	gvk := e.GVK()
+	return k.apiVersion.MatchString(gvk.GroupVersion().String()) &&
+		k.kind.MatchString(gvk.Kind) &&
+		k.name.MatchString(e.Name()) &&
+		k.namespace.MatchString(e.Namespace().String())
+}


### PR DESCRIPTION
Hello @jazzdan,

Please review the following commits I made in branch nicks/extract:

738d64af209d34a823fe1c6bd095ab0bbc8c565b (2020-06-24 19:47:38 -0400)
k8s: factor out an interface for extracting/injecting images
This is moving towards solutions for:
- https://github.com/tilt-dev/tilt/issues/3427
- https://github.com/tilt-dev/tilt/issues/3460

It ended up being kind of a yak shave, since we need to be able to attach
the object selectors to K8sTarget so that we know which entities to
inject into.

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics