### PR TITLE
tilt logs: add port/resource flags, filter by resource [ch8432 ch8433]

### DIFF
--- a/internal/cli/logs.go
+++ b/internal/cli/logs.go
@@ -47,5 +47,5 @@ func (c *logsCmd) run(ctx context.Context, args []string) error {
 		return err
 	}
 
-	return server.StreamLogs(ctx, logDeps.url, logDeps.printer)
+	return server.StreamLogs(ctx, args, logDeps.url, logDeps.printer)
 }

--- a/internal/cli/logs.go
+++ b/internal/cli/logs.go
@@ -12,9 +12,7 @@ import (
 	"github.com/tilt-dev/tilt/internal/analytics"
 )
 
-type logsCmd struct {
-	// TODO(maia): port
-}
+type logsCmd struct{}
 
 func (c *logsCmd) register() *cobra.Command {
 	cmd := &cobra.Command{
@@ -26,9 +24,8 @@ func (c *logsCmd) register() *cobra.Command {
 stuff and things
 `,
 	}
-	// TODO(maia):
-	//   - can pass port
-	//   - pass resource names
+
+	addConnectServerFlags(cmd)
 	return cmd
 }
 

--- a/internal/hud/server/logs_reader_test.go
+++ b/internal/hud/server/logs_reader_test.go
@@ -9,11 +9,16 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/tilt-dev/tilt/pkg/model"
+
 	"github.com/tilt-dev/tilt/internal/hud"
 	proto_webview "github.com/tilt-dev/tilt/pkg/webview"
 )
 
-var defaultMessages = []string{"alpha", "bravo", "charlie", "delta"}
+var alphabet = []string{"alpha", "bravo", "charlie", "delta", "echo", "foxtrot",
+	"golf", "hotel", "igloo", "juliette", "kilo", "lima", "mike", "november",
+	"oscar", "papa", "quebec", "romeo", "sierra", "tango", "uniform", "victor",
+	"whiskey", "xavier", "yankee", "zulu"}
 
 type expectedLine struct {
 	prefix  string // ~manifestName (leave blank for "global" / unprefixed)
@@ -22,10 +27,11 @@ type expectedLine struct {
 
 func TestLogStreamerPrintsLogs(t *testing.T) {
 	f := newFixture(t)
-	view := f.newViewWithLogsForManifest(defaultMessages, "foo")
+
+	view := f.newViewWithLogsForManifest(alphabet[:4], "foo", 0)
 	f.handle(view)
 
-	expected := f.expectedLinesWithPrefix(defaultMessages, "foo")
+	expected := f.expectedLinesWithPrefix(alphabet[:4], "foo")
 
 	f.assertExpectedLogLines(expected)
 }
@@ -33,28 +39,83 @@ func TestLogStreamerPrintsLogs(t *testing.T) {
 func TestLogStreamerPrefixing(t *testing.T) {
 	f := newFixture(t)
 	manifestNames := []string{"foo", "", "foo", "bar"}
-	view := f.newViewWithLogsForManifests(defaultMessages, manifestNames)
+
+	view := f.newViewWithLogsForManifests(alphabet[:4], manifestNames, 0)
 	f.handle(view)
 
-	expected := f.expectedLinesWithPrefixes(defaultMessages, manifestNames)
+	expected := f.expectedLinesWithPrefixes(alphabet[:4], manifestNames)
 
 	f.assertExpectedLogLines(expected)
 }
 
 func TestLogStreamerDoesNotPrintResentLogs(t *testing.T) {
 	f := newFixture(t)
-	view := f.newViewWithLogsForManifest(defaultMessages, "foo")
+
+	view := f.newViewWithLogsForManifest(alphabet[:4], "foo", 0)
 	f.handle(view)
 
-	view.LogList.Segments = append(view.LogList.Segments, &proto_webview.LogSegment{
-		SpanId: spanID("foo"),
-		Text:   "echo",
-	})
-	view.LogList.ToCheckpoint = int32(len(view.LogList.Segments))
+	view = f.newViewWithLogsForManifest(alphabet[:5], "foo", 0)
 	f.handle(view)
 
-	expected := f.expectedLinesWithPrefix(append(defaultMessages, "echo"), "foo")
+	expected := f.expectedLinesWithPrefix(alphabet[:5], "foo")
 
+	f.assertExpectedLogLines(expected)
+}
+
+func TestLogStreamerCheckpointHandling(t *testing.T) {
+	f := newFixture(t)
+	resourceNames := []string{
+		"foo", "", "foo", "bar",
+		"bar", "bar", "", "bar",
+		"", "foo", "bar", "baz"}
+	view := f.newViewWithLogsForManifests(alphabet[:4], resourceNames[:4], 0)
+	f.handle(view)
+
+	view = f.newViewWithLogsForManifests(alphabet[4:8], resourceNames[4:8], view.LogList.ToCheckpoint)
+	f.handle(view)
+
+	view = f.newViewWithLogsForManifests(alphabet[8:12], resourceNames[8:12], view.LogList.ToCheckpoint)
+	f.handle(view)
+
+	expected := f.expectedLinesWithPrefixes(alphabet[:12], resourceNames[:12])
+	f.assertExpectedLogLines(expected)
+}
+
+func TestLogStreamerFiltersOnResourceNamesSingle(t *testing.T) {
+	f := newFixture(t).withResourceNames("foo")
+	manifestNames := []string{"foo", "", "foo", "bar"}
+	view := f.newViewWithLogsForManifests(alphabet[:4], manifestNames, 0)
+	f.handle(view)
+
+	// Expect no prefix b/c we're filtering for a single resource, so prefixing is redundant
+	expected := f.expectedLinesWithPrefix([]string{"alpha", "charlie"}, "")
+	f.assertExpectedLogLines(expected)
+}
+
+func TestLogStreamerFiltersOnResourceNamesMultiple(t *testing.T) {
+	f := newFixture(t).withResourceNames("foo", "baz")
+	manifestNames := []string{"foo", "", "foo", "bar", "baz", "bar", "baz", "foo"}
+	view := f.newViewWithLogsForManifests(alphabet[:8], manifestNames, 0)
+	f.handle(view)
+
+	expected := f.expectedLinesWithPrefixes(
+		[]string{"alpha", "charlie", "echo", "golf", "hotel"}, []string{"foo", "foo", "baz", "baz", "foo"})
+	f.assertExpectedLogLines(expected)
+}
+
+func TestLogStreamerCheckpointHandlingWithFiltering(t *testing.T) {
+	f := newFixture(t).withResourceNames("foo", "baz")
+	view := f.newViewWithLogsForManifests(alphabet[:4], []string{"foo", "", "foo", "bar"}, 0)
+	f.handle(view)
+
+	view = f.newViewWithLogsForManifests(alphabet[4:8], []string{"bar", "bar", "", "bar"}, view.LogList.ToCheckpoint)
+	f.handle(view)
+
+	view = f.newViewWithLogsForManifests(alphabet[8:12], []string{"", "foo", "bar", "baz"}, view.LogList.ToCheckpoint)
+	f.handle(view)
+
+	expected := f.expectedLinesWithPrefixes(
+		[]string{"alpha", "charlie", "juliette", "lima"}, []string{"foo", "foo", "foo", "baz"})
 	f.assertExpectedLogLines(expected)
 }
 
@@ -72,25 +133,60 @@ func newFixture(t *testing.T) *fixture {
 		t:          t,
 		fakeStdout: fakeStdout,
 		printer:    printer,
-		ls:         NewLogStreamer(printer),
+		ls:         NewLogStreamer(nil, printer),
 	}
 }
+
+func (f *fixture) withResourceNames(resourceNames ...string) *fixture {
+	rns := make(model.ManifestNameSet, len(resourceNames))
+	for _, rn := range resourceNames {
+		rns[model.ManifestName(rn)] = true
+	}
+	f.ls.resources = rns
+	return f
+}
+
 func (f *fixture) handle(view proto_webview.View) {
 	err := f.ls.Handle(view)
 	require.NoError(f.t, err)
 }
 
-func (f *fixture) newViewWithLogsForManifest(messages []string, manifestName string) proto_webview.View {
+func (f *fixture) newViewWithLogsForManifest(messages []string, manifestName string, fromChkpt int32) proto_webview.View {
 	dummyManifestNames := make([]string, len(messages))
 	for i := 0; i < len(messages); i++ {
 		dummyManifestNames[i] = manifestName
 	}
-	return f.newViewWithLogsForManifests(messages, dummyManifestNames)
+	return f.newViewWithLogsForManifests(messages, dummyManifestNames, fromChkpt)
 }
 
-func (f *fixture) newViewWithLogsForManifests(messages []string, manifestNames []string) proto_webview.View {
+func (f *fixture) newViewWithLogsForManifests(messages []string, manifestNames []string, fromChkpt int32) proto_webview.View {
+	segs := f.segments(messages, manifestNames)
+	spans := f.spans(manifestNames, nil)
+
+	return proto_webview.View{
+		LogList: &proto_webview.LogList{
+			Spans:          spans,
+			Segments:       segs,
+			FromCheckpoint: fromChkpt,
+			ToCheckpoint:   fromChkpt + int32(len(segs)),
+		},
+	}
+}
+
+func (f *fixture) addLogs(view proto_webview.View, messages []string, manifestNames []string) proto_webview.View {
+	view.LogList.FromCheckpoint = view.LogList.ToCheckpoint
+	newSegs := f.segments(messages, manifestNames)
+	view.LogList.Segments = append(view.LogList.Segments, newSegs...)
+	view.LogList.ToCheckpoint = int32(len(view.LogList.Segments))
+
+	view.LogList.Spans = f.spans(manifestNames, view.LogList.Spans)
+
+	return view
+}
+
+func (f *fixture) segments(messages []string, manifestNames []string) []*proto_webview.LogSegment {
 	if len(messages) != len(manifestNames) {
-		f.t.Fatalf("Need same number of prefixes and manifestNames (got %d and %d)",
+		f.t.Fatalf("Need same number of messages and manifestNames (got %d and %d)",
 			len(messages), len(manifestNames))
 	}
 
@@ -102,19 +198,22 @@ func (f *fixture) newViewWithLogsForManifests(messages []string, manifestNames [
 			Level:  0, // TODO
 		}
 	}
-	spans := make(map[string]*proto_webview.LogSpan)
-	for _, mn := range manifestNames {
-		spans[spanID(mn)] = &proto_webview.LogSpan{ManifestName: mn}
+
+	return segs
+}
+
+func (f *fixture) spans(manifestNames []string,
+	existingSpans map[string]*proto_webview.LogSpan) map[string]*proto_webview.LogSpan {
+
+	if existingSpans == nil {
+		existingSpans = make(map[string]*proto_webview.LogSpan)
 	}
 
-	return proto_webview.View{
-		LogList: &proto_webview.LogList{ // TODO: be better
-			Spans:          spans,
-			Segments:       segs,
-			FromCheckpoint: 0,
-			ToCheckpoint:   int32(len(segs)),
-		},
+	for _, mn := range manifestNames {
+		existingSpans[spanID(mn)] = &proto_webview.LogSpan{ManifestName: mn}
 	}
+
+	return existingSpans
 }
 
 func (f *fixture) assertExpectedLogLines(expectedLines []expectedLine) {

--- a/pkg/model/logstore/logstore_test.go
+++ b/pkg/model/logstore/logstore_test.go
@@ -462,7 +462,7 @@ func TestContinuingLinesWithOptionsSuppressPrefix(t *testing.T) {
 	assert.Equal(t, []LogLine{
 		LogLine{Text: "layer 1: pending\n", SpanID: "fe", ProgressID: "layer 1", Time: now},
 		LogLine{Text: "layer 2: pending\n", SpanID: "fe", ProgressID: "layer 2", Time: now},
-	}, l.ContinuingLinesWithOptions(c1, lineOptions{suppressPrefix: true}))
+	}, l.ContinuingLinesWithOptions(c1, LineOptions{SuppressPrefix: true}))
 }
 
 func TestContinuingLinesWithOptionsSpans(t *testing.T) {
@@ -539,10 +539,10 @@ func assertSnapshot(t *testing.T, output string) {
 	assert.Equal(t, string(expected), output)
 }
 
-func lineOptionsWithManifests(mns ...model.ManifestName) lineOptions {
-	mnSet := make(mnSet)
+func lineOptionsWithManifests(mns ...model.ManifestName) LineOptions {
+	mnSet := make(model.ManifestNameSet)
 	for _, mn := range mns {
 		mnSet[mn] = true
 	}
-	return lineOptions{mnSet: mnSet}
+	return LineOptions{ManifestNames: mnSet}
 }

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -18,6 +18,7 @@ import (
 
 // TODO(nick): We should probably get rid of ManifestName completely and just use TargetName everywhere.
 type ManifestName string
+type ManifestNameSet map[ManifestName]bool
 
 const TiltfileManifestName = ManifestName("(Tiltfile)")
 


### PR DESCRIPTION
Hello @nicks, @jazzdan,

Please review the following commits I made in branch maiamcc/filter-resources:

857bdf022b6d19dc5f413bccb760be26297bb410 (2020-08-03 13:03:31 -0400)
tilt logs: add port/resource flags, filter by resource [ch8432 ch8433]

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics