### PR TITLE
web: get rid of blue box around tilt cloud status

### DIFF
--- a/web/src/SidebarAccount.tsx
+++ b/web/src/SidebarAccount.tsx
@@ -29,6 +29,7 @@ let SidebarAccountButton = styled.button`
   display: flex;
   align-items: center;
   border: 0;
+  outline: 0;
   cursor: pointer;
   background-color: transparent;
   padding-left: ${SizeUnit(0.25)};


### PR DESCRIPTION
fixes #3420

(only happens after clicking on it)

old:
![image](https://user-images.githubusercontent.com/7453991/86384243-77bb5400-bc5c-11ea-96d9-64d70bbeb55d.png)

new:
![image](https://user-images.githubusercontent.com/7453991/86384269-8144bc00-bc5c-11ea-9221-5aa134275a1e.png)
