### PR TITLE
tiltfile: add k8s_yaml(allow_duplicates=True) to allow duplicate yaml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,14 +17,14 @@ jobs:
       - run: sudo mv /usr/bin/helm3 /usr/bin/helm
       - restore_cache:
           keys:
-            - golangci_lint_v2_{{ .Revision }}
-            - golangci_lint_v2_ # Else find the most recently generated cache
+            - golangci_lint_v3_{{ .Revision }}
+            - golangci_lint_v3_ # Else find the most recently generated cache
       - run: make lint
       - run: make test_install_version_check
       - save_cache:
           paths:
             - /home/circleci/.cache/golangci-lint
-          key: golangci_lint_v2_{{ .Revision }}
+          key: golangci_lint_v3_{{ .Revision }}
       - run: make wire-check
       - run: make test-go
       - store_test_results:

--- a/internal/k8s/names_test.go
+++ b/internal/k8s/names_test.go
@@ -21,38 +21,37 @@ type workload struct {
 
 func TestUniqueResourceNames(t *testing.T) {
 	testCases := []struct {
-		testName      string
-		workloads     []workload
-		expectedError string
+		testName  string
+		workloads []workload
 	}{
 		{"one workload, just name", []workload{
 			{"foo", "Deployment", "default", "", "foo"},
-		}, ""},
+		}},
 		{"one workload, same name", []workload{
-			{"foo", "Deployment", "default", "", ""},
-			{"foo", "Deployment", "default", "", ""},
-		}, DuplicateYAMLDetectedError("foo:deployment:default:core")},
+			{"foo", "Deployment", "default", "", "foo:deployment:default:core:0"},
+			{"foo", "Deployment", "default", "", "foo:deployment:default:core:1"},
+		}},
 		{"one workload, by name", []workload{
 			{"foo", "Deployment", "default", "", "foo"},
 			{"bar", "Deployment", "default", "", "bar"},
-		}, ""},
+		}},
 		{"two workloads, by kind", []workload{
 			{"foo", "Deployment", "default", "", "foo:deployment"},
 			{"foo", "CronJob", "default", "", "foo:cronjob"},
-		}, ""},
+		}},
 		{"two workloads, by namespace", []workload{
 			{"foo", "Deployment", "default", "", "foo:deployment:default"},
 			{"foo", "Deployment", "fission", "", "foo:deployment:fission"},
-		}, ""},
+		}},
 		{"two workloads, by group", []workload{
 			{"foo", "Deployment", "default", "a", "foo:deployment:default:a"},
 			{"foo", "Deployment", "default", "b", "foo:deployment:default:b"},
-		}, ""},
+		}},
 		{"three workloads, one by kind, two by namespace", []workload{
 			{"foo", "Deployment", "default", "a", "foo:deployment:default"},
 			{"foo", "Deployment", "fission", "b", "foo:deployment:fission"},
 			{"foo", "CronJob", "default", "b", "foo:cronjob"},
-		}, ""},
+		}},
 	}
 
 	for _, test := range testCases {
@@ -70,14 +69,8 @@ func TestUniqueResourceNames(t *testing.T) {
 				expectedNames = append(expectedNames, w.expectedResourceName)
 			}
 
-			actualNames, err := UniqueNames(entities, 1)
-			if test.expectedError == "" {
-				require.NoError(t, err)
-				require.Equal(t, expectedNames, actualNames)
-			} else {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), test.expectedError)
-			}
+			actualNames := UniqueNames(entities, 1)
+			require.Equal(t, expectedNames, actualNames)
 		})
 	}
 }

--- a/internal/k8s/target.go
+++ b/internal/k8s/target.go
@@ -46,11 +46,7 @@ func NewTarget(
 
 	// Use a min component count of 2 for computing names,
 	// so that the resource type appears
-	displayNames, err := UniqueNames(sorted, 2)
-	if err != nil {
-		return model.K8sTarget{}, err
-	}
-
+	displayNames := UniqueNames(sorted, 2)
 	myLocators := []model.K8sImageLocator{}
 	for _, locator := range allLocators {
 		if LocatorMatchesOne(locator, entities) {

--- a/internal/tiltfile/k8s/state.go
+++ b/internal/tiltfile/k8s/state.go
@@ -1,0 +1,79 @@
+package k8s
+
+import (
+	"fmt"
+	"strings"
+
+	"go.starlark.net/starlark"
+	v1 "k8s.io/api/core/v1"
+
+	"github.com/tilt-dev/tilt/internal/k8s"
+)
+
+const fmtDuplicateYAMLDetectedError = `Duplicate YAML: %s
+Ignore this error with k8s_yaml(..., allow_duplicates=True)
+YAML originally registered at: %s`
+
+func DuplicateYAMLDetectedError(id, stackTrace string) error {
+	indentedTrace := strings.Join(strings.Split(stackTrace, "\n"), "\n  ")
+	return fmt.Errorf(fmtDuplicateYAMLDetectedError, id, indentedTrace)
+}
+
+type ObjectSpec struct {
+	// The resource spec
+	Entity k8s.K8sEntity
+
+	// The stack trace where this resource was registered.
+	// Helpful for reporting duplicates.
+	StackTrace string
+}
+
+// Keeps track of all the Kuberentes objects registered during Tiltfile Execution.
+type State struct {
+	ObjectSpecRefs  []v1.ObjectReference
+	ObjectSpecIndex map[v1.ObjectReference]ObjectSpec
+}
+
+func NewState() *State {
+	return &State{
+		ObjectSpecIndex: make(map[v1.ObjectReference]ObjectSpec),
+	}
+}
+
+func (s *State) Entities() []k8s.K8sEntity {
+	result := make([]k8s.K8sEntity, len(s.ObjectSpecIndex))
+	for i, ref := range s.ObjectSpecRefs {
+		result[i] = s.ObjectSpecIndex[ref].Entity
+	}
+	return result
+}
+
+func (s *State) EntityCount() int {
+	return len(s.ObjectSpecIndex)
+}
+
+func (s *State) Append(t *starlark.Thread, entities []k8s.K8sEntity, dupesOK bool) error {
+	stackTrace := t.CallStack().String()
+	for _, e := range entities {
+		ref := e.ToObjectReference()
+		old, exists := s.ObjectSpecIndex[ref]
+		if exists && !dupesOK {
+			humanRef := ""
+			if ref.Namespace == "" {
+				humanRef = fmt.Sprintf("%s %s", ref.Kind, ref.Name)
+			} else {
+				humanRef = fmt.Sprintf("%s %s (Namespace: %s)", ref.Kind, ref.Name, ref.Namespace)
+			}
+			return DuplicateYAMLDetectedError(humanRef, old.StackTrace)
+		}
+
+		if !exists {
+			s.ObjectSpecRefs = append(s.ObjectSpecRefs, ref)
+		}
+		s.ObjectSpecIndex[ref] = ObjectSpec{
+			Entity:     e,
+			StackTrace: stackTrace,
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
Hello @jazzdan, @abdullahzameek,

Please review the following commits I made in branch nicks/ch8756:

5599a2c77d12190132eea71569c935797571fc75 (2020-08-05 20:14:14 -0400)
tiltfile: add k8s_yaml(allow_duplicates=True) to allow duplicate yaml
Also, report the stack traces where the yaml was registered so that
the user has some hope of debugging this.

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics