### PR TITLE
Revert "web: report log highlights to analytics (#3564)"

### DIFF
--- a/web/src/HUD.test.tsx
+++ b/web/src/HUD.test.tsx
@@ -10,9 +10,8 @@ import {
   oneResourceNoAlerts,
 } from "./testdata"
 import { createMemoryHistory } from "history"
-import { SnapshotHighlight, SocketState } from "./types"
+import { SocketState } from "./types"
 import ReactModal from "react-modal"
-import { Count, memoryIncr } from "./analytics"
 
 ReactModal.setAppElement(document.body)
 
@@ -27,17 +26,17 @@ declare global {
 }
 
 const fakeHistory = createMemoryHistory()
-const emptyHUD = (counts: Array<Count> = []) => {
+const emptyHUD = () => {
   return (
     <MemoryRouter initialEntries={["/"]}>
-      <HUD history={fakeHistory} incr={memoryIncr(counts)} />
+      <HUD history={fakeHistory} />
     </MemoryRouter>
   )
 }
 const HUDAtPath = (path: string) => {
   return (
     <MemoryRouter initialEntries={[path]}>
-      <HUD history={fakeHistory} incr={memoryIncr([])} />
+      <HUD history={fakeHistory} />
     </MemoryRouter>
   )
 }
@@ -159,7 +158,7 @@ it("renders number of errors in tabnav when no resource is selected", () => {
 it("renders the number of errors a resource has in tabnav when a resource is selected", () => {
   const root = mount(
     <MemoryRouter initialEntries={["/r/vigoda"]}>
-      <HUD history={fakeHistory} incr={memoryIncr([])} />
+      <HUD history={fakeHistory} />
     </MemoryRouter>
   )
   const hud = root.find(HUD)
@@ -340,23 +339,4 @@ it("renders logs to snapshot", async () => {
       { text: "line2\n", time: now, spanId: "_", fields: { buildEvent: "1" } },
     ],
   })
-})
-
-it("reports highlights", async () => {
-  let counts: Array<Count> = []
-  const root = mount(emptyHUD(counts))
-  const hud = root.find(HUD).instance() as HUD
-
-  var highlight: SnapshotHighlight = {
-    beginningLogID: "",
-    endingLogID: "",
-    text: "",
-  }
-  // send a few to make sure it's debounced
-  hud.handleSetHighlight(highlight)
-  hud.handleSetHighlight(highlight)
-  hud.handleSetHighlight(highlight)
-  hud.flush()
-  let highlightCounts = counts.filter(c => c.name == "ui.web.highlight")
-  expect(highlightCounts.length).toEqual(1)
 })

--- a/web/src/HUD.tsx
+++ b/web/src/HUD.tsx
@@ -13,7 +13,7 @@ import PathBuilder from "./PathBuilder"
 import { matchPath } from "react-router"
 import { Route, Switch, RouteComponentProps } from "react-router-dom"
 import { History, UnregisterCallback } from "history"
-import { counter, pathToTag } from "./analytics"
+import { incr, pathToTag } from "./analytics"
 import SecondaryNav from "./SecondaryNav"
 import SocketBar from "./SocketBar"
 import "./HUD.scss"
@@ -40,11 +40,9 @@ import HUDLayout from "./HUDLayout"
 import LogStore from "./LogStore"
 import { traceNav } from "./trace"
 import ErrorModal from "./ErrorModal"
-import { debounce, Cancelable } from "lodash"
 
 type HudProps = {
   history: History
-  incr: counter
 }
 
 // The Main HUD view, as specified in
@@ -55,13 +53,11 @@ class HUD extends Component<HudProps, HudState> {
   private controller: AppController
   private history: History
   private unlisten: UnregisterCallback
-  private incrHighlight: (() => void) & Cancelable
-  flush: () => void
 
   constructor(props: HudProps) {
     super(props)
 
-    props.incr("ui.web.init", { ua: window.navigator.userAgent })
+    incr("ui.web.init", { ua: window.navigator.userAgent })
 
     this.pathBuilder = new PathBuilder(
       window.location.host,
@@ -71,7 +67,7 @@ class HUD extends Component<HudProps, HudState> {
     this.history = props.history
     this.unlisten = this.history.listen((location, _) => {
       let tags = { type: pathToTag(location.pathname) }
-      props.incr("ui.web.navigation", tags)
+      incr("ui.web.navigation", tags)
 
       this.handleClearHighlight()
       let selection = document.getSelection()
@@ -109,12 +105,6 @@ class HUD extends Component<HudProps, HudState> {
     this.handleClearHighlight = this.handleClearHighlight.bind(this)
     this.handleSetHighlight = this.handleSetHighlight.bind(this)
     this.handleOpenModal = this.handleOpenModal.bind(this)
-
-    this.incrHighlight = debounce(
-      () => props.incr("ui.web.highlight", {}),
-      3000 /* ms */
-    )
-    this.flush = this.incrHighlight.flush
   }
 
   componentDidMount() {
@@ -231,7 +221,6 @@ class HUD extends Component<HudProps, HudState> {
   }
 
   handleSetHighlight(highlight: SnapshotHighlight) {
-    this.incrHighlight()
     this.setState({
       snapshotHighlight: highlight,
     })

--- a/web/src/analytics.ts
+++ b/web/src/analytics.ts
@@ -1,7 +1,5 @@
 type Tags = { [key: string]: string }
 
-export type counter = (name: string, tags: Tags) => void
-
 // Fire and forget all analytics events
 const incr = (name: string, tags: Tags = {}): void => {
   let url = `//${window.location.host}/api/analytics`
@@ -10,17 +8,6 @@ const incr = (name: string, tags: Tags = {}): void => {
     method: "post",
     body: JSON.stringify([{ verb: "incr", name: name, tags: tags }]),
   })
-}
-
-export type Count = {
-  name: string
-  tags: Tags
-}
-
-export function memoryIncr(counts: Array<Count>): counter {
-  return (name: string, tags: Tags) => {
-    counts.push({ name: name, tags: tags })
-  }
 }
 
 const pathToTag = (path: string): string => {

--- a/web/src/index.tsx
+++ b/web/src/index.tsx
@@ -5,14 +5,13 @@ import HUD from "./HUD"
 import { Router } from "react-router-dom"
 import { createBrowserHistory } from "history"
 import ReactModal from "react-modal"
-import { incr } from "./analytics"
 
 ReactModal.setAppElement(document.body)
 
 let history = createBrowserHistory()
 let app = (
   <Router history={history}>
-    <HUD history={history} incr={incr} />
+    <HUD history={history} />
   </Router>
 )
 let root = document.getElementById("root")


### PR DESCRIPTION
Hello @landism, @victorwuky,

Please review the following commits I made in branch nicks/selection:

d40e89ccc21a6bc3d1a35bf2f70a33f884d1044b (2020-08-17 11:46:20 -0400)
Revert "web: report log highlights to analytics (#3564)"
It sounds like we have what we need from this, and don't need
to log this anymore, right?

This reverts commit 022b45ca268da13c50d5dbc2c25755b6649e4331.

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics