### PR TITLE
engine: handle tiltignore and team loading correctly if execution failed

### DIFF
--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -484,6 +484,16 @@ func handleConfigsReloaded(
 	// Retroactively scrub secrets
 	state.LogStore.ScrubSecretsStartingAt(newSecrets, event.CheckpointAtExecStart)
 
+	// Add tiltignore if it exists, even if execution failed.
+	if event.TiltIgnoreContents != "" || event.Err != nil {
+		state.TiltIgnoreContents = event.TiltIgnoreContents
+	}
+
+	// Add team id if it exists, even if execution failed.
+	if event.TeamID != "" || event.Err != nil {
+		state.TeamID = event.TeamID
+	}
+
 	// if the ConfigsReloadedAction came from a unit test, there might not be a current build
 	if !b.Empty() {
 		b.FinishTime = event.FinishTime
@@ -552,10 +562,8 @@ func handleConfigsReloaded(
 	// TODO(maia): update ConfigsManifest with new ConfigFiles/update watches
 	state.ManifestDefinitionOrder = newDefOrder
 	state.ConfigFiles = event.ConfigFiles
-	state.TiltIgnoreContents = event.TiltIgnoreContents
 
 	state.Features = event.Features
-	state.TeamID = event.TeamID
 	state.TelemetrySettings = event.TelemetrySettings
 	state.VersionSettings = event.VersionSettings
 	state.AnalyticsTiltfileOpt = event.AnalyticsTiltfileOpt


### PR DESCRIPTION
Hello @jazzdan, @landism,

Please review the following commits I made in branch nicks/ch8109:

d6fdf40ce4773816c64237e58f8a8ec567c73360 (2020-06-26 20:43:19 -0400)
engine: handle tiltignore and team loading correctly if execution failed

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics