### PR TITLE
tiltfile/cli: builtin timings mode for tiltfile-results

### DIFF
--- a/internal/cli/tiltfile_result.go
+++ b/internal/cli/tiltfile_result.go
@@ -104,7 +104,7 @@ func (c *tiltfileResultCmd) run(ctx context.Context, args []string) error {
 	// Instead of printing result JSON, print Builtin Timings instead
 	if c.builtinTimings {
 		if len(tlr.BuiltinCalls) == 0 {
-			return fmt.Errorf("oh no, got no builtin calls :(")
+			return fmt.Errorf("executed Tiltfile, but recorded no Builtin calls")
 		}
 		for _, call := range tlr.BuiltinCalls {
 			if call.Dur < c.durThreshold {

--- a/internal/cli/tiltfile_result.go
+++ b/internal/cli/tiltfile_result.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"regexp"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -15,12 +17,18 @@ import (
 	"github.com/tilt-dev/tilt/pkg/model"
 )
 
+var tupleRE = regexp.MustCompile(`,\)$`)
+
 // arbitrary non-1 value chosen to allow callers to distinguish between
 // Tilt errors and Tiltfile errors
 const TiltfileErrExitCode = 5
 
 type tiltfileResultCmd struct {
 	fileName string
+
+	// for Builtin Timings mode
+	builtinTimings bool
+	durThreshold   string
 }
 
 var _ tiltCmd = &tiltfileResultCmd{}
@@ -42,10 +50,10 @@ func newTiltfileResultCmd() *tiltfileResultCmd {
 func (c *tiltfileResultCmd) register() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "tiltfile-result",
-		Short: "Exec the Tiltfile and print results as JSON (note: the API is unstable and may change)",
-		Long: `Exec the Tiltfile and print results as JSON (note: the API is unstable and may change).
+		Short: "Exec the Tiltfile and print data about execution. By default, prints Tiltfile execution results as JSON (note: the API is unstable and may change); can also print timings of Tiltfile Builtin calls.",
+		Long: `Exec the Tiltfile and print data about execution. By default, prints Tiltfile execution results as JSON (note: the API is unstable and may change); can also print timings of Tiltfile Builtin calls.
 
-Exit code 0: successful Tiltfile evaluation (JSON printed to stdout)
+Exit code 0: successful Tiltfile evaluation (data printed to stdout)
 Exit code 1: some failure in setup, printing results, etc. (any logs printed to stderr)
 Exit code 5: error when evaluating the Tiltfile, such as syntax error, illegal Tiltfile operation, etc. (any logs printed to stderr)
 
@@ -53,6 +61,8 @@ Run with -v | --verbose to print Tiltfile execution logs on stderr, regardless o
 	}
 
 	addTiltfileFlag(cmd, &c.fileName)
+	cmd.Flags().BoolVarP(&c.builtinTimings, "builtin-timings", "b", false, "If true, print timing data for Tiltfile builtin calls instead of Tiltfile result JSON")
+	cmd.Flags().StringVar(&c.durThreshold, "dur-threshold", "", "Only compatible with Builtin Timings mode. Should be a Go duration string. If passed, only print information about builtin calls lasting this duration and longer.")
 
 	return cmd
 }
@@ -78,7 +88,9 @@ func (c *tiltfileResultCmd) run(ctx context.Context, args []string) error {
 		return errors.Wrap(err, "wiring dependencies")
 	}
 
+	start := time.Now()
 	tlr := deps.tfl.Load(ctx, c.fileName, model.NewUserConfigState(args))
+	tflDur := time.Since(start)
 	if tlr.Error != nil {
 		maybePrintDeferredLogsToStderr(ctx, showTiltfileLogs)
 
@@ -87,6 +99,29 @@ func (c *tiltfileResultCmd) run(ctx context.Context, args []string) error {
 		// from Tiltfile parsing.
 		fmt.Fprintln(os.Stderr, tlr.Error)
 		os.Exit(TiltfileErrExitCode)
+	}
+
+	// Instead of printing result JSON, print Builtin Timings instead
+	if c.builtinTimings {
+		if len(tlr.BuiltinCalls) == 0 {
+			return fmt.Errorf("oh no, got no builtin calls :(")
+		}
+		var durThreshold time.Duration
+		if c.durThreshold != "" {
+			durThreshold, err = time.ParseDuration(c.durThreshold)
+			if err != nil {
+				return errors.Wrapf(err, "parsing dur-threshold %q", c.durThreshold)
+			}
+		}
+		for _, call := range tlr.BuiltinCalls {
+			if call.Dur < durThreshold {
+				continue
+			}
+			argsStr := tupleRE.ReplaceAllString(fmt.Sprintf("%v", call.Args), ")") // clean up tuple stringification
+			fmt.Fprintf(os.Stdout, "- %s%s took %s\n", call.Name, argsStr, call.Dur)
+		}
+		fmt.Fprintf(os.Stdout, "Tiltfile execution took %s\n", tflDur.String())
+		return nil
 	}
 
 	err = encodeJSON(tlr)

--- a/internal/tiltfile/starkit/model.go
+++ b/internal/tiltfile/starkit/model.go
@@ -10,6 +10,8 @@ import (
 
 type Model struct {
 	state map[reflect.Type]interface{}
+
+	BuiltinCalls []BuiltinCall
 }
 
 func NewModel() Model {

--- a/internal/tiltfile/tiltfile.go
+++ b/internal/tiltfile/tiltfile.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/tilt-dev/tilt/internal/tiltfile/config"
+	"github.com/tilt-dev/tilt/internal/tiltfile/starkit"
 
 	wmanalytics "github.com/tilt-dev/wmclient/pkg/analytics"
 	"go.starlark.net/resolve"
@@ -56,6 +57,9 @@ type TiltfileLoadResult struct {
 	AnalyticsOpt        wmanalytics.Opt
 	VersionSettings     model.VersionSettings
 	UpdateSettings      model.UpdateSettings
+
+	// For diagnostic purposes only
+	BuiltinCalls []starkit.BuiltinCall `json:"-"`
 }
 
 func (r TiltfileLoadResult) Orchestrator() model.Orchestrator {
@@ -176,6 +180,8 @@ func (tfl tiltfileLoader) Load(ctx context.Context, filename string, userConfigS
 	s := newTiltfileState(ctx, tfl.dcCli, tfl.webHost, tfl.k8sContextExt, tfl.versionExt, tfl.configExt, localRegistry, feature.FromDefaults(tfl.fDefaults))
 
 	manifests, result, err := s.loadManifests(absFilename, userConfigState)
+
+	tlr.BuiltinCalls = result.BuiltinCalls
 
 	// NOTE(maia): if/when add secret settings that affect the engine, add them to tlr here
 	ss, _ := secretsettings.GetState(result)


### PR DESCRIPTION
this is an hour's worth of work to let someone look at the time it takes
to call various Tiltfile builtins. e.g. for the Tiltfile in the Tilt repo
(which runs linters etc.), here are all builtin calls taking longer that 500ms:
```
$ tilt alpha tiltfile-result --builtin-timings --dur-threshold 500ms
- local("cd . && find . -type f -name \"*.go\"") took 783.932424ms
- local("go list ./...") took 3.562675092s
- local("cd web && find . -type f -name \"*.ts*\" | grep -v node_modules | grep -v __snapshots__") took 609.758001ms
```
and longer than 1s:
```
$ tilt alpha tiltfile-result --builtin-timings --dur-threshold 1s
- local("go list ./...") took 3.377749034s
```

at minimum I think it's safe for Tom to install and run this off a branch;
happy to hear it shouldn't be committed (or that the data I'm gathering
should be stored elsewhere etc.)