### PR TITLE
watch: increase the windows watch i/o buffer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -85,7 +85,7 @@ require (
 	github.com/stretchr/testify v1.6.1
 	github.com/theupdateframework/notary v0.6.1 // indirect
 	github.com/tilt-dev/fsevents v0.0.0-20200515134857-2efe37af20de
-	github.com/tilt-dev/fsnotify v1.4.8-0.20200507235935-249ce517a564
+	github.com/tilt-dev/fsnotify v1.4.8-0.20200727200623-991e307aab7f
 	github.com/tilt-dev/localregistry-go v0.0.0-20200615231835-07e386f4ebd7
 	github.com/tilt-dev/wmclient v0.0.0-20200515134039-dd6b302e2564
 	github.com/tonistiigi/units v0.0.0-20180711220420-6950e57a87ea

--- a/go.sum
+++ b/go.sum
@@ -650,8 +650,8 @@ github.com/tilt-dev/client-go v0.0.0-20200326150806-41017343d309 h1:gqiy2KYVUPRB
 github.com/tilt-dev/client-go v0.0.0-20200326150806-41017343d309/go.mod h1:uQSYDYs4WhVZ9i6AIoEZuwUggLVEF64HOD37boKAtF8=
 github.com/tilt-dev/fsevents v0.0.0-20200515134857-2efe37af20de h1:tG+nJMUUxV7MJm/MeU1Mw7rvmwN9GWyHMMg+wtf9HS4=
 github.com/tilt-dev/fsevents v0.0.0-20200515134857-2efe37af20de/go.mod h1:1jUbPVh7Ani2CSublmvP7+zqTgR06A8Y0MKU9Xr2L5s=
-github.com/tilt-dev/fsnotify v1.4.8-0.20200507235935-249ce517a564 h1:X4YiQoUKHSc9sahl33PjXjck7PQdoc7xTzPbFL3eBjI=
-github.com/tilt-dev/fsnotify v1.4.8-0.20200507235935-249ce517a564/go.mod h1:c6pAambncyReVORBv+ReH61QHPhZ2ddi0/3QyJO3aF8=
+github.com/tilt-dev/fsnotify v1.4.8-0.20200727200623-991e307aab7f h1:A3/0Ild2AvlDohwdHnyHYxcrm4syPBT3olxgQrXLbXw=
+github.com/tilt-dev/fsnotify v1.4.8-0.20200727200623-991e307aab7f/go.mod h1:c6pAambncyReVORBv+ReH61QHPhZ2ddi0/3QyJO3aF8=
 github.com/tilt-dev/json-patch/v4 v4.8.1 h1:AbrhK3NMDfk/+/oMXz3NcKaCNwHYdhUJMDjBHNOHF5o=
 github.com/tilt-dev/json-patch/v4 v4.8.1/go.mod h1:tS8rrXPNPgltwGinFPfBjCwHFLxMa3ozjPngreH2eW0=
 github.com/tilt-dev/localregistry-go v0.0.0-20200615231835-07e386f4ebd7 h1:ysHGLJJRVcnG6WoZJt7GGD4hsMSwMxEg7Rxx4fJrSrY=

--- a/internal/watch/notify.go
+++ b/internal/watch/notify.go
@@ -3,7 +3,11 @@ package watch
 import (
 	"expvar"
 	"fmt"
+	"os"
 	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
 
 	"github.com/tilt-dev/tilt/pkg/logger"
 )
@@ -66,4 +70,23 @@ var _ PathMatcher = EmptyMatcher{}
 
 func NewWatcher(paths []string, ignore PathMatcher, l logger.Logger) (Notify, error) {
 	return newWatcher(paths, ignore, l)
+}
+
+const WindowsBufferSizeEnvVar = "TILT_WATCH_WINDOWS_BUFFER_SIZE"
+
+const defaultBufferSize int = 65536
+
+func DesiredWindowsBufferSize() int {
+	envVar := os.Getenv(WindowsBufferSizeEnvVar)
+	if envVar != "" {
+		size, err := strconv.Atoi(envVar)
+		if err != nil {
+			return size
+		}
+	}
+	return defaultBufferSize
+}
+
+func IsWindowsShortReadError(err error) bool {
+	return runtime.GOOS == "windows" && err != nil && strings.Contains(err.Error(), "short read")
 }

--- a/internal/watch/watcher_nonwin.go
+++ b/internal/watch/watcher_nonwin.go
@@ -1,0 +1,9 @@
+// +build !windows
+
+package watch
+
+import "github.com/tilt-dev/fsnotify"
+
+func MaybeIncreaseBufferSize(w *fsnotify.Watcher) {
+	// Not needed on non-windows
+}

--- a/internal/watch/watcher_windows.go
+++ b/internal/watch/watcher_windows.go
@@ -1,0 +1,19 @@
+// +build windows
+
+package watch
+
+import (
+	"github.com/tilt-dev/fsnotify"
+)
+
+// TODO(nick): I think the ideal API would be to automatically increase the
+// size of the buffer when we exceed capacity. But this gets messy,
+// because each time we get a short read error, we need to invalidate
+// everything we know about the currently changed files. So for now,
+// we just provide a way for people to increase the buffer ourselves.
+//
+// It might also pay to be clever about sizing the buffer
+// relative the number of files in the directory we're watching.
+func MaybeIncreaseBufferSize(w *fsnotify.Watcher) {
+	w.SetBufferSize(DesiredWindowsBufferSize())
+}

--- a/vendor/github.com/tilt-dev/fsnotify/windows.go
+++ b/vendor/github.com/tilt-dev/fsnotify/windows.go
@@ -11,11 +11,14 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"runtime"
 	"sync"
 	"syscall"
 	"unsafe"
 )
+
+const defaultBufSize = 4096
 
 // Watcher watches a set of files, delivering events to a channel.
 type Watcher struct {
@@ -28,6 +31,7 @@ type Watcher struct {
 	input     chan *input    // Inputs to the reader are sent on this channel
 	quit      chan chan<- error
 	recursive bool
+	bufSize   int
 }
 
 // NewWatcher establishes a new watcher with the underlying OS and begins waiting for events.
@@ -44,9 +48,16 @@ func NewWatcher() (*Watcher, error) {
 		Errors:    make(chan error),
 		quit:      make(chan chan<- error, 1),
 		recursive: false,
+		bufSize:   defaultBufSize,
 	}
 	go w.readEvents()
 	return w, nil
+}
+
+func (w *Watcher) SetBufferSize(bufSize int) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.bufSize = bufSize
 }
 
 // Recursively watches directories if this file system supports that.
@@ -181,7 +192,7 @@ type watch struct {
 	mask   uint64            // Directory itself is being watched with these notify flags
 	names  map[string]uint64 // Map of names being watched and their notify flags
 	rename string            // Remembers the old name while renaming a file
-	buf    [4096]byte
+	buf    []byte            // An array to pass to the windows API. Must only be allocated once.
 }
 
 type indexMap map[uint64]*watch
@@ -264,6 +275,7 @@ func (w *Watcher) addWatch(pathname string, flags uint64) error {
 	}
 	w.mu.Lock()
 	watchEntry := w.watches.get(ino)
+	bufSize := w.bufSize
 	w.mu.Unlock()
 	if watchEntry == nil {
 		if _, e := syscall.CreateIoCompletionPort(ino.handle, w.port, 0, 0); e != nil {
@@ -274,6 +286,7 @@ func (w *Watcher) addWatch(pathname string, flags uint64) error {
 			ino:   ino,
 			path:  dir,
 			names: make(map[string]uint64),
+			buf:   make([]byte, bufSize),
 		}
 		w.mu.Lock()
 		w.watches.set(ino, watchEntry)
@@ -360,8 +373,11 @@ func (w *Watcher) startRead(watch *watch) error {
 		w.mu.Unlock()
 		return nil
 	}
-	e := syscall.ReadDirectoryChanges(watch.ino.handle, &watch.buf[0],
-		uint32(unsafe.Sizeof(watch.buf)), w.recursive, mask, nil, &watch.ov, 0)
+
+	hdr := (*reflect.SliceHeader)(unsafe.Pointer(&watch.buf))
+
+	e := syscall.ReadDirectoryChanges(watch.ino.handle, (*byte)(unsafe.Pointer(hdr.Data)),
+		uint32(hdr.Len), w.recursive, mask, nil, &watch.ov, 0)
 	if e != nil {
 		err := os.NewSyscallError("ReadDirectoryChanges", e)
 		if e == syscall.ERROR_ACCESS_DENIED && watch.mask&provisional == 0 {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -555,7 +555,7 @@ github.com/theupdateframework/notary/tuf/validation
 # github.com/tilt-dev/fsevents v0.0.0-20200515134857-2efe37af20de
 ## explicit
 github.com/tilt-dev/fsevents
-# github.com/tilt-dev/fsnotify v1.4.8-0.20200507235935-249ce517a564
+# github.com/tilt-dev/fsnotify v1.4.8-0.20200727200623-991e307aab7f
 ## explicit
 github.com/tilt-dev/fsnotify
 # github.com/tilt-dev/localregistry-go v0.0.0-20200615231835-07e386f4ebd7


### PR DESCRIPTION
Hello @jazzdan,

Please review the following commits I made in branch nicks/ch8606/shortread:

7af78517cee06d89b5e7febfb4ea8059d2eb9548 (2020-07-27 16:28:14 -0400)
watch: increase the windows watch i/o buffer
fixes https://github.com/tilt-dev/tilt/issues/3556

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics