### PR TITLE
dockerignore: convert ignore patterns to absolute paths

### DIFF
--- a/internal/dockerignore/ignore.go
+++ b/internal/dockerignore/ignore.go
@@ -1,6 +1,7 @@
 package dockerignore
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -17,11 +18,10 @@ type dockerPathMatcher struct {
 }
 
 func (i dockerPathMatcher) Matches(f string) (bool, error) {
-	rp, err := filepath.Rel(i.repoRoot, f)
-	if err != nil {
-		return false, err
+	if !filepath.IsAbs(f) {
+		f = filepath.Join(i.repoRoot, f)
 	}
-	return i.matcher.Matches(rp)
+	return i.matcher.Matches(f)
 }
 
 func (i dockerPathMatcher) MatchesEntireDir(f string) (bool, error) {
@@ -36,8 +36,7 @@ func (i dockerPathMatcher) MatchesEntireDir(f string) (bool, error) {
 			if !pattern.Exclusion() {
 				continue
 			}
-			absPattern := filepath.Join(i.repoRoot, pattern.String())
-			if ospath.IsChild(f, absPattern) {
+			if ospath.IsChild(f, pattern.String()) {
 				// Found an exclusion match -- we don't match this whole dir
 				return false, nil
 			}
@@ -61,13 +60,43 @@ func NewDockerIgnoreTester(repoRoot string) (*dockerPathMatcher, error) {
 	return NewDockerPatternMatcher(absRoot, patterns)
 }
 
+// Make all the patterns use absolute paths.
+func absPatterns(absRoot string, patterns []string) []string {
+	absPatterns := make([]string, 0, len(patterns))
+	for _, p := range patterns {
+		// The pattern parsing here is loosely adapted from fileutils' NewPatternMatcher
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		p = filepath.Clean(p)
+
+		pPath := p
+		isExclusion := false
+		if p[0] == '!' {
+			pPath = p[1:]
+			isExclusion = true
+		}
+
+		if !filepath.IsAbs(pPath) {
+			pPath = filepath.Join(absRoot, pPath)
+		}
+		absPattern := pPath
+		if isExclusion {
+			absPattern = fmt.Sprintf("!%s", pPath)
+		}
+		absPatterns = append(absPatterns, absPattern)
+	}
+	return absPatterns
+}
+
 func NewDockerPatternMatcher(repoRoot string, patterns []string) (*dockerPathMatcher, error) {
 	absRoot, err := filepath.Abs(repoRoot)
 	if err != nil {
 		return nil, err
 	}
 
-	pm, err := fileutils.NewPatternMatcher(patterns)
+	pm, err := fileutils.NewPatternMatcher(absPatterns(absRoot, patterns))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/watch/notify_test.go
+++ b/internal/watch/notify_test.go
@@ -421,9 +421,6 @@ func TestWatchNonexistentDirectory(t *testing.T) {
 	f := newNotifyFixture(t)
 	defer f.tearDown()
 
-	ignore, _ := dockerignore.NewDockerPatternMatcher(f.paths[0], []string{"./"})
-	f.setIgnore(ignore)
-
 	root := f.JoinPath("root")
 	err := os.Mkdir(root, 0777)
 	if err != nil {
@@ -441,12 +438,9 @@ func TestWatchNonexistentDirectory(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if runtime.GOOS == "darwin" {
-		// for directories that were the root of an Add, we don't report creation, cf. watcher_darwin.go
-		f.assertEvents()
-	} else {
-		f.assertEvents(parent)
-	}
+	// for directories that were the root of an Add, we don't report creation, cf. watcher_darwin.go
+	f.assertEvents()
+
 	f.events = nil
 	f.WriteFile(file, "hello")
 
@@ -456,9 +450,6 @@ func TestWatchNonexistentDirectory(t *testing.T) {
 func TestWatchNonexistentFileInNonexistentDirectory(t *testing.T) {
 	f := newNotifyFixture(t)
 	defer f.tearDown()
-
-	ignore, _ := dockerignore.NewDockerPatternMatcher(f.paths[0], []string{"./"})
-	f.setIgnore(ignore)
 
 	root := f.JoinPath("root")
 	err := os.Mkdir(root, 0777)

--- a/internal/watch/watcher_naive.go
+++ b/internal/watch/watcher_naive.go
@@ -214,6 +214,12 @@ func (d *naiveNotify) shouldNotify(path string) bool {
 	}
 
 	if _, ok := d.notifyList[path]; ok {
+		// We generally don't care when directories change at the root of an ADD
+		stat, err := os.Lstat(path)
+		isDir := err == nil && stat.IsDir()
+		if isDir {
+			return false
+		}
 		return true
 	}
 	// TODO(dmiller): maybe use a prefix tree here?


### PR DESCRIPTION
Hello @landism,

Please review the following commits I made in branch nicks/ignore:

e19c0452dddf3a20acd7d3d296c46d944d781964 (2020-09-01 18:07:57 -0400)
dockerignore: convert ignore patterns to absolute paths
In most places in Tilt, we try to use absolute paths everywhere.
So this makes things more consistent with the rest of Tilt, and lets us be
a bit more flexible in how we handle subdirs and parent dirs in ignores.

Fixes https://github.com/tilt-dev/tilt/issues/3740

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics