### PR TITLE
deprecate update_mode=syncet flag

### DIFF
--- a/internal/engine/build_and_deployer_live_update_test.go
+++ b/internal/engine/build_and_deployer_live_update_test.go
@@ -9,8 +9,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"k8s.io/client-go/util/exec"
 
-	"github.com/tilt-dev/tilt/internal/engine/buildcontrol"
-
 	"github.com/tilt-dev/tilt/internal/k8s/testyaml"
 
 	"github.com/tilt-dev/tilt/internal/docker"
@@ -220,28 +218,6 @@ func TestLiveUpdateDockerBuildLocalContainerSameImgMultipleContainers(t *testing
 	runTestCase(t, f, tCase)
 }
 
-func TestLiveUpdateDockerBuildSyncletSameImgMultipleContainers(t *testing.T) {
-	f := newBDFixtureWithUpdateMode(t, k8s.EnvGKE, container.RuntimeDocker, buildcontrol.UpdateModeSynclet)
-	defer f.TearDown()
-
-	m := NewSanchoLiveUpdateManifest(f)
-	cIDs := []container.ID{"c1", "c2", "c3"}
-	tCase := testCase{
-		manifest:                  m,
-		runningContainersByTarget: map[model.TargetID][]container.ID{m.ImageTargetAt(0).ID(): cIDs},
-		changedFiles:              []string{"a.txt"},
-		expectDockerBuildCount:    0,
-		expectDockerPushCount:     0,
-
-		// one of each operation per container
-		expectSyncletUpdateContainerCount: 3,
-		expectDockerCopyCount:             3,
-		expectDockerExecCount:             3,
-		expectDockerRestartCount:          3,
-	}
-	runTestCase(t, f, tCase)
-}
-
 func TestLiveUpdateDockerBuildExecSameImgMultipleContainers(t *testing.T) {
 	f := newBDFixture(t, k8s.EnvGKE, container.RuntimeCrio)
 	defer f.TearDown()
@@ -289,34 +265,6 @@ func TestLiveUpdateDockerBuildLocalContainerDiffImgMultipleContainers(t *testing
 		expectDockerCopyCount:    2,
 		expectDockerExecCount:    2,
 		expectDockerRestartCount: 2,
-	}
-	runTestCase(t, f, tCase)
-}
-
-func TestLiveUpdateDockerBuildSyncletDiffImgMultipleContainers(t *testing.T) {
-	f := newBDFixtureWithUpdateMode(t, k8s.EnvGKE, container.RuntimeDocker, buildcontrol.UpdateModeSynclet)
-	defer f.TearDown()
-
-	sanchoTarg := NewSanchoLiveUpdateImageTarget(f)
-	sidecarTarg := NewSanchoSidecarLiveUpdateImageTarget(f)
-	tCase := testCase{
-		manifest: manifestbuilder.New(f, "sanchoWithSidecar").
-			WithK8sYAML(testyaml.SanchoSidecarYAML).
-			WithImageTargets(sanchoTarg, sidecarTarg).
-			Build(),
-		runningContainersByTarget: map[model.TargetID][]container.ID{
-			sanchoTarg.ID():  []container.ID{"c1"},
-			sidecarTarg.ID(): []container.ID{"c2"},
-		},
-		changedFiles:           []string{"a.txt"},
-		expectDockerBuildCount: 0,
-		expectDockerPushCount:  0,
-
-		// one of each operation per container
-		expectSyncletUpdateContainerCount: 2,
-		expectDockerCopyCount:             2,
-		expectDockerExecCount:             2,
-		expectDockerRestartCount:          2,
 	}
 	runTestCase(t, f, tCase)
 }
@@ -489,37 +437,6 @@ func TestLiveUpdateDockerContainerUserRunFailureDoesntFallBack(t *testing.T) {
 		// BuildAndDeploy call will ultimately fail with this error,
 		// b/c we DON'T fall back to an image build
 		expectErrorContains: "failed with exit code: 123",
-
-		// called copy and exec before hitting error
-		// (so, did not restart)
-		expectDockerCopyCount:    1,
-		expectDockerExecCount:    1,
-		expectDockerRestartCount: 0,
-
-		// DO NOT fall back to image build
-		expectDockerBuildCount: 0,
-		expectK8sDeploy:        false,
-	}
-	runTestCase(t, f, tCase)
-}
-
-// TODO(maia): make this test actually touch gRPC de/serialization,
-// which is where most of this logic lives
-func TestLiveUpdateSyncletUserRunFailureDoesntFallBack(t *testing.T) {
-	f := newBDFixtureWithUpdateMode(t, k8s.EnvGKE, container.RuntimeDocker, buildcontrol.UpdateModeSynclet)
-	defer f.TearDown()
-
-	f.docker.SetExecError(userFailureErrDocker)
-
-	tCase := testCase{
-		manifest:     NewSanchoLiveUpdateManifest(f),
-		changedFiles: []string{"a.txt"},
-
-		// BuildAndDeploy call will ultimately fail with this error,
-		// b/c we DON'T fall back to an image build
-		expectErrorContains: "failed with exit code: 123",
-
-		expectSyncletUpdateContainerCount: 1,
 
 		// called copy and exec before hitting error
 		// (so, did not restart)
@@ -778,33 +695,6 @@ func TestLiveUpdateRunTriggerLocalContainer(t *testing.T) {
 	runTestCase(t, f, tCase)
 }
 
-func TestLiveUpdateRunTriggerSynclet(t *testing.T) {
-	f := newBDFixtureWithUpdateMode(t, k8s.EnvGKE, container.RuntimeDocker, buildcontrol.UpdateModeSynclet)
-	defer f.TearDown()
-
-	runs := []model.LiveUpdateRunStep{
-		model.LiveUpdateRunStep{Command: model.ToUnixCmd("echo hello")},
-		model.LiveUpdateRunStep{Command: model.ToUnixCmd("echo a"), Triggers: f.NewPathSet("a.txt")}, // matches changed file
-		model.LiveUpdateRunStep{Command: model.ToUnixCmd("echo b"), Triggers: f.NewPathSet("b.txt")}, // does NOT match changed file
-	}
-	lu := assembleLiveUpdate(SanchoSyncSteps(f), runs, true, nil, f)
-	tCase := testCase{
-		manifest: manifestbuilder.New(f, "sancho").
-			WithK8sYAML(SanchoYAML).
-			WithImageTarget(NewSanchoDockerBuildImageTarget(f)).
-			WithLiveUpdate(lu).
-			Build(),
-		changedFiles:                      []string{"a.txt"},
-		expectDockerBuildCount:            0,
-		expectDockerPushCount:             0,
-		expectSyncletUpdateContainerCount: 1,
-		expectDockerCopyCount:             1,
-		expectDockerExecCount:             2, // one run's triggers don't match -- should only exec the other two.
-		expectDockerRestartCount:          1,
-	}
-	runTestCase(t, f, tCase)
-}
-
 func TestLiveUpdateRunTriggerExec(t *testing.T) {
 	f := newBDFixture(t, k8s.EnvGKE, container.RuntimeDocker)
 	defer f.TearDown()
@@ -833,45 +723,6 @@ func TestLiveUpdateRunTriggerExec(t *testing.T) {
 	runTestCase(t, f, tCase)
 }
 
-func TestLiveUpdateDockerBuildSynclet(t *testing.T) {
-	f := newBDFixtureWithUpdateMode(t, k8s.EnvGKE, container.RuntimeDocker, buildcontrol.UpdateModeSynclet)
-	defer f.TearDown()
-
-	tCase := testCase{
-		manifest:                          NewSanchoLiveUpdateManifest(f),
-		changedFiles:                      []string{"a.txt"},
-		expectDockerBuildCount:            0,
-		expectDockerPushCount:             0,
-		expectSyncletUpdateContainerCount: 1,
-		expectDockerCopyCount:             1,
-		expectDockerExecCount:             1,
-		expectDockerRestartCount:          1,
-	}
-	runTestCase(t, f, tCase)
-}
-
-func TestLiveUpdateCustomBuildSynclet(t *testing.T) {
-	f := newBDFixtureWithUpdateMode(t, k8s.EnvGKE, container.RuntimeDocker, buildcontrol.UpdateModeSynclet)
-	defer f.TearDown()
-
-	lu := assembleLiveUpdate(SanchoSyncSteps(f), SanchoRunSteps, true, nil, f)
-	tCase := testCase{
-		manifest: manifestbuilder.New(f, "sancho").
-			WithK8sYAML(SanchoYAML).
-			WithImageTarget(NewSanchoCustomBuildImageTarget(f)).
-			WithLiveUpdate(lu).
-			Build(),
-		changedFiles:                      []string{"app/a.txt"},
-		expectDockerBuildCount:            0,
-		expectDockerPushCount:             0,
-		expectSyncletUpdateContainerCount: 1,
-		expectDockerCopyCount:             1,
-		expectDockerExecCount:             1,
-		expectDockerRestartCount:          1,
-	}
-	runTestCase(t, f, tCase)
-}
-
 func TestLiveUpdateCustomBuildExec(t *testing.T) {
 	f := newBDFixture(t, k8s.EnvGKE, container.RuntimeDocker)
 	defer f.TearDown()
@@ -891,28 +742,6 @@ func TestLiveUpdateCustomBuildExec(t *testing.T) {
 		expectDockerExecCount:             0,
 		expectDockerRestartCount:          0,
 		expectK8sExecCount:                2,
-	}
-	runTestCase(t, f, tCase)
-}
-
-func TestLiveUpdateHotReloadSynclet(t *testing.T) {
-	f := newBDFixtureWithUpdateMode(t, k8s.EnvGKE, container.RuntimeDocker, buildcontrol.UpdateModeSynclet)
-	defer f.TearDown()
-
-	lu := assembleLiveUpdate(SanchoSyncSteps(f), SanchoRunSteps, false, nil, f)
-	tCase := testCase{
-		manifest: manifestbuilder.New(f, "sancho").
-			WithK8sYAML(SanchoYAML).
-			WithImageTarget(NewSanchoDockerBuildImageTarget(f)).
-			WithLiveUpdate(lu).
-			Build(),
-		changedFiles:                      []string{"a.txt"},
-		expectDockerBuildCount:            0,
-		expectDockerPushCount:             0,
-		expectSyncletUpdateContainerCount: 1,
-		expectDockerCopyCount:             1,
-		expectDockerExecCount:             1,
-		expectDockerRestartCount:          0, // hot reload!
 	}
 	runTestCase(t, f, tCase)
 }
@@ -960,36 +789,6 @@ func TestLiveUpdateDockerBuildExec(t *testing.T) {
 	runTestCase(t, f, tCase)
 }
 
-func TestDockerBuildWithoutLiveUpdateDoesNotDeploySynclet(t *testing.T) {
-	f := newBDFixtureWithUpdateMode(t, k8s.EnvGKE, container.RuntimeDocker, buildcontrol.UpdateModeSynclet)
-	defer f.TearDown()
-
-	tCase := testCase{
-		manifest:               NewSanchoDockerBuildManifest(f),
-		changedFiles:           nil, // will use an empty BuildResultSet, i.e. treat this as first build
-		expectDockerBuildCount: 1,
-		expectDockerPushCount:  1,
-		expectK8sDeploy:        true,
-		expectSyncletDeploy:    false,
-	}
-	runTestCase(t, f, tCase)
-}
-
-func TestLiveUpdateDockerBuildDeploysSynclet(t *testing.T) {
-	f := newBDFixtureWithUpdateMode(t, k8s.EnvGKE, container.RuntimeDocker, buildcontrol.UpdateModeSynclet)
-	defer f.TearDown()
-
-	tCase := testCase{
-		manifest:               NewSanchoLiveUpdateManifest(f),
-		changedFiles:           nil, // will use an empty BuildResultSet, i.e. treat this as first build
-		expectDockerBuildCount: 1,
-		expectDockerPushCount:  1,
-		expectK8sDeploy:        true,
-		expectSyncletDeploy:    true,
-	}
-	runTestCase(t, f, tCase)
-}
-
 func TestLiveUpdateLocalContainerFallBackOn(t *testing.T) {
 	f := newBDFixture(t, k8s.EnvDockerDesktop, container.RuntimeDocker)
 	defer f.TearDown()
@@ -1008,30 +807,6 @@ func TestLiveUpdateLocalContainerFallBackOn(t *testing.T) {
 		expectDockerExecCount:    0,
 		expectDockerRestartCount: 0,
 		expectK8sDeploy:          true, // Because we fell back to image builder, we also did a k8s deploy
-		logsContain:              []string{"Detected change to fall_back_on file", "a.txt"},
-	}
-	runTestCase(t, f, tCase)
-}
-
-func TestLiveUpdateSyncletFallBackOn(t *testing.T) {
-	f := newBDFixtureWithUpdateMode(t, k8s.EnvGKE, container.RuntimeDocker, buildcontrol.UpdateModeSynclet)
-	defer f.TearDown()
-
-	lu := assembleLiveUpdate(SanchoSyncSteps(f), SanchoRunSteps, true, []string{"a.txt"}, f)
-	tCase := testCase{
-		manifest: manifestbuilder.New(f, "sancho").
-			WithK8sYAML(SanchoYAML).
-			WithImageTarget(NewSanchoDockerBuildImageTarget(f)).
-			WithLiveUpdate(lu).
-			Build(),
-		changedFiles:             []string{"a.txt"},
-		expectDockerBuildCount:   1, // we did a Docker build instead of an in-place update!
-		expectDockerPushCount:    1,
-		expectDockerCopyCount:    0,
-		expectDockerExecCount:    0,
-		expectDockerRestartCount: 0,
-		expectK8sDeploy:          true, // because we fell back to image builder, we also did a k8s deploy
-		expectSyncletDeploy:      true, // (and expect that yaml to have contained the synclet)
 		logsContain:              []string{"Detected change to fall_back_on file", "a.txt"},
 	}
 	runTestCase(t, f, tCase)
@@ -1084,38 +859,6 @@ func TestLiveUpdateLocalContainerChangedFileNotMatchingSyncFallsBack(t *testing.
 		expectDockerExecCount:    0,
 		expectDockerRestartCount: 0,
 		expectK8sDeploy:          true, // Because we fell back to image builder, we also did a k8s deploy
-
-		logsContain:     []string{"Found file(s) not matching any sync", "a.txt"},
-		logsDontContain: []string{"unexpected error"},
-	}
-	runTestCase(t, f, tCase)
-}
-
-func TestLiveUpdateSyncletChangedFileNotMatchingSyncFallsBack(t *testing.T) {
-	f := newBDFixtureWithUpdateMode(t, k8s.EnvGKE, container.RuntimeDocker, buildcontrol.UpdateModeSynclet)
-	defer f.TearDown()
-
-	steps := []model.LiveUpdateSyncStep{model.LiveUpdateSyncStep{
-		Source: f.JoinPath("specific/directory"),
-		Dest:   "/go/src/github.com/tilt-dev/sancho",
-	}}
-
-	lu := assembleLiveUpdate(steps, SanchoRunSteps, true, []string{"a.txt"}, f)
-	tCase := testCase{
-		manifest: manifestbuilder.New(f, "sancho").
-			WithK8sYAML(SanchoYAML).
-			WithImageTarget(NewSanchoDockerBuildImageTarget(f)).
-			WithLiveUpdate(lu).
-			Build(),
-		changedFiles: []string{f.JoinPath("a.txt")}, // matches context but not sync'd directory
-
-		expectDockerBuildCount:   1, // we did a Docker build instead of an in-place update!
-		expectDockerPushCount:    1,
-		expectDockerCopyCount:    0,
-		expectDockerExecCount:    0,
-		expectDockerRestartCount: 0,
-		expectK8sDeploy:          true, // because we fell back to image builder, we also did a k8s deploy
-		expectSyncletDeploy:      true, // (and expect that yaml to have contained the synclet)
 
 		logsContain:     []string{"Found file(s) not matching any sync", "a.txt"},
 		logsDontContain: []string{"unexpected error"},

--- a/internal/engine/buildcontrol/update_mode.go
+++ b/internal/engine/buildcontrol/update_mode.go
@@ -58,7 +58,7 @@ func ProvideUpdateMode(flag UpdateModeFlag, env k8s.Env, runtime container.Runti
 	}
 
 	if mode == UpdateModeSynclet {
-		return "", fmt.Errorf("update mode %q has been deprecated; please use update mode %q instead. "+
+		return "", fmt.Errorf("update mode %q has been removed; please use update mode %q instead. "+
 			"If this breaks your workflow, contact us: https://tilt.dev/contact", flag, UpdateModeKubectlExec)
 	}
 

--- a/internal/engine/buildcontrol/update_mode.go
+++ b/internal/engine/buildcontrol/update_mode.go
@@ -58,11 +58,8 @@ func ProvideUpdateMode(flag UpdateModeFlag, env k8s.Env, runtime container.Runti
 	}
 
 	if mode == UpdateModeSynclet {
-		if runtime != container.RuntimeDocker {
-			return "", fmt.Errorf("update mode %q is only valid with Docker container runtime (and will NOT work with"+
-				"containerd, cri-o, etc.)", flag)
-
-		}
+		return "", fmt.Errorf("update mode %q has been deprecated; please use update mode %q instead. "+
+			"If this breaks your workflow, contact us: https://tilt.dev/contact", flag, UpdateModeKubectlExec)
 	}
 
 	return mode, nil


### PR DESCRIPTION
Hello @nicks, @landism,

Please review the following commits I made in branch maiamcc/rm-synclet-flag:

54489fccd9d0ad7cdfe41f7ab37b5cc6810958a9 (2020-07-30 12:44:42 -0400)
deprecate update_mode=syncet flag

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics