### PR TITLE
local_resource: run serve_cmd from workdir

### DIFF
--- a/internal/engine/local/controller.go
+++ b/internal/engine/local/controller.go
@@ -51,6 +51,7 @@ func (c *Controller) determineServeSpecs(ctx context.Context, st store.RStore) [
 		r = append(r, ServeSpec{
 			mt.Manifest.Name,
 			lt.ServeCmd,
+			lt.Workdir,
 			mt.State.LastSuccessfulDeployTime,
 		})
 	}
@@ -151,7 +152,7 @@ func (c *Controller) start(ctx context.Context, spec ServeSpec, st store.RStore)
 	go processStatuses(statusCh, st, spec.ManifestName, proc.stillHasSameProcNum())
 
 	spanID := SpanIDForServeLog(proc.procNum)
-	proc.doneCh = c.execer.Start(ctx, spec.ServeCmd, logger.Get(ctx).Writer(logger.InfoLvl), statusCh, spanID)
+	proc.doneCh = c.execer.Start(ctx, spec.ServeCmd, spec.WorkDir, logger.Get(ctx).Writer(logger.InfoLvl), statusCh, spanID)
 }
 
 func processStatuses(
@@ -229,6 +230,7 @@ func SpanIDForServeLog(procNum int) logstore.SpanID {
 type ServeSpec struct {
 	ManifestName model.ManifestName
 	ServeCmd     model.Cmd
+	WorkDir      string
 	TriggerTime  time.Time // TriggerTime is how Runner knows to restart; if it's newer than the TriggerTime of the currently running command, then Runner should restart it
 }
 

--- a/internal/engine/local/execer_test.go
+++ b/internal/engine/local/execer_test.go
@@ -31,7 +31,12 @@ func TestWorkdir(t *testing.T) {
 	d := tempdir.NewTempDirFixture(t)
 	defer d.TearDown()
 
-	f.startWithWorkdir("pwd", d.Path())
+	cmd := "pwd"
+	if runtime.GOARCH == "windows" {
+		cmd = "cd"
+	}
+
+	f.startWithWorkdir(cmd, d.Path())
 
 	f.assertCmdSucceeds()
 	f.assertLogContains(d.Path())

--- a/internal/engine/local/execer_test.go
+++ b/internal/engine/local/execer_test.go
@@ -32,7 +32,7 @@ func TestWorkdir(t *testing.T) {
 	defer d.TearDown()
 
 	cmd := "pwd"
-	if runtime.GOARCH == "windows" {
+	if runtime.GOOS == "windows" {
 		cmd = "cd"
 	}
 


### PR DESCRIPTION
Fixes #3602

### Problem

local_resource does not use the command's workdir when running serve_cmd, e.g.:

in test/Tiltfile:
```
local_resource(
    'example-cmd',
    cmd='echo "cmd pwd $PWD"',
    serve_cmd='echo "serve pwd $PWD"',
)
```

in Tiltfile:
```
include('test/Tiltfile')
```

### Expected

tilt outputs (modulo tiltfile dir)
```
cmd pwd /Users/matt/w/tilt-serve-cmd-repo/test
serve pwd /Users/matt/w/tilt-serve-cmd-repo/test
```

### Observed

tilt outputs
```
cmd pwd /Users/matt/w/tilt-serve-cmd-repo/test
serve pwd /Users/matt/w/tilt-serve-cmd-repo
```

note the lack of "test" at the end of "serve"

### Solution

Use workdir when running serve_cmd.

This is a breaking change along the lines of #3150, but presumably far less contentious, since no one is likely to argue that update_cmd and serve_cmd should behave differently in this respect.

As with #3150, users who want the serve_cmd to run from the Tiltfile dir instead of the include dir can get that behavior by importing a function that declares the local_resource and then calling that function from the root Tiltfile.
