### PR TITLE
integration: rename resources so they don't interfere with each other

### DIFF
--- a/integration/restart_process_different_user/Tiltfile
+++ b/integration/restart_process_different_user/Tiltfile
@@ -15,11 +15,11 @@ default_registry(read_json('tilt_option.json', {})
 # 1) A SYNC step
 # 2) A RUN step that executes at build time (cp source.txt compiled.txt)
 # 3) Process restart (via `docker_build_with_restart`)
-docker_build_with_restart('sameimg', '.',
+docker_build_with_restart('rpdu', '.',
              entrypoint=['/src/main.sh'],
              live_update=[
                  sync('.', '/src'),
                  run('cp source.txt compiled.txt'),
              ])
-k8s_yaml('sameimg.yaml')
-k8s_resource('sameimg', port_forwards=['8100:8000', '8101:8001'])
+k8s_yaml('rpdu.yaml')
+k8s_resource('rpdu', port_forwards=['8100:8000', '8101:8001'])

--- a/integration/restart_process_different_user/rpdu.yaml
+++ b/integration/restart_process_different_user/rpdu.yaml
@@ -1,22 +1,22 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: sameimg
+  name: rpdu
   namespace: tilt-integration
   labels:
-    app: sameimg
+    app: rpdu
 spec:
   selector:
     matchLabels:
-      app: sameimg
+      app: rpdu
   template:
     metadata:
       labels:
-        app: sameimg
+        app: rpdu
     spec:
       containers:
       - name: c1
-        image: sameimg
+        image: rpdu
         command: ["/src/start.sh", "/src/main.sh"]
         args: ["8000"]
         ports:
@@ -25,7 +25,7 @@ spec:
           requests:
             cpu: "10m"
       - name: c2
-        image: sameimg
+        image: rpdu
         command: ["/src/start.sh", "/src/main.sh"]
         args: ["8001"]
         ports:

--- a/integration/restart_process_different_user_test.go
+++ b/integration/restart_process_different_user_test.go
@@ -18,7 +18,7 @@ func TestRestartProcessDifferentUser(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(f.ctx, time.Minute)
 	defer cancel()
-	firstPods := f.WaitForAllPodsReady(ctx, "app=sameimg")
+	firstPods := f.WaitForAllPodsReady(ctx, "app=rpdu")
 
 	ctx, cancel = context.WithTimeout(f.ctx, time.Minute)
 	defer cancel()
@@ -32,7 +32,7 @@ func TestRestartProcessDifferentUser(t *testing.T) {
 	f.CurlUntil(ctx, "http://localhost:8100", "🍄 Two-Up! 🍄")
 	f.CurlUntil(ctx, "http://localhost:8101", "🍄 Two-Up! 🍄")
 
-	secondPods := f.WaitForAllPodsReady(ctx, "app=sameimg")
+	secondPods := f.WaitForAllPodsReady(ctx, "app=rpdu")
 
 	// Assert that the pods were changed in-place, and not that we
 	// created new pods.
@@ -47,6 +47,6 @@ func TestRestartProcessDifferentUser(t *testing.T) {
 	defer cancel()
 	f.CurlUntil(ctx, "http://localhost:8101", "🍄 Two-Up! 🍄")
 
-	replacedPods := f.WaitForAllPodsReady(ctx, "app=sameimg")
+	replacedPods := f.WaitForAllPodsReady(ctx, "app=rpdu")
 	assert.NotEqual(t, secondPods, replacedPods)
 }


### PR DESCRIPTION
Hello @nicks, @jazzdan,

Please review the following commits I made in branch nicks/sameimg:

ef69af995969d6c8cefc051c1a6287d354bf0256 (2020-07-30 18:48:40 -0400)
integration: rename resources so they don't interfere with each other

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics