### PR TITLE
engine: roll forward of https://github.com/tilt-dev/tilt/pull/3362, re-using image builds from other resources

### DIFF
--- a/internal/engine/buildcontroller_test.go
+++ b/internal/engine/buildcontroller_test.go
@@ -1265,6 +1265,136 @@ func TestErrorHandlingWithMultipleBuilds(t *testing.T) {
 	f.assertAllBuildsConsumed()
 }
 
+func TestManifestsWithSameTwoImages(t *testing.T) {
+	f := newTestFixture(t)
+	m1, m2 := NewManifestsWithSameTwoImages(f)
+	f.Start([]model.Manifest{m1, m2})
+
+	f.waitForCompletedBuildCount(2)
+
+	call := f.nextCall("m1 build1")
+	assert.Equal(t, m1.K8sTarget(), call.k8s())
+
+	call = f.nextCall("m2 build1")
+	assert.Equal(t, m2.K8sTarget(), call.k8s())
+
+	aPath := f.JoinPath("common", "a.txt")
+	f.fsWatcher.Events <- watch.NewFileEvent(aPath)
+
+	f.waitForCompletedBuildCount(4)
+
+	// Make sure that both builds are triggered, and that they
+	// are triggered in a particular order.
+	call = f.nextCall("m1 build2")
+	assert.Equal(t, m1.K8sTarget(), call.k8s())
+
+	state := call.state[m1.ImageTargets[0].ID()]
+	assert.Equal(t, map[string]bool{aPath: true}, state.FilesChangedSet)
+
+	// Make sure that when the second build is triggered, we did the bookkeeping
+	// correctly around marking the first and second image built and only deploying
+	// the k8s resources.
+	call = f.nextCall("m2 build2")
+	assert.Equal(t, m2.K8sTarget(), call.k8s())
+
+	id := m2.ImageTargets[0].ID()
+	result := f.b.resultsByID[id]
+	assert.Equal(t, store.NewBuildState(result, nil, nil), call.state[id])
+
+	id = m2.ImageTargets[1].ID()
+	result = f.b.resultsByID[id]
+	assert.Equal(t, store.NewBuildState(result, nil, nil), call.state[id])
+
+	err := f.Stop()
+	assert.NoError(t, err)
+	f.assertAllBuildsConsumed()
+}
+
+func TestManifestsWithTwoCommonAncestors(t *testing.T) {
+	f := newTestFixture(t)
+	m1, m2 := NewManifestsWithTwoCommonAncestors(f)
+	f.Start([]model.Manifest{m1, m2})
+
+	f.waitForCompletedBuildCount(2)
+
+	call := f.nextCall("m1 build1")
+	assert.Equal(t, m1.K8sTarget(), call.k8s())
+
+	call = f.nextCall("m2 build1")
+	assert.Equal(t, m2.K8sTarget(), call.k8s())
+
+	aPath := f.JoinPath("base", "a.txt")
+	f.fsWatcher.Events <- watch.NewFileEvent(aPath)
+
+	f.waitForCompletedBuildCount(4)
+
+	// Make sure that both builds are triggered, and that they
+	// are triggered in a particular order.
+	call = f.nextCall("m1 build2")
+	assert.Equal(t, m1.K8sTarget(), call.k8s())
+
+	state := call.state[m1.ImageTargets[0].ID()]
+	assert.Equal(t, map[string]bool{aPath: true}, state.FilesChangedSet)
+
+	// Make sure that when the second build is triggered, we did the bookkeeping
+	// correctly around marking the first and second image built, and only
+	// rebuilding the third image and k8s deploy.
+	call = f.nextCall("m2 build2")
+	assert.Equal(t, m2.K8sTarget(), call.k8s())
+
+	id := m2.ImageTargets[0].ID()
+	result := f.b.resultsByID[id]
+	assert.Equal(t,
+		store.NewBuildState(result, nil, nil),
+		call.state[id])
+
+	id = m2.ImageTargets[1].ID()
+	result = f.b.resultsByID[id]
+	assert.Equal(t,
+		store.NewBuildState(result, nil, nil),
+		call.state[id])
+
+	id = m2.ImageTargets[2].ID()
+	result = f.b.resultsByID[id]
+
+	// Assert the 3rd image was not reused from the previous build.
+	assert.NotEqual(t, result, call.state[id].LastResult)
+	assert.Equal(t,
+		map[model.TargetID]bool{m2.ImageTargets[1].ID(): true},
+		call.state[id].DepsChangedSet)
+
+	err := f.Stop()
+	assert.NoError(t, err)
+	f.assertAllBuildsConsumed()
+}
+
+func TestManifestsWithCommonAncestorAndTrigger(t *testing.T) {
+	f := newTestFixture(t)
+	m1, m2 := NewManifestsWithCommonAncestor(f)
+	f.Start([]model.Manifest{m1, m2})
+
+	f.waitForCompletedBuildCount(2)
+
+	call := f.nextCall("m1 build1")
+	assert.Equal(t, m1.K8sTarget(), call.k8s())
+
+	call = f.nextCall("m2 build1")
+	assert.Equal(t, m2.K8sTarget(), call.k8s())
+
+	f.store.Dispatch(server.AppendToTriggerQueueAction{Name: m1.Name})
+	f.waitForCompletedBuildCount(3)
+
+	// Make sure that only one build was triggered.
+	call = f.nextCall("m1 build2")
+	assert.Equal(t, m1.K8sTarget(), call.k8s())
+
+	f.assertNoCall("m2 should not be rebuilt")
+
+	err := f.Stop()
+	assert.NoError(t, err)
+	f.assertAllBuildsConsumed()
+}
+
 func (f *testFixture) waitUntilManifestBuilding(name model.ManifestName) {
 	msg := fmt.Sprintf("manifest %q is building", name)
 	f.WaitUntilManifestState(msg, name, func(ms store.ManifestState) bool {

--- a/internal/store/engine_state.go
+++ b/internal/store/engine_state.go
@@ -169,7 +169,6 @@ func (e *EngineState) BuildStatus(id model.TargetID) BuildStatus {
 		}
 	}
 	return BuildStatus{}
-
 }
 
 func (e *EngineState) AvailableBuildSlots() int {
@@ -241,6 +240,19 @@ func (e EngineState) Targets() []*ManifestTarget {
 		if !ok {
 			continue
 		}
+		result = append(result, mt)
+	}
+	return result
+}
+
+func (e EngineState) TargetsBesides(mn model.ManifestName) []*ManifestTarget {
+	targets := e.Targets()
+	result := make([]*ManifestTarget, 0, len(targets))
+	for _, mt := range targets {
+		if mt.Manifest.Name == mn {
+			continue
+		}
+
 		result = append(result, mt)
 	}
 	return result
@@ -338,6 +350,19 @@ func (s BuildStatus) IsEmpty() bool {
 	return len(s.PendingFileChanges) == 0 &&
 		len(s.PendingDependencyChanges) == 0 &&
 		s.LastResult == nil
+}
+
+func (s *BuildStatus) ClearPendingChangesBefore(startTime time.Time) {
+	for file, modTime := range s.PendingFileChanges {
+		if BeforeOrEqual(modTime, startTime) {
+			delete(s.PendingFileChanges, file)
+		}
+	}
+	for file, modTime := range s.PendingDependencyChanges {
+		if BeforeOrEqual(modTime, startTime) {
+			delete(s.PendingDependencyChanges, file)
+		}
+	}
 }
 
 type ManifestState struct {

--- a/internal/store/engine_state_test.go
+++ b/internal/store/engine_state_test.go
@@ -154,11 +154,18 @@ func TestNextBuildReason(t *testing.T) {
 
 	iTargetID := model.ImageID(container.MustParseSelector("sancho"))
 	status := mt.State.MutableBuildStatus(kTarget.ID())
+	assert.Equal(t, "Initial Build",
+		mt.NextBuildReason().String())
+
 	status.PendingDependencyChanges[iTargetID] = time.Now()
-	assert.Equal(t, "Initial Build | Dependency Updated",
+	assert.Equal(t, "Initial Build",
+		mt.NextBuildReason().String())
+
+	mt.State.AddCompletedBuild(model.BuildRecord{StartTime: time.Now(), FinishTime: time.Now()})
+	assert.Equal(t, "Dependency Updated",
 		mt.NextBuildReason().String())
 
 	status.PendingFileChanges["a.txt"] = time.Now()
-	assert.Equal(t, "Initial Build | Changed Files | Dependency Updated",
+	assert.Equal(t, "Changed Files | Dependency Updated",
 		mt.NextBuildReason().String())
 }

--- a/pkg/model/build_reason.go
+++ b/pkg/model/build_reason.go
@@ -93,6 +93,11 @@ func (r BuildReason) String() string {
 		}
 	}
 
+	// The Init build reason should be listed alone too.
+	if r.Has(BuildReasonFlagInit) {
+		return translations[BuildReasonFlagInit]
+	}
+
 	// Use an array to iterate over the translations to ensure the iteration order
 	// is consistent.
 	for _, v := range allBuildReasons {

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -63,6 +63,22 @@ func (m Manifest) DependencyIDs() []TargetID {
 	return result
 }
 
+// A map from each target id to the target IDs that depend on it.
+func (m Manifest) ReverseDependencyIDs() map[TargetID][]TargetID {
+	result := make(map[TargetID][]TargetID)
+	for _, iTarget := range m.ImageTargets {
+		for _, depID := range iTarget.DependencyIDs() {
+			result[depID] = append(result[depID], iTarget.ID())
+		}
+	}
+	if !m.deployTarget.ID().Empty() {
+		for _, depID := range m.deployTarget.DependencyIDs() {
+			result[depID] = append(result[depID], m.deployTarget.ID())
+		}
+	}
+	return result
+}
+
 func (m Manifest) WithImageTarget(iTarget ImageTarget) Manifest {
 	m.ImageTargets = []ImageTarget{iTarget}
 	return m


### PR DESCRIPTION
Hello @maiamcc, @landism,

Please review the following commits I made in branch nicks/ch6738:

24351f95b0d93a5cd8323e227a2a7c15a45ede25 (2020-07-06 11:43:41 -0400)
engine: roll forward of https://github.com/tilt-dev/tilt/pull/3362, re-using image builds from other resources

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics