### PR TITLE
build: close the tar pipe, to avoid zombie goroutines

### DIFF
--- a/internal/build/docker_builder.go
+++ b/internal/build/docker_builder.go
@@ -153,6 +153,10 @@ func (d *dockerImageBuilder) buildFromDf(ctx context.Context, ps *PipelineState,
 		}
 	}(ctx)
 
+	defer func() {
+		_ = pr.Close()
+	}()
+
 	ps.StartBuildStep(ctx, "Building image")
 	spanBuild, ctx := opentracing.StartSpanFromContext(ctx, "daemon-ImageBuild")
 	imageBuildResponse, err := d.dCli.ImageBuild(

--- a/internal/engine/build_and_deployer_test.go
+++ b/internal/engine/build_and_deployer_test.go
@@ -553,7 +553,7 @@ func TestIgnoredFiles(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	tr := tar.NewReader(f.docker.BuildOptions.Context)
+	tr := tar.NewReader(f.docker.BuildContext)
 	testutils.AssertFilesInTar(t, tr, []expectedFile{
 		expectedFile{
 			Path:     "a.txt",

--- a/internal/engine/docker_compose_build_and_deployer_test.go
+++ b/internal/engine/docker_compose_build_and_deployer_test.go
@@ -132,7 +132,7 @@ RUN go install github.com/tilt-dev/sancho
 ENTRYPOINT /go/bin/sancho
 `,
 	}
-	testutils.AssertFileInTar(t, tar.NewReader(f.dCli.BuildOptions.Context), expected)
+	testutils.AssertFileInTar(t, tar.NewReader(f.dCli.BuildContext), expected)
 }
 
 func TestMultiStageDockerComposeWithOnlyOneDirtyImage(t *testing.T) {
@@ -164,7 +164,7 @@ RUN go install github.com/tilt-dev/sancho
 ENTRYPOINT /go/bin/sancho
 `,
 	}
-	testutils.AssertFileInTar(t, tar.NewReader(f.dCli.BuildOptions.Context), expected)
+	testutils.AssertFileInTar(t, tar.NewReader(f.dCli.BuildContext), expected)
 }
 
 type dcbdFixture struct {

--- a/internal/engine/image_build_and_deployer_test.go
+++ b/internal/engine/image_build_and_deployer_test.go
@@ -231,7 +231,7 @@ RUN go install github.com/tilt-dev/sancho
 ENTRYPOINT /go/bin/sancho
 `,
 	}
-	testutils.AssertFileInTar(t, tar.NewReader(f.docker.BuildOptions.Context), expected)
+	testutils.AssertFileInTar(t, tar.NewReader(f.docker.BuildContext), expected)
 }
 
 func TestMultiStageDockerBuildPreservesSyntaxDirective(t *testing.T) {
@@ -278,7 +278,7 @@ RUN go install github.com/tilt-dev/sancho
 ENTRYPOINT /go/bin/sancho
 `,
 	}
-	testutils.AssertFileInTar(t, tar.NewReader(f.docker.BuildOptions.Context), expected)
+	testutils.AssertFileInTar(t, tar.NewReader(f.docker.BuildContext), expected)
 }
 
 func TestMultiStageDockerBuildWithFirstImageDirty(t *testing.T) {
@@ -314,7 +314,7 @@ RUN go install github.com/tilt-dev/sancho
 ENTRYPOINT /go/bin/sancho
 `,
 	}
-	testutils.AssertFileInTar(t, tar.NewReader(f.docker.BuildOptions.Context), expected)
+	testutils.AssertFileInTar(t, tar.NewReader(f.docker.BuildContext), expected)
 }
 
 func TestMultiStageDockerBuildWithSecondImageDirty(t *testing.T) {
@@ -349,7 +349,7 @@ RUN go install github.com/tilt-dev/sancho
 ENTRYPOINT /go/bin/sancho
 `,
 	}
-	testutils.AssertFileInTar(t, tar.NewReader(f.docker.BuildOptions.Context), expected)
+	testutils.AssertFileInTar(t, tar.NewReader(f.docker.BuildContext), expected)
 }
 
 func TestK8sUpsertTimeout(t *testing.T) {


### PR DESCRIPTION
Hello @jazzdan,

Please review the following commits I made in branch nicks/close:

e55aebeb4e5834d42ea6037c7b7ebbce48b93c94 (2020-06-26 16:14:18 -0400)
build: close the tar pipe, to avoid zombie goroutines
I was finding it hard to debug some tests because there were zombie
goroutines blocked forever on writing to the pipe. This changes
the semantics so that ImageBuild must consume the pipe.

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics