### PR TITLE
cli: add 'tilt dump image-deploy-ref', for determining the deploy tag of an image

### DIFF
--- a/internal/build/docker_builder_test.go
+++ b/internal/build/docker_builder_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/opencontainers/go-digest"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/tilt-dev/tilt/internal/container"
@@ -91,6 +92,17 @@ func TestDigestFromOutputV1_23(t *testing.T) {
 	if actual != expected {
 		t.Errorf("Expected %s, got %s", expected, actual)
 	}
+}
+
+func TestDumpImageDeployRef(t *testing.T) {
+	f := newFakeDockerBuildFixture(t)
+	defer f.teardown()
+
+	digest := digest.Digest("sha256:11cd0eb38bc3ceb958ffb2f9bd70be3fb317ce7d255c8a4c3f4af30e298aa1aab")
+	f.fakeDocker.Images["example-image:dev"] = types.ImageInspect{ID: string(digest)}
+	ref, err := f.b.DumpImageDeployRef(f.ctx, "example-image:dev")
+	require.NoError(t, err)
+	assert.Equal(t, "docker.io/library/example-image:tilt-11cd0eb38bc3ceb9", ref.String())
 }
 
 func makeDockerBuildErrorOutput(s string) string {

--- a/internal/cli/wire.go
+++ b/internal/cli/wire.go
@@ -260,3 +260,14 @@ func ProvideDownDeps(
 func provideClock() func() time.Time {
 	return time.Now
 }
+
+type DumpImageDeployRefDeps struct {
+	DockerBuilder build.DockerBuilder
+	DockerClient  docker.Client
+}
+
+func wireDumpImageDeployRefDeps(ctx context.Context) (DumpImageDeployRefDeps, error) {
+	wire.Build(BaseWireSet,
+		wire.Struct(new(DumpImageDeployRefDeps), "*"))
+	return DumpImageDeployRefDeps{}, nil
+}


### PR DESCRIPTION
Hello @maiamcc, @landism,

Please review the following commits I made in branch nicks/ch8524:

d77706bcae5c133327ff1e21e067f9b59b9105b3 (2020-07-22 16:58:12 -0400)
cli: add 'tilt dump image-deploy-ref', for determining the deploy tag of an image
helps with more complex custom_build commands as described in https://github.com/tilt-dev/tilt/issues/3584

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics