### PR TITLE
tiltfile: StringOrStringList: require Union[string,Union[List,Tuple]] instead of Union[string,Iterable]

### DIFF
--- a/internal/tiltfile/docker.go
+++ b/internal/tiltfile/docker.go
@@ -192,18 +192,19 @@ func (s *tiltfileState) dockerBuild(thread *starlark.Thread, fn *starlark.Builti
 		return nil, err
 	}
 
-	ssh, ok := value.AsStringOrStringList(sshVal)
-	if !ok {
-		return nil, fmt.Errorf("Argument 'ssh' must be string or list of strings. Actual: %T", sshVal)
+	ssh, err := value.AsStringOrStringList(sshVal)
+	if err != nil {
+		return nil, errors.Wrap(err, "Argument 'ssh'")
 	}
 
-	secret, ok := value.AsStringOrStringList(secretVal)
-	if !ok {
-		return nil, fmt.Errorf("Argument 'secret' must be string or list of strings. Actual: %T", secretVal)
+	secret, err := value.AsStringOrStringList(secretVal)
+	if err != nil {
+		return nil, errors.Wrap(err, "Argument 'secret'")
 	}
 
 	network := ""
 	if networkVal != nil {
+		var ok bool
 		network, ok = value.AsString(networkVal)
 		if !ok {
 			return nil, fmt.Errorf("Argument 'network' must be string. Actual: %T", networkVal)
@@ -224,9 +225,9 @@ func (s *tiltfileState) dockerBuild(thread *starlark.Thread, fn *starlark.Builti
 		containerArgs = model.OverrideArgs{ShouldOverride: true, Args: args}
 	}
 
-	extraTags, ok := value.AsStringOrStringList(extraTagsVal)
-	if !ok {
-		return nil, fmt.Errorf("Argument 'extra_tag' must be string or list of strings. Actual: %T", extraTagsVal)
+	extraTags, err := value.AsStringOrStringList(extraTagsVal)
+	if err != nil {
+		return nil, errors.Wrap(err, "Argument 'extra_tag'")
 	}
 
 	for _, extraTag := range extraTags {

--- a/internal/tiltfile/files.go
+++ b/internal/tiltfile/files.go
@@ -138,15 +138,14 @@ func (s *tiltfileState) helm(thread *starlark.Thread, fn *starlark.Builtin, args
 		return nil, fmt.Errorf("Argument 0 (paths): %v", err)
 	}
 
-	valueFiles, ok := value.AsStringOrStringList(valueFilesV)
-	if !ok {
-		return nil, fmt.Errorf("Argument 'values' must be string or list of strings. Actual: %T",
-			valueFilesV)
+	valueFiles, err := value.AsStringOrStringList(valueFilesV)
+	if err != nil {
+		return nil, errors.Wrap(err, "Argument 'values'")
 	}
 
-	set, ok := value.AsStringOrStringList(setV)
-	if !ok {
-		return nil, fmt.Errorf("Argument 'set' must be string or list of strings. Actual: %T", setV)
+	set, err := value.AsStringOrStringList(setV)
+	if err != nil {
+		return nil, errors.Wrap(err, "Argument 'set'")
 	}
 
 	info, err := os.Stat(localPath)

--- a/internal/tiltfile/helm_test.go
+++ b/internal/tiltfile/helm_test.go
@@ -52,7 +52,7 @@ yml = helm('./helm', name='rose-quartz', namespace='garnet', set={'a': 'b'})
 k8s_yaml(yml)
 `)
 
-	f.loadErrString("Argument 'set': value should be a string or List of strings, but is of type dict")
+	f.loadErrString("helm: for parameter \"set\"", "string", "List", "type dict")
 }
 
 const exampleHelmV2VersionOutput = `Client: v2.12.3geecf22f`

--- a/internal/tiltfile/helm_test.go
+++ b/internal/tiltfile/helm_test.go
@@ -41,6 +41,20 @@ k8s_yaml(yml)
 	assert.Contains(t, yaml, "servicePort: 1234")
 }
 
+func TestHelmSetArgsMap(t *testing.T) {
+	f := newFixture(t)
+	defer f.TearDown()
+
+	f.setupHelm()
+
+	f.file("Tiltfile", `
+yml = helm('./helm', name='rose-quartz', namespace='garnet', set={'a': 'b'})
+k8s_yaml(yml)
+`)
+
+	f.loadErrString("Argument 'set': value should be a string or List of strings, but is of type dict")
+}
+
 const exampleHelmV2VersionOutput = `Client: v2.12.3geecf22f`
 const exampleHelmV3VersionOutput = `v3.0.0`
 

--- a/internal/tiltfile/value/string_test.go
+++ b/internal/tiltfile/value/string_test.go
@@ -8,31 +8,35 @@ import (
 )
 
 func TestAsStringOrStringList_String(t *testing.T) {
-	actual, err := AsStringOrStringList(starlark.String("foo"))
+	var v StringOrStringList
+	err := v.Unpack(starlark.String("foo"))
 
 	require.NoError(t, err)
-	require.Equal(t, []string{"foo"}, actual)
+	require.Equal(t, []string{"foo"}, v.Values)
 }
 
 func TestAsStringOrStringList_ListOfStrings(t *testing.T) {
-	actual, err := AsStringOrStringList(starlark.NewList([]starlark.Value{
+	var v StringOrStringList
+	err := v.Unpack(starlark.NewList([]starlark.Value{
 		starlark.String("foo"),
 		starlark.String("bar"),
 		starlark.String("baz"),
 	}))
 
 	require.NoError(t, err)
-	require.Equal(t, []string{"foo", "bar", "baz"}, actual)
+	require.Equal(t, []string{"foo", "bar", "baz"}, v.Values)
 }
 
 func TestAsStringOrStringList_NonStringOrList(t *testing.T) {
-	_, err := AsStringOrStringList(starlark.Bool(true))
+	var v StringOrStringList
+	err := v.Unpack(starlark.Bool(true))
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "value should be a string or List of strings, but is of type bool")
+	require.Contains(t, err.Error(), "value should be a string or List or Tuple of strings, but is of type bool")
 }
 
 func TestAsStringOrStringList_ListWithNonStringElement(t *testing.T) {
-	_, err := AsStringOrStringList(starlark.NewList([]starlark.Value{starlark.String("foo"), starlark.Bool(true)}))
+	var v StringOrStringList
+	err := v.Unpack(starlark.NewList([]starlark.Value{starlark.String("foo"), starlark.Bool(true)}))
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "list should contain only strings, but element \"True\" was of type bool")
 }
@@ -45,7 +49,8 @@ func TestAsStringOrStringList_Map(t *testing.T) {
 	err = m.SetKey(starlark.String("bar"), starlark.String("2"))
 	require.NoError(t, err)
 
-	_, err = AsStringOrStringList(m)
+	var v StringOrStringList
+	err = v.Unpack(m)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "value should be a string or List of strings, but is of type dict")
+	require.Contains(t, err.Error(), "value should be a string or List or Tuple of strings, but is of type dict")
 }

--- a/internal/tiltfile/value/string_test.go
+++ b/internal/tiltfile/value/string_test.go
@@ -1,0 +1,51 @@
+package value
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.starlark.net/starlark"
+)
+
+func TestAsStringOrStringList_String(t *testing.T) {
+	actual, err := AsStringOrStringList(starlark.String("foo"))
+
+	require.NoError(t, err)
+	require.Equal(t, []string{"foo"}, actual)
+}
+
+func TestAsStringOrStringList_ListOfStrings(t *testing.T) {
+	actual, err := AsStringOrStringList(starlark.NewList([]starlark.Value{
+		starlark.String("foo"),
+		starlark.String("bar"),
+		starlark.String("baz"),
+	}))
+
+	require.NoError(t, err)
+	require.Equal(t, []string{"foo", "bar", "baz"}, actual)
+}
+
+func TestAsStringOrStringList_NonStringOrList(t *testing.T) {
+	_, err := AsStringOrStringList(starlark.Bool(true))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "value should be a string or List of strings, but is of type bool")
+}
+
+func TestAsStringOrStringList_ListWithNonStringElement(t *testing.T) {
+	_, err := AsStringOrStringList(starlark.NewList([]starlark.Value{starlark.String("foo"), starlark.Bool(true)}))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "list should contain only strings, but element \"True\" was of type bool")
+}
+
+// https://github.com/tilt-dev/tilt/issues/3570
+func TestAsStringOrStringList_Map(t *testing.T) {
+	m := starlark.NewDict(2)
+	err := m.SetKey(starlark.String("foo"), starlark.String("1"))
+	require.NoError(t, err)
+	err = m.SetKey(starlark.String("bar"), starlark.String("2"))
+	require.NoError(t, err)
+
+	_, err = AsStringOrStringList(m)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "value should be a string or List of strings, but is of type dict")
+}


### PR DESCRIPTION
fixes #3570

also improves the error message when one of the list elements is the wrong type

My main outstanding concern is if there are non-List Iterables other than map that we still want to accept. I did test that generators still get represented as lists.