### PR TITLE
tiltfile: allow escaping of selector strings

### DIFF
--- a/internal/k8s/names.go
+++ b/internal/k8s/names.go
@@ -88,7 +88,7 @@ func potentialNames(e K8sEntity, minComponents int) []string {
 	}
 	var ret []string
 	for i := minComponents - 1; i < len(components); i++ {
-		ret = append(ret, strings.ToLower(strings.Join(components[:i+1], ":")))
+		ret = append(ret, strings.ToLower(SelectorStringFromParts(components[:i+1])))
 	}
 	return ret
 }

--- a/internal/sliceutils/sliceutils_test.go
+++ b/internal/sliceutils/sliceutils_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAppendWithoutDupesNoDupes(t *testing.T) {
@@ -36,4 +37,52 @@ func TestAppendWithoutDupesEmptyB(t *testing.T) {
 	observed := AppendWithoutDupes(a, b...)
 	expected := []string{"a", "b"}
 	assert.Equal(t, expected, observed)
+}
+
+func TestUnescapeAndSplitNoEscape(t *testing.T) {
+	parts, err := UnescapeAndSplit("a:b:c", NewEscapeSplitOptions())
+	require.NoError(t, err)
+	require.Equal(t, []string{"a", "b", "c"}, parts)
+}
+
+func TestUnescapeAndSplitEscapedDelimiter(t *testing.T) {
+	parts, err := UnescapeAndSplit(`a\:d:b:c`, NewEscapeSplitOptions())
+	require.NoError(t, err)
+	require.Equal(t, []string{"a:d", "b", "c"}, parts)
+}
+
+func TestUnescapeAndSplitEscapedEscapeChar(t *testing.T) {
+	parts, err := UnescapeAndSplit(`a\\d:b:c`, NewEscapeSplitOptions())
+	require.NoError(t, err)
+	require.Equal(t, []string{`a\d`, "b", "c"}, parts)
+}
+
+func TestUnescapeAndSplitInvalidEscape(t *testing.T) {
+	_, err := UnescapeAndSplit(`a\d:b:c`, NewEscapeSplitOptions())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), `invalid escape sequence '\d' in 'a\d:b'`)
+}
+
+func TestEscapeAndJoinNoEscape(t *testing.T) {
+	s := EscapeAndJoin([]string{"a", "b", "c"}, NewEscapeSplitOptions())
+	require.Equal(t, s, "a:b:c", s)
+}
+
+func TestEscapeAndJoinEscapeDelimiter(t *testing.T) {
+	s := EscapeAndJoin([]string{"a:d", "b", "c"}, NewEscapeSplitOptions())
+	require.Equal(t, s, `a\:d:b:c`, s)
+}
+
+func TestEscapeAndJoinEscapeEscapeChar(t *testing.T) {
+	s := EscapeAndJoin([]string{`a\d`, "b", "c"}, NewEscapeSplitOptions())
+	require.Equal(t, s, `a\\d:b:c`, s)
+}
+
+func TestUnescapeAndSplitRoundtrip(t *testing.T) {
+	expected := `a\\d:\:b\:::c\:e`
+	opts := NewEscapeSplitOptions()
+	parts, err := UnescapeAndSplit(expected, opts)
+	require.NoError(t, err)
+	observed := EscapeAndJoin(parts, opts)
+	require.Equal(t, expected, observed)
 }

--- a/internal/tiltfile/tiltfile_state.go
+++ b/internal/tiltfile/tiltfile_state.go
@@ -717,7 +717,7 @@ func (s *tiltfileState) assembleK8sV2() error {
 
 			selectors := make([]k8s.ObjectSelector, len(opts.objects))
 			for i, o := range opts.objects {
-				s, err := selectorFromString(o)
+				s, err := k8s.SelectorFromString(o)
 				if err != nil {
 					return errors.Wrapf(err, "Error making selector from string %q", o)
 				}
@@ -780,26 +780,7 @@ func (s *tiltfileState) assembleK8sV2() error {
 // we decided to leave it off for now. When we encounter a concrete use case for specifying group it shouldn't be too
 // hard to add it here and in the docs.
 func fullNameFromK8sEntity(e k8s.K8sEntity) string {
-	return fmt.Sprintf("%s:%s:%s", e.Name(), e.GVK().Kind, e.Namespace())
-}
-
-// format is <name:required>:<kind:optional>:<namespace:optional>
-func selectorFromString(s string) (k8s.ObjectSelector, error) {
-	parts := strings.Split(s, ":")
-	if len(s) == 0 {
-		return k8s.ObjectSelector{}, fmt.Errorf("selector can't be empty")
-	}
-	if len(parts) == 1 {
-		return k8s.NewFullmatchCaseInsensitiveObjectSelector("", "", parts[0], "")
-	}
-	if len(parts) == 2 {
-		return k8s.NewFullmatchCaseInsensitiveObjectSelector("", parts[1], parts[0], "")
-	}
-	if len(parts) == 3 {
-		return k8s.NewFullmatchCaseInsensitiveObjectSelector("", parts[1], parts[0], parts[2])
-	}
-
-	return k8s.ObjectSelector{}, fmt.Errorf("Too many parts in selector. Selectors must contain between 1 and 3 parts (colon separated), found %d parts in %s", len(parts), s)
+	return k8s.SelectorStringFromParts([]string{e.Name(), e.GVK().Kind, e.Namespace().String()})
 }
 
 func filterEntitiesBySelector(entities []k8s.K8sEntity, sel k8s.ObjectSelector) []k8s.K8sEntity {


### PR DESCRIPTION
fixes #3761

I wanted to use some existing library for splitting w/ escapes, but I failed to find one.