### PR TITLE
change GITHUB_API_TOKEN back to GITHUB_TOKEN...i misunderstood something in https://github.com/tilt-dev/tilt/pull/3703

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -266,7 +266,7 @@ We use [goreleaser](https://goreleaser.com) for releases.
 Requirements:
 - Python
 - [gsutil](https://cloud.google.com/storage/docs/gsutil_install)
-- `GITHUB_API_TOKEN` env variable with repo scope
+- `GITHUB_TOKEN` env variable with repo scope
 
 We cross-compile the binary in a container, so that you don't need to have xcode
 or goreleaser installed.

--- a/scripts/goreleaser.sh
+++ b/scripts/goreleaser.sh
@@ -5,8 +5,8 @@
 
 set -ex
 
-if [[ "$GITHUB_API_TOKEN" == "" ]]; then
-    echo "Missing GITHUB_API_TOKEN"
+if [[ "$GITHUB_TOKEN" == "" ]]; then
+    echo "Missing GITHUB_TOKEN"
     exit 1
 fi
 
@@ -14,7 +14,7 @@ DIR=$(dirname "$0")
 cd "$DIR/.."
 
 docker run --rm --privileged \
-       -e GITHUB_TOKEN="$GITHUB_API_TOKEN" \
+       -e GITHUB_TOKEN="$GITHUB_TOKEN" \
        -w /src/tilt \
        -v "$PWD:/src/tilt" \
        -v /var/run/docker.sock:/var/run/docker.sock \

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -5,8 +5,8 @@
 
 set -ex
 
-if [[ "$GITHUB_API_TOKEN" == "" ]]; then
-    echo "Missing GITHUB_API_TOKEN"
+if [[ "$GITHUB_TOKEN" == "" ]]; then
+    echo "Missing GITHUB_TOKEN"
     exit 1
 fi
 


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/token:

93688dbf1ce1d93263407a318a322f0f8352053b (2020-08-14 18:06:21 -0400)
change GITHUB_API_TOKEN back to GITHUB_TOKEN...i misunderstood something in https://github.com/tilt-dev/tilt/pull/3703

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics