### PR TITLE
model: changes to deps don't invalidate build

### DIFF
--- a/internal/sliceutils/sliceutils.go
+++ b/internal/sliceutils/sliceutils.go
@@ -52,6 +52,18 @@ func StringSliceEquals(a, b []string) bool {
 	return true
 }
 
+func StringSliceElementsMatch(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	aCopy := append([]string{}, a...)
+	sort.Strings(aCopy)
+	bCopy := append([]string{}, b...)
+	sort.Strings(bCopy)
+	return StringSliceEquals(aCopy, bCopy)
+}
+
 // StringSliceStartsWith returns true if slice A starts with the given elem.
 func StringSliceStartsWith(a []string, elem string) bool {
 	if len(a) == 0 {

--- a/internal/sliceutils/sliceutils.go
+++ b/internal/sliceutils/sliceutils.go
@@ -52,18 +52,6 @@ func StringSliceEquals(a, b []string) bool {
 	return true
 }
 
-func StringSliceElementsMatch(a, b []string) bool {
-	if len(a) != len(b) {
-		return false
-	}
-
-	aCopy := append([]string{}, a...)
-	sort.Strings(aCopy)
-	bCopy := append([]string{}, b...)
-	sort.Strings(bCopy)
-	return StringSliceEquals(aCopy, bCopy)
-}
-
 // StringSliceStartsWith returns true if slice A starts with the given elem.
 func StringSliceStartsWith(a []string, elem string) bool {
 	if len(a) == 0 {

--- a/pkg/model/local_target.go
+++ b/pkg/model/local_target.go
@@ -11,7 +11,7 @@ type LocalTarget struct {
 	UpdateCmd Cmd      // e.g. `make proto`
 	ServeCmd  Cmd      // e.g. `python main.py`
 	Workdir   string   // directory from which the commands should be run
-	deps      []string // a list of ABSOLUTE file paths that are dependencies of this target
+	Deps      []string // a list of ABSOLUTE file paths that are dependencies of this target
 	ignores   []Dockerignore
 
 	repos []LocalGitRepo
@@ -28,7 +28,7 @@ func NewLocalTarget(name TargetName, updateCmd Cmd, serveCmd Cmd, deps []string,
 		Name:      name,
 		UpdateCmd: updateCmd,
 		Workdir:   workdir,
-		deps:      deps,
+		Deps:      deps,
 		ServeCmd:  serveCmd,
 	}
 }
@@ -74,7 +74,7 @@ func (lt LocalTarget) Validate() error {
 
 // Implements: engine.WatchableManifest
 func (lt LocalTarget) Dependencies() []string {
-	return sliceutils.DedupedAndSorted(lt.deps)
+	return sliceutils.DedupedAndSorted(lt.Deps)
 }
 
 func (lt LocalTarget) LocalRepos() []LocalGitRepo {

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -196,13 +196,13 @@ func (m Manifest) LocalPaths() []string {
 	case LocalTarget:
 		return di.Dependencies()
 	case ImageTarget, K8sTarget:
-		paths := []string{}
-		for _, iTarget := range m.ImageTargets {
-			paths = append(paths, iTarget.LocalPaths()...)
-		}
-		return sliceutils.DedupedAndSorted(paths)
+		// fall through to paths for image targets, below
 	}
-	panic(fmt.Sprintf("Unknown deploy target type (%T) while trying to get LocalPaths", m.deployTarget))
+	paths := []string{}
+	for _, iTarget := range m.ImageTargets {
+		paths = append(paths, iTarget.LocalPaths()...)
+	}
+	return sliceutils.DedupedAndSorted(paths)
 }
 
 func (m Manifest) Validate() error {
@@ -228,22 +228,22 @@ func (m Manifest) Validate() error {
 }
 
 func (m1 Manifest) Equal(m2 Manifest) bool {
-	primitivesEq, dockerEq, k8sEq, dcEq, localEq, depsEq := m1.fieldGroupsEqual(m2)
-	return primitivesEq && dockerEq && k8sEq && dcEq && localEq && depsEq
+	primitivesEq, dockerEq, k8sEq, dcEq, localEq, depsEq, resourceDepsEq := m1.fieldGroupsEqual(m2)
+	return primitivesEq && dockerEq && k8sEq && dcEq && localEq && depsEq && resourceDepsEq
 }
 
 // ChangesInvalidateBuild checks whether the changes from old => new manifest
 // invalidate our build of the old one; i.e. if we're replacing `old` with `new`,
 // should we perform a full rebuild?
 func ChangesInvalidateBuild(old, new Manifest) bool {
-	_, dockerEq, k8sEq, dcEq, localEq, _ := old.fieldGroupsEqual(new)
+	_, dockerEq, k8sEq, dcEq, localEq, _, _ := old.fieldGroupsEqual(new)
 
 	// We only need to update for this manifest if any of the field-groups
 	// affecting build+deploy have changed (i.e. a change in primitives doesn't matter)
 	return !dockerEq || !k8sEq || !dcEq || !localEq
 
 }
-func (m1 Manifest) fieldGroupsEqual(m2 Manifest) (primitivesEq, dockerEq, k8sEq, dcEq, localEq, depsEq bool) {
+func (m1 Manifest) fieldGroupsEqual(m2 Manifest) (primitivesEq, dockerEq, k8sEq, dcEq, localEq, depsEq, resourceDepsEq bool) {
 	primitivesEq = m1.Name == m2.Name && m1.TriggerMode == m2.TriggerMode
 
 	dockerEq = DeepEqual(m1.ImageTargets, m2.ImageTargets)
@@ -260,9 +260,11 @@ func (m1 Manifest) fieldGroupsEqual(m2 Manifest) (primitivesEq, dockerEq, k8sEq,
 	lt2 := m2.LocalTarget()
 	localEq = DeepEqual(lt1, lt2)
 
-	depsEq = DeepEqual(m1.ResourceDependencies, m2.ResourceDependencies)
+	depsEq = sliceutils.StringSliceElementsMatch(m1.LocalPaths(), m2.LocalPaths())
 
-	return primitivesEq, dockerEq, dcEq, k8sEq, localEq, depsEq
+	resourceDepsEq = DeepEqual(m1.ResourceDependencies, m2.ResourceDependencies)
+
+	return primitivesEq, dockerEq, dcEq, k8sEq, localEq, depsEq, resourceDepsEq
 }
 
 func (m Manifest) ManifestName() ManifestName {
@@ -460,6 +462,8 @@ var localTargetAllowUnexported = cmp.AllowUnexported(LocalTarget{})
 var selectorAllowUnexported = cmp.AllowUnexported(container.RefSelector{})
 var refSetAllowUnexported = cmp.AllowUnexported(container.RefSet{})
 var registryAllowUnexported = cmp.AllowUnexported(container.Registry{})
+var ignoreCustomBuildDepsField = cmpopts.IgnoreFields(CustomBuild{}, "Deps")
+var ignoreLocalTargetDepsField = cmpopts.IgnoreFields(LocalTarget{}, "Deps")
 
 var dockerRefEqual = cmp.Comparer(func(a, b reference.Named) bool {
 	aNil := a == nil
@@ -491,5 +495,8 @@ func DeepEqual(x, y interface{}) bool {
 		refSetAllowUnexported,
 		registryAllowUnexported,
 		dockerRefEqual,
-		imageLocatorEqual)
+		imageLocatorEqual,
+		ignoreCustomBuildDepsField,
+		ignoreLocalTargetDepsField,
+	)
 }

--- a/pkg/model/manifest_test.go
+++ b/pkg/model/manifest_test.go
@@ -59,168 +59,144 @@ var equalitytests = []struct {
 	name                string
 	m1                  Manifest
 	m2                  Manifest
-	expectedEqual       bool
 	expectedInvalidates bool
 }{
 	{
 		"empty manifests equal",
 		Manifest{},
 		Manifest{},
-		true,
 		false,
 	},
 	{
 		"PortForwards unequal",
 		Manifest{}.WithDeployTarget(K8sTarget{PortForwards: portFwd8000}),
 		Manifest{}.WithDeployTarget(K8sTarget{PortForwards: portFwd8001}),
-		false,
 		true,
 	},
 	{
 		"PortForwards equal",
 		Manifest{}.WithDeployTarget(K8sTarget{PortForwards: portFwd8000}),
 		Manifest{}.WithDeployTarget(K8sTarget{PortForwards: portFwd8000}),
-		true,
 		false,
 	},
 	{
 		"DockerBuild.Dockerfile unequal",
 		Manifest{}.WithImageTarget(ImageTarget{}.WithBuildDetails(DockerBuild{Dockerfile: "FROM foo"})),
 		Manifest{}.WithImageTarget(ImageTarget{}.WithBuildDetails(DockerBuild{Dockerfile: "FROM bar"})),
-		false,
 		true,
 	},
 	{
 		"DockerBuild.Dockerfile equal",
 		Manifest{}.WithImageTarget(ImageTarget{}.WithBuildDetails(DockerBuild{Dockerfile: "FROM foo"})),
 		Manifest{}.WithImageTarget(ImageTarget{}.WithBuildDetails(DockerBuild{Dockerfile: "FROM foo"})),
-		true,
 		false,
 	},
 	{
 		"DockerBuild.BuildPath unequal",
 		Manifest{}.WithImageTarget(ImageTarget{}.WithBuildDetails(DockerBuild{BuildPath: "foo/bar"})),
 		Manifest{}.WithImageTarget(ImageTarget{}.WithBuildDetails(DockerBuild{BuildPath: "foo/bar/baz"})),
-		false,
 		true,
 	},
 	{
 		"DockerBuild.BuildPath equal",
 		Manifest{}.WithImageTarget(ImageTarget{}.WithBuildDetails(DockerBuild{BuildPath: "foo/bar"})),
 		Manifest{}.WithImageTarget(ImageTarget{}.WithBuildDetails(DockerBuild{BuildPath: "foo/bar"})),
-		true,
 		false,
 	},
 	{
 		"DockerBuild.BuildArgs unequal",
 		Manifest{}.WithImageTarget(ImageTarget{}.WithBuildDetails(DockerBuild{BuildArgs: buildArgs1})),
 		Manifest{}.WithImageTarget(ImageTarget{}.WithBuildDetails(DockerBuild{BuildArgs: buildArgs2})),
-		false,
 		true,
 	},
 	{
 		"DockerBuild.BuildArgs equal",
 		Manifest{}.WithImageTarget(ImageTarget{}.WithBuildDetails(DockerBuild{BuildArgs: buildArgs1})),
 		Manifest{}.WithImageTarget(ImageTarget{}.WithBuildDetails(DockerBuild{BuildArgs: buildArgs1})),
-		true,
 		false,
 	},
 	{
 		"ImageTarget.cachePaths unequal",
 		Manifest{}.WithImageTarget(ImageTarget{cachePaths: []string{"foo"}}),
 		Manifest{}.WithImageTarget(ImageTarget{cachePaths: []string{"bar"}}),
-		false,
 		true,
 	},
 	{
 		"ImageTarget.cachePaths equal",
 		Manifest{}.WithImageTarget(ImageTarget{cachePaths: []string{"foo"}}),
 		Manifest{}.WithImageTarget(ImageTarget{cachePaths: []string{"foo"}}),
-		true,
 		false,
 	},
 	{
 		"ImageTarget.ConfigurationRef unequal",
 		Manifest{}.WithImageTarget(ImageTarget{Refs: container.RefSet{ConfigurationRef: img1}}),
 		Manifest{}.WithImageTarget(ImageTarget{Refs: container.RefSet{ConfigurationRef: img2}}),
-		false,
 		true,
 	},
 	{
 		"ImageTarget.ConfigurationRef equal",
 		Manifest{}.WithImageTarget(ImageTarget{Refs: container.RefSet{ConfigurationRef: img1}}),
 		Manifest{}.WithImageTarget(ImageTarget{Refs: container.RefSet{ConfigurationRef: img1}}),
-		true,
 		false,
 	},
 	{
 		"ImageTarget.DockerIgnores unequal",
 		Manifest{}.WithImageTarget(ImageTarget{dockerignores: []Dockerignore{{"a", "b"}}}),
 		Manifest{}.WithImageTarget(ImageTarget{dockerignores: []Dockerignore{{"b", "a"}}}),
-		false,
 		true,
 	},
 	{
 		"ImageTarget.DockerIgnores equal",
 		Manifest{}.WithImageTarget(ImageTarget{dockerignores: []Dockerignore{{"a", "b"}}}),
 		Manifest{}.WithImageTarget(ImageTarget{dockerignores: []Dockerignore{{"a", "b"}}}),
-		true,
 		false,
 	},
 	{
 		"DockerCompose.ConfigPaths equal",
 		Manifest{}.WithDeployTarget(DockerComposeTarget{ConfigPaths: []string{"/src/docker-compose.yml"}}),
 		Manifest{}.WithDeployTarget(DockerComposeTarget{ConfigPaths: []string{"/src/docker-compose.yml"}}),
-		true,
 		false,
 	},
 	{
 		"DockerCompose.ConfigPaths unequal",
 		Manifest{}.WithDeployTarget(DockerComposeTarget{ConfigPaths: []string{"/src/docker-compose1.yml"}}),
 		Manifest{}.WithDeployTarget(DockerComposeTarget{ConfigPaths: []string{"/src/docker-compose2.yml"}}),
-		false,
 		true,
 	},
 	{
 		"DockerCompose.YAMLRaw equal",
 		Manifest{}.WithDeployTarget(DockerComposeTarget{YAMLRaw: []byte("hello world")}),
 		Manifest{}.WithDeployTarget(DockerComposeTarget{YAMLRaw: []byte("hello world")}),
-		true,
 		false,
 	},
 	{
 		"DockerCompose.YAMLRaw unequal",
 		Manifest{}.WithDeployTarget(DockerComposeTarget{YAMLRaw: []byte("hello world")}),
 		Manifest{}.WithDeployTarget(DockerComposeTarget{YAMLRaw: []byte("goodbye world")}),
-		false,
 		true,
 	},
 	{
 		"DockerCompose.DfRaw equal",
 		Manifest{}.WithDeployTarget(DockerComposeTarget{DfRaw: []byte("hello world")}),
 		Manifest{}.WithDeployTarget(DockerComposeTarget{DfRaw: []byte("hello world")}),
-		true,
 		false,
 	},
 	{
 		"DockerCompose.DfRaw unequal",
 		Manifest{}.WithDeployTarget(DockerComposeTarget{DfRaw: []byte("hello world")}),
 		Manifest{}.WithDeployTarget(DockerComposeTarget{DfRaw: []byte("goodbye world")}),
-		false,
 		true,
 	},
 	{
 		"k8s.YAML equal",
 		Manifest{}.WithDeployTarget(K8sTarget{YAML: "hello world"}),
 		Manifest{}.WithDeployTarget(K8sTarget{YAML: "hello world"}),
-		true,
 		false,
 	},
 	{
 		"k8s.YAML unequal",
 		Manifest{}.WithDeployTarget(K8sTarget{YAML: "hello world"}),
 		Manifest{}.WithDeployTarget(K8sTarget{YAML: "goodbye world"}),
-		false,
 		true,
 	},
 	{
@@ -231,7 +207,6 @@ var equalitytests = []struct {
 		Manifest{}.WithDeployTarget(K8sTarget{
 			ExtraPodSelectors: []labels.Selector{labels.Set{"foo": "bar"}.AsSelector()},
 		}),
-		true,
 		false,
 	},
 	{
@@ -242,14 +217,12 @@ var equalitytests = []struct {
 		Manifest{}.WithDeployTarget(K8sTarget{
 			ExtraPodSelectors: []labels.Selector{labels.Set{"foo": "baz"}.AsSelector()},
 		}),
-		false,
 		true,
 	},
 	{
 		"TriggerMode equal",
 		Manifest{TriggerMode: TriggerModeManualAfterInitial},
 		Manifest{TriggerMode: TriggerModeManualAfterInitial},
-		true,
 		false,
 	},
 	{
@@ -257,48 +230,41 @@ var equalitytests = []struct {
 		Manifest{TriggerMode: TriggerModeAuto},
 		Manifest{TriggerMode: TriggerModeManualAfterInitial},
 		false,
-		false,
 	},
 	{
 		"Name equal",
 		Manifest{Name: "foo"},
 		Manifest{Name: "bar"},
 		false,
-		false,
 	},
 	{
 		"Name & k8s YAML unequal",
 		Manifest{Name: "foo"}.WithDeployTarget(K8sTarget{YAML: "hello world"}),
 		Manifest{Name: "bar"}.WithDeployTarget(K8sTarget{YAML: "goodbye world"}),
-		false,
 		true,
 	},
 	{
 		"LocalTarget equal",
 		Manifest{}.WithDeployTarget(NewLocalTarget("foo", ToHostCmd("beep boop"), Cmd{}, []string{"bar", "baz"}, "path/to/tiltfile")),
 		Manifest{}.WithDeployTarget(NewLocalTarget("foo", ToHostCmd("beep boop"), Cmd{}, []string{"bar", "baz"}, "path/to/tiltfile")),
-		true,
 		false,
 	},
 	{
 		"LocalTarget.Name unequal",
 		Manifest{}.WithDeployTarget(NewLocalTarget("foo", ToHostCmd("beep boop"), Cmd{}, []string{"bar", "baz"}, "path/to/tiltfile")),
 		Manifest{}.WithDeployTarget(NewLocalTarget("foooooo", ToHostCmd("beep boop"), Cmd{}, []string{"bar", "baz"}, "path/to/tiltfile")),
-		false,
 		true,
 	},
 	{
 		"LocalTarget.UpdateCmd unequal",
 		Manifest{}.WithDeployTarget(NewLocalTarget("foo", ToHostCmd("beep boop"), Cmd{}, []string{"bar", "baz"}, "path/to/tiltfile")),
 		Manifest{}.WithDeployTarget(NewLocalTarget("foo", ToHostCmd("bippity boppity"), Cmd{}, []string{"bar", "baz"}, "path/to/tiltfile")),
-		false,
 		true,
 	},
 	{
 		"LocalTarget.workdir unequal",
 		Manifest{}.WithDeployTarget(NewLocalTarget("foo", ToHostCmd("beep boop"), Cmd{}, []string{"bar", "baz"}, "path/to/tiltfile")),
 		Manifest{}.WithDeployTarget(NewLocalTarget("foo", ToHostCmd("beep boop"), Cmd{}, []string{"bar", "baz"}, "some/other/path")),
-		false,
 		true,
 	},
 	{
@@ -306,13 +272,11 @@ var equalitytests = []struct {
 		Manifest{}.WithDeployTarget(NewLocalTarget("foo", ToHostCmd("beep boop"), Cmd{}, []string{"bar", "baz"}, "path/to/tiltfile")),
 		Manifest{}.WithDeployTarget(NewLocalTarget("foo", ToHostCmd("beep boop"), Cmd{}, []string{"quux", "baz"}, "path/to/tiltfile")),
 		false,
-		false,
 	},
 	{
 		"CustomBuild.Deps unequal and doesn't invalidate",
 		Manifest{}.WithImageTarget(ImageTarget{}.WithBuildDetails(CustomBuild{Deps: []string{"foo", "bar"}})),
 		Manifest{}.WithImageTarget(ImageTarget{}.WithBuildDetails(CustomBuild{Deps: []string{"bar", "quux"}})),
-		false,
 		false,
 	},
 }
@@ -320,12 +284,6 @@ var equalitytests = []struct {
 func TestManifestEquality(t *testing.T) {
 	for _, c := range equalitytests {
 		t.Run(c.name, func(t *testing.T) {
-			actualEqual := c.m1.Equal(c.m2)
-
-			if actualEqual != c.expectedEqual {
-				t.Errorf("Expected m1==m2 to be %t, but got %t\n\tm1: %+v\n\tm2: %+v", c.expectedEqual, actualEqual, c.m1, c.m2)
-			}
-
 			actualInvalidates := ChangesInvalidateBuild(c.m1, c.m2)
 
 			if actualInvalidates != c.expectedInvalidates {


### PR DESCRIPTION
this addresses the problem i was seeing with my [POC for async deps loading](https://github.com/tilt-dev/kubernetes/blob/maiamcc/async-poc/Tiltfile)
where a change to a resource's Deps would cause the resource to rebuild.
With this PR, a change in CustomBuild.Deps or LocalResource.Deps alone
does not invalidate a build and cause the resource to rebuild.