### PR TITLE
engine: parallize builds with common re-usable images. Fixes https://github.com/tilt-dev/tilt/issues/3468

### DIFF
--- a/internal/engine/buildcontrol/build_control.go
+++ b/internal/engine/buildcontrol/build_control.go
@@ -86,6 +86,43 @@ func isWaitingOnDependencies(state store.EngineState, mt *store.ManifestTarget) 
 	return false
 }
 
+// Check to see if this is an ImageTarget where the built image
+// can be potentially reused.
+//
+// Note that this is a quick heuristic check for making parallelization decisions.
+//
+// The "correct" decision about whether an image can be re-used is more complex
+// and expensive, and includes:
+//
+// 1) Checks of dependent images
+// 2) Live-update sync checks
+// 3) Checks that the image still exists on the image store
+//
+// But in this particular context, we can cheat a bit.
+func canReuseImageTargetHeuristic(spec model.TargetSpec, status store.BuildStatus) bool {
+	id := spec.ID()
+	if id.Type != model.TargetTypeImage {
+		return false
+	}
+
+	// NOTE(nick): A more accurate check might see if the pending file changes
+	// are potentially live-updatable, but this is OK for the case of a base image.
+	if len(status.PendingFileChanges) > 0 || len(status.PendingDependencyChanges) > 0 {
+		return false
+	}
+
+	result := status.LastResult
+	if result == nil {
+		return false
+	}
+
+	switch result.(type) {
+	case store.ImageBuildResult, store.LiveUpdateBuildResult:
+		return true
+	}
+	return false
+}
+
 func RemoveTargetsWithBuildingComponents(mts []*store.ManifestTarget) []*store.ManifestTarget {
 	building := make(map[model.TargetID]bool)
 
@@ -93,20 +130,27 @@ func RemoveTargetsWithBuildingComponents(mts []*store.ManifestTarget) []*store.M
 		if mt.State.IsBuilding() {
 			building[mt.Manifest.ID()] = true
 
-			// TODO(nick): This logic isn't quite right.  A manifest can re-use image
-			// results from another manifest's build.
 			for _, spec := range mt.Manifest.TargetSpecs() {
+				if canReuseImageTargetHeuristic(spec, mt.State.BuildStatus(spec.ID())) {
+					continue
+				}
+
 				building[spec.ID()] = true
 			}
 		}
 	}
 
-	isBuilding := func(m model.Manifest) bool {
+	hasBuildingComponent := func(mt *store.ManifestTarget) bool {
+		m := mt.Manifest
 		if building[m.ID()] {
 			return true
 		}
 
 		for _, spec := range m.TargetSpecs() {
+			if canReuseImageTargetHeuristic(spec, mt.State.BuildStatus(spec.ID())) {
+				continue
+			}
+
 			if building[spec.ID()] {
 				return true
 			}
@@ -116,7 +160,7 @@ func RemoveTargetsWithBuildingComponents(mts []*store.ManifestTarget) []*store.M
 
 	var ret []*store.ManifestTarget
 	for _, mt := range mts {
-		if !isBuilding(mt.Manifest) {
+		if !hasBuildingComponent(mt) {
 			ret = append(ret, mt)
 		}
 	}

--- a/internal/engine/buildcontrol/build_control_test.go
+++ b/internal/engine/buildcontrol/build_control_test.go
@@ -95,6 +95,36 @@ func TestTwoK8sTargetsWithBaseImage(t *testing.T) {
 	f.assertNextTargetToBuild("sancho-two")
 }
 
+func TestTwoK8sTargetsWithBaseImagePrebuilt(t *testing.T) {
+	f := newTestFixture(t)
+	defer f.TearDown()
+
+	baseImage := model.MustNewImageTarget(container.MustParseSelector("sancho-base"))
+	sanchoOneImage := model.MustNewImageTarget(container.MustParseSelector("sancho-one")).
+		WithDependencyIDs([]model.TargetID{baseImage.ID()})
+	sanchoTwoImage := model.MustNewImageTarget(container.MustParseSelector("sancho-two")).
+		WithDependencyIDs([]model.TargetID{baseImage.ID()})
+
+	sanchoOne := f.upsertManifest(manifestbuilder.New(f, "sancho-one").
+		WithImageTargets(baseImage, sanchoOneImage).
+		WithK8sYAML(testyaml.SanchoYAML).
+		Build())
+	sanchoTwo := f.upsertManifest(manifestbuilder.New(f, "sancho-two").
+		WithImageTargets(baseImage, sanchoTwoImage).
+		WithK8sYAML(testyaml.SanchoYAML).
+		Build())
+
+	sanchoOne.State.MutableBuildStatus(baseImage.ID()).LastResult = store.ImageBuildResult{}
+	sanchoTwo.State.MutableBuildStatus(baseImage.ID()).LastResult = store.ImageBuildResult{}
+
+	f.assertNextTargetToBuild("sancho-one")
+
+	sanchoOne.State.CurrentBuild = model.BuildRecord{StartTime: time.Now()}
+
+	// Make sure sancho-two can start while sanchoOne is still pending.
+	f.assertNextTargetToBuild("sancho-two")
+}
+
 type testFixture struct {
 	*tempdir.TempDirFixture
 	t  *testing.T


### PR DESCRIPTION
Hello @maiamcc, @landism,

Please review the following commits I made in branch nicks/ch7744:

75a55f0ae520130718dc631413ab292bd0025475 (2020-07-08 14:47:03 -0400)
engine: parallize builds with common re-usable images. Fixes https://github.com/tilt-dev/tilt/issues/3468

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics