### PR TITLE
tiltfile: helm() should return CRDs in the new helm3 format. Fixes https://github.com/tilt-dev/tilt/issues/3605

### DIFF
--- a/internal/tiltfile/helm.go
+++ b/internal/tiltfile/helm.go
@@ -49,12 +49,15 @@ type helmVersion int
 const (
 	unknownHelmVersion helmVersion = iota
 	helmV2
-	helmV3
+	helmV3_0
+	helmV3_1andAbove
 )
 
 func parseVersion(version string) helmVersion {
-	if strings.HasPrefix(version, "v3") {
-		return helmV3
+	if strings.HasPrefix(version, "v3.0.") {
+		return helmV3_0
+	} else if strings.HasPrefix(version, "v3.") {
+		return helmV3_1andAbove
 	} else if strings.HasPrefix(version, "Client: v2") {
 		return helmV2
 	}

--- a/internal/tiltfile/helm_test.go
+++ b/internal/tiltfile/helm_test.go
@@ -56,7 +56,9 @@ k8s_yaml(yml)
 }
 
 const exampleHelmV2VersionOutput = `Client: v2.12.3geecf22f`
-const exampleHelmV3VersionOutput = `v3.0.0`
+const exampleHelmV3_0VersionOutput = `v3.0.0`
+const exampleHelmV3_1VersionOutput = `v3.1.0`
+const exampleHelmV3_2VersionOutput = `v3.2.4`
 
 func TestParseHelmV2Version(t *testing.T) {
 	expected := helmV2
@@ -66,8 +68,22 @@ func TestParseHelmV2Version(t *testing.T) {
 }
 
 func TestParseHelmV3Version(t *testing.T) {
-	expected := helmV3
-	actual := parseVersion(exampleHelmV3VersionOutput)
+	expected := helmV3_0
+	actual := parseVersion(exampleHelmV3_0VersionOutput)
+
+	assert.Equal(t, expected, actual)
+}
+
+func TestParseHelmV3_1Version(t *testing.T) {
+	expected := helmV3_1andAbove
+	actual := parseVersion(exampleHelmV3_1VersionOutput)
+
+	assert.Equal(t, expected, actual)
+}
+
+func TestParseHelmV3_2Version(t *testing.T) {
+	expected := helmV3_1andAbove
+	actual := parseVersion(exampleHelmV3_2VersionOutput)
 
 	assert.Equal(t, expected, actual)
 }
@@ -138,4 +154,48 @@ k8s_yaml(helm('./helm'))
 	yaml := m.K8sTarget().YAML
 	assert.NotContains(t, yaml, "RELEASE-NAME")
 	assert.Contains(t, yaml, "name: chart-grafana")
+}
+
+func TestHelm3CRD(t *testing.T) {
+	f := newFixture(t)
+	defer f.TearDown()
+
+	f.file("helm/Chart.yaml", `apiVersion: v1
+description: crd chart
+name: crd
+version: 0.1.0`)
+
+	f.file("helm/templates/service-account.yaml", `apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: crd-sa`)
+
+	// Only works in Helm3
+	// https://helm.sh/docs/chart_best_practices/custom_resource_definitions/
+	f.file("helm/crds/um.yaml", `apiVersion: tilt.dev/v1alpha1
+kind: UselessMachine
+metadata:
+  name: bobo
+spec:
+  image: bobo`)
+
+	f.file("Tiltfile", `
+k8s_yaml(helm('./helm'))
+`)
+
+	f.load()
+
+	manifests := f.loadResult.Manifests
+	require.Equal(t, 1, len(manifests))
+
+	m := manifests[0]
+	yaml := m.K8sTarget().YAML
+	v, err := getHelmVersion()
+	assert.NoError(t, err)
+	assert.Contains(t, yaml, "kind: ServiceAccount")
+	if v == helmV3_0 || v == helmV3_1andAbove {
+		assert.Contains(t, yaml, "kind: UselessMachine")
+	} else {
+		assert.NotContains(t, yaml, "kind: UselessMachine")
+	}
 }


### PR DESCRIPTION
Hello @jazzdan, @landism,

Please review the following commits I made in branch nicks/ch8617:

21f07304f033d19d41f1dc2617d27d8155a4dd55 (2020-07-28 18:34:10 -0400)
tiltfile: helm() should return CRDs in the new helm3 format. Fixes https://github.com/tilt-dev/tilt/issues/3605

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics