### PR TITLE
add __file__ variable to environment

### DIFF
--- a/internal/tiltfile/starkit/environment.go
+++ b/internal/tiltfile/starkit/environment.go
@@ -241,7 +241,14 @@ func (e *Environment) doLoad(t *starlark.Thread, localPath string) (starlark.Str
 		contentBytes = []byte(contents)
 	}
 
-	return starlark.ExecFile(t, localPath, contentBytes, e.predeclared)
+	// Create a copy of predeclared variables so we can specify Tiltfile-specific values.
+	predeclared := starlark.StringDict{}
+	for k, v := range e.predeclared {
+		predeclared[k] = v
+	}
+	predeclared["__file__"] = starlark.String(localPath)
+
+	return starlark.ExecFile(t, localPath, contentBytes, predeclared)
 }
 
 type ArgUnpacker func(fnName string, args starlark.Tuple, kwargs []starlark.Tuple, pairs ...interface{}) error

--- a/internal/tiltfile/starkit/environment_test.go
+++ b/internal/tiltfile/starkit/environment_test.go
@@ -198,3 +198,25 @@ load('../bar/Tiltfile', 'unused')
 	path := strings.TrimSpace(f.out.String())
 	require.Equal(t, "bar", filepath.Base(filepath.Dir(path)))
 }
+
+// Tiltfile loads Tiltfile2
+// 1 prints its __file__ and calls a method in 2 to do the same
+func TestUseMagicFileVar(t *testing.T) {
+	f := NewFixture(t, PwdExtension{})
+	f.File("Tiltfile2", `
+def print_mypath():
+  print(__file__)
+`)
+	f.File("Tiltfile", `
+load('Tiltfile2', 'print_mypath')
+print(__file__)
+print_mypath()
+`)
+
+	_, err := f.ExecFile("Tiltfile")
+	require.NoError(t, err)
+
+	paths := strings.Split(strings.TrimSpace(f.out.String()), "\n")
+	require.Equal(t, "Tiltfile", filepath.Base(paths[0]))
+	require.Equal(t, "Tiltfile2", filepath.Base(paths[1]))
+}


### PR DESCRIPTION
Trying to add `__file__` as a predefined variable for all Tiltfiles. 

This is my first foray into tilt development, and I understand this attempt may be *super* off base. Guidance is welcome.

### Usecase
I'm writing a common Tiltfile for a bunch of our argo repositories to leverage. Part of that is to provide a function like...

```python
# In a separate corporate git repo, like "common-tilt"
def install_argo():
   k8s_yaml('install-argocd.yaml')
```
I load the function like...

```python
load('ext://git_resource', 'git_checkout')

git_checkout('ssh://....', checkout_dir="tilt_git/common-tilt")

load('tilt_git/common-tilt/Tiltfile', 'install_argocd')
install_argocd()
```
Right now this breaks because install_argocd() tries to load the the YAML file from the root of the original Tiltfile

Example:
```python
_mydir = os.getcwd()

def install_argocd():
    # Works! 
    k8s_yaml(os.path.join(_mydir, 'install-argocd.yaml'))
    # does not work! Gets the root cwd, not the directory of the Tiltfile
    k8s_yaml(os.path.join(os.getcwd(), 'install-argocd.yaml'))
```

This PR tries to accomplish adding the pythonic `__file__` variable, which may be used within any scope.

### Issue
https://github.com/tilt-dev/tilt/issues/3700