### PR TITLE
k8swatch: only watch pods in namespaces we've deployed to. fixes https://github.com/tilt-dev/tilt/issues/2846

### DIFF
--- a/internal/engine/k8swatch/event_watch_manager.go
+++ b/internal/engine/k8swatch/event_watch_manager.go
@@ -95,7 +95,7 @@ func (m *EventWatchManager) OnChange(ctx context.Context, st store.RStore) {
 func (m *EventWatchManager) setupWatch(ctx context.Context, st store.RStore, ns k8s.Namespace, tiltStartTime time.Time) {
 	ch, err := m.kClient.WatchEvents(ctx, ns)
 	if err != nil {
-		err = errors.Wrap(err, "Error watching k8s events\n")
+		err = errors.Wrapf(err, "Error watching events. Are you connected to kubernetes?\nTry running `kubectl get events -n %q`", ns)
 		st.Dispatch(store.NewErrorAction(err))
 		return
 	}

--- a/internal/engine/k8swatch/event_watch_manager_test.go
+++ b/internal/engine/k8swatch/event_watch_manager_test.go
@@ -134,7 +134,7 @@ func TestEventWatchManager_watchError(t *testing.T) {
 
 	f.ewm.OnChange(f.ctx, f.store)
 
-	expectedErr := errors.Wrap(err, "Error watching k8s events\n")
+	expectedErr := errors.Wrap(err, "Error watching events. Are you connected to kubernetes?\nTry running `kubectl get events -n \"default\"`")
 	expected := store.ErrorAction{Error: expectedErr}
 	f.assertActions(expected)
 	f.store.ClearActions()

--- a/internal/engine/k8swatch/service_watch.go
+++ b/internal/engine/k8swatch/service_watch.go
@@ -68,7 +68,7 @@ func (w *ServiceWatcher) OnChange(ctx context.Context, st store.RStore) {
 func (w *ServiceWatcher) setupWatch(ctx context.Context, st store.RStore, ns k8s.Namespace) {
 	ch, err := w.kCli.WatchServices(ctx, ns, k8s.ManagedByTiltSelector())
 	if err != nil {
-		err = errors.Wrap(err, "Error watching services. Are you connected to kubernetes?\nTry running `kubectl get services`")
+		err = errors.Wrapf(err, "Error watching services. Are you connected to kubernetes?\nTry running `kubectl get services -n %q`", ns)
 		st.Dispatch(store.NewErrorAction(err))
 		return
 	}

--- a/internal/k8s/fake_client.go
+++ b/internal/k8s/fake_client.go
@@ -188,9 +188,15 @@ func (c *FakeK8sClient) EmitPod(ls labels.Selector, p *v1.Pod) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	for _, w := range c.podWatches {
-		if SelectorEqual(ls, w.ls) {
-			w.ch <- ObjectUpdate{obj: p}
+		if w.ns != "" && w.ns != Namespace(p.Namespace) {
+			continue
 		}
+
+		if !SelectorEqual(w.ls, ls) {
+			continue
+		}
+
+		w.ch <- ObjectUpdate{obj: p}
 	}
 }
 
@@ -198,9 +204,15 @@ func (c *FakeK8sClient) EmitPodDelete(ls labels.Selector, p *v1.Pod) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	for _, w := range c.podWatches {
-		if SelectorEqual(ls, w.ls) {
-			w.ch <- ObjectUpdate{obj: p, isDelete: true}
+		if w.ns != "" && w.ns != Namespace(p.Namespace) {
+			continue
 		}
+
+		if !SelectorEqual(w.ls, ls) {
+			continue
+		}
+
+		w.ch <- ObjectUpdate{obj: p, isDelete: true}
 	}
 }
 


### PR DESCRIPTION
Hello @landism,

Please review the following commits I made in branch nicks/ch9648:

553494746ff7b15e9a686fb9e4c5db9b7b687155 (2020-10-01 17:20:07 -0400)
k8swatch: only watch pods in namespaces we've deployed to. fixes https://github.com/tilt-dev/tilt/issues/2846
This is a big change!

Before this change, Tilt watched all pods with the "managed-by: tilt" label and
extra pod selector labels. Then it traces owner references (or uses
extra_pod_selectors) to determine which resource they belong to.

After this change, Tilt watches all pods in namespaces you deploy to, and traces
owner references (or uses extra_pod_selectors) to determine which resource they
belong to.

I think that for most users (where they're using a local cluster, or a remote
cluster where each user gets their own namespace), this will be a big
improvement. The watches will be more efficient, get throttled less, and require
less configuration (since there will now be many cases where Tilt doesn't need
extra_pod_selectors).

But I could also imagine edge cases where this will be worse (e.g., a big
namespace with lots of non-Tilt stuff).

45be8d2a04cff5d475b1534fcba50fe8dbd0a992 (2020-10-01 16:19:36 -0400)
k8swatch: only watch events and services in namespaces we've deployed to. fixes https://github.com/tilt-dev/tilt/issues/3792

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics