### PR TITLE
tilt: indicate snapshot is private when running w/ a team id

### DIFF
--- a/web/src/ShareSnapshotModal.tsx
+++ b/web/src/ShareSnapshotModal.tsx
@@ -27,8 +27,9 @@ export default class ShareSnapshotModal extends PureComponent<props> {
         <h2 className="ShareSnapshotModal-title">Share a Shapshot</h2>
         <section className="ShareSnapshotModal-pane u-flexColumn">
           <p className="ShareSnapshotModal-description">
-            Get a link to a {this.props.tiltCloudTeamID ? "private team " : null} snapshot — a browsable, sharable view of the current
-            state of your Tilt session.
+            Get a link to a{" "}
+            {this.props.tiltCloudTeamID ? "private team " : null} snapshot — a
+            browsable, sharable view of the current state of your Tilt session.
           </p>
           {this.renderCallToAction()}
         </section>

--- a/web/src/ShareSnapshotModal.tsx
+++ b/web/src/ShareSnapshotModal.tsx
@@ -27,7 +27,7 @@ export default class ShareSnapshotModal extends PureComponent<props> {
         <h2 className="ShareSnapshotModal-title">Share a Shapshot</h2>
         <section className="ShareSnapshotModal-pane u-flexColumn">
           <p className="ShareSnapshotModal-description">
-            Get a link to a snapshot — a browsable, sharable view of the current
+            Get a link to a {this.props.tiltCloudTeamID ? "private team " : null} snapshot — a browsable, sharable view of the current
             state of your Tilt session.
           </p>
           {this.renderCallToAction()}

--- a/web/src/__snapshots__/ShareSnapshotModal.test.tsx.snap
+++ b/web/src/__snapshots__/ShareSnapshotModal.test.tsx.snap
@@ -37,7 +37,9 @@ exports[`ShareSnapshotModal renders team link 1`] = `
       <p
         className="ShareSnapshotModal-description"
       >
-        Get a link to a snapshot — a browsable, sharable view of the current state of your Tilt session.
+        Get a link to a 
+        private team 
+         snapshot — a browsable, sharable view of the current state of your Tilt session.
       </p>
       <section
         className="ShareSnapshotModal-shareLinkWrap"
@@ -158,7 +160,8 @@ exports[`ShareSnapshotModal renders with modal open w/ known username 1`] = `
       <p
         className="ShareSnapshotModal-description"
       >
-        Get a link to a snapshot — a browsable, sharable view of the current state of your Tilt session.
+        Get a link to a 
+         snapshot — a browsable, sharable view of the current state of your Tilt session.
       </p>
       <section
         className="ShareSnapshotModal-shareLinkWrap"
@@ -260,7 +263,8 @@ exports[`ShareSnapshotModal renders with modal open w/o known username 1`] = `
       <p
         className="ShareSnapshotModal-description"
       >
-        Get a link to a snapshot — a browsable, sharable view of the current state of your Tilt session.
+        Get a link to a 
+         snapshot — a browsable, sharable view of the current state of your Tilt session.
       </p>
       <section>
         <div
@@ -369,7 +373,8 @@ exports[`ShareSnapshotModal renders without snapshotUrl 1`] = `
       <p
         className="ShareSnapshotModal-description"
       >
-        Get a link to a snapshot — a browsable, sharable view of the current state of your Tilt session.
+        Get a link to a 
+         snapshot — a browsable, sharable view of the current state of your Tilt session.
       </p>
       <section>
         <div

--- a/web/src/__snapshots__/ShareSnapshotModal.test.tsx.snap
+++ b/web/src/__snapshots__/ShareSnapshotModal.test.tsx.snap
@@ -37,7 +37,8 @@ exports[`ShareSnapshotModal renders team link 1`] = `
       <p
         className="ShareSnapshotModal-description"
       >
-        Get a link to a 
+        Get a link to a
+         
         private team 
          snapshot — a browsable, sharable view of the current state of your Tilt session.
       </p>
@@ -160,7 +161,8 @@ exports[`ShareSnapshotModal renders with modal open w/ known username 1`] = `
       <p
         className="ShareSnapshotModal-description"
       >
-        Get a link to a 
+        Get a link to a
+         
          snapshot — a browsable, sharable view of the current state of your Tilt session.
       </p>
       <section
@@ -263,7 +265,8 @@ exports[`ShareSnapshotModal renders with modal open w/o known username 1`] = `
       <p
         className="ShareSnapshotModal-description"
       >
-        Get a link to a 
+        Get a link to a
+         
          snapshot — a browsable, sharable view of the current state of your Tilt session.
       </p>
       <section>
@@ -373,7 +376,8 @@ exports[`ShareSnapshotModal renders without snapshotUrl 1`] = `
       <p
         className="ShareSnapshotModal-description"
       >
-        Get a link to a 
+        Get a link to a
+         
          snapshot — a browsable, sharable view of the current state of your Tilt session.
       </p>
       <section>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/7453991/85877966-f704df80-b7a5-11ea-836f-243fd59c1d86.png)
