### PR TITLE
builder implementation of outputs_image_ref_to for custom build scripts that want to compute their own tag

### DIFF
--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -49,12 +49,12 @@ func ParseNamedMulti(strs []string) ([]reference.Named, error) {
 func ParseNamedTagged(s string) (reference.NamedTagged, error) {
 	ref, err := reference.ParseNormalizedNamed(s)
 	if err != nil {
-		return nil, errors.Wrapf(err, "parsing %s", s)
+		return nil, errors.Wrapf(err, "parsing %q", s)
 	}
 
 	nt, ok := ref.(reference.NamedTagged)
 	if !ok {
-		return nil, fmt.Errorf("could not parse ref %s as NamedTagged", ref)
+		return nil, fmt.Errorf("Expected reference %q to contain a tag", s)
 	}
 	return nt, nil
 }

--- a/internal/container/reference.go
+++ b/internal/container/reference.go
@@ -47,6 +47,10 @@ func (rs RefSet) WithoutRegistry() RefSet {
 	return MustSimpleRefSet(rs.ConfigurationRef)
 }
 
+func (rs RefSet) Registry() Registry {
+	return rs.registry
+}
+
 func (rs RefSet) MustWithRegistry(reg Registry) RefSet {
 	rs.registry = reg
 	err := rs.Validate()

--- a/pkg/model/image_target.go
+++ b/pkg/model/image_target.go
@@ -293,6 +293,10 @@ type CustomBuild struct {
 	LiveUpdate       LiveUpdate // Optionally, can use LiveUpdate to update this build in place.
 	DisablePush      bool
 	SkipsLocalDocker bool
+
+	// We expect the custom build script to print the image ref to this file,
+	// so that Tilt can read it out when we're done.
+	OutputsImageRefTo string
 }
 
 func (CustomBuild) buildDetails() {}


### PR DESCRIPTION
Hello @landism,

Please review the following commits I made in branch nicks/custombuilder:

82d91d839043c16f298908009fc5df0333bd820b (2020-09-11 15:28:27 -0400)
builder implementation of outputs_image_ref_to for custom build scripts that want to compute their own tag

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics