### PR TITLE
k8s: make the local registry discovery errors debug logs for now. they're not really actionable yet

### DIFF
--- a/internal/k8s/registry.go
+++ b/internal/k8s/registry.go
@@ -148,7 +148,7 @@ func (r *registryAsync) inferRegistryFromNodeAnnotations(ctx context.Context) co
 func (r *registryAsync) inferRegistryFromConfigMap(ctx context.Context) (registry container.Registry, help string) {
 	hosting, err := localregistry.Discover(ctx, r.core)
 	if err != nil {
-		logger.Get(ctx).Warnf("Local registry discovery error: %v", err)
+		logger.Get(ctx).Debugf("Local registry discovery error: %v", err)
 		return container.Registry{}, ""
 	}
 
@@ -159,7 +159,7 @@ func (r *registryAsync) inferRegistryFromConfigMap(ctx context.Context) (registr
 	registry, err = container.NewRegistryWithHostFromCluster(
 		hosting.Host, hosting.HostFromContainerRuntime)
 	if err != nil {
-		logger.Get(ctx).Warnf("Local registry discovery error: %v", err)
+		logger.Get(ctx).Debugf("Local registry discovery error: %v", err)
 		return container.Registry{}, hosting.Help
 	}
 	return registry, hosting.Help


### PR DESCRIPTION
Hello @maiamcc,

Please review the following commits I made in branch nicks/local-registry:

aa431a55bfc38c746ad4a2cc585f6c640e823120 (2020-07-22 19:56:14 -0400)
k8s: make the local registry discovery errors debug logs for now. they're not really actionable yet

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics