### PR TITLE
Check home path in linux before installing

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -14,6 +14,9 @@ set -e
 
 function copy_binary() {
   if [[ ":$PATH:" == *":$HOME/.local/bin:"* ]]; then
+      if [ ! -d "$HOME/.local/bin" ]; then
+        mkdir -p "$HOME/.local/bin"
+      fi
       mv tilt "$HOME/.local/bin/tilt"
   else
       echo "Installing Tilt to /usr/local/bin which is write protected"


### PR DESCRIPTION
Today I saw Brandon Philips report the same issue on twitter that I had when trying the install script.
He reported it in Ubuntu, I had the same issue on Fedora:

```
+ mv tilt /home/user/.local/bin/tilt
mv: cannot move 'tilt' to '/home/user/.local/bin/tilt': No such file or directory
```
The installer would assume that `$HOME/.local/bin` always exists Here is the fix.
