### PR TITLE
scripts: update release container to contain a Go compile cache

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,8 +147,7 @@ wire-check:
 	wire check ./internal/synclet
 
 release-container:
-	docker build -t gcr.io/windmill-public-containers/tilt-releaser -f scripts/release.Dockerfile scripts
-	docker push gcr.io/windmill-public-containers/tilt-releaser
+	scripts/build-tilt-releaser.sh
 
 ci-container:
 	docker build -t gcr.io/windmill-public-containers/tilt-ci -f .circleci/Dockerfile .circleci

--- a/scripts/build-tilt-releaser.sh
+++ b/scripts/build-tilt-releaser.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+#
+# Build a Docker container with all the cross-compiling toolchains
+# we need to do a release. Pre-populate it with a Go cache.
+
+set -ex
+
+DIR=$(dirname "$0")
+cd "$DIR/.."
+
+docker build -t tilt-releaser-base -f scripts/release.Dockerfile scripts
+docker container rm tilt-releaser-go-cache || true
+
+# We deliberately don't give this container any API keys so it can't
+# accidentally publish.
+docker run --name tilt-releaser-go-cache --privileged \
+       -w /src/tilt \
+       -v "$PWD:/src/tilt:delegated" \
+       -v /var/run/docker.sock:/var/run/docker.sock \
+       tilt-releaser-base \
+       --rm-dist --skip-validate --snapshot --skip-publish
+
+# Commit all the Go cache artifacts we generated
+docker commit tilt-releaser-go-cache gcr.io/windmill-public-containers/tilt-releaser
+docker push gcr.io/windmill-public-containers/tilt-releaser
+docker container rm tilt-releaser-go-cache

--- a/scripts/goreleaser.sh
+++ b/scripts/goreleaser.sh
@@ -14,11 +14,12 @@ DIR=$(dirname "$0")
 cd "$DIR/.."
 
 docker login
+docker pull gcr.io/windmill-public-containers/tilt-releaser
 docker run --rm --privileged \
        -e GITHUB_TOKEN="$GITHUB_TOKEN" \
        -w /src/tilt \
        -v ~/.docker:/root/.docker \
-       -v "$PWD:/src/tilt" \
+       -v "$PWD:/src/tilt:delegated" \
        -v /var/run/docker.sock:/var/run/docker.sock \
-       gcr.io/windmill-public-containers/tilt-releaser@sha256:d033db8b2180aef7dcdefb28bd094aa6f162dbe182c923d84c7e61826c49e33f \
+       gcr.io/windmill-public-containers/tilt-releaser \
        --rm-dist


### PR DESCRIPTION
Hello @maiamcc,

Please review the following commits I made in branch nicks/ch9069:

a8e4b1f59b0eb723dc80e395a1ec2a646d3f154f (2020-08-24 17:29:50 -0400)
scripts: update release container to contain a Go compile cache

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics