### PR TITLE
store: Use the NonWorkload field to determine runtime status

### DIFF
--- a/internal/engine/exit/controller_test.go
+++ b/internal/engine/exit/controller_test.go
@@ -105,7 +105,8 @@ func TestExitControlCIFirstRuntimeFailure(t *testing.T) {
 	assert.False(t, f.store.exitSignal)
 
 	f.store.WithState(func(state *store.EngineState) {
-		state.ManifestTargets["fe"].State.RuntimeState = store.NewK8sRuntimeState("fe", store.Pod{
+		mt := state.ManifestTargets["fe"]
+		mt.State.RuntimeState = store.NewK8sRuntimeState(mt.Manifest, store.Pod{
 			PodID:  "pod-a",
 			Status: "ErrImagePull",
 			Containers: []store.Container{
@@ -141,14 +142,15 @@ func TestExitControlCISuccess(t *testing.T) {
 			StartTime:  time.Now(),
 			FinishTime: time.Now(),
 		})
-		state.ManifestTargets["fe"].State.RuntimeState = store.NewK8sRuntimeState("fe", readyPod("pod-a"))
+		state.ManifestTargets["fe"].State.RuntimeState = store.NewK8sRuntimeState(m, readyPod("pod-a"))
 	})
 
 	f.c.OnChange(f.ctx, f.store)
 	assert.False(t, f.store.exitSignal)
 
 	f.store.WithState(func(state *store.EngineState) {
-		state.ManifestTargets["fe2"].State.RuntimeState = store.NewK8sRuntimeState("fe2", readyPod("pod-b"))
+		mt := state.ManifestTargets["fe2"]
+		mt.State.RuntimeState = store.NewK8sRuntimeState(mt.Manifest, readyPod("pod-b"))
 	})
 
 	// Verify that if one pod fails with an error, it fails immediately.
@@ -169,14 +171,15 @@ func TestExitControlCIJobSuccess(t *testing.T) {
 			StartTime:  time.Now(),
 			FinishTime: time.Now(),
 		})
-		state.ManifestTargets["fe"].State.RuntimeState = store.NewK8sRuntimeState("fe", readyPod("pod-a"))
+		state.ManifestTargets["fe"].State.RuntimeState = store.NewK8sRuntimeState(m, readyPod("pod-a"))
 	})
 
 	f.c.OnChange(f.ctx, f.store)
 	assert.False(t, f.store.exitSignal)
 
 	f.store.WithState(func(state *store.EngineState) {
-		state.ManifestTargets["fe"].State.RuntimeState = store.NewK8sRuntimeState("fe", successPod("pod-a"))
+		mt := state.ManifestTargets["fe"]
+		mt.State.RuntimeState = store.NewK8sRuntimeState(mt.Manifest, successPod("pod-a"))
 	})
 
 	// Verify that if one pod fails with an error, it fails immediately.
@@ -193,11 +196,12 @@ func TestExitControlCIDontBlockOnAutoInitFalse(t *testing.T) {
 		manifestAutoInitTrue := manifestbuilder.New(f, "fe").WithK8sYAML(testyaml.JobYAML).Build()
 		state.UpsertManifestTarget(store.NewManifestTarget(manifestAutoInitTrue))
 
-		state.ManifestTargets["fe"].State.AddCompletedBuild(model.BuildRecord{
+		mt := state.ManifestTargets["fe"]
+		mt.State.AddCompletedBuild(model.BuildRecord{
 			StartTime:  time.Now(),
 			FinishTime: time.Now(),
 		})
-		state.ManifestTargets["fe"].State.RuntimeState = store.NewK8sRuntimeState("fe", readyPod("pod-a"))
+		mt.State.RuntimeState = store.NewK8sRuntimeState(mt.Manifest, readyPod("pod-a"))
 
 		manifestAutoInitFalse := manifestbuilder.New(f, "local").WithLocalResource("echo hi", nil).
 			WithTriggerMode(model.TriggerModeManualIncludingInitial).Build()
@@ -208,7 +212,8 @@ func TestExitControlCIDontBlockOnAutoInitFalse(t *testing.T) {
 	assert.False(t, f.store.exitSignal)
 
 	f.store.WithState(func(state *store.EngineState) {
-		state.ManifestTargets["fe"].State.RuntimeState = store.NewK8sRuntimeState("fe", successPod("pod-a"))
+		mt := state.ManifestTargets["fe"]
+		mt.State.RuntimeState = store.NewK8sRuntimeState(mt.Manifest, successPod("pod-a"))
 	})
 
 	// Verify that if one pod fails with an error, it fails immediately.

--- a/internal/engine/k8swatch/event_watch_manager_test.go
+++ b/internal/engine/k8swatch/event_watch_manager_test.go
@@ -201,7 +201,7 @@ func (f *ewmFixture) addDeployedUID(m model.Manifest, uid types.UID) {
 	if !ok {
 		f.t.Fatalf("Unknown manifest: %s", m.Name)
 	}
-	runtimeState := mState.GetOrCreateK8sRuntimeState()
+	runtimeState := mState.K8sRuntimeState()
 	runtimeState.DeployedUIDSet[uid] = true
 }
 

--- a/internal/engine/k8swatch/pod_watch_test.go
+++ b/internal/engine/k8swatch/pod_watch_test.go
@@ -401,7 +401,7 @@ func (f *pwFixture) addDeployedUID(m model.Manifest, uid types.UID) {
 	if !ok {
 		f.t.Fatalf("Unknown manifest: %s", m.Name)
 	}
-	runtimeState := mState.GetOrCreateK8sRuntimeState()
+	runtimeState := mState.K8sRuntimeState()
 	runtimeState.DeployedUIDSet[uid] = true
 }
 

--- a/internal/engine/k8swatch/service_watch_test.go
+++ b/internal/engine/k8swatch/service_watch_test.go
@@ -96,7 +96,7 @@ func (f *swFixture) addDeployedUID(m model.Manifest, uid types.UID) {
 	if !ok {
 		f.t.Fatalf("Unknown manifest: %s", m.Name)
 	}
-	runtimeState := mState.GetOrCreateK8sRuntimeState()
+	runtimeState := mState.K8sRuntimeState()
 	runtimeState.DeployedUIDSet[uid] = true
 }
 

--- a/internal/engine/pod.go
+++ b/internal/engine/pod.go
@@ -111,7 +111,7 @@ func matchPodChangeToManifest(state *store.EngineState, action k8swatch.PodChang
 	}
 
 	ms := mt.State
-	runtime := ms.GetOrCreateK8sRuntimeState()
+	runtime := ms.K8sRuntimeState()
 
 	// If the event has an ancestor UID attached, but that ancestor isn't in the
 	// deployed UID set anymore, we can ignore it.
@@ -129,7 +129,7 @@ func matchPodChangeToManifest(state *store.EngineState, action k8swatch.PodChang
 func maybeTrackPod(ms *store.ManifestState, action k8swatch.PodChangeAction) (*store.Pod, bool) {
 	pod := action.Pod
 	podID := k8s.PodIDFromPod(pod)
-	runtime := ms.GetOrCreateK8sRuntimeState()
+	runtime := ms.K8sRuntimeState()
 	isCurrentDeploy := runtime.HasOKPodTemplateSpecHash(pod) // is pod from the most recent Tilt deploy?
 
 	// Only attach a new pod to the runtime state if it's from the current deploy;
@@ -278,7 +278,7 @@ func checkForContainerCrash(ctx context.Context, state *store.EngineState, mt *s
 // that they don't clutter the output.
 func prunePods(ms *store.ManifestState) {
 	// Always remove pods that were manually deleted.
-	runtime := ms.GetOrCreateK8sRuntimeState()
+	runtime := ms.K8sRuntimeState()
 	for key, pod := range runtime.Pods {
 		if pod.Deleting {
 			delete(runtime.Pods, key)

--- a/internal/engine/pod_test.go
+++ b/internal/engine/pod_test.go
@@ -24,7 +24,7 @@ func TestPodDeleteAction(t *testing.T) {
 	m, _ := f.state.Manifest("sancho")
 	hash := k8s.PodTemplateSpecHash("ptsh")
 	pod := podbuilder.New(f.T(), m).WithTemplateSpecHash(hash).Build()
-	runtime := ms.GetOrCreateK8sRuntimeState()
+	runtime := ms.K8sRuntimeState()
 	runtime.DeployedPodTemplateSpecHashSet.Add(hash)
 
 	assert.Equal(t, 0, len(ms.K8sRuntimeState().Pods))

--- a/internal/engine/portforward/controller_test.go
+++ b/internal/engine/portforward/controller_test.go
@@ -41,7 +41,9 @@ func TestPortForward(t *testing.T) {
 	assert.Equal(t, 0, len(f.plc.activeForwards))
 
 	state = f.st.LockMutableStateForTesting()
-	state.ManifestTargets["fe"].State.RuntimeState = store.NewK8sRuntimeState("fe", store.Pod{PodID: "pod-id", Phase: v1.PodRunning})
+	mt := state.ManifestTargets["fe"]
+	mt.State.RuntimeState = store.NewK8sRuntimeState(mt.Manifest,
+		store.Pod{PodID: "pod-id", Phase: v1.PodRunning})
 	f.st.UnlockMutableState()
 
 	f.onChange()
@@ -50,7 +52,9 @@ func TestPortForward(t *testing.T) {
 	firstPodForwardCtx := f.kCli.LastForwardContext
 
 	state = f.st.LockMutableStateForTesting()
-	state.ManifestTargets["fe"].State.RuntimeState = store.NewK8sRuntimeState("fe", store.Pod{PodID: "pod-id2", Phase: v1.PodRunning})
+	mt = state.ManifestTargets["fe"]
+	mt.State.RuntimeState = store.NewK8sRuntimeState(mt.Manifest,
+		store.Pod{PodID: "pod-id2", Phase: v1.PodRunning})
 	f.st.UnlockMutableState()
 
 	f.onChange()
@@ -58,7 +62,8 @@ func TestPortForward(t *testing.T) {
 	assert.Equal(t, "pod-id2", f.kCli.LastForwardPortPodID.String())
 
 	state = f.st.LockMutableStateForTesting()
-	state.ManifestTargets["fe"].State.RuntimeState = store.NewK8sRuntimeState("fe", store.Pod{PodID: "pod-id2", Phase: v1.PodPending})
+	mt = state.ManifestTargets["fe"]
+	mt.State.RuntimeState = store.NewK8sRuntimeState(mt.Manifest, store.Pod{PodID: "pod-id2", Phase: v1.PodPending})
 	f.st.UnlockMutableState()
 
 	f.onChange()
@@ -84,7 +89,10 @@ func TestPortForwardAutoDiscovery(t *testing.T) {
 		},
 	})
 	state.UpsertManifestTarget(store.NewManifestTarget(m))
-	state.ManifestTargets["fe"].State.RuntimeState = store.NewK8sRuntimeState("fe", store.Pod{PodID: "pod-id", Phase: v1.PodRunning})
+
+	mt := state.ManifestTargets["fe"]
+	mt.State.RuntimeState = store.NewK8sRuntimeState(mt.Manifest,
+		store.Pod{PodID: "pod-id", Phase: v1.PodRunning})
 	f.st.UnlockMutableState()
 
 	f.onChange()
@@ -116,7 +124,9 @@ func TestPortForwardAutoDiscovery2(t *testing.T) {
 		},
 	})
 	state.UpsertManifestTarget(store.NewManifestTarget(m))
-	state.ManifestTargets["fe"].State.RuntimeState = store.NewK8sRuntimeState("fe", store.Pod{
+
+	mt := state.ManifestTargets["fe"]
+	mt.State.RuntimeState = store.NewK8sRuntimeState(mt.Manifest, store.Pod{
 		PodID: "pod-id",
 		Phase: v1.PodRunning,
 		Containers: []store.Container{
@@ -144,7 +154,8 @@ func TestPortForwardChangePort(t *testing.T) {
 		},
 	})
 	state.UpsertManifestTarget(store.NewManifestTarget(m))
-	state.ManifestTargets["fe"].State.RuntimeState = store.NewK8sRuntimeState("fe", store.Pod{PodID: "pod-id", Phase: v1.PodRunning})
+	mt := state.ManifestTargets["fe"]
+	mt.State.RuntimeState = store.NewK8sRuntimeState(mt.Manifest, store.Pod{PodID: "pod-id", Phase: v1.PodRunning})
 	f.st.UnlockMutableState()
 
 	f.onChange()
@@ -178,7 +189,9 @@ func TestPortForwardRestart(t *testing.T) {
 		},
 	})
 	state.UpsertManifestTarget(store.NewManifestTarget(m))
-	state.ManifestTargets["fe"].State.RuntimeState = store.NewK8sRuntimeState("fe", store.Pod{PodID: "pod-id", Phase: v1.PodRunning})
+	mt := state.ManifestTargets["fe"]
+	mt.State.RuntimeState = store.NewK8sRuntimeState(mt.Manifest,
+		store.Pod{PodID: "pod-id", Phase: v1.PodRunning})
 	f.st.UnlockMutableState()
 
 	f.onChange()

--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -326,14 +326,14 @@ func handleBuildCompleted(ctx context.Context, engineState *store.EngineState, c
 	if manifest.IsK8s() {
 		deployedUIDSet := cb.Result.DeployedUIDSet()
 		if len(deployedUIDSet) > 0 {
-			state := ms.GetOrCreateK8sRuntimeState()
+			state := ms.K8sRuntimeState()
 			state.DeployedUIDSet = deployedUIDSet
 			ms.RuntimeState = state
 		}
 
 		deployedPodTemplateSpecHashSet := cb.Result.DeployedPodTemplateSpecHashes()
 		if len(deployedPodTemplateSpecHashSet) > 0 {
-			state := ms.GetOrCreateK8sRuntimeState()
+			state := ms.K8sRuntimeState()
 			state.DeployedPodTemplateSpecHashSet = deployedPodTemplateSpecHashSet
 			ms.RuntimeState = state
 		}
@@ -600,7 +600,7 @@ func handleServiceEvent(ctx context.Context, state *store.EngineState, action k8
 		return
 	}
 
-	runtime := ms.GetOrCreateK8sRuntimeState()
+	runtime := ms.K8sRuntimeState()
 	runtime.LBs[k8s.ServiceName(service.Name)] = action.URL
 }
 
@@ -664,7 +664,7 @@ func handleLocalServeStatusAction(ctx context.Context, state *store.EngineState,
 		logger.Get(ctx).Infof("got runtime status information for unknown local resource %s", action.ManifestName)
 	}
 
-	lrs := ms.GetOrCreateLocalRuntimeState()
+	lrs := ms.LocalRuntimeState()
 	lrs.Status = action.Status
 	lrs.PID = action.PID
 	lrs.SpanID = action.SpanID

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -1960,7 +1960,7 @@ func TestPodAddedToStateOrNotByTemplateHash(t *testing.T) {
 			ms, ok := st.ManifestState(model.ManifestName(mName))
 			require.True(t, ok, "couldn't find manifest state for %s", mName)
 
-			runtime := ms.GetOrCreateK8sRuntimeState()
+			runtime := ms.K8sRuntimeState()
 			runtime.Pods = make(map[k8s.PodID]*store.Pod)
 			if test.ancestorSeen {
 				runtime.PodAncestorUID = ancestorUID
@@ -4168,7 +4168,7 @@ func (f *testFixture) registerDeployedPodTemplateSpecHashToManifest(name model.M
 	st := f.store.LockMutableStateForTesting()
 	ms, ok := st.ManifestState(name)
 	require.True(f.T(), ok, "no manifest found on state matching name %q", name)
-	runtime := ms.GetOrCreateK8sRuntimeState()
+	runtime := ms.K8sRuntimeState()
 	runtime.DeployedPodTemplateSpecHashSet.Add(ptsh)
 	ms.RuntimeState = runtime
 	f.store.UnlockMutableState()

--- a/internal/store/engine_state_test.go
+++ b/internal/store/engine_state_test.go
@@ -73,7 +73,7 @@ func TestStateToViewPortForwards(t *testing.T) {
 		res.Endpoints)
 }
 
-func TestRuntimeStateUnresourced(t *testing.T) {
+func TestRuntimeStateNonWorkload(t *testing.T) {
 	f := tempdir.NewTempDirFixture(t)
 	defer f.TearDown()
 
@@ -82,7 +82,7 @@ func TestRuntimeStateUnresourced(t *testing.T) {
 		Build()
 	state := newState([]model.Manifest{m})
 	assert.Equal(t, model.RuntimeStatusOK,
-		state.ManifestTargets[m.Name].State.GetOrCreateK8sRuntimeState().RuntimeStatus())
+		state.ManifestTargets[m.Name].State.K8sRuntimeState().RuntimeStatus())
 }
 
 func TestStateToViewUnresourcedYAMLManifest(t *testing.T) {
@@ -125,7 +125,8 @@ func TestMostRecentPod(t *testing.T) {
 	podA := Pod{PodID: "pod-a", StartedAt: time.Now()}
 	podB := Pod{PodID: "pod-b", StartedAt: time.Now().Add(time.Minute)}
 	podC := Pod{PodID: "pod-c", StartedAt: time.Now().Add(-time.Minute)}
-	podSet := NewK8sRuntimeState("fe", podA, podB, podC)
+	m := model.Manifest{Name: "fe"}
+	podSet := NewK8sRuntimeState(m, podA, podB, podC)
 	assert.Equal(t, "pod-b", podSet.MostRecentPod().PodID.String())
 }
 

--- a/internal/store/manifest_target.go
+++ b/internal/store/manifest_target.go
@@ -16,7 +16,7 @@ type ManifestTarget struct {
 func NewManifestTarget(m model.Manifest) *ManifestTarget {
 	return &ManifestTarget{
 		Manifest: m,
-		State:    newManifestState(m.Name),
+		State:    newManifestState(m),
 	}
 }
 

--- a/internal/testutils/manifestutils/manifest.go
+++ b/internal/testutils/manifestutils/manifest.go
@@ -7,6 +7,6 @@ import (
 
 func NewManifestTargetWithPod(m model.Manifest, pod store.Pod) *store.ManifestTarget {
 	mt := store.NewManifestTarget(m)
-	mt.State.RuntimeState = store.NewK8sRuntimeState(m.Name, pod)
+	mt.State.RuntimeState = store.NewK8sRuntimeState(m, pod)
 	return mt
 }


### PR DESCRIPTION
Hello @jazzdan, @maiamcc,

Please review the following commits I made in branch nicks/ch8127:

869806be986d5d9ac938b399c766c1d0d1bbbe64 (2020-06-29 16:40:46 -0400)
store: Use the NonWorkload field to determine runtime status
This is a better indicator if a manifest has pods

Fixes https://github.com/tilt-dev/tilt/issues/3497

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics