### PR TITLE
tiltfile: add support for docker build --pull, docker build --cache-from. Fixes https://github.com/tilt-dev/tilt/issues/3569

### DIFF
--- a/internal/build/options.go
+++ b/internal/build/options.go
@@ -19,6 +19,8 @@ func Options(archive io.Reader, db model.DockerBuild) docker.BuildOptions {
 		Network:     db.Network,
 		ExtraTags:   db.ExtraTags,
 		SecretSpecs: db.SecretSpecs,
+		CacheFrom:   db.CacheFrom,
+		PullParent:  db.PullParent,
 	}
 }
 

--- a/internal/docker/client.go
+++ b/internal/docker/client.go
@@ -488,6 +488,8 @@ func (c *Cli) ImageBuild(ctx context.Context, buildContext io.Reader, options Bu
 	opts.Tags = append([]string{}, options.ExtraTags...)
 	opts.Target = options.Target
 	opts.NetworkMode = options.Network
+	opts.CacheFrom = options.CacheFrom
+	opts.PullParent = options.PullParent
 
 	opts.Labels = BuiltByTiltLabel // label all images as built by us
 

--- a/internal/docker/options.go
+++ b/internal/docker/options.go
@@ -11,5 +11,7 @@ type BuildOptions struct {
 	SSHSpecs    []string
 	SecretSpecs []string
 	Network     string
+	CacheFrom   []string
+	PullParent  bool
 	ExtraTags   []string
 }

--- a/internal/tiltfile/docker.go
+++ b/internal/tiltfile/docker.go
@@ -35,6 +35,8 @@ type dockerImage struct {
 	targetStage      string    // optional: if specified, we build a particular target in the dockerfile
 	network          string
 	extraTags        []string // Extra tags added at build-time.
+	cacheFrom        []string
+	pullParent       bool
 
 	// Overrides the container args. Used as an escape hatch in case people want the old entrypoint behavior.
 	// See discussion here:
@@ -95,8 +97,8 @@ func (s *tiltfileState) dockerBuild(thread *starlark.Thread, fn *starlark.Builti
 		onlyVal,
 		networkVal,
 		entrypoint starlark.Value
-	var ssh, secret, extraTags value.StringOrStringList
-	var matchInEnvVars bool
+	var ssh, secret, extraTags, cacheFrom value.StringOrStringList
+	var matchInEnvVars, pullParent bool
 	var containerArgsVal starlark.Sequence
 	if err := s.unpackArgs(fn.Name(), args, kwargs,
 		"ref", &dockerRef,
@@ -116,6 +118,8 @@ func (s *tiltfileState) dockerBuild(thread *starlark.Thread, fn *starlark.Builti
 		"secret?", &secret,
 		"network?", &networkVal,
 		"extra_tag?", &extraTags,
+		"cache_from?", &cacheFrom,
+		"pull?", &pullParent,
 	); err != nil {
 		return nil, err
 	}
@@ -238,6 +242,8 @@ func (s *tiltfileState) dockerBuild(thread *starlark.Thread, fn *starlark.Builti
 		targetStage:      targetStage,
 		network:          network,
 		extraTags:        extraTags.Values,
+		cacheFrom:        cacheFrom.Values,
+		pullParent:       pullParent,
 	}
 	err = s.buildIndex.addImage(r)
 	if err != nil {

--- a/internal/tiltfile/tiltfile_state.go
+++ b/internal/tiltfile/tiltfile_state.go
@@ -1329,6 +1329,8 @@ func (s *tiltfileState) imgTargetsForDependencyIDsHelper(ids []model.TargetID, c
 				SSHSpecs:    image.sshSpecs,
 				SecretSpecs: image.secretSpecs,
 				Network:     image.network,
+				CacheFrom:   image.cacheFrom,
+				PullParent:  image.pullParent,
 				ExtraTags:   image.extraTags,
 			})
 		case CustomBuild:

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -488,6 +488,34 @@ docker_build("gcr.io/foo", "foo", network='default')
 	assert.Equal(t, "default", m.ImageTargets[0].BuildDetails.(model.DockerBuild).Network)
 }
 
+func TestDockerBuildPull(t *testing.T) {
+	f := newFixture(t)
+	defer f.TearDown()
+
+	f.setupFoo()
+	f.file("Tiltfile", `
+k8s_yaml('foo.yaml')
+docker_build("gcr.io/foo", "foo", pull=True)
+`)
+	f.load()
+	m := f.assertNextManifest("foo")
+	assert.True(t, m.ImageTargets[0].BuildDetails.(model.DockerBuild).PullParent)
+}
+
+func TestDockerBuildCacheFrom(t *testing.T) {
+	f := newFixture(t)
+	defer f.TearDown()
+
+	f.setupFoo()
+	f.file("Tiltfile", `
+k8s_yaml('foo.yaml')
+docker_build("gcr.io/foo", "foo", cache_from='gcr.io/foo')
+`)
+	f.load()
+	m := f.assertNextManifest("foo")
+	assert.Equal(t, []string{"gcr.io/foo"}, m.ImageTargets[0].BuildDetails.(model.DockerBuild).CacheFrom)
+}
+
 func TestDockerBuildExtraTagString(t *testing.T) {
 	f := newFixture(t)
 	defer f.TearDown()

--- a/pkg/model/image_target.go
+++ b/pkg/model/image_target.go
@@ -230,6 +230,9 @@ type DockerBuild struct {
 
 	Network string
 
+	PullParent bool
+	CacheFrom  []string
+
 	// By default, Tilt creates a new temporary image reference for each build.
 	// The user can also specify their own reference, to integrate with other tooling
 	// (like build IDs for Jenkins build pipelines)


### PR DESCRIPTION
Hello @jazzdan, @maiamcc,

Please review the following commits I made in branch nicks/ch8626:

a12186c87eb304d9d0690ecd0e05138ec4f29a86 (2020-07-28 20:12:05 -0400)
tiltfile: add support for docker build --pull, docker build --cache-from. Fixes https://github.com/tilt-dev/tilt/issues/3569

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics