### PR TITLE
tiltfile: add a stringable type to make it easier to unpack strings

### DIFF
--- a/internal/tiltfile/docker.go
+++ b/internal/tiltfile/docker.go
@@ -96,8 +96,8 @@ func (s *tiltfileState) dockerBuild(thread *starlark.Thread, fn *starlark.Builti
 		liveUpdateVal,
 		ignoreVal,
 		onlyVal,
-		networkVal,
 		entrypoint starlark.Value
+	var network value.Stringable
 	var ssh, secret, extraTags, cacheFrom value.StringOrStringList
 	var matchInEnvVars, pullParent bool
 	var containerArgsVal starlark.Sequence
@@ -117,7 +117,7 @@ func (s *tiltfileState) dockerBuild(thread *starlark.Thread, fn *starlark.Builti
 		"target?", &targetStage,
 		"ssh?", &ssh,
 		"secret?", &secret,
-		"network?", &networkVal,
+		"network?", &network,
 		"extra_tag?", &extraTags,
 		"cache_from?", &cacheFrom,
 		"pull?", &pullParent,
@@ -195,15 +195,6 @@ func (s *tiltfileState) dockerBuild(thread *starlark.Thread, fn *starlark.Builti
 		return nil, err
 	}
 
-	network := ""
-	if networkVal != nil {
-		var ok bool
-		network, ok = value.AsString(networkVal)
-		if !ok {
-			return nil, fmt.Errorf("Argument 'network' must be string. Actual: %T", networkVal)
-		}
-	}
-
 	entrypointCmd, err := value.ValueToUnixCmd(entrypoint)
 	if err != nil {
 		return nil, err
@@ -241,7 +232,7 @@ func (s *tiltfileState) dockerBuild(thread *starlark.Thread, fn *starlark.Builti
 		entrypoint:       entrypointCmd,
 		containerArgs:    containerArgs,
 		targetStage:      targetStage,
-		network:          network,
+		network:          network.Value,
 		extraTags:        extraTags.Values,
 		cacheFrom:        cacheFrom.Values,
 		pullParent:       pullParent,

--- a/internal/tiltfile/encoding/json.go
+++ b/internal/tiltfile/encoding/json.go
@@ -41,17 +41,12 @@ func readJSON(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple
 
 // reads json from a string
 func decodeJSON(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-	var contents starlark.Value
+	var contents value.Stringable
 	if err := starkit.UnpackArgs(thread, fn.Name(), args, kwargs, "json", &contents); err != nil {
 		return nil, err
 	}
 
-	s, ok := value.AsString(contents)
-	if !ok {
-		return nil, fmt.Errorf("%s arg must be a string or blob. got %s", fn.Name(), contents.Type())
-	}
-
-	return jsonStringToStarlark(s, "")
+	return jsonStringToStarlark(contents.Value, "")
 }
 
 func jsonStringToStarlark(s string, source string) (starlark.Value, error) {

--- a/internal/tiltfile/encoding/yaml.go
+++ b/internal/tiltfile/encoding/yaml.go
@@ -80,17 +80,12 @@ func readYAML(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple
 }
 
 func decodeYAMLStreamAsStarlarkList(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (*starlark.List, error) {
-	var contents starlark.Value
+	var contents value.Stringable
 	if err := starkit.UnpackArgs(thread, fn.Name(), args, kwargs, "yaml", &contents); err != nil {
 		return nil, err
 	}
 
-	s, ok := value.AsString(contents)
-	if !ok {
-		return nil, fmt.Errorf("%s arg must be a string or blob. got %s", fn.Name(), contents.Type())
-	}
-
-	return yamlStreamToStarlark(s, "")
+	return yamlStreamToStarlark(contents.Value, "")
 }
 
 func decodeYAMLStream(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {

--- a/internal/tiltfile/os/os.go
+++ b/internal/tiltfile/os/os.go
@@ -86,7 +86,7 @@ func osName() string {
 }
 
 func getenv(t *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-	var key starlark.Value
+	var key value.Stringable
 	var defaultVal starlark.Value = starlark.None
 	err := starkit.UnpackArgs(t, fn.Name(), args, kwargs,
 		"key", &key,
@@ -96,12 +96,7 @@ func getenv(t *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwarg
 		return nil, err
 	}
 
-	keyStr, ok := value.AsString(key)
-	if !ok {
-		return nil, fmt.Errorf("key must be a string, actual: %s", key)
-	}
-
-	envVal, found := os.LookupEnv(keyStr)
+	envVal, found := os.LookupEnv(key.Value)
 	if !found {
 		return defaultVal, nil
 	}
@@ -110,7 +105,7 @@ func getenv(t *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwarg
 }
 
 func putenv(t *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-	var key, v starlark.String
+	var key, v value.Stringable
 	err := starkit.UnpackArgs(t, fn.Name(), args, kwargs,
 		"key", &key,
 		"value", &v,
@@ -119,22 +114,12 @@ func putenv(t *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwarg
 		return nil, err
 	}
 
-	keyStr, ok := value.AsString(key)
-	if !ok {
-		return nil, fmt.Errorf("key must be a string, actual: %s", key)
-	}
-
-	valueStr, ok := value.AsString(v)
-	if !ok {
-		return nil, fmt.Errorf("value must be a string, actual: %s", v)
-	}
-
-	os.Setenv(keyStr, valueStr)
+	os.Setenv(key.Value, v.Value)
 	return starlark.None, nil
 }
 
 func unsetenv(t *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-	var key starlark.Value
+	var key value.Stringable
 	err := starkit.UnpackArgs(t, fn.Name(), args, kwargs,
 		"key", &key,
 	)
@@ -142,12 +127,7 @@ func unsetenv(t *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwa
 		return nil, err
 	}
 
-	keyStr, ok := value.AsString(key)
-	if !ok {
-		return nil, fmt.Errorf("key must be a string, actual: %s", key)
-	}
-
-	os.Unsetenv(keyStr)
+	os.Unsetenv(key.Value)
 	return starlark.None, nil
 }
 

--- a/internal/tiltfile/value/string.go
+++ b/internal/tiltfile/value/string.go
@@ -6,6 +6,19 @@ import (
 	"go.starlark.net/starlark"
 )
 
+type Stringable struct {
+	Value string
+}
+
+func (s *Stringable) Unpack(v starlark.Value) error {
+	str, ok := AsString(v)
+	if !ok {
+		return fmt.Errorf("Value should be convertible to string, but is type %s", v.Type())
+	}
+	s.Value = str
+	return nil
+}
+
 type ImplicitStringer interface {
 	ImplicitString() string
 }


### PR DESCRIPTION
Hello @maiamcc, @landism,

Please review the following commits I made in branch nicks/stringable:

0422a04e761f78a4880c43997f1b2db003517a69 (2020-08-12 19:35:49 -0400)
tiltfile: add a stringable type to make it easier to unpack strings

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics