### PR TITLE
engine: record update stats (with more tags) for ALL BaDs

### DIFF
--- a/internal/engine/build_and_deployer.go
+++ b/internal/engine/build_and_deployer.go
@@ -4,12 +4,9 @@ import (
 	"context"
 	"fmt"
 	"strings"
-	"time"
 
 	"go.opentelemetry.io/otel/api/core"
 	"go.opentelemetry.io/otel/api/trace"
-
-	"github.com/tilt-dev/tilt/internal/analytics"
 
 	"github.com/tilt-dev/tilt/internal/container"
 	"github.com/tilt-dev/tilt/internal/engine/buildcontrol"
@@ -135,18 +132,4 @@ func DefaultBuildOrder(lubad *LiveUpdateBuildAndDeployer, ibad *ImageBuildAndDep
 	}
 
 	return BuildOrder{lubad, dcbad, ibad, ltbad}
-}
-
-func sendBuildCompleteTiming(ctx context.Context, startTime time.Time, updateType string, err error) {
-	hasErr := fmt.Sprintf("%t", err != nil)
-
-	analytics.Get(ctx).Timer("update", time.Since(startTime), map[string]string{
-		"type":     updateType,
-		"hasError": hasErr,
-	})
-
-	// legacy format ("build.image" etc.)
-	analytics.Get(ctx).Timer(fmt.Sprintf("build.%s", updateType), time.Since(startTime), map[string]string{
-		"hasError": hasErr,
-	})
 }

--- a/internal/engine/build_and_deployer.go
+++ b/internal/engine/build_and_deployer.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"go.opentelemetry.io/otel/api/core"
 	"go.opentelemetry.io/otel/api/trace"
+
+	"github.com/tilt-dev/tilt/internal/analytics"
 
 	"github.com/tilt-dev/tilt/internal/container"
 	"github.com/tilt-dev/tilt/internal/engine/buildcontrol"
@@ -132,4 +135,18 @@ func DefaultBuildOrder(lubad *LiveUpdateBuildAndDeployer, ibad *ImageBuildAndDep
 	}
 
 	return BuildOrder{lubad, dcbad, ibad, ltbad}
+}
+
+func sendBuildCompleteTiming(ctx context.Context, startTime time.Time, updateType string, err error) {
+	hasErr := fmt.Sprintf("%t", err != nil)
+
+	analytics.Get(ctx).Timer("update", time.Since(startTime), map[string]string{
+		"type":     updateType,
+		"hasError": hasErr,
+	})
+
+	// legacy format ("build.image" etc.)
+	analytics.Get(ctx).Timer(fmt.Sprintf("build.%s", updateType), time.Since(startTime), map[string]string{
+		"hasError": hasErr,
+	})
 }

--- a/internal/engine/docker_compose_build_and_deployer.go
+++ b/internal/engine/docker_compose_build_and_deployer.go
@@ -9,6 +9,8 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/opentracing/opentracing-go"
 
+	"github.com/tilt-dev/tilt/internal/analytics"
+
 	"github.com/tilt-dev/tilt/internal/build"
 	"github.com/tilt-dev/tilt/internal/container"
 	"github.com/tilt-dev/tilt/internal/docker"
@@ -71,7 +73,9 @@ func (bd *DockerComposeBuildAndDeployer) BuildAndDeploy(ctx context.Context, st 
 
 	startTime := time.Now()
 	defer func() {
-		sendBuildCompleteTiming(ctx, startTime, "docker-compose", err)
+		analytics.Get(ctx).Timer("build.docker-compose", time.Since(startTime), map[string]string{
+			"hasError": fmt.Sprintf("%t", err != nil),
+		})
 	}()
 
 	q, err := buildcontrol.NewImageTargetQueue(ctx, iTargets, currentState, bd.ib.CanReuseRef)

--- a/internal/engine/docker_compose_build_and_deployer.go
+++ b/internal/engine/docker_compose_build_and_deployer.go
@@ -9,8 +9,6 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/opentracing/opentracing-go"
 
-	"github.com/tilt-dev/tilt/internal/analytics"
-
 	"github.com/tilt-dev/tilt/internal/build"
 	"github.com/tilt-dev/tilt/internal/container"
 	"github.com/tilt-dev/tilt/internal/docker"
@@ -73,10 +71,7 @@ func (bd *DockerComposeBuildAndDeployer) BuildAndDeploy(ctx context.Context, st 
 
 	startTime := time.Now()
 	defer func() {
-		analytics.Get(ctx).Timer("update", time.Since(startTime), map[string]string{
-			"type":     "local",
-			"hasError": fmt.Sprintf("%t", err != nil),
-		})
+		sendBuildCompleteTiming(ctx, startTime, "docker-compose", err)
 	}()
 
 	q, err := buildcontrol.NewImageTargetQueue(ctx, iTargets, currentState, bd.ib.CanReuseRef)

--- a/internal/engine/image_build_and_deployer.go
+++ b/internal/engine/image_build_and_deployer.go
@@ -115,8 +115,10 @@ func (ibd *ImageBuildAndDeployer) BuildAndDeploy(ctx context.Context, st store.R
 
 	startTime := time.Now()
 	defer func() {
-		// todo: image tag?
-		ibd.analytics.Timer("build.image", time.Since(startTime), nil)
+		ibd.analytics.Timer("update", time.Since(startTime), map[string]string{
+			"type":     "image",
+			"hasError": fmt.Sprintf("%t", err != nil),
+		})
 	}()
 
 	q, err := buildcontrol.NewImageTargetQueue(ctx, iTargets, stateSet, ibd.ib.CanReuseRef)

--- a/internal/engine/image_build_and_deployer.go
+++ b/internal/engine/image_build_and_deployer.go
@@ -115,10 +115,7 @@ func (ibd *ImageBuildAndDeployer) BuildAndDeploy(ctx context.Context, st store.R
 
 	startTime := time.Now()
 	defer func() {
-		ibd.analytics.Timer("update", time.Since(startTime), map[string]string{
-			"type":     "image",
-			"hasError": fmt.Sprintf("%t", err != nil),
-		})
+		sendBuildCompleteTiming(ctx, startTime, "image", err)
 	}()
 
 	q, err := buildcontrol.NewImageTargetQueue(ctx, iTargets, stateSet, ibd.ib.CanReuseRef)

--- a/internal/engine/image_build_and_deployer.go
+++ b/internal/engine/image_build_and_deployer.go
@@ -115,7 +115,9 @@ func (ibd *ImageBuildAndDeployer) BuildAndDeploy(ctx context.Context, st store.R
 
 	startTime := time.Now()
 	defer func() {
-		sendBuildCompleteTiming(ctx, startTime, "image", err)
+		ibd.analytics.Timer("build.image", time.Since(startTime), map[string]string{
+			"hasError": fmt.Sprintf("%t", err != nil),
+		})
 	}()
 
 	q, err := buildcontrol.NewImageTargetQueue(ctx, iTargets, stateSet, ibd.ib.CanReuseRef)

--- a/internal/engine/live_update_build_and_deployer.go
+++ b/internal/engine/live_update_build_and_deployer.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/tilt-dev/tilt/internal/ospath"
 
-	"github.com/tilt-dev/tilt/internal/analytics"
 	"github.com/tilt-dev/tilt/internal/engine/buildcontrol"
 
 	"github.com/tilt-dev/tilt/internal/container"
@@ -123,10 +122,7 @@ func (lubad *LiveUpdateBuildAndDeployer) buildAndDeploy(ctx context.Context, ps 
 
 	startTime := time.Now()
 	defer func() {
-		analytics.Get(ctx).Timer("update", time.Since(startTime), map[string]string{
-			"type":     "container",
-			"hasError": fmt.Sprintf("%t", err != nil),
-		})
+		sendBuildCompleteTiming(ctx, startTime, "container", err)
 	}()
 
 	l := logger.Get(ctx)

--- a/internal/engine/live_update_build_and_deployer.go
+++ b/internal/engine/live_update_build_and_deployer.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/tilt-dev/tilt/internal/ospath"
 
+	"github.com/tilt-dev/tilt/internal/analytics"
 	"github.com/tilt-dev/tilt/internal/engine/buildcontrol"
 
 	"github.com/tilt-dev/tilt/internal/container"
@@ -122,7 +123,9 @@ func (lubad *LiveUpdateBuildAndDeployer) buildAndDeploy(ctx context.Context, ps 
 
 	startTime := time.Now()
 	defer func() {
-		sendBuildCompleteTiming(ctx, startTime, "container", err)
+		analytics.Get(ctx).Timer("build.container", time.Since(startTime), map[string]string{
+			"hasError": fmt.Sprintf("%t", err != nil),
+		})
 	}()
 
 	l := logger.Get(ctx)

--- a/internal/engine/local_target_build_and_deployer.go
+++ b/internal/engine/local_target_build_and_deployer.go
@@ -2,9 +2,11 @@ package engine
 
 import (
 	"context"
+	"fmt"
 	"os/exec"
 	"time"
 
+	"github.com/tilt-dev/tilt/internal/analytics"
 	"github.com/tilt-dev/tilt/internal/build"
 	"github.com/tilt-dev/tilt/internal/engine/buildcontrol"
 	"github.com/tilt-dev/tilt/internal/store"
@@ -32,7 +34,10 @@ func (bd *LocalTargetBuildAndDeployer) BuildAndDeploy(ctx context.Context, st st
 
 	startTime := time.Now()
 	defer func() {
-		sendBuildCompleteTiming(ctx, startTime, "local", err)
+		analytics.Get(ctx).Timer("build.local", time.Since(startTime), map[string]string{
+			"type":     "local",
+			"hasError": fmt.Sprintf("%t", err != nil),
+		})
 	}()
 
 	targ := targets[0]

--- a/internal/engine/local_target_build_and_deployer.go
+++ b/internal/engine/local_target_build_and_deployer.go
@@ -2,9 +2,11 @@ package engine
 
 import (
 	"context"
+	"fmt"
 	"os/exec"
 	"time"
 
+	"github.com/tilt-dev/tilt/internal/analytics"
 	"github.com/tilt-dev/tilt/internal/build"
 	"github.com/tilt-dev/tilt/internal/engine/buildcontrol"
 	"github.com/tilt-dev/tilt/internal/store"
@@ -29,6 +31,14 @@ func (bd *LocalTargetBuildAndDeployer) BuildAndDeploy(ctx context.Context, st st
 		return store.BuildResultSet{}, buildcontrol.SilentRedirectToNextBuilderf(
 			"LocalTargetBuildAndDeployer requires exactly one LocalTarget (got %d)", len(targets))
 	}
+
+	startTime := time.Now()
+	defer func() {
+		analytics.Get(ctx).Timer("update", time.Since(startTime), map[string]string{
+			"type":     "local",
+			"hasError": fmt.Sprintf("%t", err != nil),
+		})
+	}()
 
 	targ := targets[0]
 	err = bd.run(ctx, targ.UpdateCmd, targ.Workdir)

--- a/internal/engine/local_target_build_and_deployer.go
+++ b/internal/engine/local_target_build_and_deployer.go
@@ -2,11 +2,9 @@ package engine
 
 import (
 	"context"
-	"fmt"
 	"os/exec"
 	"time"
 
-	"github.com/tilt-dev/tilt/internal/analytics"
 	"github.com/tilt-dev/tilt/internal/build"
 	"github.com/tilt-dev/tilt/internal/engine/buildcontrol"
 	"github.com/tilt-dev/tilt/internal/store"
@@ -34,10 +32,7 @@ func (bd *LocalTargetBuildAndDeployer) BuildAndDeploy(ctx context.Context, st st
 
 	startTime := time.Now()
 	defer func() {
-		analytics.Get(ctx).Timer("update", time.Since(startTime), map[string]string{
-			"type":     "local",
-			"hasError": fmt.Sprintf("%t", err != nil),
-		})
+		sendBuildCompleteTiming(ctx, startTime, "local", err)
 	}()
 
 	targ := targets[0]

--- a/internal/engine/local_target_build_and_deployer.go
+++ b/internal/engine/local_target_build_and_deployer.go
@@ -35,7 +35,6 @@ func (bd *LocalTargetBuildAndDeployer) BuildAndDeploy(ctx context.Context, st st
 	startTime := time.Now()
 	defer func() {
 		analytics.Get(ctx).Timer("build.local", time.Since(startTime), map[string]string{
-			"type":     "local",
 			"hasError": fmt.Sprintf("%t", err != nil),
 		})
 	}()


### PR DESCRIPTION
(If we really don't want to make changes to internal analytics right now
I can rescind this)

was talking to @victorwuky about how to get events for user updates,
realized what we have in place right now is a. kludgy and b. incompletely
instrumented--wdyt of this instead?