### PR TITLE
analytics: tag tilt.up.running w/ subcommand

### DIFF
--- a/internal/cli/down.go
+++ b/internal/cli/down.go
@@ -12,7 +12,6 @@ import (
 	"github.com/tilt-dev/tilt/internal/analytics"
 	"github.com/tilt-dev/tilt/internal/engine"
 	"github.com/tilt-dev/tilt/internal/k8s"
-	"github.com/tilt-dev/tilt/internal/tiltfile/config"
 	"github.com/tilt-dev/tilt/pkg/logger"
 	"github.com/tilt-dev/tilt/pkg/model"
 )
@@ -20,7 +19,7 @@ import (
 type downCmd struct {
 	fileName         string
 	deleteNamespaces bool
-	downDepsProvider func(ctx context.Context, tiltAnalytics *analytics.TiltAnalytics, subcommand config.TiltSubcommand) (DownDeps, error)
+	downDepsProvider func(ctx context.Context, tiltAnalytics *analytics.TiltAnalytics, subcommand model.TiltSubcommand) (DownDeps, error)
 }
 
 func newDownCmd() *downCmd {

--- a/internal/cli/down_test.go
+++ b/internal/cli/down_test.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/tilt-dev/tilt/internal/tiltfile/config"
-
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -143,7 +141,7 @@ func newDownFixture(t *testing.T) downFixture {
 	dcc := dockercompose.NewFakeDockerComposeClient(t, ctx)
 	kCli := k8s.NewFakeK8sClient()
 	downDeps := DownDeps{tfl, dcc, kCli}
-	cmd := &downCmd{downDepsProvider: func(ctx context.Context, tiltAnalytics *analytics.TiltAnalytics, subcommand config.TiltSubcommand) (deps DownDeps, err error) {
+	cmd := &downCmd{downDepsProvider: func(ctx context.Context, tiltAnalytics *analytics.TiltAnalytics, subcommand model.TiltSubcommand) (deps DownDeps, err error) {
 		return downDeps, nil
 	}}
 	return downFixture{

--- a/internal/cli/wire.go
+++ b/internal/cli/wire.go
@@ -7,8 +7,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/tilt-dev/tilt/internal/tiltfile/config"
-
 	"github.com/google/wire"
 	"github.com/jonboulle/clockwork"
 	"github.com/tilt-dev/wmclient/pkg/dirs"
@@ -136,17 +134,17 @@ var BaseWireSet = wire.NewSet(
 	wire.Value(feature.MainDefaults),
 )
 
-func wireTiltfileResult(ctx context.Context, analytics *analytics.TiltAnalytics, subcommand config.TiltSubcommand) (cmdTiltfileResultDeps, error) {
+func wireTiltfileResult(ctx context.Context, analytics *analytics.TiltAnalytics, subcommand model.TiltSubcommand) (cmdTiltfileResultDeps, error) {
 	wire.Build(BaseWireSet, newTiltfileResultDeps)
 	return cmdTiltfileResultDeps{}, nil
 }
 
-func wireDockerPrune(ctx context.Context, analytics *analytics.TiltAnalytics, subcommand config.TiltSubcommand) (dpDeps, error) {
+func wireDockerPrune(ctx context.Context, analytics *analytics.TiltAnalytics, subcommand model.TiltSubcommand) (dpDeps, error) {
 	wire.Build(BaseWireSet, newDPDeps)
 	return dpDeps{}, nil
 }
 
-func wireCmdUp(ctx context.Context, analytics *analytics.TiltAnalytics, cmdTags engineanalytics.CmdTags, subcommand config.TiltSubcommand) (CmdUpDeps, error) {
+func wireCmdUp(ctx context.Context, analytics *analytics.TiltAnalytics, cmdTags engineanalytics.CmdTags, subcommand model.TiltSubcommand) (CmdUpDeps, error) {
 	wire.Build(BaseWireSet,
 		build.ProvideClock,
 		wire.Struct(new(CmdUpDeps), "*"))
@@ -162,7 +160,7 @@ type CmdUpDeps struct {
 	Prompt       *prompt.TerminalPrompt
 }
 
-func wireCmdCI(ctx context.Context, analytics *analytics.TiltAnalytics, subcommand config.TiltSubcommand) (CmdCIDeps, error) {
+func wireCmdCI(ctx context.Context, analytics *analytics.TiltAnalytics, subcommand model.TiltSubcommand) (CmdCIDeps, error) {
 	wire.Build(BaseWireSet,
 		build.ProvideClock,
 		wire.Value(engineanalytics.CmdTags(map[string]string{})),
@@ -237,7 +235,7 @@ func wireDockerLocalClient(ctx context.Context) (docker.LocalClient, error) {
 	return nil, nil
 }
 
-func wireDownDeps(ctx context.Context, tiltAnalytics *analytics.TiltAnalytics, subcommand config.TiltSubcommand) (DownDeps, error) {
+func wireDownDeps(ctx context.Context, tiltAnalytics *analytics.TiltAnalytics, subcommand model.TiltSubcommand) (DownDeps, error) {
 	wire.Build(BaseWireSet, ProvideDownDeps)
 	return DownDeps{}, nil
 }

--- a/internal/cli/wire_gen.go
+++ b/internal/cli/wire_gen.go
@@ -57,7 +57,7 @@ import (
 
 // Injectors from wire.go:
 
-func wireTiltfileResult(ctx context.Context, analytics2 *analytics.TiltAnalytics, subcommand config.TiltSubcommand) (cmdTiltfileResultDeps, error) {
+func wireTiltfileResult(ctx context.Context, analytics2 *analytics.TiltAnalytics, subcommand model.TiltSubcommand) (cmdTiltfileResultDeps, error) {
 	clientConfig := k8s.ProvideClientConfig()
 	apiConfig, err := k8s.ProvideKubeConfig(clientConfig)
 	if err != nil {
@@ -95,7 +95,7 @@ var (
 	_wireDefaultsValue = feature.MainDefaults
 )
 
-func wireDockerPrune(ctx context.Context, analytics2 *analytics.TiltAnalytics, subcommand config.TiltSubcommand) (dpDeps, error) {
+func wireDockerPrune(ctx context.Context, analytics2 *analytics.TiltAnalytics, subcommand model.TiltSubcommand) (dpDeps, error) {
 	clientConfig := k8s.ProvideClientConfig()
 	apiConfig, err := k8s.ProvideKubeConfig(clientConfig)
 	if err != nil {
@@ -135,7 +135,7 @@ func wireDockerPrune(ctx context.Context, analytics2 *analytics.TiltAnalytics, s
 	return cliDpDeps, nil
 }
 
-func wireCmdUp(ctx context.Context, analytics3 *analytics.TiltAnalytics, cmdTags analytics2.CmdTags, subcommand config.TiltSubcommand) (CmdUpDeps, error) {
+func wireCmdUp(ctx context.Context, analytics3 *analytics.TiltAnalytics, cmdTags analytics2.CmdTags, subcommand model.TiltSubcommand) (CmdUpDeps, error) {
 	reducer := _wireReducerValue
 	storeLogActionsFlag := provideLogActions()
 	storeStore := store.NewStore(reducer, storeLogActionsFlag)
@@ -234,7 +234,7 @@ func wireCmdUp(ctx context.Context, analytics3 *analytics.TiltAnalytics, cmdTags
 	eventWatcher := dcwatch.NewEventWatcher(dockerComposeClient, localClient)
 	dockerComposeLogManager := runtimelog.NewDockerComposeLogManager(dockerComposeClient)
 	profilerManager := engine.NewProfilerManager()
-	analyticsReporter := analytics2.ProvideAnalyticsReporter(analytics3, storeStore, client, env)
+	analyticsReporter := analytics2.ProvideAnalyticsReporter(analytics3, storeStore, client, env, subcommand)
 	webMode, err := provideWebMode(tiltBuild)
 	if err != nil {
 		return CmdUpDeps{}, err
@@ -292,7 +292,7 @@ var (
 	_wireLabelsValue    = dockerfile.Labels{}
 )
 
-func wireCmdCI(ctx context.Context, analytics3 *analytics.TiltAnalytics, subcommand config.TiltSubcommand) (CmdCIDeps, error) {
+func wireCmdCI(ctx context.Context, analytics3 *analytics.TiltAnalytics, subcommand model.TiltSubcommand) (CmdCIDeps, error) {
 	reducer := _wireReducerValue
 	storeLogActionsFlag := provideLogActions()
 	storeStore := store.NewStore(reducer, storeLogActionsFlag)
@@ -391,7 +391,7 @@ func wireCmdCI(ctx context.Context, analytics3 *analytics.TiltAnalytics, subcomm
 	eventWatcher := dcwatch.NewEventWatcher(dockerComposeClient, localClient)
 	dockerComposeLogManager := runtimelog.NewDockerComposeLogManager(dockerComposeClient)
 	profilerManager := engine.NewProfilerManager()
-	analyticsReporter := analytics2.ProvideAnalyticsReporter(analytics3, storeStore, client, env)
+	analyticsReporter := analytics2.ProvideAnalyticsReporter(analytics3, storeStore, client, env, subcommand)
 	webMode, err := provideWebMode(tiltBuild)
 	if err != nil {
 		return CmdCIDeps{}, err
@@ -606,7 +606,7 @@ func wireDockerLocalClient(ctx context.Context) (docker.LocalClient, error) {
 	return localClient, nil
 }
 
-func wireDownDeps(ctx context.Context, tiltAnalytics *analytics.TiltAnalytics, subcommand config.TiltSubcommand) (DownDeps, error) {
+func wireDownDeps(ctx context.Context, tiltAnalytics *analytics.TiltAnalytics, subcommand model.TiltSubcommand) (DownDeps, error) {
 	clientConfig := k8s.ProvideClientConfig()
 	apiConfig, err := k8s.ProvideKubeConfig(clientConfig)
 	if err != nil {

--- a/internal/engine/analytics/analytics_reporter.go
+++ b/internal/engine/analytics/analytics_reporter.go
@@ -8,17 +8,19 @@ import (
 	"github.com/tilt-dev/tilt/internal/analytics"
 	"github.com/tilt-dev/tilt/internal/k8s"
 	"github.com/tilt-dev/tilt/internal/store"
+	"github.com/tilt-dev/tilt/pkg/model"
 )
 
 // How often to periodically report data for analytics while Tilt is running
 const analyticsReportingInterval = time.Minute * 15
 
 type AnalyticsReporter struct {
-	a       *analytics.TiltAnalytics
-	store   store.RStore
-	kClient k8s.Client
-	env     k8s.Env
-	started bool
+	a          *analytics.TiltAnalytics
+	subcommand model.TiltSubcommand
+	store      store.RStore
+	kClient    k8s.Client
+	env        k8s.Env
+	started    bool
 }
 
 func (ar *AnalyticsReporter) OnChange(ctx context.Context, st store.RStore) {
@@ -55,13 +57,19 @@ func (ar *AnalyticsReporter) OnChange(ctx context.Context, st store.RStore) {
 
 var _ store.Subscriber = &AnalyticsReporter{}
 
-func ProvideAnalyticsReporter(a *analytics.TiltAnalytics, st store.RStore, kClient k8s.Client, env k8s.Env) *AnalyticsReporter {
+func ProvideAnalyticsReporter(
+	a *analytics.TiltAnalytics,
+	st store.RStore,
+	kClient k8s.Client,
+	env k8s.Env,
+	subcommand model.TiltSubcommand) *AnalyticsReporter {
 	return &AnalyticsReporter{
-		a:       a,
-		store:   st,
-		kClient: kClient,
-		env:     env,
-		started: false,
+		a:          a,
+		subcommand: subcommand,
+		store:      st,
+		kClient:    kClient,
+		env:        env,
+		started:    false,
 	}
 }
 
@@ -112,6 +120,8 @@ func (ar *AnalyticsReporter) report(ctx context.Context) {
 		"env": string(ar.env),
 
 		"term_mode": strconv.Itoa(int(st.TerminalMode)),
+
+		"subcommand": ar.subcommand.String(),
 	}
 
 	if k8sCount > 1 {

--- a/internal/engine/analytics/analytics_reporter_test.go
+++ b/internal/engine/analytics/analytics_reporter_test.go
@@ -81,6 +81,7 @@ func TestAnalyticsReporter_Everything(t *testing.T) {
 		"k8s.runtime":                                         "docker",
 		"k8s.registry.host":                                   "1",
 		"k8s.registry.hostFromCluster":                        "1",
+		"subcommand":                                          "up",
 	}
 
 	tf.assertStats(t, expectedTags)
@@ -162,6 +163,7 @@ func TestAnalyticsReporter_TiltfileError(t *testing.T) {
 		"env":                    string(k8s.EnvDockerDesktop),
 		"term_mode":              "0",
 		"k8s.runtime":            "docker",
+		"subcommand":             "up",
 	}
 
 	tf.assertStats(t, expectedTags)
@@ -180,7 +182,7 @@ func newAnalyticsReporterTestFixture() *analyticsReporterTestFixture {
 	opter := tiltanalytics.NewFakeOpter(analytics.OptIn)
 	ma, a := tiltanalytics.NewMemoryTiltAnalyticsForTest(opter)
 	kClient := k8s.NewFakeK8sClient()
-	ar := ProvideAnalyticsReporter(a, st, kClient, k8s.EnvDockerDesktop)
+	ar := ProvideAnalyticsReporter(a, st, kClient, k8s.EnvDockerDesktop, "up")
 	return &analyticsReporterTestFixture{
 		manifestCount: 0,
 		ar:            ar,

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -3564,7 +3564,7 @@ func newTestFixture(t *testing.T) *testFixture {
 	fwm := fswatch.NewWatchManager(watcher.NewSub, timerMaker.Maker())
 	pfc := portforward.NewController(kCli)
 	au := engineanalytics.NewAnalyticsUpdater(ta, engineanalytics.CmdTags{})
-	ar := engineanalytics.ProvideAnalyticsReporter(ta, st, kCli, env)
+	ar := engineanalytics.ProvideAnalyticsReporter(ta, st, kCli, env, "up")
 	fakeDcc := dockercompose.NewFakeDockerComposeClient(t, ctx)
 	k8sContextExt := k8scontext.NewExtension("fake-context", env)
 	versionExt := version.NewExtension(model.TiltBuild{Version: "0.5.0"})

--- a/internal/tiltfile/config/config.go
+++ b/internal/tiltfile/config/config.go
@@ -25,15 +25,12 @@ type Settings struct {
 	seenWorkingDirectory string
 }
 
-// e.g., "up", "down", "ci"
-type TiltSubcommand string
-
 type Extension struct {
 	UserConfigState model.UserConfigState
-	TiltSubcommand  TiltSubcommand
+	TiltSubcommand  model.TiltSubcommand
 }
 
-func NewExtension(tiltSubcommand TiltSubcommand) *Extension {
+func NewExtension(tiltSubcommand model.TiltSubcommand) *Extension {
 	return &Extension{TiltSubcommand: tiltSubcommand}
 }
 

--- a/internal/tiltfile/config/config_test.go
+++ b/internal/tiltfile/config/config_test.go
@@ -459,7 +459,7 @@ print(config.tilt_subcommand)
 	require.Equal(t, "foo\n", f.PrintOutput())
 }
 
-func NewFixture(tb testing.TB, userConfigState model.UserConfigState, tiltSubcommand TiltSubcommand) *starkit.Fixture {
+func NewFixture(tb testing.TB, userConfigState model.UserConfigState, tiltSubcommand model.TiltSubcommand) *starkit.Fixture {
 	ext := NewExtension(tiltSubcommand)
 	ext.UserConfigState = userConfigState
 	ret := starkit.NewFixture(tb, ext, io.NewExtension(), include.IncludeFn{})

--- a/pkg/model/tilt_subcommand.go.go
+++ b/pkg/model/tilt_subcommand.go.go
@@ -1,0 +1,8 @@
+package model
+
+// e.g., "up", "down", "ci"
+type TiltSubcommand string
+
+func (t TiltSubcommand) String() string {
+	return string(t)
+}


### PR DESCRIPTION
### Problem

The `tilt.up.running` event also gets emitted by `tilt ci`, and includes no information to distinguish `tilt ci` from `tilt up`.

### Solution

Add a tag for the subcommand (e.g., "up", "ci") on `tilt.up.running` events.

### Notes

* We should rename `tilt.up.running` as well, but that makes this change riskier (since it gives us an inconsistency to account for in our analytics queries) and can be decoupled from this change.
* Ideally we have a separate mechanism to filter out runs in CI from human runs and this isn't the only thing we rely on, but:
  * that's always going to be a heuristic situation and more signal is better
  * this might be nice to have for other reasons
* Perhaps it'd be better add this as a global tag rather than just on this one count, but that's probably a couple hours of work instead of a few minutes.