### PR TITLE
use keg_only install for homebrew if tilt gem is installed

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -47,6 +47,10 @@ brews:
   description: "Tilt powers multi-service developments for teams that deploy to Kubernetes."
   test: |
     system "#{bin}/tilt version"
+  custom_block: |
+    if  Gem::Specification::find_all_by_name('tilt').any?
+      keg_only :param, 'because you you requested it'
+    end 
 dockers:
 - image_templates:
     - "tiltdev/tilt"


### PR DESCRIPTION
#3598 

A [known issue](https://docs.tilt.dev/faq.html#q-when-i-run-tilt-version-i-see-template-engine-not-found-for-version-what-do-i-do) with home-brew installations of tilt is that they can conflict with the `tilt` gem. We can fix this by checking if this gem is installed and doing a keg_only brew install