### PR TITLE
Add tilt version and tilt verify-install to windows installer

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,6 +82,7 @@ jobs:
       # Check to make sure Windows binaries compile
       - run: go install -mod vendor ./cmd/tilt
       - run: make shorttestsum
+      - run: iex ./scripts/install.ps1
       - store_test_results:
           path: test-results
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -20,6 +20,8 @@ if ("true" -eq $useScoop) {
     scoop bucket add tilt-dev https://github.com/tilt-dev/scoop-bucket
     scoop install tilt
     scoop update tilt
+    tilt version
+    tilt verify-install
     Write-Output "Tilt installed with Scoop! Run 'tilt up' to start."
     return
 }
@@ -42,6 +44,9 @@ Move-Item -Force -Path "$extractDir\tilt.exe" -Destination "$dest"
 
 Remove-Item -Force -Path "$zip"
 Remove-Item -Force -Recurse -Path "$extractDir"
+
+iex "$dest version"
+iex "$dest verify-install"
 
 Write-Output "Tilt installed!"
 Write-Output "Run '$dest up' to start."


### PR DESCRIPTION
Hello @abdullahzameek,

Please review the following commits I made in branch nicks/win-verify-install:

9d9eb91a71290f0c04cd8856a530d12c588f21cf (2020-08-06 16:17:01 -0400)
Add tilt version and tilt verify-install to windows installer
fixes https://github.com/tilt-dev/tilt/issues/3674

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics