### PR TITLE
Add support for .dockerignore specified by non-default Dockerfile name

### DIFF
--- a/internal/tiltfile/docker.go
+++ b/internal/tiltfile/docker.go
@@ -3,6 +3,7 @@ package tiltfile
 import (
 	"fmt"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -521,7 +522,7 @@ func (s *tiltfileState) defaultRegistry(thread *starlark.Thread, fn *starlark.Bu
 	return starlark.None, nil
 }
 
-func (s *tiltfileState) dockerignoresFromPathsAndContextFilters(paths []string, ignores []string, onlys []string) []model.Dockerignore {
+func (s *tiltfileState) dockerignoresFromPathsAndContextFilters(paths []string, ignores []string, onlys []string, dbDockerfilePath string) []model.Dockerignore {
 	var result []model.Dockerignore
 	dupeSet := map[string]bool{}
 	ignoreContents := ignoresToDockerignoreContents(ignores)
@@ -552,6 +553,12 @@ func (s *tiltfileState) dockerignoresFromPathsAndContextFilters(paths []string, 
 		}
 
 		diFile := filepath.Join(path, ".dockerignore")
+		customDiFile := dbDockerfilePath + ".dockerignore"
+		_, err := os.Stat(customDiFile)
+		if !os.IsNotExist(err) {
+			diFile = customDiFile
+		}
+
 		s.postExecReadFiles = sliceutils.AppendWithoutDupes(s.postExecReadFiles, diFile)
 
 		contents, err := ioutil.ReadFile(diFile)
@@ -603,5 +610,5 @@ func (s *tiltfileState) dockerignoresForImage(image *dockerImage) []model.Docker
 	case CustomBuild:
 		paths = append(paths, image.customDeps...)
 	}
-	return s.dockerignoresFromPathsAndContextFilters(paths, image.ignores, image.onlys)
+	return s.dockerignoresFromPathsAndContextFilters(paths, image.ignores, image.onlys, image.dbDockerfilePath)
 }

--- a/internal/tiltfile/docker_compose.go
+++ b/internal/tiltfile/docker_compose.go
@@ -301,7 +301,7 @@ func (s *tiltfileState) dcServiceToManifest(service *dcService, dcSet dcResource
 	paths = append(paths, dcInfo.LocalPaths()...)
 	paths = append(paths, filepath.Dir(dcSet.tiltfilePath))
 
-	dcInfo = dcInfo.WithDockerignores(s.dockerignoresFromPathsAndContextFilters(paths, []string{}, []string{}))
+	dcInfo = dcInfo.WithDockerignores(s.dockerignoresFromPathsAndContextFilters(paths, []string{}, []string{}, ""))
 
 	localPaths := []string{dcSet.tiltfilePath}
 	for _, p := range paths {

--- a/internal/tiltfile/docker_compose.go
+++ b/internal/tiltfile/docker_compose.go
@@ -301,7 +301,7 @@ func (s *tiltfileState) dcServiceToManifest(service *dcService, dcSet dcResource
 	paths = append(paths, dcInfo.LocalPaths()...)
 	paths = append(paths, filepath.Dir(dcSet.tiltfilePath))
 
-	dcInfo = dcInfo.WithDockerignores(s.dockerignoresFromPathsAndContextFilters(paths, []string{}, []string{}, ""))
+	dcInfo = dcInfo.WithDockerignores(s.dockerignoresFromPathsAndContextFilters(paths, []string{}, []string{}, service.DfPath))
 
 	localPaths := []string{dcSet.tiltfilePath}
 	for _, p := range paths {

--- a/internal/tiltfile/docker_test.go
+++ b/internal/tiltfile/docker_test.go
@@ -25,6 +25,7 @@ docker_build('gcr.io/fe', '.', live_update=[
 ])
 `)
 	f.file(".dockerignore", "build")
+	f.file("Dockerfile.custom.dockerignore", "shouldntmatch")
 	f.file(filepath.Join("src", "index.html"), "Hello world!")
 	f.file(filepath.Join("src", ".dockerignore"), "**")
 
@@ -55,6 +56,7 @@ docker_build('gcr.io/fe', '.', dockerfile="Dockerfile.custom", live_update=[
   sync('./src', '/src')
 ])
 `)
+	f.file(".dockerignore", "shouldntmatch")
 	f.file("Dockerfile.custom.dockerignore", "build")
 	f.file(filepath.Join("src", "index.html"), "Hello world!")
 	f.file(filepath.Join("src", "Dockerfile.custom.dockerignore"), "**")

--- a/internal/tiltfile/docker_test.go
+++ b/internal/tiltfile/docker_test.go
@@ -71,7 +71,7 @@ docker_build('gcr.io/fe', '.', dockerfile="Dockerfile.custom", live_update=[
 		m.ImageTargetAt(0).Dockerignores())
 }
 
-func TestCustomBuldDepsAreLocalRepos(t *testing.T) {
+func TestCustomBuildDepsAreLocalRepos(t *testing.T) {
 	f := newFixture(t)
 	defer f.TearDown()
 

--- a/internal/tiltfile/tiltfile_docker_compose_test.go
+++ b/internal/tiltfile/tiltfile_docker_compose_test.go
@@ -189,7 +189,6 @@ services:
 	f.assertConfigFiles(expectedConfFiles...)
 }
 
-
 func TestMultipleDockerComposeDifferentDirsNotSupported(t *testing.T) {
 	f := newFixture(t)
 	defer f.TearDown()

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -46,6 +46,8 @@ import (
 
 const simpleDockerfile = "FROM golang:1.10"
 
+const simpleDockerignore = "build/"
+
 func TestNoTiltfile(t *testing.T) {
 	f := newFixture(t)
 	defer f.TearDown()
@@ -5233,6 +5235,10 @@ type k8sOpts interface{}
 
 func (f *fixture) dockerfile(path string) {
 	f.file(path, simpleDockerfile)
+}
+
+func (f *fixture) dockerignore(path string) {
+	f.file(path, simpleDockerignore)
 }
 
 func (f *fixture) yaml(path string, entities ...k8sOpts) {


### PR DESCRIPTION
Fixes #3231 

I'm not super confident in how this impacts docker-compose, but all tests pass.