### PR TITLE
cli: fix duplicate error printing

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -46,6 +46,8 @@ Tilt watches your files for edits, automatically builds your container images,
 and applies any changes to bring your environment
 up-to-date in real-time. Think 'docker build && kubectl apply' or 'docker-compose up'.
 `,
+		// We're going to print the errors ourselves.
+		SilenceErrors: true,
 	}
 
 	addCommand(rootCmd, &ciCmd{})
@@ -92,7 +94,7 @@ func Execute() {
 	cmd := Cmd()
 
 	if err := cmd.Execute(); err != nil {
-		_, _ = fmt.Fprintln(output.OriginalStderr, err)
+		_, _ = fmt.Fprintf(output.OriginalStderr, "Error: %v\n", err)
 
 		exitCode := 1
 		if ece, ok := err.(ExitCodeError); ok {


### PR DESCRIPTION
Hello @landism,

Please review the following commits I made in branch nicks/issue3541:

ef4193b0724d803b2b58afd5bf190cf5a7b5c3c8 (2020-07-02 17:48:27 -0400)
cli: fix duplicate error printing

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics