### PR TITLE
tiltfile: fix a bug in decode_yaml_stream when there are empty entries

### DIFF
--- a/internal/tiltfile/encoding/yaml.go
+++ b/internal/tiltfile/encoding/yaml.go
@@ -103,9 +103,9 @@ func decodeYAML(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tup
 
 func yamlStreamToStarlark(s string, source string) (*starlark.List, error) {
 	var ret []starlark.Value
-	var decodedYAML interface{}
 	d := k8syaml.NewYAMLToJSONDecoder(strings.NewReader(s))
 	for {
+		var decodedYAML interface{}
 		err := d.Decode(&decodedYAML)
 		if err == io.EOF {
 			break
@@ -126,6 +126,9 @@ func yamlStreamToStarlark(s string, source string) (*starlark.List, error) {
 				errmsg += fmt.Sprintf(" from %s", source)
 			}
 			return nil, errors.Wrap(err, errmsg)
+		}
+		if v == starlark.None {
+			continue // ignore empty entries
 		}
 
 		ret = append(ret, v)

--- a/internal/tiltfile/encoding/yaml_test.go
+++ b/internal/tiltfile/encoding/yaml_test.go
@@ -277,6 +277,33 @@ assert.equals(expected, observed)
 	require.NoError(t, err)
 }
 
+func TestDecodeYAMLStreamEmptyEntries(t *testing.T) {
+	f := newFixture(t)
+	defer f.TearDown()
+
+	yaml := `name: hello
+---
+
+---
+name: goodbye
+---
+
+---`
+	d := fmt.Sprintf("observed = decode_yaml_stream('''%s''')\n", yaml)
+	tf := d + `
+load('assert.tilt', 'assert')
+assert.equals(['hello', 'goodbye'], [r['name'] for r in observed])
+
+`
+	f.File("Tiltfile", tf)
+
+	_, err := f.ExecFile("Tiltfile")
+	if err != nil {
+		fmt.Println(f.PrintOutput())
+	}
+	require.NoError(t, err)
+}
+
 func TestDecodeYAMLUnexpectedStream(t *testing.T) {
 	f := newFixture(t)
 	defer f.TearDown()


### PR DESCRIPTION
Hello @landism,

Please review the following commits I made in branch nicks/decodeyaml:

d20281da983a31e9a0cddbbba8778fef25282c1a (2020-08-25 12:49:28 -0400)
tiltfile: fix a bug in decode_yaml_stream when there are empty entries

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics