### PR TITLE
tiltfile: add experimental_analytics_report

### DIFF
--- a/internal/tiltfile/analytics/analytics.go
+++ b/internal/tiltfile/analytics/analytics.go
@@ -5,10 +5,12 @@ import (
 	"go.starlark.net/starlark"
 
 	"github.com/tilt-dev/tilt/internal/tiltfile/starkit"
+	"github.com/tilt-dev/tilt/internal/tiltfile/value"
 )
 
 type Settings struct {
-	Opt analytics.Opt
+	Opt                analytics.Opt
+	CustomTagsToReport map[string]string
 }
 
 type Extension struct {
@@ -20,12 +22,26 @@ func NewExtension() Extension {
 
 func (e Extension) NewState() interface{} {
 	return Settings{
-		Opt: analytics.OptDefault,
+		Opt:                analytics.OptDefault,
+		CustomTagsToReport: make(map[string]string),
 	}
 }
 
 func (Extension) OnStart(env *starkit.Environment) error {
-	return env.AddBuiltin("analytics_settings", setAnalyticsSettings)
+	err := env.AddBuiltin("analytics_settings", setAnalyticsSettings)
+	if err != nil {
+		return err
+	}
+
+	// This is an experimental feature to allow Tiltfiles to specify custom data to report to analytics
+	// to allow teams to get more visibility into, e.g., who's using Tilt or what k8s distributions are
+	// their members using. It is not intended for use without coordinating with the Tilt team.
+	err = env.AddBuiltin("experimental_report_custom_tags", reportCustomTags)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func setAnalyticsSettings(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
@@ -41,6 +57,23 @@ func setAnalyticsSettings(thread *starlark.Thread, fn *starlark.Builtin, args st
 		} else {
 			settings.Opt = analytics.OptOut
 		}
+		return settings
+	})
+
+	return starlark.None, err
+}
+
+func reportCustomTags(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var tags value.StringStringMap
+	if err := starkit.UnpackArgs(thread, fn.Name(), args, kwargs, "tags", &tags); err != nil {
+		return nil, err
+	}
+
+	err := starkit.SetState(thread, func(settings Settings) Settings {
+		for k, v := range tags {
+			settings.CustomTagsToReport[k] = v
+		}
+
 		return settings
 	})
 

--- a/internal/tiltfile/analytics/analytics.go
+++ b/internal/tiltfile/analytics/analytics.go
@@ -36,7 +36,7 @@ func (Extension) OnStart(env *starkit.Environment) error {
 	// This is an experimental feature to allow Tiltfiles to specify custom data to report to analytics
 	// to allow teams to get more visibility into, e.g., who's using Tilt or what k8s distributions are
 	// their members using. It is not intended for use without coordinating with the Tilt team.
-	err = env.AddBuiltin("experimental_report_custom_tags", reportCustomTags)
+	err = env.AddBuiltin("experimental_analytics_report", reportCustomTags)
 	if err != nil {
 		return err
 	}

--- a/internal/tiltfile/analytics/analytics_test.go
+++ b/internal/tiltfile/analytics/analytics_test.go
@@ -39,6 +39,18 @@ analytics_settings(enable=False)
 	assert.Equal(t, analytics.OptOut, MustState(result).Opt)
 }
 
+func TestReportToAnalytics(t *testing.T) {
+	f := NewFixture(t)
+	f.File("Tiltfile", `
+experimental_report_custom_tags({'1': '2'})
+# the second call's "1" value replaces the first
+experimental_report_custom_tags({'1': '2a', '3': '4'})
+`)
+	result, err := f.ExecFile("Tiltfile")
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]string{"1": "2a", "3": "4"}, MustState(result).CustomTagsToReport)
+}
+
 func NewFixture(tb testing.TB) *starkit.Fixture {
 	return starkit.NewFixture(tb, NewExtension())
 }

--- a/internal/tiltfile/analytics/analytics_test.go
+++ b/internal/tiltfile/analytics/analytics_test.go
@@ -42,9 +42,9 @@ analytics_settings(enable=False)
 func TestReportToAnalytics(t *testing.T) {
 	f := NewFixture(t)
 	f.File("Tiltfile", `
-experimental_report_custom_tags({'1': '2'})
+experimental_analytics_report({'1': '2'})
 # the second call's "1" value replaces the first
-experimental_report_custom_tags({'1': '2a', '3': '4'})
+experimental_analytics_report({'1': '2a', '3': '4'})
 `)
 	result, err := f.ExecFile("Tiltfile")
 	assert.NoError(t, err)

--- a/internal/tiltfile/tiltfile.go
+++ b/internal/tiltfile/tiltfile.go
@@ -220,6 +220,10 @@ func (tfl tiltfileLoader) Load(ctx context.Context, filename string, userConfigS
 	s.logger.Infof("Successfully loaded Tiltfile (%s)", duration)
 	tfl.reportTiltfileLoaded(s.builtinCallCounts, s.builtinArgCounts, duration)
 
+	if len(aSettings.CustomTagsToReport) > 0 {
+		reportCustomTags(tfl.analytics, aSettings.CustomTagsToReport)
+	}
+
 	return tlr
 }
 
@@ -230,6 +234,10 @@ func tiltIgnorePath(tiltfilePath string) string {
 
 func starlarkValueOrSequenceToSlice(v starlark.Value) []starlark.Value {
 	return value.ValueOrSequenceToSlice(v)
+}
+
+func reportCustomTags(a *analytics.TiltAnalytics, tags map[string]string) {
+	a.Incr("tiltfile.custom.report", tags)
 }
 
 func (tfl *tiltfileLoader) reportTiltfileLoaded(callCounts map[string]int,

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -4853,7 +4853,7 @@ func TestCustomTagsReported(t *testing.T) {
 	defer f.TearDown()
 
 	f.file("Tiltfile", `
-experimental_report_custom_tags({'foo': 'bar'})
+experimental_analytics_report({'foo': 'bar'})
 `)
 
 	f.load()


### PR DESCRIPTION
Adds a new command that allows Tiltfile owners to report data to analytics to allow Tilt members to work with those Tiltfile owners to give them more insight into their team's Tilt use.

Sample Tiltfile usage:
```
username = local('whoami').rstrip('\n')
experimental_analytics_report({'user': username})
```

I'm not in love with the name, but it's less bad than a lot of the ones I came up with.