### PR TITLE
Recognise Krucible clusters as development clusters

### DIFF
--- a/internal/k8s/env.go
+++ b/internal/k8s/env.go
@@ -24,6 +24,7 @@ const (
 	EnvDockerDesktop Env = "docker-for-desktop"
 	EnvMicroK8s      Env = "microk8s"
 	EnvCRC           Env = "crc"
+	EnvKrucible      Env = "krucible"
 
 	// Kind v0.6 substantially changed the protocol for detecting and pulling,
 	// so we represent them as two separate envs.
@@ -37,8 +38,8 @@ func (e Env) UsesLocalDockerRegistry() bool {
 	return e == EnvMinikube || e == EnvDockerDesktop || e == EnvMicroK8s
 }
 
-func (e Env) IsLocalCluster() bool {
-	return e == EnvMinikube || e == EnvDockerDesktop || e == EnvMicroK8s || e == EnvCRC || e == EnvKIND5 || e == EnvKIND6 || e == EnvK3D
+func (e Env) IsDevCluster() bool {
+	return e == EnvMinikube || e == EnvDockerDesktop || e == EnvMicroK8s || e == EnvCRC || e == EnvKIND5 || e == EnvKIND6 || e == EnvK3D || e == EnvKrucible
 }
 
 func ProvideKubeContext(config *api.Config) (KubeContext, error) {
@@ -94,6 +95,8 @@ func ProvideEnv(ctx context.Context, config *api.Config) Env {
 		return EnvMicroK8s
 	} else if strings.HasPrefix(cn, "api-crc-testing") {
 		return EnvCRC
+	} else if strings.HasPrefix(cn, "krucible-") {
+		return EnvKrucible
 	}
 
 	loc := c.LocationOfOrigin

--- a/internal/k8s/env_test.go
+++ b/internal/k8s/env_test.go
@@ -66,6 +66,11 @@ func TestProvideEnv(t *testing.T) {
 			Cluster: "microk8s-cluster-dev-cluster-1",
 		},
 	}
+	krucibleContexts := map[string]*api.Context{
+		"krucible-c-74701fe1a05596b3": &api.Context{
+			Cluster: "krucible-c-74701fe1a05596b3",
+		},
+	}
 	crcContexts := map[string]*api.Context{
 		"api-crc-testing": &api.Context{
 			Cluster: "api-crc-testing",
@@ -111,6 +116,7 @@ func TestProvideEnv(t *testing.T) {
 		{EnvMicroK8s, &api.Config{CurrentContext: "microk8s-dev-cluster-1", Contexts: microK8sPrefixContexts}},
 		{EnvCRC, &api.Config{CurrentContext: "api-crc-testing", Contexts: crcContexts}},
 		{EnvCRC, &api.Config{CurrentContext: "api-crc-testing:6443", Contexts: crcPrefixContexts}},
+		{EnvKrucible, &api.Config{CurrentContext: "krucible-c-74701fe1a05596b3", Contexts: krucibleContexts}},
 		{EnvK3D, &api.Config{CurrentContext: "default", Contexts: k3dContexts}},
 		{EnvKIND5, &api.Config{CurrentContext: "default", Contexts: kind5NamedClusterContexts}},
 		{EnvKIND6, &api.Config{CurrentContext: "kind-custom-name", Contexts: kind6Contexts}},

--- a/internal/tiltfile/k8scontext/k8scontext.go
+++ b/internal/tiltfile/k8scontext/k8scontext.go
@@ -88,7 +88,7 @@ func (s State) KubeContext() k8s.KubeContext {
 }
 
 func (s State) IsAllowed() bool {
-	if s.env == k8s.EnvNone || s.env.IsLocalCluster() {
+	if s.env == k8s.EnvNone || s.env.IsDevCluster() {
 		return true
 	}
 


### PR DESCRIPTION
Hi,

I was trying to use Tilt with Krucible, a platform for creating Kubernetes clusters specifically for development, and having to explicitly whitelist the clusters is a bit of a nuisance. This PR adds support for recognising Krucible Kubernetes clusters as development clusters. I also took the liberty of renaming the function to better reflect the intent.

Krucible: https://usekrucible.com/

Let me know what you think!
Cheers,
Ben