### PR TITLE
tiltfile: add an api for changing the readiness mode of a resource

### DIFF
--- a/internal/engine/buildcontrol/build_control_test.go
+++ b/internal/engine/buildcontrol/build_control_test.go
@@ -89,8 +89,8 @@ func TestLocalDependsOnNonWorkloadK8s(t *testing.T) {
 	defer f.TearDown()
 
 	local1 := f.upsertLocalManifest("local1", withResourceDeps("k8s1"))
-	k8s1 := f.upsertK8sManifest("k8s1", withK8sNonWorkload())
-	k8s2 := f.upsertK8sManifest("k8s2", withK8sNonWorkload())
+	k8s1 := f.upsertK8sManifest("k8s1", withK8sPodReadiness(model.PodReadinessIgnore))
+	k8s2 := f.upsertK8sManifest("k8s2", withK8sPodReadiness(model.PodReadinessIgnore))
 
 	f.assertNextTargetToBuild("k8s1")
 
@@ -98,7 +98,10 @@ func TestLocalDependsOnNonWorkloadK8s(t *testing.T) {
 		StartTime:  time.Now(),
 		FinishTime: time.Now(),
 	})
-	k8s1.State.RuntimeState = store.K8sRuntimeState{NonWorkload: true, HasEverDeployedSuccessfully: true}
+	k8s1.State.RuntimeState = store.K8sRuntimeState{
+		PodReadinessMode:            model.PodReadinessIgnore,
+		HasEverDeployedSuccessfully: true,
+	}
 
 	f.assertNextTargetToBuild("local1")
 	local1.State.AddCompletedBuild(model.BuildRecord{
@@ -260,8 +263,8 @@ func withResourceDeps(deps ...string) manifestOption {
 		return m.WithResourceDeps(deps...)
 	})
 }
-func withK8sNonWorkload() manifestOption {
+func withK8sPodReadiness(pr model.PodReadinessMode) manifestOption {
 	return manifestOption(func(m manifestbuilder.ManifestBuilder) manifestbuilder.ManifestBuilder {
-		return m.WithK8sNonWorkload()
+		return m.WithK8sPodReadiness(pr)
 	})
 }

--- a/internal/engine/buildcontroller_test.go
+++ b/internal/engine/buildcontroller_test.go
@@ -1378,7 +1378,7 @@ func TestLocalDependsOnNonWorkloadK8s(t *testing.T) {
 		Build()
 	k8s1 := manifestbuilder.New(f, "k8s1").
 		WithK8sYAML(testyaml.SanchoYAML).
-		WithK8sNonWorkload().
+		WithK8sPodReadiness(model.PodReadinessIgnore).
 		Build()
 	f.Start([]model.Manifest{local1, k8s1})
 

--- a/internal/hud/webview/analytics_nudge.go
+++ b/internal/hud/webview/analytics_nudge.go
@@ -18,12 +18,7 @@ func NeedsNudge(st store.EngineState) bool {
 	}
 
 	for _, targ := range manifestTargs {
-		if targ.Manifest.NonWorkloadManifest() {
-			continue
-		}
-
 		if !targ.State.LastSuccessfulDeployTime.IsZero() {
-			// A resource has been green at some point
 			return true
 		}
 	}

--- a/internal/hud/webview/analytics_nudge_test.go
+++ b/internal/hud/webview/analytics_nudge_test.go
@@ -7,25 +7,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/tilt-dev/wmclient/pkg/analytics"
 
-	"github.com/tilt-dev/tilt/internal/k8s"
-	"github.com/tilt-dev/tilt/internal/k8s/testyaml"
 	"github.com/tilt-dev/tilt/internal/store"
 	"github.com/tilt-dev/tilt/pkg/model"
 )
-
-func TestNeedsNudgeK8sYaml(t *testing.T) {
-	state := newState(nil)
-
-	m, err := k8s.NewK8sOnlyManifestFromYAML(testyaml.SanchoYAML)
-	assert.NoError(t, err)
-	targ := store.NewManifestTarget(m)
-	targ.State = &store.ManifestState{LastSuccessfulDeployTime: time.Now()}
-	state.UpsertManifestTarget(targ)
-
-	nudge := NeedsNudge(*state)
-	assert.False(t, nudge,
-		"manifest is k8s_yaml, expected needsNudge = false")
-}
 
 func TestNeedsNudgeRedManifest(t *testing.T) {
 	state := newState(nil)

--- a/internal/hud/webview/convert.go
+++ b/internal/hud/webview/convert.go
@@ -212,7 +212,7 @@ func tiltfileResourceProtoView(s store.EngineState) (*proto_webview.Resource, er
 func protoPopulateResourceInfoView(mt *store.ManifestTarget, r *proto_webview.Resource) error {
 	r.RuntimeStatus = string(model.RuntimeStatusNotApplicable)
 
-	if mt.Manifest.NonWorkloadManifest() {
+	if mt.Manifest.PodReadinessMode() == model.PodReadinessIgnore {
 		r.YamlResourceInfo = &proto_webview.YAMLResourceInfo{
 			K8SResources: mt.Manifest.K8sTarget().DisplayNames,
 		}

--- a/internal/k8s/target.go
+++ b/internal/k8s/target.go
@@ -17,7 +17,7 @@ func MustTarget(name model.TargetName, yaml string) model.K8sTarget {
 	if err != nil {
 		panic(fmt.Errorf("MustTarget: %v", err))
 	}
-	target, err := NewTarget(name, entities, nil, nil, nil, nil, false, nil)
+	target, err := NewTarget(name, entities, nil, nil, nil, nil, model.PodReadinessIgnore, nil)
 	if err != nil {
 		panic(fmt.Errorf("MustTarget: %v", err))
 	}
@@ -31,7 +31,7 @@ func NewTarget(
 	extraPodSelectors []labels.Selector,
 	dependencyIDs []model.TargetID,
 	refInjectCounts map[string]int,
-	nonWorkload bool,
+	podReadinessMode model.PodReadinessMode,
 	allLocators []ImageLocator) (model.K8sTarget, error) {
 	sorted := SortedEntities(entities)
 	yaml, err := SerializeSpecYAML(sorted)
@@ -65,13 +65,13 @@ func NewTarget(
 		ExtraPodSelectors: extraPodSelectors,
 		DisplayNames:      displayNames,
 		ObjectRefs:        objectRefs,
-		NonWorkload:       nonWorkload,
+		PodReadinessMode:  podReadinessMode,
 		ImageLocators:     myLocators,
 	}.WithDependencyIDs(dependencyIDs).WithRefInjectCounts(refInjectCounts), nil
 }
 
 func NewK8sOnlyManifest(name model.ManifestName, entities []K8sEntity, allLocators []ImageLocator) (model.Manifest, error) {
-	kTarget, err := NewTarget(name.TargetName(), entities, nil, nil, nil, nil, true, allLocators)
+	kTarget, err := NewTarget(name.TargetName(), entities, nil, nil, nil, nil, model.PodReadinessIgnore, allLocators)
 	if err != nil {
 		return model.Manifest{}, err
 	}

--- a/internal/k8s/target_test.go
+++ b/internal/k8s/target_test.go
@@ -7,11 +7,12 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/tilt-dev/tilt/internal/k8s/testyaml"
+	"github.com/tilt-dev/tilt/pkg/model"
 )
 
 func TestNewTargetSortsK8sEntities(t *testing.T) {
 	entities := MustParseYAMLFromString(t, testyaml.OutOfOrderYaml)
-	targ, err := NewTarget("foo", entities, nil, nil, nil, nil, false, nil)
+	targ, err := NewTarget("foo", entities, nil, nil, nil, nil, model.PodReadinessWait, nil)
 	require.NoError(t, err)
 
 	expectedKindOrder := []string{"PersistentVolume", "PersistentVolumeClaim", "ConfigMap", "Service", "StatefulSet", "Job", "Pod"}

--- a/internal/store/engine_state.go
+++ b/internal/store/engine_state.go
@@ -756,7 +756,7 @@ func resourceInfoView(mt *ManifestTarget) view.ResourceInfoView {
 		runStatus = mt.State.RuntimeState.RuntimeStatus()
 	}
 
-	if mt.Manifest.NonWorkloadManifest() {
+	if mt.Manifest.PodReadinessMode() == model.PodReadinessIgnore {
 		return view.YAMLResourceInfo{
 			K8sDisplayNames: mt.Manifest.K8sTarget().DisplayNames,
 		}

--- a/internal/store/runtime_state.go
+++ b/internal/store/runtime_state.go
@@ -75,7 +75,7 @@ type K8sRuntimeState struct {
 	LastReadyOrSucceededTime    time.Time
 	HasEverDeployedSuccessfully bool
 
-	NonWorkload bool
+	PodReadinessMode model.PodReadinessMode
 }
 
 func (K8sRuntimeState) RuntimeState() {}
@@ -94,7 +94,7 @@ func NewK8sRuntimeStateWithPods(m model.Manifest, pods ...Pod) K8sRuntimeState {
 
 func NewK8sRuntimeState(m model.Manifest) K8sRuntimeState {
 	return K8sRuntimeState{
-		NonWorkload:                    m.K8sTarget().NonWorkload,
+		PodReadinessMode:               m.PodReadinessMode(),
 		Pods:                           make(map[k8s.PodID]*Pod),
 		LBs:                            make(map[k8s.ServiceName]*url.URL),
 		DeployedUIDSet:                 NewUIDSet(),
@@ -116,7 +116,7 @@ func (s K8sRuntimeState) RuntimeStatus() model.RuntimeStatus {
 		return model.RuntimeStatusPending
 	}
 
-	if s.NonWorkload {
+	if s.PodReadinessMode == model.PodReadinessIgnore {
 		return model.RuntimeStatusOK
 	}
 
@@ -149,7 +149,7 @@ func (s K8sRuntimeState) HasEverBeenReadyOrSucceeded() bool {
 	if !s.HasEverDeployedSuccessfully {
 		return false
 	}
-	if s.NonWorkload {
+	if s.PodReadinessMode == model.PodReadinessIgnore {
 		return true
 	}
 	return !s.LastReadyOrSucceededTime.IsZero()

--- a/internal/tiltfile/k8s/readiness.go
+++ b/internal/tiltfile/k8s/readiness.go
@@ -1,0 +1,39 @@
+package k8s
+
+import (
+	"fmt"
+
+	"go.starlark.net/starlark"
+
+	"github.com/tilt-dev/tilt/internal/tiltfile/value"
+	"github.com/tilt-dev/tilt/pkg/model"
+)
+
+// Deserializing pod readiness from starlark values.
+type PodReadinessMode struct {
+	Value model.PodReadinessMode
+}
+
+func (m *PodReadinessMode) Unpack(v starlark.Value) error {
+	s, ok := value.AsString(v)
+	if !ok {
+		return fmt.Errorf("Must be a string. Got: %s", v.Type())
+	}
+
+	if s == string(model.PodReadinessIgnore) {
+		m.Value = model.PodReadinessIgnore
+		return nil
+	}
+
+	if s == string(model.PodReadinessWait) {
+		m.Value = model.PodReadinessWait
+		return nil
+	}
+
+	if s == "" {
+		m.Value = model.PodReadinessNone
+		return nil
+	}
+
+	return fmt.Errorf("Invalid value. Allowed: {%s, %s}. Got: %s", model.PodReadinessIgnore, model.PodReadinessWait, s)
+}

--- a/pkg/model/k8s_target.go
+++ b/pkg/model/k8s_target.go
@@ -13,6 +13,22 @@ type K8sImageLocator interface {
 	EqualsImageLocator(other interface{}) bool
 }
 
+// Whether or not to wait for pods to become ready before
+// marking the k8s resource healthy.
+//
+// TODO(nick): I strongly suspect we will at least want a separate mode
+// for jobs that waits until they become complete, as we do in `tilt ci`
+type PodReadinessMode string
+
+// Pod readiness isn't applicable to this resource
+const PodReadinessNone PodReadinessMode = ""
+
+// Always wait for pods to become ready.
+const PodReadinessWait PodReadinessMode = "wait"
+
+// Don't even wait for pods to appear.
+const PodReadinessIgnore PodReadinessMode = "ignore"
+
 type K8sTarget struct {
 	Name         TargetName
 	YAML         string
@@ -28,9 +44,7 @@ type K8sTarget struct {
 	// for easy access. This should duplicate what's specified in the YAML.
 	ObjectRefs []v1.ObjectReference
 
-	// NonWorkload indicates whether or not a given K8sTarget was
-	// determined to have workloads at assembly time during Tiltfile execution
-	NonWorkload bool
+	PodReadinessMode PodReadinessMode
 
 	// Implementations of k8s.ImageLocator
 	//

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -128,11 +128,11 @@ func (m Manifest) IsK8s() bool {
 	return ok
 }
 
-func (m Manifest) NonWorkloadManifest() bool {
+func (m Manifest) PodReadinessMode() PodReadinessMode {
 	if k8sTarget, ok := m.deployTarget.(K8sTarget); ok {
-		return k8sTarget.NonWorkload
+		return k8sTarget.PodReadinessMode
 	}
-	return false
+	return PodReadinessNone
 }
 
 func (m Manifest) DeployTarget() TargetSpec {


### PR DESCRIPTION
Hello @jazzdan, @maiamcc,

Please review the following commits I made in branch nicks/ch8647:

95ef863dd3726c566748fc7340dbfb6d6030270c (2020-07-30 10:01:37 -0400)
tiltfile: add an api for changing the readiness mode of a resource
Helps resolve https://github.com/tilt-dev/tilt/issues/3619

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics