### PR TITLE
tilt logs: add --follow flag, by default don't follow [ch8923]

### DIFF
--- a/internal/cli/logs.go
+++ b/internal/cli/logs.go
@@ -12,19 +12,23 @@ import (
 	"github.com/tilt-dev/tilt/internal/analytics"
 )
 
-type logsCmd struct{}
+type logsCmd struct {
+	follow bool // if true, follow logs (otherwise print current logs and exit)
+}
 
 func (c *logsCmd) register() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:                   "logs [resource1, resource2...]",
 		DisableFlagsInUseLine: true,
-		Short:                 "stream logs from a running Tilt instance (optionally filtered for the specified resources)",
-		Long: `Stream logs from a running Tilt instance (optionally filtered for the specified resources).
+		Short:                 "Get logs from a running Tilt instance (optionally filtered for the specified resources)",
+		Long: `Get logs from a running Tilt instance (optionally filtered for the specified resources).
 
 By default, looks for a running Tilt instance on localhost:10350
 (this is configurable with the --port and --host flags).
 `,
 	}
+
+	cmd.Flags().BoolVarP(&c.follow, "follow", "f", false, "If true, stream the requested logs; otherwise, print the requested logs at the current moment in time, then exit.")
 
 	// TODO: log level flags
 	addConnectServerFlags(cmd)
@@ -46,5 +50,5 @@ func (c *logsCmd) run(ctx context.Context, args []string) error {
 		return err
 	}
 
-	return server.StreamLogs(ctx, logDeps.url, args, logDeps.printer)
+	return server.StreamLogs(ctx, c.follow, logDeps.url, args, logDeps.printer)
 }

--- a/internal/hud/server/logs_reader.go
+++ b/internal/hud/server/logs_reader.go
@@ -28,21 +28,21 @@ type WebsocketReader struct {
 	conn         WebsocketConn
 	marshaller   jsonpb.Marshaler
 	unmarshaller jsonpb.Unmarshaler
-	keepAlive    bool // whether to keep listening on websocket, or close after first message
+	persistent   bool // whether to keep listening on websocket, or close after first message
 	handler      ViewHandler
 }
 
-func newWebsocketReaderForLogs(conn WebsocketConn, keepAlive bool, resources []string, p *hud.IncrementalPrinter) *WebsocketReader {
+func newWebsocketReaderForLogs(conn WebsocketConn, persistent bool, resources []string, p *hud.IncrementalPrinter) *WebsocketReader {
 	ls := NewLogStreamer(resources, p)
-	return newWebsocketReader(conn, keepAlive, ls)
+	return newWebsocketReader(conn, persistent, ls)
 }
 
-func newWebsocketReader(conn WebsocketConn, keepAlive bool, handler ViewHandler) *WebsocketReader {
+func newWebsocketReader(conn WebsocketConn, persistent bool, handler ViewHandler) *WebsocketReader {
 	return &WebsocketReader{
 		conn:         conn,
 		marshaller:   jsonpb.Marshaler{OrigName: false, EmitDefaults: true},
 		unmarshaller: jsonpb.Unmarshaler{},
-		keepAlive:    keepAlive,
+		persistent:   persistent,
 		handler:      handler,
 	}
 }
@@ -136,7 +136,7 @@ func (wsr *WebsocketReader) Listen(ctx context.Context) error {
 					// will I want this to be an Info sometimes??
 					logger.Get(ctx).Verbosef("Error handling websocket message: %v", err)
 				}
-				if !wsr.keepAlive {
+				if !wsr.persistent {
 					return
 				}
 			}

--- a/internal/hud/server/websocket_reader_test.go
+++ b/internal/hud/server/websocket_reader_test.go
@@ -67,8 +67,8 @@ func TestHandlerErrorDoesntStopLoop(t *testing.T) {
 	f.tearDown()
 }
 
-func TestKeepAliveFalseExistsAfterHandling(t *testing.T) {
-	f := newWebsocketReaderFixture(t).withKeepAlive(false)
+func TestNonPersistentReaderExistsAfterHandling(t *testing.T) {
+	f := newWebsocketReaderFixture(t).withPersistent(false)
 	f.start()
 
 	v := &proto_webview.View{Log: "hello world"}
@@ -120,8 +120,8 @@ func newWebsocketReaderFixture(t *testing.T) *websocketReaderFixture {
 	}
 }
 
-func (f *websocketReaderFixture) withKeepAlive(keepAlive bool) *websocketReaderFixture {
-	f.wsr.keepAlive = keepAlive
+func (f *websocketReaderFixture) withPersistent(persistent bool) *websocketReaderFixture {
+	f.wsr.persistent = persistent
 	return f
 }
 

--- a/internal/hud/server/websocket_reader_test.go
+++ b/internal/hud/server/websocket_reader_test.go
@@ -67,6 +67,19 @@ func TestHandlerErrorDoesntStopLoop(t *testing.T) {
 	f.tearDown()
 }
 
+func TestKeepAliveFalseExistsAfterHandling(t *testing.T) {
+	f := newWebsocketReaderFixture(t).withKeepAlive(false)
+	f.start()
+
+	v := &proto_webview.View{Log: "hello world"}
+	f.sendView(v)
+	f.assertHandlerCallCount(1)
+	assert.Equal(t, "hello world", f.handler.lastViewLog)
+	f.assertDone()
+
+	f.tearDown()
+}
+
 func TestWebsocketCloseOnNextReaderError(t *testing.T) {
 	f := newWebsocketReaderFixture(t)
 	f.start()
@@ -102,9 +115,14 @@ func newWebsocketReaderFixture(t *testing.T) *websocketReaderFixture {
 		out:     out,
 		conn:    conn,
 		handler: handler,
-		wsr:     newWebsocketReader(conn, handler),
+		wsr:     newWebsocketReader(conn, true, handler),
 		done:    make(chan error),
 	}
+}
+
+func (f *websocketReaderFixture) withKeepAlive(keepAlive bool) *websocketReaderFixture {
+	f.wsr.keepAlive = keepAlive
+	return f
 }
 
 func (f *websocketReaderFixture) start() {


### PR DESCRIPTION
Resolves issue #3692.

I'm really on the fence about
a. the `--follow` flag naming (trying to imitate `tail`, but also `-f` exists on `tilt up` and does a different thing
b. whether the default should be following or not following

Will gladly accept roll with any (even weak) opinions here.