### PR TITLE
tiltfile: add default_registry(single_name) to push all images to the same image name

### DIFF
--- a/internal/build/custom_builder.go
+++ b/internal/build/custom_builder.go
@@ -44,13 +44,13 @@ func (b *ExecCustomBuilder) Build(ctx context.Context, refs container.RefSet, cb
 		// If the tag is coming from the user script, we expect that the user script
 		// also doesn't know about the local registry. So we have to strip off
 		// the registry, and re-add it later.
-		expectedBuildRefs, err = refs.WithoutRegistry().TagRefs(expectedTag)
+		expectedBuildRefs, err = refs.WithoutRegistry().AddTagSuffix(expectedTag)
 		if err != nil {
 			return container.TaggedRefs{}, errors.Wrap(err, "CustomBuilder.Build")
 		}
 	} else {
 		// In "normal" mode, the user's script should use whichever registry tag we give it.
-		expectedBuildRefs, err = refs.TagRefs(fmt.Sprintf("tilt-build-%d", b.clock.Now().Unix()))
+		expectedBuildRefs, err = refs.AddTagSuffix(fmt.Sprintf("tilt-build-%d", b.clock.Now().Unix()))
 		if err != nil {
 			return container.TaggedRefs{}, errors.Wrap(err, "CustomBuilder.Build")
 		}
@@ -103,7 +103,7 @@ func (b *ExecCustomBuilder) Build(ctx context.Context, refs container.RefSet, cb
 		return container.TaggedRefs{}, errors.Wrap(err, "CustomBuilder.Build")
 	}
 
-	taggedWithDigest, err := refs.TagRefs(tag)
+	taggedWithDigest, err := refs.AddTagSuffix(tag)
 	if err != nil {
 		return container.TaggedRefs{}, errors.Wrap(err, "CustomBuilder.Build")
 	}

--- a/internal/build/docker_builder.go
+++ b/internal/build/docker_builder.go
@@ -101,7 +101,7 @@ func (d *dockerImageBuilder) TagRefs(ctx context.Context, refs container.RefSet,
 		return container.TaggedRefs{}, errors.Wrap(err, "TagImage")
 	}
 
-	tagged, err := refs.TagRefs(tag)
+	tagged, err := refs.AddTagSuffix(tag)
 	if err != nil {
 		return container.TaggedRefs{}, errors.Wrap(err, "TagImage")
 	}

--- a/internal/tiltfile/docker.go
+++ b/internal/tiltfile/docker.go
@@ -502,10 +502,11 @@ func (s *tiltfileState) defaultRegistry(thread *starlark.Thread, fn *starlark.Bu
 		return starlark.None, errors.New("default registry already defined")
 	}
 
-	var host, hostFromCluster string
+	var host, hostFromCluster, singleName string
 	if err := s.unpackArgs(fn.Name(), args, kwargs,
 		"host", &host,
-		"host_from_cluster?", &hostFromCluster); err != nil {
+		"host_from_cluster?", &hostFromCluster,
+		"single_name?", &singleName); err != nil {
 		return nil, err
 	}
 
@@ -513,6 +514,8 @@ func (s *tiltfileState) defaultRegistry(thread *starlark.Thread, fn *starlark.Bu
 	if err != nil {
 		return starlark.None, errors.Wrapf(err, "validating defaultRegistry")
 	}
+
+	reg.SingleName = singleName
 
 	s.defaultReg = reg
 

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -2878,6 +2878,47 @@ default_registry('example.com')
 	f.assertConfigFiles("Tiltfile", ".tiltignore", "bar/Dockerfile", "bar/.dockerignore", "bar.yaml", "baz/Dockerfile", "baz/.dockerignore", "baz.yaml")
 }
 
+func TestDefaultRegistrySingleName(t *testing.T) {
+	f := newFixture(t)
+	defer f.TearDown()
+
+	f.dockerfile("fe/Dockerfile")
+	f.yaml("fe.yaml", deployment("fe", image("fe")))
+
+	f.dockerfile("be/Dockerfile")
+	f.yaml("be.yaml", deployment("be", image("be")))
+
+	f.gitInit("")
+	f.file("Tiltfile", `
+
+docker_build('fe', './fe')
+docker_build('be', './be')
+k8s_yaml('fe.yaml')
+k8s_yaml('be.yaml')
+default_registry('123.dkr.ecr.us-east-1.amazonaws.com', single_name='team-a/dev')
+`)
+
+	f.load()
+
+	fe := f.assertNextManifest("fe",
+		db(image("fe").withLocalRef("123.dkr.ecr.us-east-1.amazonaws.com/team-a/dev")),
+		deployment("fe"))
+
+	feTaggedRefs, err := fe.ImageTargets[0].Refs.AddTagSuffix("tilt-build-123")
+	assert.NoError(t, err)
+	assert.Equal(t, "123.dkr.ecr.us-east-1.amazonaws.com/team-a/dev:fe-tilt-build-123",
+		feTaggedRefs.LocalRef.String())
+
+	be := f.assertNextManifest("be",
+		db(image("be").withLocalRef("123.dkr.ecr.us-east-1.amazonaws.com/team-a/dev")),
+		deployment("be"))
+
+	beTaggedRefs, err := be.ImageTargets[0].Refs.AddTagSuffix("tilt-build-456")
+	assert.NoError(t, err)
+	assert.Equal(t, "123.dkr.ecr.us-east-1.amazonaws.com/team-a/dev:be-tilt-build-456",
+		beTaggedRefs.LocalRef.String())
+}
+
 func TestDefaultReadFile(t *testing.T) {
 	f := newFixture(t)
 	defer f.TearDown()


### PR DESCRIPTION
Hello @maiamcc,

Please review the following commits I made in branch nicks/ch8726:

c8e1b3ec17a962a72946491176a0e28bfa1aaa13 (2020-08-12 19:50:01 -0400)
tiltfile: add default_registry(single_name) to push all images to the same image name
Fixes https://github.com/tilt-dev/tilt/issues/2419

0422a04e761f78a4880c43997f1b2db003517a69 (2020-08-12 19:35:49 -0400)
tiltfile: add a stringable type to make it easier to unpack strings

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics