### PR TITLE
tiltfile: workaround a bug in kustomize

### DIFF
--- a/internal/tiltfile/files.go
+++ b/internal/tiltfile/files.go
@@ -95,26 +95,34 @@ func (s *tiltfileState) kustomize(thread *starlark.Thread, fn *starlark.Builtin,
 		return nil, err
 	}
 
-	kustomizePath, err := value.ValueToAbsPath(thread, path)
+	absKustomizePath, err := value.ValueToAbsPath(thread, path)
 	if err != nil {
 		return nil, fmt.Errorf("Argument 0 (paths): %v", err)
 	}
 
-	cmd := []string{"kustomize", "build", kustomizePath}
+	// NOTE(nick): There's a bug in kustomize where it doesn't properly
+	// handle absolute paths. Convert to relative paths instead:
+	// https://github.com/kubernetes-sigs/kustomize/issues/2789
+	relKustomizePath, err := filepath.Rel(starkit.AbsWorkingDir(thread), absKustomizePath)
+	if err != nil {
+		return nil, err
+	}
+
+	cmd := []string{"kustomize", "build", relKustomizePath}
 
 	_, err = exec.LookPath(cmd[0])
 	if err != nil {
 		s.logger.Infof("Falling back to `kubectl kustomize` since `%s` was not found in PATH", cmd[0])
-		cmd = []string{"kubectl", "kustomize", kustomizePath}
+		cmd = []string{"kubectl", "kustomize", relKustomizePath}
 	}
 
 	yaml, err := s.execLocalCmd(thread, exec.Command(cmd[0], cmd[1:]...), false)
 	if err != nil {
 		return nil, err
 	}
-	deps, err := kustomize.Deps(kustomizePath)
+	deps, err := kustomize.Deps(absKustomizePath)
 	if err != nil {
-		return nil, fmt.Errorf("internal error: %v", err)
+		return nil, fmt.Errorf("resolving deps: %v", err)
 	}
 	for _, d := range deps {
 		err := tiltfile_io.RecordReadPath(thread, tiltfile_io.WatchRecursive, d)
@@ -123,7 +131,7 @@ func (s *tiltfileState) kustomize(thread *starlark.Thread, fn *starlark.Builtin,
 		}
 	}
 
-	return tiltfile_io.NewBlob(yaml, fmt.Sprintf("kustomize: %s", kustomizePath)), nil
+	return tiltfile_io.NewBlob(yaml, fmt.Sprintf("kustomize: %s", absKustomizePath)), nil
 }
 
 func (s *tiltfileState) helm(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -379,10 +379,6 @@ k8s_yaml(yaml)
 }
 
 func TestKustomize(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("TODO(nick): investigate")
-	}
-
 	f := newFixture(t)
 	defer f.TearDown()
 
@@ -411,10 +407,6 @@ func TestKustomizeError(t *testing.T) {
 }
 
 func TestKustomization(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("TODO(nick): investigate")
-	}
-
 	f := newFixture(t)
 	defer f.TearDown()
 


### PR DESCRIPTION
Hello @jazzdan,

Please review the following commits I made in branch nicks/kustomize:

df553001268feccc0df9bd32da99a15d29e9912e (2020-07-30 11:34:10 -0400)
tiltfile: workaround a bug in kustomize
for more details, see https://github.com/kubernetes-sigs/kustomize/issues/2789

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics