### PR TITLE
fswatch: fix a race condition in the nnew test

### DIFF
--- a/internal/engine/fswatch/gitmanager_test.go
+++ b/internal/engine/fswatch/gitmanager_test.go
@@ -44,6 +44,9 @@ func TestGitManagerRemove(t *testing.T) {
 	f.WriteFile(head, "ref: refs/heads/nicks/branch")
 	f.UpsertManifestTarget("fe", model.LocalGitRepo{LocalPath: f.Path()})
 	f.gm.OnChange(f.ctx, f.store)
+	assert.Equal(t, "ref: refs/heads/nicks/branch",
+		f.NextGitBranchStatusAction().Head)
+	f.store.ClearActions()
 
 	f.WriteFile(head, "ref: refs/heads/nicks/branch2")
 	f.fakeMultiWatcher.Events <- watch.NewFileEvent(head)


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/test:

e984a1a851721a995308ffe875e771cd1363413d (2020-08-20 16:10:10 -0400)
fswatch: fix a race condition in the nnew test

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics