### PR TITLE
tiltfile: add an api for adjusting the metrics reporting period

### DIFF
--- a/internal/tiltfile/metrics/metrics_test.go
+++ b/internal/tiltfile/metrics/metrics_test.go
@@ -2,10 +2,12 @@ package metrics
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
 	"github.com/tilt-dev/tilt/internal/tiltfile/starkit"
+	"github.com/tilt-dev/tilt/pkg/model"
 )
 
 func TestMetricsEnabled(t *testing.T) {
@@ -18,6 +20,7 @@ func TestMetricsEnabled(t *testing.T) {
 	assert.True(t, MustState(result).Enabled)
 	assert.Equal(t, "opentelemetry.tilt.dev:443", MustState(result).Address)
 	assert.False(t, MustState(result).Insecure)
+	assert.Equal(t, model.DefaultReportingPeriod, MustState(result).ReportingPeriod)
 }
 
 func TestMetricsAddress(t *testing.T) {
@@ -28,12 +31,14 @@ func TestMetricsAddress(t *testing.T) {
 experimental_metrics_settings(enabled=True)
 experimental_metrics_settings(address='localhost:5678')
 experimental_metrics_settings(insecure=True)
+experimental_metrics_settings(reporting_period='1s')
 `)
 	result, err := f.ExecFile("Tiltfile")
 	assert.NoError(t, err)
 	assert.True(t, MustState(result).Enabled)
 	assert.Equal(t, "localhost:5678", MustState(result).Address)
 	assert.True(t, MustState(result).Insecure)
+	assert.Equal(t, time.Second, MustState(result).ReportingPeriod)
 }
 
 func newFixture(tb testing.TB) *starkit.Fixture {

--- a/pkg/model/metrics.go
+++ b/pkg/model/metrics.go
@@ -1,9 +1,17 @@
 package model
 
+import "time"
+
+var DefaultReportingPeriod = 5 * time.Minute
+
 // Metrics settings generally map to exporter options
 // https://pkg.go.dev/contrib.go.opencensus.io/exporter/ocagent?tab=doc#ExporterOption
 type MetricsSettings struct {
 	Enabled  bool
 	Address  string
 	Insecure bool
+
+	// How often Tilt reports its metrics. Useful for testing.
+	// https://pkg.go.dev/go.opencensus.io/stats/view?tab=doc#SetReportingPeriod
+	ReportingPeriod time.Duration
 }


### PR DESCRIPTION
Hello @landism,

Please review the following commits I made in branch nicks/reportingperiod:

17f89a0050f1a277b4662415d86c8a536f462647 (2020-09-02 17:11:46 -0400)
tiltfile: add an api for adjusting the metrics reporting period

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics