### PR TITLE
engine: updateMode=synclet only if explicitly set with flag [8240]

### DIFF
--- a/internal/containerupdate/exec_updater.go
+++ b/internal/containerupdate/exec_updater.go
@@ -39,6 +39,7 @@ func (cu *ExecUpdater) UpdateContainer(ctx context.Context, cInfo store.Containe
 	l := logger.Get(ctx)
 	w := logger.Get(ctx).Writer(logger.InfoLvl)
 
+	// delete files (if any)
 	if len(filesToDelete) > 0 {
 		err := cu.kCli.Exec(ctx,
 			cInfo.PodID, cInfo.ContainerName, cInfo.Namespace,
@@ -48,12 +49,14 @@ func (cu *ExecUpdater) UpdateContainer(ctx context.Context, cInfo store.Containe
 		}
 	}
 
+	// copy files to container
 	err := cu.kCli.Exec(ctx, cInfo.PodID, cInfo.ContainerName, cInfo.Namespace,
 		[]string{"tar", "-C", "/", "-x", "-f", "-"}, archiveToCopy, w, w)
 	if err != nil {
 		return err
 	}
 
+	// run commands
 	for i, c := range cmds {
 		l.Infof("[CMD %d/%d] %s", i+1, len(cmds), strings.Join(c.Argv, " "))
 		err := cu.kCli.Exec(ctx, cInfo.PodID, cInfo.ContainerName, cInfo.Namespace,

--- a/internal/engine/build_and_deployer.go
+++ b/internal/engine/build_and_deployer.go
@@ -127,13 +127,9 @@ func DefaultBuildOrder(lubad *LiveUpdateBuildAndDeployer, ibad *ImageBuildAndDep
 		return BuildOrder{dcbad, ibad, ltbad}
 	}
 
-	if updMode == buildcontrol.UpdateModeSynclet || shouldUseSynclet(updMode, env, runtime) {
+	if updMode == buildcontrol.UpdateModeSynclet {
 		ibad.SetInjectSynclet(true)
 	}
 
 	return BuildOrder{lubad, dcbad, ibad, ltbad}
-}
-
-func shouldUseSynclet(updMode buildcontrol.UpdateMode, env k8s.Env, runtime container.Runtime) bool {
-	return updMode == buildcontrol.UpdateModeAuto && !env.UsesLocalDockerRegistry() && runtime == container.RuntimeDocker
 }

--- a/internal/engine/build_and_deployer.go
+++ b/internal/engine/build_and_deployer.go
@@ -123,7 +123,7 @@ func (composite *CompositeBuildAndDeployer) BuildAndDeploy(ctx context.Context, 
 
 func DefaultBuildOrder(lubad *LiveUpdateBuildAndDeployer, ibad *ImageBuildAndDeployer, dcbad *DockerComposeBuildAndDeployer,
 	ltbad *LocalTargetBuildAndDeployer, updMode buildcontrol.UpdateMode, env k8s.Env, runtime container.Runtime) BuildOrder {
-	if updMode == buildcontrol.UpdateModeImage || updMode == buildcontrol.UpdateModeNaive {
+	if updMode == buildcontrol.UpdateModeImage {
 		return BuildOrder{dcbad, ibad, ltbad}
 	}
 

--- a/internal/engine/build_and_deployer_live_update_test.go
+++ b/internal/engine/build_and_deployer_live_update_test.go
@@ -7,8 +7,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/tilt-dev/tilt/internal/engine/buildcontrol"
 	"k8s.io/client-go/util/exec"
+
+	"github.com/tilt-dev/tilt/internal/engine/buildcontrol"
 
 	"github.com/tilt-dev/tilt/internal/k8s/testyaml"
 

--- a/internal/engine/build_and_deployer_test.go
+++ b/internal/engine/build_and_deployer_test.go
@@ -1013,6 +1013,10 @@ type bdFixture struct {
 }
 
 func newBDFixture(t *testing.T, env k8s.Env, runtime container.Runtime) *bdFixture {
+	return newBDFixtureWithUpdateMode(t, env, runtime, buildcontrol.UpdateModeAuto)
+}
+
+func newBDFixtureWithUpdateMode(t *testing.T, env k8s.Env, runtime container.Runtime, um buildcontrol.UpdateMode) *bdFixture {
 	logs := new(bytes.Buffer)
 	ctx, _, ta := testutils.ForkedCtxAndAnalyticsForTest(logs)
 	ctx, cancel := context.WithCancel(ctx)
@@ -1029,7 +1033,7 @@ func newBDFixture(t *testing.T, env k8s.Env, runtime container.Runtime) *bdFixtu
 	k8s := k8s.NewFakeK8sClient()
 	k8s.Runtime = runtime
 	sCli := synclet.NewTestSyncletClient(docker)
-	mode := buildcontrol.UpdateModeFlag(buildcontrol.UpdateModeAuto)
+	mode := buildcontrol.UpdateModeFlag(um)
 	dcc := dockercompose.NewFakeDockerComposeClient(t, ctx)
 	kl := &fakeKINDLoader{}
 	bd, err := provideBuildAndDeployer(ctx, docker, k8s, dir, env, mode, sCli, dcc, fakeClock{now: time.Unix(1551202573, 0)}, kl, ta)

--- a/internal/engine/buildcontrol/update_mode.go
+++ b/internal/engine/buildcontrol/update_mode.go
@@ -19,9 +19,6 @@ var (
 	// Only do image builds
 	UpdateModeImage UpdateMode = "image"
 
-	// Only do image builds from scratch
-	UpdateModeNaive UpdateMode = "naive" // NOTE(maia): this is redundant now?
-
 	// Deploy a synclet to make container updates faster
 	UpdateModeSynclet UpdateMode = "synclet"
 
@@ -36,7 +33,6 @@ var (
 var AllUpdateModes = []UpdateMode{
 	UpdateModeAuto,
 	UpdateModeImage,
-	UpdateModeNaive,
 	UpdateModeSynclet,
 	UpdateModeContainer,
 	UpdateModeKubectlExec,

--- a/internal/engine/buildcontrol/update_mode.go
+++ b/internal/engine/buildcontrol/update_mode.go
@@ -20,7 +20,7 @@ var (
 	UpdateModeImage UpdateMode = "image"
 
 	// Only do image builds from scratch
-	UpdateModeNaive UpdateMode = "naive"
+	UpdateModeNaive UpdateMode = "naive" // NOTE(maia): this is redundant now?
 
 	// Deploy a synclet to make container updates faster
 	UpdateModeSynclet UpdateMode = "synclet"

--- a/internal/engine/live_update_build_and_deployer.go
+++ b/internal/engine/live_update_build_and_deployer.go
@@ -265,10 +265,6 @@ func (lubad *LiveUpdateBuildAndDeployer) containerUpdaterForSpecs(specs []model.
 		return lubad.ecu
 	}
 
-	if shouldUseSynclet(lubad.updMode, lubad.env, lubad.runtime) {
-		return lubad.scu
-	}
-
 	if lubad.runtime == container.RuntimeDocker && lubad.env.UsesLocalDockerRegistry() {
 		return lubad.dcu
 	}


### PR DESCRIPTION
Hello @landism, @nicks,

Please review the following commits I made in branch maiamcc/rm-default-synclet:

dee0445636115c5ccea6139a21ed2afd3c5cd8b5 (2020-07-07 18:16:45 -0400)
fix other tests, rm redundant ones

da404d3ff71a9969b57d47c7da4faec34aed94b7 (2020-07-07 17:14:54 -0400)
fix liveupdate tests that expected synclet

12a71c2d55e9e4ec4a3646c4d158008890129d4f (2020-07-07 12:19:47 -0400)
only use synclet with explicit flag (needs tests)

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics