### PR TITLE
metrics: only send metrics when logged in. Attach token and other env info

### DIFF
--- a/internal/cli/analytics.go
+++ b/internal/cli/analytics.go
@@ -2,15 +2,12 @@ package cli
 
 import (
 	"os"
-	"os/exec"
 	"runtime"
-	"strings"
 
 	tiltanalytics "github.com/tilt-dev/tilt/internal/analytics"
+	"github.com/tilt-dev/tilt/internal/git"
 	"github.com/tilt-dev/tilt/pkg/logger"
 	"github.com/tilt-dev/tilt/pkg/model"
-
-	giturls "github.com/whilp/git-urls"
 
 	"github.com/tilt-dev/wmclient/pkg/analytics"
 )
@@ -44,14 +41,15 @@ func (al analyticsLogger) Printf(fmt string, v ...interface{}) {
 	al.logger.Debugf(fmt, v...)
 }
 
-func newAnalytics(l logger.Logger, cmdName model.TiltSubcommand) (*tiltanalytics.TiltAnalytics, error) {
+func newAnalytics(l logger.Logger, cmdName model.TiltSubcommand, tiltBuild model.TiltBuild,
+	gitRemote git.GitRemote) (*tiltanalytics.TiltAnalytics, error) {
 	var err error
 
 	options := []analytics.Option{}
 	// enabled: true because TiltAnalytics wraps the RemoteAnalytics and has its own guards for whether analytics
 	//   is enabled. When TiltAnalytics decides to pass a call through to RemoteAnalytics, it should always work.
 	options = append(options,
-		analytics.WithGlobalTags(globalTags(cmdName)),
+		analytics.WithGlobalTags(globalTags(cmdName, tiltBuild, gitRemote)),
 		analytics.WithEnabled(true),
 		analytics.WithLogger(analyticsLogger{logger: l}))
 	analyticsURL := os.Getenv(analyticsURLEnvVar)
@@ -63,55 +61,21 @@ func newAnalytics(l logger.Logger, cmdName model.TiltSubcommand) (*tiltanalytics
 		return nil, err
 	}
 
-	return tiltanalytics.NewTiltAnalytics(analyticsOpter{}, backingAnalytics, provideTiltInfo().AnalyticsVersion())
+	return tiltanalytics.NewTiltAnalytics(analyticsOpter{}, backingAnalytics, tiltBuild.AnalyticsVersion())
 }
 
-func globalTags(cmdName model.TiltSubcommand) map[string]string {
+func globalTags(cmdName model.TiltSubcommand, tiltBuild model.TiltBuild, gr git.GitRemote) map[string]string {
 	ret := map[string]string{
-		tiltanalytics.TagVersion:    provideTiltInfo().AnalyticsVersion(),
+		tiltanalytics.TagVersion:    tiltBuild.AnalyticsVersion(),
 		tiltanalytics.TagOS:         runtime.GOOS,
 		tiltanalytics.TagSubcommand: cmdName.String(),
 	}
 
 	// store a hash of the git remote to help us guess how many users are running it on the same repository
-	origin := normalizeGitRemote(gitOrigin("."))
+	origin := gr.String()
 	if origin != "" {
 		ret[tiltanalytics.TagGitRepoHash] = tiltanalytics.HashMD5(origin)
 	}
 
 	return ret
-}
-
-func gitOrigin(fromDir string) string {
-	cmd := exec.Command("git", "-C", fromDir, "remote", "get-url", "origin")
-	b, err := cmd.Output()
-	if err != nil {
-		return ""
-	}
-
-	return strings.TrimRight(string(b), "\n")
-}
-
-func normalizeGitRemote(s string) string {
-	u, err := giturls.Parse(string(s))
-	if err != nil {
-		return s
-	}
-
-	// treat "http://", "https://", "git://", "ssh://", etc as equiv
-	u.Scheme = ""
-
-	u.User = nil
-
-	// github.com/tilt-dev/tilt is the same as github.com/tilt-dev/tilt/
-	if strings.HasSuffix(u.Path, "/") {
-		u.Path = u.Path[:len(u.Path)-1]
-	}
-
-	// github.com/tilt-dev/tilt is the same as github.com/tilt-dev/tilt.git
-	if strings.HasSuffix(u.Path, ".git") {
-		u.Path = u.Path[:len(u.Path)-4]
-	}
-
-	return u.String()
 }

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -99,7 +99,7 @@ func preCommand(ctx context.Context, cmdName model.TiltSubcommand) (context.Cont
 
 	stats.Record(ctx, CommandCountMeasure.M(1))
 
-	a, err := newAnalytics(l, cmdName)
+	a, err := wireAnalytics(l, cmdName)
 	if err != nil {
 		l.Errorf("Fatal error initializing analytics: %v", err)
 		os.Exit(1)

--- a/internal/cli/wire.go
+++ b/internal/cli/wire.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd/api"
 
 	"github.com/tilt-dev/tilt/internal/analytics"
+	tiltanalytics "github.com/tilt-dev/tilt/internal/analytics"
 	"github.com/tilt-dev/tilt/internal/build"
 	"github.com/tilt-dev/tilt/internal/cloud"
 	"github.com/tilt-dev/tilt/internal/cloud/cloudurl"
@@ -36,6 +37,7 @@ import (
 	"github.com/tilt-dev/tilt/internal/engine/runtimelog"
 	"github.com/tilt-dev/tilt/internal/engine/telemetry"
 	"github.com/tilt-dev/tilt/internal/feature"
+	"github.com/tilt-dev/tilt/internal/git"
 	"github.com/tilt-dev/tilt/internal/hud"
 	"github.com/tilt-dev/tilt/internal/hud/prompt"
 	"github.com/tilt-dev/tilt/internal/hud/server"
@@ -44,6 +46,7 @@ import (
 	"github.com/tilt-dev/tilt/internal/tiltfile"
 	"github.com/tilt-dev/tilt/internal/token"
 	"github.com/tilt-dev/tilt/internal/tracer"
+	"github.com/tilt-dev/tilt/pkg/logger"
 	"github.com/tilt-dev/tilt/pkg/model"
 )
 
@@ -68,6 +71,7 @@ var BaseWireSet = wire.NewSet(
 	K8sWireSet,
 	tiltfile.WireSet,
 	provideKubectlLogLevel,
+	git.ProvideGitRemote,
 
 	docker.SwitchWireSet,
 
@@ -291,4 +295,10 @@ func wireDumpImageDeployRefDeps(ctx context.Context) (DumpImageDeployRefDeps, er
 	wire.Build(BaseWireSet,
 		wire.Struct(new(DumpImageDeployRefDeps), "*"))
 	return DumpImageDeployRefDeps{}, nil
+}
+
+func wireAnalytics(l logger.Logger, cmdName model.TiltSubcommand) (*tiltanalytics.TiltAnalytics, error) {
+	wire.Build(BaseWireSet,
+		newAnalytics)
+	return nil, nil
 }

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -3655,7 +3655,7 @@ func newTestFixture(t *testing.T) *testFixture {
 	ec := exit.NewController()
 
 	de := metrics.NewDeferredExporter()
-	mc := metrics.NewController(de)
+	mc := metrics.NewController(de, model.TiltBuild{}, "")
 
 	subs := ProvideSubscribers(h, ts, tp, pw, sw, plm, pfc, fwm, gm, bc, cc, dcw, dclm, pm, sm, ar, hudsc, au, ewm, tcum, dp, tc, lc, podm, ec, mc)
 	ret.upper = NewUpper(ctx, st, subs)

--- a/internal/git/remote.go
+++ b/internal/git/remote.go
@@ -1,0 +1,52 @@
+package git
+
+import (
+	"os/exec"
+	"strings"
+
+	giturls "github.com/whilp/git-urls"
+)
+
+type GitRemote string
+
+func (gr GitRemote) String() string {
+	return string(gr)
+}
+
+func ProvideGitRemote() GitRemote {
+	return GitRemote(normalizeGitRemote(gitOrigin(".")))
+}
+
+func gitOrigin(fromDir string) string {
+	cmd := exec.Command("git", "-C", fromDir, "remote", "get-url", "origin")
+	b, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+
+	return strings.TrimRight(string(b), "\n")
+}
+
+func normalizeGitRemote(s string) string {
+	u, err := giturls.Parse(string(s))
+	if err != nil {
+		return s
+	}
+
+	// treat "http://", "https://", "git://", "ssh://", etc as equiv
+	u.Scheme = ""
+
+	u.User = nil
+
+	// github.com/tilt-dev/tilt is the same as github.com/tilt-dev/tilt/
+	if strings.HasSuffix(u.Path, "/") {
+		u.Path = u.Path[:len(u.Path)-1]
+	}
+
+	// github.com/tilt-dev/tilt is the same as github.com/tilt-dev/tilt.git
+	if strings.HasSuffix(u.Path, ".git") {
+		u.Path = u.Path[:len(u.Path)-4]
+	}
+
+	return u.String()
+}

--- a/internal/git/remote_test.go
+++ b/internal/git/remote_test.go
@@ -1,12 +1,12 @@
-package cli
+package git
 
 import (
 	"os/exec"
 	"testing"
 
-	"github.com/tilt-dev/tilt/internal/testutils/tempdir"
-
 	"github.com/stretchr/testify/assert"
+
+	"github.com/tilt-dev/tilt/internal/testutils/tempdir"
 )
 
 func TestNormalizeGitRemoteSuffix(t *testing.T) {


### PR DESCRIPTION
Hello @landism,

Please review the following commits I made in branch nicks/metrics:

d907da2425af9d72fcdaf375cbb2b94ef2bc06d6 (2020-09-04 16:30:16 -0400)
metrics: only send metrics when logged in. Attach token and other env info

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics