### PR TITLE
analytics: test for opt precedence

### DIFF
--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -132,6 +132,7 @@ func (c *doctorCmd) run(ctx context.Context, args []string) error {
 
 	fmt.Println("---")
 	fmt.Println("Analytics Settings")
+	fmt.Println("--> (These results reflect your personal opt in/out status and may be overridden by an `analytics_settings` call in your Tiltfile)")
 
 	a := analytics.Get(ctx)
 	opt := a.UserOpt()


### PR DESCRIPTION
Hello @landism, @abdullahzameek,

Was verifying the interaction between a user's opt in/out and the tiltfile `analytics_settings(enable=True|False)`
call, and saw we didn't have a test for it, so added one.

Please review the following commits I made in branch maiamcc/opt-precedence-test:

158b1953daecdf0ae74e4f511b0e1f34a9c549c0 (2020-07-06 12:49:15 -0400)
analytics: test for opt precedence

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics