### PR TITLE
tilt logs: docstring and unhide cmd

### DIFF
--- a/internal/cli/logs.go
+++ b/internal/cli/logs.go
@@ -18,13 +18,15 @@ func (c *logsCmd) register() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:                   "logs [resource1, resource2...]",
 		DisableFlagsInUseLine: true,
-		Hidden:                true, // show when out of alpha
-		Short:                 "stuff",
-		Long: `
-stuff and things
+		Short:                 "stream logs from a running Tilt instance (optionally filtered for the specified resources)",
+		Long: `Stream logs from a running Tilt instance (optionally filtered for the specified resources).
+
+By default, looks for a running Tilt instance on localhost:10350
+(this is configurable with the --port and --host flags).
 `,
 	}
 
+	// TODO: log level flags
 	addConnectServerFlags(cmd)
 	return cmd
 }


### PR DESCRIPTION
Hello @nicks, @landism,

Please review the following commits I made in branch maiamcc/logsdocs:

c2066a54dd0752c6b607c0947121ab8204512e38 (2020-08-10 12:27:21 -0400)
tilt logs: docstring and unhide cmd

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics