### PR TITLE
tiltfile: added error when duplicate yaml is detected

### DIFF
--- a/internal/k8s/names.go
+++ b/internal/k8s/names.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 )
 
-const FmtduplicateYamlDetectedError = "Duplicate YAML Entity(s): [%s] has been detected across one or more resources.  Only one specification per entity can be applied to the cluster; to ensure expected behavior, remove the duplicate specifications."
+const FmtduplicateYamlDetectedError = "Duplicate YAML Entity: %s has been detected across one or more resources.  Only one specification per entity can be applied to the cluster; to ensure expected behavior, remove the duplicate specifications."
 
 func DuplicateYamlDetectedError(duplicatedYaml string) string {
 	return fmt.Sprintf(FmtduplicateYamlDetectedError, duplicatedYaml)

--- a/internal/k8s/names.go
+++ b/internal/k8s/names.go
@@ -5,10 +5,10 @@ import (
 	"strings"
 )
 
-const FmtduplicateYamlDetectedError = "Duplicate YAML Entity: %s has been detected across one or more resources.  Only one specification per entity can be applied to the cluster; to ensure expected behavior, remove the duplicate specifications."
+const fmtduplicateYAMLDetectedError = "Duplicate YAML Entity: %s has been detected across one or more resources.  Only one specification per entity can be applied to the cluster; to ensure expected behavior, remove the duplicate specifications."
 
-func DuplicateYamlDetectedError(duplicatedYaml string) string {
-	return fmt.Sprintf(FmtduplicateYamlDetectedError, duplicatedYaml)
+func DuplicateYAMLDetectedError(duplicatedYaml string) string {
+	return fmt.Sprintf(fmtduplicateYAMLDetectedError, duplicatedYaml)
 }
 
 // Calculates names for workloads by using the shortest uniquely matching identifiers
@@ -36,7 +36,7 @@ func UniqueNames(es []K8sEntity, minComponents int) ([]string, error) {
 		if ret[i] == "" {
 			// Previously, we appended an index to the duplicate yaml entity, but as of July 21st 2020, we return an error
 			//if we've detected a duplicate yaml entity.
-			return nil, fmt.Errorf(DuplicateYamlDetectedError(names[len(names)-1]))
+			return nil, fmt.Errorf(DuplicateYAMLDetectedError(names[len(names)-1]))
 		}
 	}
 

--- a/internal/k8s/names_test.go
+++ b/internal/k8s/names_test.go
@@ -31,7 +31,7 @@ func TestUniqueResourceNames(t *testing.T) {
 		{"one workload, same name", []workload{
 			{"foo", "Deployment", "default", "", ""},
 			{"foo", "Deployment", "default", "", ""},
-		}, DuplicateYamlDetectedError("foo:deployment:default:core")},
+		}, DuplicateYAMLDetectedError("foo:deployment:default:core")},
 		{"one workload, by name", []workload{
 			{"foo", "Deployment", "default", "", "foo"},
 			{"bar", "Deployment", "default", "", "bar"},

--- a/internal/k8s/names_test.go
+++ b/internal/k8s/names_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/tilt-dev/tilt/internal/k8s/testyaml"
@@ -20,37 +21,38 @@ type workload struct {
 
 func TestUniqueResourceNames(t *testing.T) {
 	testCases := []struct {
-		testName  string
-		workloads []workload
+		testName      string
+		workloads     []workload
+		expectedError string
 	}{
 		{"one workload, just name", []workload{
 			{"foo", "Deployment", "default", "", "foo"},
-		}},
+		}, ""},
 		{"one workload, same name", []workload{
-			{"foo", "Deployment", "default", "", "foo:deployment:default:core:0"},
-			{"foo", "Deployment", "default", "", "foo:deployment:default:core:1"},
-		}},
+			{"foo", "Deployment", "default", "", ""},
+			{"foo", "Deployment", "default", "", ""},
+		}, DuplicateYamlDetectedError("foo:deployment:default:core")},
 		{"one workload, by name", []workload{
 			{"foo", "Deployment", "default", "", "foo"},
 			{"bar", "Deployment", "default", "", "bar"},
-		}},
+		}, ""},
 		{"two workloads, by kind", []workload{
 			{"foo", "Deployment", "default", "", "foo:deployment"},
 			{"foo", "CronJob", "default", "", "foo:cronjob"},
-		}},
+		}, ""},
 		{"two workloads, by namespace", []workload{
 			{"foo", "Deployment", "default", "", "foo:deployment:default"},
 			{"foo", "Deployment", "fission", "", "foo:deployment:fission"},
-		}},
+		}, ""},
 		{"two workloads, by group", []workload{
 			{"foo", "Deployment", "default", "a", "foo:deployment:default:a"},
 			{"foo", "Deployment", "default", "b", "foo:deployment:default:b"},
-		}},
+		}, ""},
 		{"three workloads, one by kind, two by namespace", []workload{
 			{"foo", "Deployment", "default", "a", "foo:deployment:default"},
 			{"foo", "Deployment", "fission", "b", "foo:deployment:fission"},
 			{"foo", "CronJob", "default", "b", "foo:cronjob"},
-		}},
+		}, ""},
 	}
 
 	for _, test := range testCases {
@@ -68,8 +70,14 @@ func TestUniqueResourceNames(t *testing.T) {
 				expectedNames = append(expectedNames, w.expectedResourceName)
 			}
 
-			actualNames := UniqueNames(entities, 1)
-			assert.Equal(t, expectedNames, actualNames)
+			actualNames, err := UniqueNames(entities, 1)
+			if test.expectedError == "" {
+				require.NoError(t, err)
+				require.Equal(t, expectedNames, actualNames)
+			} else {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), test.expectedError)
+			}
 		})
 	}
 }

--- a/internal/k8s/target.go
+++ b/internal/k8s/target.go
@@ -46,7 +46,10 @@ func NewTarget(
 
 	// Use a min component count of 2 for computing names,
 	// so that the resource type appears
-	displayNames := UniqueNames(sorted, 2)
+	displayNames, err := UniqueNames(sorted, 2)
+	if err != nil {
+		return model.K8sTarget{}, err
+	}
 
 	myLocators := []model.K8sImageLocator{}
 	for _, locator := range allLocators {

--- a/internal/tiltfile/k8s.go
+++ b/internal/tiltfile/k8s.go
@@ -944,7 +944,7 @@ func (s *tiltfileState) calculateResourceNames(workloads []k8s.K8sEntity) ([]str
 		}
 		return names, nil
 	} else {
-		return k8s.UniqueNames(workloads, 1), nil
+		return k8s.UniqueNames(workloads, 1)
 	}
 }
 

--- a/internal/tiltfile/tiltfile_state.go
+++ b/internal/tiltfile/tiltfile_state.go
@@ -651,7 +651,7 @@ func (s *tiltfileState) assembleK8sV1() error {
 }
 
 func (s *tiltfileState) assembleK8sV2() error {
-	//Note: We're using UniqueNames() over here just to check for duplicate resources, hence
+	//Note: We're using UniqueNames() over here just to check for duplicate YAML Entities, hence
 	//why only the error is being considered here
 	_, err := k8s.UniqueNames(s.k8sUnresourced, 1)
 	if err != nil {

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -3837,7 +3837,7 @@ k8s_yaml('foo.yaml')
 		f.assertNextManifest("foo").ImageTargets[0].OverrideArgs)
 }
 
-func TestDuplicateYamlEntityWithinSingleResource(t *testing.T) {
+func TestDuplicateYAMLEntityWithinSingleResource(t *testing.T) {
 	f := newFixture(t)
 	defer f.TearDown()
 
@@ -3848,9 +3848,9 @@ func TestDuplicateYamlEntityWithinSingleResource(t *testing.T) {
 	f.file("Tiltfile", `
 k8s_yaml('resource.yaml')
 `)
-	f.loadErrString(k8s.DuplicateYamlDetectedError("doggos:service:default:core"))
+	f.loadErrString(k8s.DuplicateYAMLDetectedError("doggos:service:default:core"))
 }
-func TestDuplicateYamlEntityAcrossResources(t *testing.T) {
+func TestDuplicateYAMLEntityAcrossResources(t *testing.T) {
 	f := newFixture(t)
 	defer f.TearDown()
 
@@ -3861,10 +3861,10 @@ func TestDuplicateYamlEntityAcrossResources(t *testing.T) {
 k8s_yaml(['foo1.yaml', 'foo1.yaml'])
 k8s_resource('foo:deployment:ns1', new_name='foo')
 `)
-	f.loadErrString(k8s.DuplicateYamlDetectedError("foo:deployment:ns1:apps"))
+	f.loadErrString(k8s.DuplicateYAMLDetectedError("foo:deployment:ns1:apps"))
 }
 
-func TestDuplicateYamlEntityInSingleWorkload(t *testing.T) {
+func TestDuplicateYAMLEntityInSingleWorkload(t *testing.T) {
 	//Services corresponding to a deployment get pulled into the same resource.
 	f := newFixture(t)
 	defer f.TearDown()
@@ -3877,10 +3877,10 @@ func TestDuplicateYamlEntityInSingleWorkload(t *testing.T) {
 	f.file("Tiltfile", `
 k8s_yaml('all.yaml')
 `)
-	f.loadErrString(k8s.DuplicateYamlDetectedError("foo-service:service:default:core"))
+	f.loadErrString(k8s.DuplicateYAMLDetectedError("foo-service:service:default:core"))
 }
 
-func TestDuplicateYamlEntityInUserAssembledNonWorkloadResource(t *testing.T) {
+func TestDuplicateYAMLEntityInUserAssembledNonWorkloadResource(t *testing.T) {
 	f := newFixture(t)
 	defer f.TearDown()
 	f.gitInit("")
@@ -3891,7 +3891,7 @@ func TestDuplicateYamlEntityInUserAssembledNonWorkloadResource(t *testing.T) {
 k8s_yaml('all.yaml')
 k8s_resource(objects=['foo-service:Service:default'], new_name='my-services')
 `)
-	f.loadErrString(k8s.DuplicateYamlDetectedError("foo-service:service:default:core"))
+	f.loadErrString(k8s.DuplicateYAMLDetectedError("foo-service:service:default:core"))
 }
 
 func TestSetTeamID(t *testing.T) {

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -1302,7 +1302,8 @@ k8s_yaml(yml)
 	entities, err := k8s.ParseYAMLFromString(yaml)
 	require.NoError(t, err)
 
-	names := k8s.UniqueNames(entities, 2)
+	names, err := k8s.UniqueNames(entities, 2)
+	assert.NoError(t, err)
 	expectedNames := []string{"rose-quartz-helloworld-chart:service"}
 	assert.ElementsMatch(t, expectedNames, names)
 
@@ -3836,57 +3837,61 @@ k8s_yaml('foo.yaml')
 		f.assertNextManifest("foo").ImageTargets[0].OverrideArgs)
 }
 
-func TestDuplicateResource(t *testing.T) {
+func TestDuplicateYamlEntityWithinSingleResource(t *testing.T) {
 	f := newFixture(t)
 	defer f.TearDown()
 
 	f.gitInit("")
-	f.file("resource.yaml", fmt.Sprintf(`
-%s
----
-%s
-`, testyaml.DoggosServiceYaml, testyaml.DoggosServiceYaml))
+	f.yaml("resource.yaml",
+		service("doggos"),
+		service("doggos"))
 	f.file("Tiltfile", `
 k8s_yaml('resource.yaml')
 `)
-	f.loadAllowWarnings()
-	m := f.assertNextManifestUnresourced("doggos", "doggos")
-	displayNames := []string{}
-	displayNames = append(displayNames, m.K8sTarget().DisplayNames...)
-	assert.Equal(t, []string{"doggos:service:default:core:0", "doggos:service:default:core:1"}, displayNames)
+	f.loadErrString(k8s.DuplicateYamlDetectedError("doggos:service:default:core"))
+}
+func TestDuplicateYamlEntityAcrossResources(t *testing.T) {
+	f := newFixture(t)
+	defer f.TearDown()
 
-	duplicateWarningStr := "Resource uncategorized contains multiple specifications of k8s entity(s): doggos:service:default:core. Only one specification per entity can be applied to the cluster; to ensure expected behavior, remove the duplicate specifications"
-	f.assertWarnings(duplicateWarningStr)
+	f.dockerfile("foo1/Dockerfile")
+	f.yaml("foo1.yaml", deployment("foo", image("gcr.io/foo1"), namespace("ns1")))
+	f.file("Tiltfile", `
+
+k8s_yaml(['foo1.yaml', 'foo1.yaml'])
+k8s_resource('foo:deployment:ns1', new_name='foo')
+`)
+	f.loadErrString(k8s.DuplicateYamlDetectedError("foo:deployment:ns1:apps"))
 }
 
-func TestMultipleDuplicateResources(t *testing.T) {
+func TestDuplicateYamlEntityInSingleWorkload(t *testing.T) {
+	//Services corresponding to a deployment get pulled into the same resource.
 	f := newFixture(t)
 	defer f.TearDown()
 
-	f.gitInit("")
-	f.file("resource.yaml", fmt.Sprintf(`
-%s
----
-%s
----
-%s
----
-%s
-`, testyaml.DoggosServiceYaml, testyaml.DoggosServiceYaml, testyaml.CatsServiceYaml, testyaml.CatsServiceYaml))
+	labelsFoo := map[string]string{"foo": "bar"}
+	f.yaml("all.yaml",
+		deployment("foo-deployment", image("gcr.io/foo1"), namespace("ns1"), withLabels(labelsFoo)),
+		service("foo-service", withLabels(labelsFoo)),
+		service("foo-service", withLabels(labelsFoo)))
 	f.file("Tiltfile", `
-k8s_yaml('resource.yaml')
+k8s_yaml('all.yaml')
 `)
-	f.loadAllowWarnings()
+	f.loadErrString(k8s.DuplicateYamlDetectedError("foo-service:service:default:core"))
+}
 
-	m := f.assertNextManifestUnresourced("doggos", "doggos", "cats", "cats")
-	displayNames := []string{}
-	displayNames = append(displayNames, m.K8sTarget().DisplayNames...)
-	assert.Equal(t, []string{"doggos:service:default:core:0", "doggos:service:default:core:1", "cats:service:default:core:2", "cats:service:default:core:3"}, displayNames)
-
-	duplicateWarningStr := "Resource uncategorized contains multiple specifications of k8s entity(s): doggos:service:default:core, cats:service:default:core. Only one specification per entity can be applied to the cluster; to ensure expected behavior, remove the duplicate specifications"
-
-	f.assertWarnings(duplicateWarningStr)
-
+func TestDuplicateYamlEntityInUserAssembledNonWorkloadResource(t *testing.T) {
+	f := newFixture(t)
+	defer f.TearDown()
+	f.gitInit("")
+	f.yaml("all.yaml",
+		service("foo-service"),
+		service("foo-service"))
+	f.file("Tiltfile", `
+k8s_yaml('all.yaml')
+k8s_resource(objects=['foo-service:Service:default'], new_name='my-services')
+`)
+	f.loadErrString(k8s.DuplicateYamlDetectedError("foo-service:service:default:core"))
 }
 
 func TestSetTeamID(t *testing.T) {


### PR DESCRIPTION
Hi @maiamcc @jazzdan, 

Please review the following commits I made in branch abdullahzameek/3588-duplicate-yaml:

0b8e13f234d1c34c1eeeb3129f2512978c523b77 (Tue Jul 21 17:27:42 2020 +0400)
tiltfile: added error when duplicate yaml is detected

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics