### PR TITLE
build: set permission bits when we tar dockerfile into docker context

### DIFF
--- a/internal/build/tar.go
+++ b/internal/build/tar.go
@@ -55,6 +55,7 @@ func (a *ArchiveBuilder) archiveDf(ctx context.Context, df dockerfile.Dockerfile
 		Name:       "Dockerfile",
 		Typeflag:   tar.TypeReg,
 		Size:       int64(len(df)),
+		Mode:       0644,
 		ModTime:    time.Now(),
 		AccessTime: time.Now(),
 		ChangeTime: time.Now(),

--- a/internal/build/tar_test.go
+++ b/internal/build/tar_test.go
@@ -40,6 +40,7 @@ func TestArchiveDf(t *testing.T) {
 		Path:                   "Dockerfile",
 		Contents:               dfText,
 		AssertUidAndGidAreZero: true,
+		Mode:                   0644,
 	})
 }
 

--- a/internal/testutils/tar.go
+++ b/internal/testutils/tar.go
@@ -30,6 +30,9 @@ type ExpectedFile struct {
 	// If true, we will assert that this is a symlink with a linkname.
 	Linkname string
 
+	// If non-zero, assert that file permission and mode bits match this value
+	Mode int64
+
 	// Windows filesystem APIs don't expose an executable bit.
 	// So when we create docker images on windows, we set the executable
 	// bit on all files, for consistency with Docker.
@@ -113,6 +116,10 @@ func AssertFilesInTar(t testing.TB, tr *tar.Reader, expectedFiles []ExpectedFile
 
 		if expected.AssertUidAndGidAreZero && header.Gid != expectedUidAndGid {
 			t.Errorf("Expected %s to have GID 0, got %d (%s)", header.Name, header.Gid, msg)
+		}
+
+		if expected.Mode != 0 && header.Mode != expected.Mode {
+			t.Errorf("Expected %s to have mode %d, got %d", header.Name, expected.Mode, header.Mode)
 		}
 
 		if expected.HasExecBitWindows && runtime.GOOS == "windows" && (os.FileMode(header.Mode)&0111 == 0) {


### PR DESCRIPTION
a user had an issue copying `.` (in their container) into a volume: they got permission errors b/c we tar in the dockerfile with no permission bits. this PR sets permissions arbitrarily to 0644.

we tar in the dockerfile b/c docker requires that the dockerfile exist _somewhere_ in the archive. the idea solution here would be to [replicate Docker's behavior](https://github.com/docker/cli/blob/bece8cc41c248050e1c70ea73ce0097bc5a8e11e/cli/command/image/build/context.go#L374) of putting the Dockerfile _somewhere random_ in the context such that it's in the archive (as is needed for building the image) but doesn't get copied into the container if the user runs `COPY . ...`.