### PR TITLE
Add Homebrew install instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ up-to-date. Think `docker build && kubectl apply` or `docker-compose up`.
 
 Installing the `tilt` binary is a one-step command.
 
+### macOS using Homebrew
+
+```bash
+brew install tilt-dev/homebrew-tap/tilt
+```
+
 ### macOS/Linux
 
 ```bash


### PR DESCRIPTION
I noticed you folks [actively maintain a Homebrew tap](https://github.com/tilt-dev/homebrew-tap) for Tilt, but don't make any mention of it in the installation docs or the main repo's README.

Most macOS users that I'm aware of use Homebrew, and would prefer it to curling a script into `bash`. Defaulting to Homebrew is one less adoption barrier, and also means that the package can be upgraded much easier (`brew upgrade tilt`), and that it will auto-upgrade whenever users do a `brew upgrade`, helping you keep the Tilt userbase closer to the latest release :)

This PR, and [its accompanying PR](https://github.com/tilt-dev/tilt.build/pull/684), add the missing documentation to make people aware of the `brew install` option

Also, there seems to have been an attempt to [upstream this into Homebrew's core tap](https://github.com/Homebrew/homebrew-core/pull/36309) that died out due to staleness. Maybe it would be worth trying to upstream it again?

Thanks for Tilt, it's been a really helpful tool so far 🎉