### PR TITLE
k8s: add the ability to watch a specific namespace

### DIFF
--- a/internal/engine/k8swatch/event_watch_manager.go
+++ b/internal/engine/k8swatch/event_watch_manager.go
@@ -91,7 +91,7 @@ func (m *EventWatchManager) OnChange(ctx context.Context, st store.RStore) {
 func (m *EventWatchManager) setupWatch(ctx context.Context, st store.RStore, tiltStartTime time.Time) {
 	m.watching = true
 
-	ch, err := m.kClient.WatchEvents(ctx)
+	ch, err := m.kClient.WatchEvents(ctx, "")
 	if err != nil {
 		err = errors.Wrap(err, "Error watching k8s events\n")
 		st.Dispatch(store.NewErrorAction(err))

--- a/internal/engine/k8swatch/event_watch_manager_test.go
+++ b/internal/engine/k8swatch/event_watch_manager_test.go
@@ -123,6 +123,8 @@ func TestEventWatchManager_eventBeforeUID(t *testing.T) {
 
 	// Seed the k8s client with a pod and its owner tree
 	manifest := f.addManifest(mn)
+	f.ewm.OnChange(f.ctx, f.store)
+
 	pb := podbuilder.New(t, manifest)
 	f.kClient.InjectEntityByName(pb.ObjectTreeEntities()...)
 

--- a/internal/engine/k8swatch/pod_watch.go
+++ b/internal/engine/k8swatch/pod_watch.go
@@ -124,7 +124,7 @@ func (w *PodWatcher) OnChange(ctx context.Context, st store.RStore) {
 		ctx, cancel := context.WithCancel(ctx)
 		pw.cancel = cancel
 		w.addWatch(pw)
-		ch, err := w.kCli.WatchPods(ctx, pw.labels)
+		ch, err := w.kCli.WatchPods(ctx, "", pw.labels)
 		if err != nil {
 			err = errors.Wrap(err, "Error watching pods. Are you connected to kubernetes?\nTry running `kubectl get pods`")
 			st.Dispatch(store.NewErrorAction(err))

--- a/internal/engine/k8swatch/service_watch.go
+++ b/internal/engine/k8swatch/service_watch.go
@@ -65,7 +65,7 @@ func (w *ServiceWatcher) OnChange(ctx context.Context, st store.RStore) {
 func (w *ServiceWatcher) setupWatch(ctx context.Context, st store.RStore) {
 	w.watching = true
 
-	ch, err := w.kCli.WatchServices(ctx, k8s.ManagedByTiltSelector())
+	ch, err := w.kCli.WatchServices(ctx, "", k8s.ManagedByTiltSelector())
 	if err != nil {
 		err = errors.Wrap(err, "Error watching services. Are you connected to kubernetes?\nTry running `kubectl get services`")
 		st.Dispatch(store.NewErrorAction(err))

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -91,11 +91,20 @@ type Client interface {
 	// Opens a tunnel to the specified pod+port. Returns the tunnel's local port and a function that closes the tunnel
 	CreatePortForwarder(ctx context.Context, namespace Namespace, podID PodID, optionalLocalPort, remotePort int, host string) (PortForwarder, error)
 
-	WatchPods(ctx context.Context, lps labels.Selector) (<-chan ObjectUpdate, error)
+	// Currently, WatchPods, WatchServices, and WatchEvents all take a namespace.
+	//
+	// If the namespace is "", they will try to watch all namespaces. If that fails, they will watch
+	// the config namespace only.
+	//
+	// Otherwise, they will only try to watch the specified namespace.
+	//
+	// Over time, we want to remove the ability to watch all namespaces
+	// https://github.com/tilt-dev/tilt/issues/3792
+	WatchPods(ctx context.Context, ns Namespace, lps labels.Selector) (<-chan ObjectUpdate, error)
 
-	WatchServices(ctx context.Context, lps labels.Selector) (<-chan *v1.Service, error)
+	WatchServices(ctx context.Context, ns Namespace, lps labels.Selector) (<-chan *v1.Service, error)
 
-	WatchEvents(ctx context.Context) (<-chan *v1.Event, error)
+	WatchEvents(ctx context.Context, ns Namespace) (<-chan *v1.Event, error)
 
 	ConnectedToCluster(ctx context.Context) error
 

--- a/internal/k8s/exploding_client.go
+++ b/internal/k8s/exploding_client.go
@@ -57,15 +57,15 @@ func (ec *explodingClient) CreatePortForwarder(ctx context.Context, namespace Na
 	return nil, errors.Wrap(ec.err, "could not set up k8s client")
 }
 
-func (ec *explodingClient) WatchPods(ctx context.Context, lps labels.Selector) (<-chan ObjectUpdate, error) {
+func (ec *explodingClient) WatchPods(ctx context.Context, ns Namespace, lps labels.Selector) (<-chan ObjectUpdate, error) {
 	return nil, errors.Wrap(ec.err, "could not set up k8s client")
 }
 
-func (ec *explodingClient) WatchServices(ctx context.Context, lps labels.Selector) (<-chan *v1.Service, error) {
+func (ec *explodingClient) WatchServices(ctx context.Context, ns Namespace, lps labels.Selector) (<-chan *v1.Service, error) {
 	return nil, errors.Wrap(ec.err, "could not set up k8s client")
 }
 
-func (ec *explodingClient) WatchEvents(ctx context.Context) (<-chan *v1.Event, error) {
+func (ec *explodingClient) WatchEvents(ctx context.Context, ns Namespace) (<-chan *v1.Event, error) {
 	return nil, errors.Wrap(ec.err, "could not set up k8s client")
 }
 

--- a/internal/k8s/fake_test.go
+++ b/internal/k8s/fake_test.go
@@ -35,7 +35,8 @@ func fakePod(podID PodID, imageID string) *v1.Pod {
 func fakeService(name string) *v1.Service {
 	return &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
+			Name:      name,
+			Namespace: "default",
 		},
 	}
 }
@@ -43,7 +44,8 @@ func fakeService(name string) *v1.Service {
 func fakeEvent(name string, message string, count int) *v1.Event {
 	return &v1.Event{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
+			Name:      name,
+			Namespace: "default",
 		},
 		Message: message,
 		Count:   int32(count),


### PR DESCRIPTION
Hello @landism,

Please review the following commits I made in branch nicks/namespace:

9b1ecc0d0327a7c0d497b0fbd12e7697d8533df3 (2020-09-30 10:28:43 -0400)
k8s: add the ability to watch a specific namespace

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics