### PR TITLE
tiltfile: removed logging of executed command in local()

### DIFF
--- a/internal/tiltfile/files.go
+++ b/internal/tiltfile/files.go
@@ -37,7 +37,7 @@ func (s *tiltfileState) local(thread *starlark.Thread, fn *starlark.Builtin, arg
 	if err != nil {
 		return nil, err
 	}
-	s.logger.Infof("local: %s", cmd)
+	//Removed the info log that logged the local command being executed as per https://github.com/tilt-dev/tilt/issues/3528
 	out, err := s.execLocalCmd(thread, exec.Command(cmd.Argv[0], cmd.Argv[1:]...), !quiet)
 	if err != nil {
 		return nil, err

--- a/internal/tiltfile/files.go
+++ b/internal/tiltfile/files.go
@@ -24,10 +24,12 @@ const localLogPrefix = " → "
 func (s *tiltfileState) local(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	var commandValue, commandBatValue starlark.Value
 	quiet := false
+	echoOff := false
 	err := s.unpackArgs(fn.Name(), args, kwargs,
 		"command", &commandValue,
 		"quiet?", &quiet,
 		"command_bat", &commandBatValue,
+		"echo_off", &echoOff,
 	)
 	if err != nil {
 		return nil, err
@@ -37,7 +39,11 @@ func (s *tiltfileState) local(thread *starlark.Thread, fn *starlark.Builtin, arg
 	if err != nil {
 		return nil, err
 	}
-	//Removed the info log that logged the local command being executed as per https://github.com/tilt-dev/tilt/issues/3528
+
+	if !echoOff {
+		s.logger.Infof("local: %s", cmd)
+	}
+
 	out, err := s.execLocalCmd(thread, exec.Command(cmd.Argv[0], cmd.Argv[1:]...), !quiet)
 	if err != nil {
 		return nil, err

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -328,6 +328,20 @@ local('echo foobar', quiet=True)
 	assert.NotContains(t, f.out.String(), " → foobar")
 }
 
+func TestLocalEchoOff(t *testing.T) {
+	f := newFixture(t)
+	defer f.TearDown()
+
+	f.setupFoo()
+
+	f.file("Tiltfile", `
+local('echo foobar', echo_off=True)
+`)
+
+	f.load()
+
+	assert.NotContains(t, f.out.String(), "local: echo foobar")
+}
 func TestLocalArgvCmd(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("windows doesn't support argv commands. Go converts it to a single string")


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch abdullahzameek/3528-remove-local-log

50e4e5b5a16f1342269d350f570319710c8a6f88  (Wed Jul 15 17:35:30 2020 +0400)
tiltfile: removed logging of executed command in local()

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics