### PR TITLE
scripts: tilt 0.17.5 requires you to have git installed to use extensions

### DIFF
--- a/scripts/tilt.Dockerfile
+++ b/scripts/tilt.Dockerfile
@@ -2,10 +2,13 @@
 # - tilt
 # - Docker
 # - kubectl
+# - git
 # and scripts you need to run integration tests with tilt.
 #
 # Built with goreleaser.
 
 FROM tiltdev/circleci-kind:v1.2.0
+
+RUN apt update && apt install -y git
 
 COPY tilt /usr/local/bin/tilt


### PR DESCRIPTION
Hello @landism,

Please review the following commits I made in branch nicks/tiltgit:

5f055f887d645761c81aa7e1839399e585f6b5ba (2020-09-18 12:38:15 -0400)
scripts: tilt 0.17.5 requires you to have git installed to use extensions

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics