### PR TITLE
engine: fix bugs in image build caching

### DIFF
--- a/internal/build/docker_builder.go
+++ b/internal/build/docker_builder.go
@@ -10,8 +10,7 @@ import (
 	"time"
 
 	"github.com/docker/distribution/reference"
-	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/jsonmessage"
 	controlapi "github.com/moby/buildkit/api/services/control"
 	"github.com/opencontainers/go-digest"
@@ -122,11 +121,14 @@ func (d *dockerImageBuilder) PushImage(ctx context.Context, ref reference.NamedT
 }
 
 func (d *dockerImageBuilder) ImageExists(ctx context.Context, ref reference.NamedTagged) (bool, error) {
-	images, err := d.dCli.ImageList(ctx, types.ImageListOptions{Filters: filters.NewArgs(filters.Arg("reference", ref.String()))})
+	_, _, err := d.dCli.ImageInspectWithRaw(ctx, ref.String())
 	if err != nil {
+		if client.IsErrNotFound(err) {
+			return false, nil
+		}
 		return false, errors.Wrapf(err, "error checking if %s exists", ref.String())
 	}
-	return len(images) > 0, nil
+	return true, nil
 }
 
 func (d *dockerImageBuilder) buildFromDf(ctx context.Context, ps *PipelineState, db model.DockerBuild, paths []PathMapping, filter model.PathMatcher, refs container.RefSet) (container.TaggedRefs, error) {

--- a/internal/cli/wire_gen.go
+++ b/internal/cli/wire_gen.go
@@ -7,8 +7,15 @@ package cli
 
 import (
 	"context"
+	"time"
+
 	"github.com/google/wire"
 	"github.com/jonboulle/clockwork"
+	"github.com/tilt-dev/wmclient/pkg/dirs"
+	trace2 "go.opentelemetry.io/otel/sdk/trace"
+	version2 "k8s.io/apimachinery/pkg/version"
+	"k8s.io/client-go/tools/clientcmd/api"
+
 	"github.com/tilt-dev/tilt/internal/analytics"
 	"github.com/tilt-dev/tilt/internal/build"
 	"github.com/tilt-dev/tilt/internal/cloud"
@@ -46,11 +53,6 @@ import (
 	"github.com/tilt-dev/tilt/internal/token"
 	"github.com/tilt-dev/tilt/internal/tracer"
 	"github.com/tilt-dev/tilt/pkg/model"
-	"github.com/tilt-dev/wmclient/pkg/dirs"
-	trace2 "go.opentelemetry.io/otel/sdk/trace"
-	version2 "k8s.io/apimachinery/pkg/version"
-	"k8s.io/client-go/tools/clientcmd/api"
-	"time"
 )
 
 // Injectors from wire.go:

--- a/internal/docker/fake_client.go
+++ b/internal/docker/fake_client.go
@@ -112,7 +112,13 @@ type FakeClient struct {
 	RestartsByContainer map[string]int
 	RemovedImageIDs     []string
 
-	Images            map[string]types.ImageInspect
+	// Images returned by ImageInspect.
+	Images map[string]types.ImageInspect
+
+	// If true, ImageInspectWithRaw will always return an ImageInspect,
+	// even if one hasn't been explicitly pre-loaded.
+	ImageAlwaysExists bool
+
 	Orchestrator      model.Orchestrator
 	CheckConnectedErr error
 
@@ -259,6 +265,11 @@ func (c *FakeClient) ImageInspectWithRaw(ctx context.Context, imageID string) (t
 	if ok {
 		return result, nil, nil
 	}
+
+	if c.ImageAlwaysExists {
+		return types.ImageInspect{}, nil, nil
+	}
+
 	return types.ImageInspect{}, nil, newNotFoundErrorf("fakeClient.Images key: %s", imageID)
 }
 

--- a/internal/engine/buildcontrol/target_queue_test.go
+++ b/internal/engine/buildcontrol/target_queue_test.go
@@ -220,7 +220,7 @@ func newTargetQueueFixture(t *testing.T) *targetQueueFixture {
 	}
 }
 
-func (f *targetQueueFixture) imageExists(ctx context.Context, namedTagged reference.NamedTagged) (b bool, e error) {
+func (f *targetQueueFixture) imageExists(ctx context.Context, iTarget model.ImageTarget, namedTagged reference.NamedTagged) (b bool, e error) {
 	for _, ref := range f.missingImages {
 		if ref == namedTagged {
 			return false, nil

--- a/internal/engine/docker_compose_build_and_deployer.go
+++ b/internal/engine/docker_compose_build_and_deployer.go
@@ -68,7 +68,7 @@ func (bd *DockerComposeBuildAndDeployer) BuildAndDeploy(ctx context.Context, st 
 	span.SetTag("target", dcTargets[0].Name)
 	defer span.Finish()
 
-	q, err := buildcontrol.NewImageTargetQueue(ctx, iTargets, currentState, bd.ib.db.ImageExists)
+	q, err := buildcontrol.NewImageTargetQueue(ctx, iTargets, currentState, bd.ib.CanReuseRef)
 	if err != nil {
 		return store.BuildResultSet{}, err
 	}

--- a/internal/engine/docker_compose_build_and_deployer_test.go
+++ b/internal/engine/docker_compose_build_and_deployer_test.go
@@ -146,7 +146,6 @@ func TestMultiStageDockerComposeWithOnlyOneDirtyImage(t *testing.T) {
 	result := store.NewImageBuildResultSingleRef(iTargetID, container.MustParseNamedTagged("sancho-base:tilt-prebuilt"))
 	state := store.NewBuildState(result, nil, nil)
 	stateSet := store.BuildStateSet{iTargetID: state}
-	f.dCli.ImageListCount = 1
 	_, err := f.dcbad.BuildAndDeploy(f.ctx, f.st, buildTargets(manifest), stateSet)
 	if err != nil {
 		t.Fatal(err)
@@ -184,6 +183,11 @@ func newDCBDFixture(t *testing.T) *dcbdFixture {
 	dir := dirs.NewWindmillDirAt(f.Path())
 	dcCli := dockercompose.NewFakeDockerComposeClient(t, ctx)
 	dCli := docker.NewFakeClient()
+
+	// Make the fake ImageExists always return true, which is the behavior we want
+	// when testing the BuildAndDeployers.
+	dCli.ImageAlwaysExists = true
+
 	dcbad, err := provideDockerComposeBuildAndDeployer(ctx, dcCli, dCli, dir)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/engine/image_build_and_deployer.go
+++ b/internal/engine/image_build_and_deployer.go
@@ -118,7 +118,7 @@ func (ibd *ImageBuildAndDeployer) BuildAndDeploy(ctx context.Context, st store.R
 		ibd.analytics.Timer("build.image", time.Since(startTime), nil)
 	}()
 
-	q, err := buildcontrol.NewImageTargetQueue(ctx, iTargets, stateSet, ibd.db.ImageExists)
+	q, err := buildcontrol.NewImageTargetQueue(ctx, iTargets, stateSet, ibd.ib.CanReuseRef)
 	if err != nil {
 		return store.BuildResultSet{}, err
 	}

--- a/internal/engine/image_build_and_deployer_test.go
+++ b/internal/engine/image_build_and_deployer_test.go
@@ -922,9 +922,9 @@ func newIBDFixture(t *testing.T, env k8s.Env) *ibdFixture {
 
 	docker := docker.NewFakeClient()
 
-	// Setting ImageListCount makes the fake ImageExists always return true,
-	// which is the behavior we want when testing the ImageBuildAndDeployer.
-	docker.ImageListCount = 1
+	// Make the fake ImageExists always return true, which is the behavior we want
+	// when testing the ImageBuildAndDeployer.
+	docker.ImageAlwaysExists = true
 
 	out := bufsync.NewThreadSafeBuffer()
 	l := logger.NewLogger(logger.DebugLvl, out)

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -282,7 +282,7 @@ func (b *fakeBuildAndDeployer) BuildAndDeploy(ctx context.Context, st store.RSto
 	}
 
 	iTargets := model.ExtractImageTargets(specs)
-	fakeImageExistsCheck := func(ctx context.Context, namedTagged reference.NamedTagged) (bool, error) {
+	fakeImageExistsCheck := func(ctx context.Context, iTarget model.ImageTarget, namedTagged reference.NamedTagged) (bool, error) {
 		return true, nil
 	}
 	queue, err := buildcontrol.NewImageTargetQueue(ctx, iTargets, state, fakeImageExistsCheck)

--- a/internal/engine/wire_gen.go
+++ b/internal/engine/wire_gen.go
@@ -7,7 +7,11 @@ package engine
 
 import (
 	"context"
+
 	"github.com/google/wire"
+	"github.com/tilt-dev/wmclient/pkg/dirs"
+	"go.opentelemetry.io/otel/sdk/trace"
+
 	"github.com/tilt-dev/tilt/internal/analytics"
 	"github.com/tilt-dev/tilt/internal/build"
 	"github.com/tilt-dev/tilt/internal/containerupdate"
@@ -19,8 +23,6 @@ import (
 	"github.com/tilt-dev/tilt/internal/synclet"
 	"github.com/tilt-dev/tilt/internal/synclet/sidecar"
 	"github.com/tilt-dev/tilt/internal/tracer"
-	"github.com/tilt-dev/wmclient/pkg/dirs"
-	"go.opentelemetry.io/otel/sdk/trace"
 )
 
 // Injectors from wire.go:

--- a/internal/synclet/wire_gen.go
+++ b/internal/synclet/wire_gen.go
@@ -7,6 +7,7 @@ package synclet
 
 import (
 	"context"
+
 	"github.com/tilt-dev/tilt/internal/container"
 	"github.com/tilt-dev/tilt/internal/docker"
 )


### PR DESCRIPTION
Hello @maiamcc, @landism,

Please review the following commits I made in branch nicks/image-reuse:

f888022a89d06e71acda9de2c89713677136516a (2020-07-02 13:30:48 -0400)
engine: fix bugs in image build caching
this is the source of a lot of the infinite rebuild problems in
https://github.com/tilt-dev/tilt/pull/3362

There are a lot of weird cases where the original image existence check would
fail, and so we would deliberately rebuild the image. This makes the check more
robust, and adds logging when it does fail so that we have some hope of figuring
out the problem.

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics