### PR TITLE
engine: fix a bug where resource_deps on non-workloads didn't work correctly

### DIFF
--- a/internal/engine/exit/controller_test.go
+++ b/internal/engine/exit/controller_test.go
@@ -106,7 +106,7 @@ func TestExitControlCIFirstRuntimeFailure(t *testing.T) {
 
 	f.store.WithState(func(state *store.EngineState) {
 		mt := state.ManifestTargets["fe"]
-		mt.State.RuntimeState = store.NewK8sRuntimeState(mt.Manifest, store.Pod{
+		mt.State.RuntimeState = store.NewK8sRuntimeStateWithPods(mt.Manifest, store.Pod{
 			PodID:  "pod-a",
 			Status: "ErrImagePull",
 			Containers: []store.Container{
@@ -142,7 +142,7 @@ func TestExitControlCISuccess(t *testing.T) {
 			StartTime:  time.Now(),
 			FinishTime: time.Now(),
 		})
-		state.ManifestTargets["fe"].State.RuntimeState = store.NewK8sRuntimeState(m, readyPod("pod-a"))
+		state.ManifestTargets["fe"].State.RuntimeState = store.NewK8sRuntimeStateWithPods(m, readyPod("pod-a"))
 	})
 
 	f.c.OnChange(f.ctx, f.store)
@@ -150,7 +150,7 @@ func TestExitControlCISuccess(t *testing.T) {
 
 	f.store.WithState(func(state *store.EngineState) {
 		mt := state.ManifestTargets["fe2"]
-		mt.State.RuntimeState = store.NewK8sRuntimeState(mt.Manifest, readyPod("pod-b"))
+		mt.State.RuntimeState = store.NewK8sRuntimeStateWithPods(mt.Manifest, readyPod("pod-b"))
 	})
 
 	// Verify that if one pod fails with an error, it fails immediately.
@@ -171,7 +171,7 @@ func TestExitControlCIJobSuccess(t *testing.T) {
 			StartTime:  time.Now(),
 			FinishTime: time.Now(),
 		})
-		state.ManifestTargets["fe"].State.RuntimeState = store.NewK8sRuntimeState(m, readyPod("pod-a"))
+		state.ManifestTargets["fe"].State.RuntimeState = store.NewK8sRuntimeStateWithPods(m, readyPod("pod-a"))
 	})
 
 	f.c.OnChange(f.ctx, f.store)
@@ -179,7 +179,7 @@ func TestExitControlCIJobSuccess(t *testing.T) {
 
 	f.store.WithState(func(state *store.EngineState) {
 		mt := state.ManifestTargets["fe"]
-		mt.State.RuntimeState = store.NewK8sRuntimeState(mt.Manifest, successPod("pod-a"))
+		mt.State.RuntimeState = store.NewK8sRuntimeStateWithPods(mt.Manifest, successPod("pod-a"))
 	})
 
 	// Verify that if one pod fails with an error, it fails immediately.
@@ -201,7 +201,7 @@ func TestExitControlCIDontBlockOnAutoInitFalse(t *testing.T) {
 			StartTime:  time.Now(),
 			FinishTime: time.Now(),
 		})
-		mt.State.RuntimeState = store.NewK8sRuntimeState(mt.Manifest, readyPod("pod-a"))
+		mt.State.RuntimeState = store.NewK8sRuntimeStateWithPods(mt.Manifest, readyPod("pod-a"))
 
 		manifestAutoInitFalse := manifestbuilder.New(f, "local").WithLocalResource("echo hi", nil).
 			WithTriggerMode(model.TriggerModeManualIncludingInitial).Build()
@@ -213,7 +213,7 @@ func TestExitControlCIDontBlockOnAutoInitFalse(t *testing.T) {
 
 	f.store.WithState(func(state *store.EngineState) {
 		mt := state.ManifestTargets["fe"]
-		mt.State.RuntimeState = store.NewK8sRuntimeState(mt.Manifest, successPod("pod-a"))
+		mt.State.RuntimeState = store.NewK8sRuntimeStateWithPods(mt.Manifest, successPod("pod-a"))
 	})
 
 	// Verify that if one pod fails with an error, it fails immediately.

--- a/internal/engine/portforward/controller_test.go
+++ b/internal/engine/portforward/controller_test.go
@@ -42,7 +42,7 @@ func TestPortForward(t *testing.T) {
 
 	state = f.st.LockMutableStateForTesting()
 	mt := state.ManifestTargets["fe"]
-	mt.State.RuntimeState = store.NewK8sRuntimeState(mt.Manifest,
+	mt.State.RuntimeState = store.NewK8sRuntimeStateWithPods(mt.Manifest,
 		store.Pod{PodID: "pod-id", Phase: v1.PodRunning})
 	f.st.UnlockMutableState()
 
@@ -53,7 +53,7 @@ func TestPortForward(t *testing.T) {
 
 	state = f.st.LockMutableStateForTesting()
 	mt = state.ManifestTargets["fe"]
-	mt.State.RuntimeState = store.NewK8sRuntimeState(mt.Manifest,
+	mt.State.RuntimeState = store.NewK8sRuntimeStateWithPods(mt.Manifest,
 		store.Pod{PodID: "pod-id2", Phase: v1.PodRunning})
 	f.st.UnlockMutableState()
 
@@ -63,7 +63,7 @@ func TestPortForward(t *testing.T) {
 
 	state = f.st.LockMutableStateForTesting()
 	mt = state.ManifestTargets["fe"]
-	mt.State.RuntimeState = store.NewK8sRuntimeState(mt.Manifest, store.Pod{PodID: "pod-id2", Phase: v1.PodPending})
+	mt.State.RuntimeState = store.NewK8sRuntimeStateWithPods(mt.Manifest, store.Pod{PodID: "pod-id2", Phase: v1.PodPending})
 	f.st.UnlockMutableState()
 
 	f.onChange()
@@ -91,7 +91,7 @@ func TestPortForwardAutoDiscovery(t *testing.T) {
 	state.UpsertManifestTarget(store.NewManifestTarget(m))
 
 	mt := state.ManifestTargets["fe"]
-	mt.State.RuntimeState = store.NewK8sRuntimeState(mt.Manifest,
+	mt.State.RuntimeState = store.NewK8sRuntimeStateWithPods(mt.Manifest,
 		store.Pod{PodID: "pod-id", Phase: v1.PodRunning})
 	f.st.UnlockMutableState()
 
@@ -126,7 +126,7 @@ func TestPortForwardAutoDiscovery2(t *testing.T) {
 	state.UpsertManifestTarget(store.NewManifestTarget(m))
 
 	mt := state.ManifestTargets["fe"]
-	mt.State.RuntimeState = store.NewK8sRuntimeState(mt.Manifest, store.Pod{
+	mt.State.RuntimeState = store.NewK8sRuntimeStateWithPods(mt.Manifest, store.Pod{
 		PodID: "pod-id",
 		Phase: v1.PodRunning,
 		Containers: []store.Container{
@@ -155,7 +155,7 @@ func TestPortForwardChangePort(t *testing.T) {
 	})
 	state.UpsertManifestTarget(store.NewManifestTarget(m))
 	mt := state.ManifestTargets["fe"]
-	mt.State.RuntimeState = store.NewK8sRuntimeState(mt.Manifest, store.Pod{PodID: "pod-id", Phase: v1.PodRunning})
+	mt.State.RuntimeState = store.NewK8sRuntimeStateWithPods(mt.Manifest, store.Pod{PodID: "pod-id", Phase: v1.PodRunning})
 	f.st.UnlockMutableState()
 
 	f.onChange()
@@ -190,7 +190,7 @@ func TestPortForwardRestart(t *testing.T) {
 	})
 	state.UpsertManifestTarget(store.NewManifestTarget(m))
 	mt := state.ManifestTargets["fe"]
-	mt.State.RuntimeState = store.NewK8sRuntimeState(mt.Manifest,
+	mt.State.RuntimeState = store.NewK8sRuntimeStateWithPods(mt.Manifest,
 		store.Pod{PodID: "pod-id", Phase: v1.PodRunning})
 	f.st.UnlockMutableState()
 

--- a/internal/store/engine_state_test.go
+++ b/internal/store/engine_state_test.go
@@ -81,8 +81,12 @@ func TestRuntimeStateNonWorkload(t *testing.T) {
 		WithK8sYAML(testyaml.SecretYaml).
 		Build()
 	state := newState([]model.Manifest{m})
-	assert.Equal(t, model.RuntimeStatusOK,
-		state.ManifestTargets[m.Name].State.K8sRuntimeState().RuntimeStatus())
+	runtimeState := state.ManifestTargets[m.Name].State.K8sRuntimeState()
+	assert.Equal(t, model.RuntimeStatusPending, runtimeState.RuntimeStatus())
+
+	runtimeState.HasEverDeployedSuccessfully = true
+
+	assert.Equal(t, model.RuntimeStatusOK, runtimeState.RuntimeStatus())
 }
 
 func TestStateToViewUnresourcedYAMLManifest(t *testing.T) {
@@ -126,7 +130,7 @@ func TestMostRecentPod(t *testing.T) {
 	podB := Pod{PodID: "pod-b", StartedAt: time.Now().Add(time.Minute)}
 	podC := Pod{PodID: "pod-c", StartedAt: time.Now().Add(-time.Minute)}
 	m := model.Manifest{Name: "fe"}
-	podSet := NewK8sRuntimeState(m, podA, podB, podC)
+	podSet := NewK8sRuntimeStateWithPods(m, podA, podB, podC)
 	assert.Equal(t, "pod-b", podSet.MostRecentPod().PodID.String())
 }
 

--- a/internal/testutils/manifestutils/manifest.go
+++ b/internal/testutils/manifestutils/manifest.go
@@ -7,6 +7,6 @@ import (
 
 func NewManifestTargetWithPod(m model.Manifest, pod store.Pod) *store.ManifestTarget {
 	mt := store.NewManifestTarget(m)
-	mt.State.RuntimeState = store.NewK8sRuntimeState(m, pod)
+	mt.State.RuntimeState = store.NewK8sRuntimeStateWithPods(m, pod)
 	return mt
 }


### PR DESCRIPTION
Hello @jazzdan, @landism,

Please review the following commits I made in branch nicks/resource-deps:

872a060679f012121fc30770539ca2dc3a4acc12 (2020-07-09 19:21:48 -0400)
engine: fix a bug where resource_deps on non-workloads didn't work correctly

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics