### PR TITLE
cli: added verify-install option to tilt 

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -53,6 +53,7 @@ up-to-date in real-time. Think 'docker build && kubectl apply' or 'docker-compos
 	addCommand(rootCmd, &doctorCmd{})
 	addCommand(rootCmd, newDownCmd())
 	addCommand(rootCmd, &versionCmd{})
+	addCommand(rootCmd, &verifyInstallCmd{})
 	addCommand(rootCmd, &dockerPruneCmd{})
 	addCommand(rootCmd, newArgsCmd())
 	addCommand(rootCmd, &logsCmd{})

--- a/internal/cli/verify_install.go
+++ b/internal/cli/verify_install.go
@@ -1,0 +1,30 @@
+package cli
+
+import (
+	"context"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/tilt-dev/tilt/internal/analytics"
+)
+
+type verifyInstallCmd struct {
+}
+
+func (c *verifyInstallCmd) register() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "verify-install",
+		Short: "Verifies Tilt Installation",
+	}
+	return cmd
+}
+
+//send info including "machine" tag to the wmstats db
+func (c *verifyInstallCmd) run(ctx context.Context, args []string) error {
+	a := analytics.Get(ctx)
+	a.Incr("cmd.verifyInstall", nil)
+	defer a.Flush(time.Second)
+
+	return nil
+}


### PR DESCRIPTION
Hi @nicks ,

Please review the following commit in the branch abdullahzameek/create-verify-install

95ba68639092fba840b44b8cb498e0d8a7a7d52e ( Tue Jul 28 19:00:00 2020 +0400) - cli: created tilt verify install

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics
