### PR TITLE
cli: fix duplicate fatal error logging

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -8,12 +8,11 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/tilt-dev/tilt/internal/output"
-
 	"github.com/spf13/cobra"
 	"github.com/tilt-dev/wmclient/pkg/analytics"
 
 	tiltanalytics "github.com/tilt-dev/tilt/internal/analytics"
+	"github.com/tilt-dev/tilt/internal/output"
 	"github.com/tilt-dev/tilt/internal/tracer"
 	"github.com/tilt-dev/tilt/pkg/logger"
 )
@@ -33,7 +32,7 @@ func logLevel(verbose, debug bool) logger.Level {
 	}
 }
 
-func Cmd() *cobra.Command {
+func Execute() {
 	rootCmd := &cobra.Command{
 		Use:   "tilt",
 		Short: "Multi-service development with no stress",
@@ -76,30 +75,9 @@ up-to-date in real-time. Think 'docker build && kubectl apply' or 'docker-compos
 		globalFlags.IntVar(&klogLevel, "klog", 0, "Enable Kubernetes API logging. Uses klog v-levels (0-4 are debug logs, 5-9 are tracing logs)")
 	}
 
-	return rootCmd
-}
-
-type ExitCodeError struct {
-	ExitCode int
-	Err      error
-}
-
-func (ece ExitCodeError) Error() string {
-	return ece.Err.Error()
-}
-
-func Execute() {
-	cmd := Cmd()
-
-	if err := cmd.Execute(); err != nil {
-		_, _ = fmt.Fprintln(output.OriginalStderr, err)
-
-		exitCode := 1
-		if ece, ok := err.(ExitCodeError); ok {
-			exitCode = ece.ExitCode
-		}
-
-		os.Exit(exitCode)
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
 	}
 }
 
@@ -160,13 +138,7 @@ func preCommand(ctx context.Context) (context.Context, func() error) {
 
 func addCommand(parent *cobra.Command, child tiltCmd) {
 	cobraChild := child.register()
-	cobraChild.RunE = func(_ *cobra.Command, args []string) error {
-		// by default, cobra prints usage on any kind of error
-		// if we've made it this far, we're past arg-parsing, so an error is not likely to be
-		// a usage error, so printing usage isn't appropriate
-		// cobra doesn't support this well: https://github.com/spf13/cobra/issues/340#issuecomment-374617413
-		cobraChild.SilenceUsage = true
-
+	cobraChild.Run = func(_ *cobra.Command, args []string) {
 		ctx, cleanup := preCommand(context.Background())
 
 		err := child.run(ctx, args)
@@ -177,7 +149,14 @@ func addCommand(parent *cobra.Command, child tiltCmd) {
 			err = err2
 		}
 
-		return err
+		if err != nil {
+			// TODO(maia): this shouldn't print if we've already pretty-printed it
+			_, printErr := fmt.Fprintf(output.OriginalStderr, "Error: %v\n", err)
+			if printErr != nil {
+				panic(printErr)
+			}
+			os.Exit(1)
+		}
 	}
 
 	parent.AddCommand(cobraChild)

--- a/internal/cli/tiltfile_result.go
+++ b/internal/cli/tiltfile_result.go
@@ -85,10 +85,8 @@ func (c *tiltfileResultCmd) run(ctx context.Context, args []string) error {
 		// Some errors won't JSONify properly by default, so just print it
 		// to STDERR and use the exit code to indicate that it's an error
 		// from Tiltfile parsing.
-		return ExitCodeError{
-			ExitCode: TiltfileErrExitCode,
-			Err:      tlr.Error,
-		}
+		fmt.Fprintln(os.Stderr, tlr.Error)
+		os.Exit(TiltfileErrExitCode)
 	}
 
 	err = encodeJSON(tlr)


### PR DESCRIPTION
fix #3541

midstream through #3544 I changed approaches, and failed to revert all of the first approach when implementing the new approach

you can scroll through the top of [this comparison](https://github.com/tilt-dev/tilt/compare/e14064a17a14da12938811bb40ecf73a6aeed6b7...matt/more_revert) to see the net internal/cli changes