### PR TITLE
tiltfile: resources with extra pod selectors or images should be considered workloads

### DIFF
--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -1447,7 +1447,8 @@ func TestExtraPodSelectors(t *testing.T) {
 	f.load()
 
 	f.assertNextManifest("foo",
-		extraPodSelectors(labels.Set{"foo": "bar", "baz": "qux"}, labels.Set{"quux": "corge"}))
+		extraPodSelectors(labels.Set{"foo": "bar", "baz": "qux"}, labels.Set{"quux": "corge"}),
+		nonWorkload(false))
 }
 
 func TestExtraPodSelectorsNotList(t *testing.T) {
@@ -1465,7 +1466,8 @@ func TestExtraPodSelectorsDict(t *testing.T) {
 	f.setupExtraPodSelectors("{'foo': 'bar'}")
 	f.load()
 	f.assertNextManifest("foo",
-		extraPodSelectors(labels.Set{"foo": "bar"}))
+		extraPodSelectors(labels.Set{"foo": "bar"}),
+		nonWorkload(false))
 }
 
 func TestExtraPodSelectorsElementNotDict(t *testing.T) {
@@ -2166,7 +2168,8 @@ docker_build('tilt.dev/frontend', '.')
 `)
 
 	f.load()
-	m := f.assertNextManifest("um")
+	m := f.assertNextManifest("um",
+		nonWorkload(false))
 	assert.Equal(t, "tilt.dev/frontend",
 		m.ImageTargets[0].Refs.LocalRef().String())
 }


### PR DESCRIPTION
Hello @jazzdan,

Please review the following commits I made in branch nicks/nonworkload:

993df2b62ed73023b453e2d30d3980b359a8a301 (2020-07-07 12:30:59 -0400)
tiltfile: resources with extra pod selectors or images should be considered workloads

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics