### PR TITLE
cli: rename mode metric to update_mode for readability

### DIFF
--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -125,7 +125,7 @@ func (c *upCmd) run(ctx context.Context, args []string) error {
 	}
 
 	cmdUpTags := engineanalytics.CmdTags(map[string]string{
-		"update_mode": updateModeFlag,
+		"update_mode": updateModeFlag, // before 7/8/20 this was just called "mode"
 		"term_mode":   strconv.Itoa(int(termMode)),
 	})
 	a.Incr("cmd.up", cmdUpTags.AsMap())

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -125,8 +125,8 @@ func (c *upCmd) run(ctx context.Context, args []string) error {
 	}
 
 	cmdUpTags := engineanalytics.CmdTags(map[string]string{
-		"mode":      string(updateModeFlag),
-		"term_mode": strconv.Itoa(int(termMode)),
+		"update_mode": updateModeFlag,
+		"term_mode":   strconv.Itoa(int(termMode)),
 	})
 	a.Incr("cmd.up", cmdUpTags.AsMap())
 	defer a.Flush(time.Second)


### PR DESCRIPTION
Hello @abdullahzameek, @nicks,

Please review the following commits I made in branch maiamcc/update_mode-metric:

890db9b7c837944e99687fc115a30e1345c95bc3 (2020-07-08 14:22:29 -0400)
cli: rename mode metric to update_mode for readability

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics