### PR TITLE
containerupdate: add a span where we were missing one

### DIFF
--- a/internal/cli/wire_gen.go
+++ b/internal/cli/wire_gen.go
@@ -189,7 +189,7 @@ func wireCmdUp(ctx context.Context, analytics3 *analytics.TiltAnalytics, cmdTags
 		return CmdUpDeps{}, err
 	}
 	switchCli := docker.ProvideSwitchCli(clusterClient, localClient)
-	dockerContainerUpdater := containerupdate.NewDockerContainerUpdater(switchCli)
+	dockerContainerUpdater := containerupdate.NewDockerUpdater(switchCli)
 	syncletImageRef, err := sidecar.ProvideSyncletImageRef(ctx)
 	if err != nil {
 		return CmdUpDeps{}, err
@@ -346,7 +346,7 @@ func wireCmdCI(ctx context.Context, analytics3 *analytics.TiltAnalytics, subcomm
 		return CmdCIDeps{}, err
 	}
 	switchCli := docker.ProvideSwitchCli(clusterClient, localClient)
-	dockerContainerUpdater := containerupdate.NewDockerContainerUpdater(switchCli)
+	dockerContainerUpdater := containerupdate.NewDockerUpdater(switchCli)
 	syncletImageRef, err := sidecar.ProvideSyncletImageRef(ctx)
 	if err != nil {
 		return CmdCIDeps{}, err

--- a/internal/containerupdate/docker_container_updater.go
+++ b/internal/containerupdate/docker_container_updater.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 
 	"github.com/tilt-dev/tilt/internal/build"
@@ -16,18 +17,21 @@ import (
 	"github.com/tilt-dev/tilt/pkg/model"
 )
 
-type DockerContainerUpdater struct {
+type DockerUpdater struct {
 	dCli docker.Client
 }
 
-var _ ContainerUpdater = &DockerContainerUpdater{}
+var _ ContainerUpdater = &DockerUpdater{}
 
-func NewDockerContainerUpdater(dCli docker.Client) *DockerContainerUpdater {
-	return &DockerContainerUpdater{dCli: dCli}
+func NewDockerUpdater(dCli docker.Client) *DockerUpdater {
+	return &DockerUpdater{dCli: dCli}
 }
 
-func (cu *DockerContainerUpdater) UpdateContainer(ctx context.Context, cInfo store.ContainerInfo,
+func (cu *DockerUpdater) UpdateContainer(ctx context.Context, cInfo store.ContainerInfo,
 	archiveToCopy io.Reader, filesToDelete []string, cmds []model.Cmd, hotReload bool) error {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "DockerUpdater-UpdateContainer")
+	defer span.Finish()
+
 	l := logger.Get(ctx)
 
 	err := cu.rmPathsFromContainer(ctx, cInfo.ContainerID, filesToDelete)
@@ -64,7 +68,7 @@ func (cu *DockerContainerUpdater) UpdateContainer(ctx context.Context, cInfo sto
 	return nil
 }
 
-func (cu *DockerContainerUpdater) rmPathsFromContainer(ctx context.Context, cID container.ID, paths []string) error {
+func (cu *DockerUpdater) rmPathsFromContainer(ctx context.Context, cID container.ID, paths []string) error {
 	if len(paths) == 0 {
 		return nil
 	}

--- a/internal/containerupdate/docker_container_updater_test.go
+++ b/internal/containerupdate/docker_container_updater_test.go
@@ -110,12 +110,12 @@ type dockerContainerUpdaterFixture struct {
 	t    testing.TB
 	ctx  context.Context
 	dCli *docker.FakeClient
-	dcu  *DockerContainerUpdater
+	dcu  *DockerUpdater
 }
 
 func newDCUFixture(t testing.TB) *dockerContainerUpdaterFixture {
 	fakeCli := docker.NewFakeClient()
-	cu := &DockerContainerUpdater{dCli: fakeCli}
+	cu := &DockerUpdater{dCli: fakeCli}
 	ctx, _, _ := testutils.CtxAndAnalyticsForTest()
 
 	return &dockerContainerUpdaterFixture{

--- a/internal/engine/live_update_build_and_deployer.go
+++ b/internal/engine/live_update_build_and_deployer.go
@@ -29,7 +29,7 @@ import (
 var _ BuildAndDeployer = &LiveUpdateBuildAndDeployer{}
 
 type LiveUpdateBuildAndDeployer struct {
-	dcu     *containerupdate.DockerContainerUpdater
+	dcu     *containerupdate.DockerUpdater
 	scu     *containerupdate.SyncletUpdater
 	ecu     *containerupdate.ExecUpdater
 	updMode buildcontrol.UpdateMode
@@ -38,7 +38,7 @@ type LiveUpdateBuildAndDeployer struct {
 	clock   build.Clock
 }
 
-func NewLiveUpdateBuildAndDeployer(dcu *containerupdate.DockerContainerUpdater,
+func NewLiveUpdateBuildAndDeployer(dcu *containerupdate.DockerUpdater,
 	scu *containerupdate.SyncletUpdater, ecu *containerupdate.ExecUpdater,
 	updMode buildcontrol.UpdateMode, env k8s.Env, runtime container.Runtime, c build.Clock) *LiveUpdateBuildAndDeployer {
 	return &LiveUpdateBuildAndDeployer{

--- a/internal/engine/wire.go
+++ b/internal/engine/wire.go
@@ -39,7 +39,7 @@ var DeployerBaseWireSet = wire.NewSet(
 	// BuildOrder
 	NewLocalTargetBuildAndDeployer,
 	NewImageBuildAndDeployer,
-	containerupdate.NewDockerContainerUpdater,
+	containerupdate.NewDockerUpdater,
 	containerupdate.NewSyncletUpdater,
 	containerupdate.NewExecUpdater,
 	NewLiveUpdateBuildAndDeployer,

--- a/internal/engine/wire_gen.go
+++ b/internal/engine/wire_gen.go
@@ -28,7 +28,7 @@ import (
 // Injectors from wire.go:
 
 func provideBuildAndDeployer(ctx context.Context, docker2 docker.Client, kClient k8s.Client, dir *dirs.WindmillDir, env k8s.Env, updateMode buildcontrol.UpdateModeFlag, sCli *synclet.TestSyncletClient, dcc dockercompose.DockerComposeClient, clock build.Clock, kp KINDLoader, analytics2 *analytics.TiltAnalytics) (BuildAndDeployer, error) {
-	dockerContainerUpdater := containerupdate.NewDockerContainerUpdater(docker2)
+	dockerContainerUpdater := containerupdate.NewDockerUpdater(docker2)
 	syncletClient, err := synclet.FakeGRPCWrapper(ctx, sCli)
 	if err != nil {
 		return nil, err
@@ -137,7 +137,7 @@ var (
 // wire.go:
 
 var DeployerBaseWireSet = wire.NewSet(wire.Value(dockerfile.Labels{}), wire.Value(UpperReducer), sidecar.WireSet, k8s.ProvideMinikubeClient, build.DefaultDockerBuilder, build.NewDockerImageBuilder, build.NewExecCustomBuilder, wire.Bind(new(build.CustomBuilder), new(*build.ExecCustomBuilder)), NewLocalTargetBuildAndDeployer,
-	NewImageBuildAndDeployer, containerupdate.NewDockerContainerUpdater, containerupdate.NewSyncletUpdater, containerupdate.NewExecUpdater, NewLiveUpdateBuildAndDeployer,
+	NewImageBuildAndDeployer, containerupdate.NewDockerUpdater, containerupdate.NewSyncletUpdater, containerupdate.NewExecUpdater, NewLiveUpdateBuildAndDeployer,
 	NewDockerComposeBuildAndDeployer,
 	NewImageBuilder,
 	DefaultBuildOrder, tracer.InitOpenTelemetry, wire.Bind(new(BuildAndDeployer), new(*CompositeBuildAndDeployer)), NewCompositeBuildAndDeployer, buildcontrol.ProvideUpdateMode,


### PR DESCRIPTION
was looking thru how we instrumented updates and saw that the DockerUpdater
was missing a span where the other updaters had one, so added it
(and renamed the type to be consistent with the other container updaters)