### PR TITLE
k8s: add a locator for image objects

### DIFF
--- a/internal/k8s/image_test.go
+++ b/internal/k8s/image_test.go
@@ -271,13 +271,15 @@ func TestEntityHasImage(t *testing.T) {
 		t.Fatal(err)
 	}
 	assert.False(t, match, "deployment yaml should not match image %s", img.String())
+}
 
-	entities, err = ParseYAMLFromString(testyaml.CRDYAML)
+func TestCRDExtract(t *testing.T) {
+	entities, err := ParseYAMLFromString(testyaml.CRDYAML)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	img = container.MustParseTaggedSelector("docker.io/bitnami/minideb:latest")
+	img := container.MustParseTaggedSelector("docker.io/bitnami/minideb:latest")
 	e := entities[0]
 	selector, err := NewPartialMatchObjectSelector("", "", "projects.example.martin-helmich.de", "")
 	require.NoError(t, err)
@@ -287,18 +289,20 @@ func TestEntityHasImage(t *testing.T) {
 		"{.spec.validation.openAPIV3Schema.properties.spec.properties.image}")
 	require.NoError(t, err)
 
-	match, err = e.HasImage(img, []ImageLocator{jp}, false)
+	match, err := e.HasImage(img, []ImageLocator{jp}, false)
 	require.NoError(t, err)
 
 	assert.True(t, match, "CRD yaml should match image %s", img.String())
+}
 
-	entities, err = ParseYAMLFromString(testyaml.SanchoImageInEnvYAML)
+func TestEnvExtract(t *testing.T) {
+	entities, err := ParseYAMLFromString(testyaml.SanchoImageInEnvYAML)
 	if err != nil {
 		t.Fatal(err)
 	}
-	img = container.MustParseSelector("gcr.io/some-project-162817/sancho")
-	e = entities[0]
-	match, err = e.HasImage(img, nil, false)
+	img := container.MustParseSelector("gcr.io/some-project-162817/sancho")
+	e := entities[0]
+	match, err := e.HasImage(img, nil, false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/k8s/locator_test.go
+++ b/internal/k8s/locator_test.go
@@ -1,0 +1,34 @@
+package k8s
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tilt-dev/tilt/internal/container"
+	"github.com/tilt-dev/tilt/internal/k8s/testyaml"
+)
+
+func TestCRDImageObjectInjection(t *testing.T) {
+	entities, err := ParseYAMLFromString(testyaml.CRDImageObjectYAML)
+	require.NoError(t, err)
+
+	e := entities[0]
+	selector := MustKindSelector("UselessMachine")
+	locator := MustJSONPathImageObjectLocator(selector, "{.spec.imageObject}", "repo", "tag")
+	images, err := locator.Extract(e)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(images))
+	assert.Equal(t, "docker.io/library/frontend", images[0].String())
+
+	e, modified, err := locator.Inject(e, container.MustParseSelector("frontend"),
+		container.MustParseNamed("frontend:tilt-123"))
+	require.NoError(t, err)
+	assert.True(t, modified)
+
+	images, err = locator.Extract(e)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(images))
+	assert.Equal(t, "docker.io/library/frontend:tilt-123", images[0].String())
+}

--- a/internal/k8s/object_selector.go
+++ b/internal/k8s/object_selector.go
@@ -120,6 +120,13 @@ func NewPartialMatchObjectSelector(apiVersion string, kind string, name string, 
 	return ret, nil
 }
 
+func (o1 ObjectSelector) EqualsSelector(o2 ObjectSelector) bool {
+	return o1.name == o2.name &&
+		o1.namespace == o2.namespace &&
+		o1.kind == o2.kind &&
+		o1.apiVersion == o2.apiVersion
+}
+
 func (k ObjectSelector) Matches(e K8sEntity) bool {
 	gvk := e.GVK()
 	return k.apiVersion.MatchString(gvk.GroupVersion().String()) &&

--- a/internal/k8s/testyaml/testyaml.go
+++ b/internal/k8s/testyaml/testyaml.go
@@ -1424,6 +1424,15 @@ spec:
 
 const CRDImage = "docker.io/bitnami/minideb:latest"
 
+const CRDImageObjectYAML = `apiVersion: tilt.dev/v1alpha1
+kind: UselessMachine
+metadata:
+  name: um
+spec:
+  imageObject:
+    repo: frontend
+`
+
 const MyNamespaceYAML = `apiVersion: v1
 kind: Namespace
 metadata:


### PR DESCRIPTION
Hello @landism, @jazzdan,

Please review the following commits I made in branch nicks/locators:

d6af15ae8a3b8cd809598650b1953d645b102827 (2020-06-29 12:46:56 -0400)
k8s: add a locator for image objects
This is moving towards https://github.com/tilt-dev/tilt/issues/3427,
but also is a good model of how to write new kinds of image locators

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics