### PR TITLE
tiltfile: record the helm dependency before running helm, to help iterate on helm charts

### DIFF
--- a/internal/tiltfile/files.go
+++ b/internal/tiltfile/files.go
@@ -165,6 +165,11 @@ func (s *tiltfileState) helm(thread *starlark.Thread, fn *starlark.Builtin, args
 		return nil, fmt.Errorf("helm() may only be called on directories with Chart.yaml: %q", localPath)
 	}
 
+	err = tiltfile_io.RecordReadPath(thread, tiltfile_io.WatchRecursive, localPath)
+	if err != nil {
+		return nil, err
+	}
+
 	deps, err := localSubchartDependenciesFromPath(localPath)
 	if err != nil {
 		return nil, err
@@ -216,11 +221,6 @@ func (s *tiltfileState) helm(thread *starlark.Thread, fn *starlark.Builtin, args
 	s.logger.Infof("Running: %s", cmd)
 
 	stdout, err := s.execLocalCmd(thread, exec.Command(cmd[0], cmd[1:]...), false)
-	if err != nil {
-		return nil, err
-	}
-
-	err = tiltfile_io.RecordReadPath(thread, tiltfile_io.WatchRecursive, localPath)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/tiltfile/helm_test.go
+++ b/internal/tiltfile/helm_test.go
@@ -9,6 +9,25 @@ import (
 	"github.com/tilt-dev/tilt/internal/tiltfile/testdata"
 )
 
+func TestHelmMalformedChart(t *testing.T) {
+	f := newFixture(t)
+	defer f.TearDown()
+
+	f.WriteFile("./helm/Chart.yaml", "brrrrr")
+
+	f.file("Tiltfile", `
+yml = helm('helm')
+k8s_yaml(yml)
+`)
+
+	f.loadErrString("error unmarshaling JSON")
+	f.assertConfigFiles(
+		"Tiltfile",
+		".tiltignore",
+		"helm",
+	)
+}
+
 func TestHelmNamespace(t *testing.T) {
 	f := newFixture(t)
 	defer f.TearDown()


### PR DESCRIPTION
Hello @landism,

Please review the following commits I made in branch nicks/helmwatch:

2abde4f65f56f0b1ceed530f1d5d33121bfc7548 (2020-08-26 17:53:58 -0400)
tiltfile: record the helm dependency before running helm, to help iterate on helm charts

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics