### PR TITLE
tiltfile/helm: throw error when we can't parse helm version, more robust version check if version output is dirty [ch9459]

### DIFF
--- a/internal/tiltfile/helm_test.go
+++ b/internal/tiltfile/helm_test.go
@@ -112,7 +112,8 @@ const exampleHelmV3_2VersionOutput = `v3.2.4`
 // see https://github.com/tilt-dev/tilt/issues/3788
 const exampleHelmV3_3VersionOutput = `WARNING: Kubernetes configuration file is group-readable. This is insecure. Location: /Users/someone/.kube/config
 WARNING: Kubernetes configuration file is world-readable. This is insecure. Location: /Users/someone/.kube/config
-v3.3.3+g55e3ca0`
+v3.3.3+g55e3ca0
+`
 
 func TestParseHelmV2Version(t *testing.T) {
 	expected := helmV2

--- a/internal/tiltfile/helm_test.go
+++ b/internal/tiltfile/helm_test.go
@@ -109,39 +109,40 @@ const exampleHelmV3_0VersionOutput = `v3.0.0`
 const exampleHelmV3_1VersionOutput = `v3.1.0`
 const exampleHelmV3_2VersionOutput = `v3.2.4`
 
+// see https://github.com/tilt-dev/tilt/issues/3788
+const exampleHelmV3_3VersionOutput = `WARNING: Kubernetes configuration file is group-readable. This is insecure. Location: /Users/someone/.kube/config
+WARNING: Kubernetes configuration file is world-readable. This is insecure. Location: /Users/someone/.kube/config
+v3.3.3+g55e3ca0`
+
 func TestParseHelmV2Version(t *testing.T) {
 	expected := helmV2
-	actual := parseVersion(exampleHelmV2VersionOutput)
-
-	assert.Equal(t, expected, actual)
+	assertHelmVersion(t, exampleHelmV2VersionOutput, expected)
 }
 
 func TestParseHelmV3Version(t *testing.T) {
 	expected := helmV3_0
-	actual := parseVersion(exampleHelmV3_0VersionOutput)
-
-	assert.Equal(t, expected, actual)
+	assertHelmVersion(t, exampleHelmV3_0VersionOutput, expected)
 }
 
 func TestParseHelmV3_1Version(t *testing.T) {
 	expected := helmV3_1andAbove
-	actual := parseVersion(exampleHelmV3_1VersionOutput)
-
-	assert.Equal(t, expected, actual)
+	assertHelmVersion(t, exampleHelmV3_1VersionOutput, expected)
 }
 
 func TestParseHelmV3_2Version(t *testing.T) {
 	expected := helmV3_1andAbove
-	actual := parseVersion(exampleHelmV3_2VersionOutput)
-
-	assert.Equal(t, expected, actual)
+	assertHelmVersion(t, exampleHelmV3_2VersionOutput, expected)
 }
 
-func TestHelmUnknownVersion(t *testing.T) {
-	expected := unknownHelmVersion
-	actual := parseVersion("v4.1.2")
+func TestParseHelmV3_3Version(t *testing.T) {
+	expected := helmV3_1andAbove
+	assertHelmVersion(t, exampleHelmV3_3VersionOutput, expected)
+}
 
-	assert.Equal(t, expected, actual)
+func TestHelmUnknownVersionError(t *testing.T) {
+	_, err := parseVersion("v4.1.2")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "could not parse Helm version from string")
 }
 
 const fileRequirementsYAML = `dependencies:
@@ -247,4 +248,10 @@ k8s_yaml(helm('./helm'))
 	} else {
 		assert.NotContains(t, yaml, "kind: UselessMachine")
 	}
+}
+
+func assertHelmVersion(t *testing.T, versionOutput string, expectedV helmVersion) {
+	actualV, err := parseVersion(versionOutput)
+	require.NoError(t, err, "parsing helm version")
+	require.Equal(t, expectedV, actualV)
 }


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch maiamcc/helm-version-check:

aa38f01a8ec2a855eaf9e0d334288fae12705e5c (2020-09-25 14:01:01 -0400)
tiltfile/helm: throw error when we can't parse helm version, more robust version check if version output is dirty [ch9459]

Fixes #3788 (tho the helm behavior in question is fixed as of v3.3.4 -- see https://github.com/helm/helm/issues/8776)