### PR TITLE
model/webview: endpoints sent to web UI contain name [ch9649]

### DIFF
--- a/internal/hud/webview/convert.go
+++ b/internal/hud/webview/convert.go
@@ -110,7 +110,7 @@ func StateToProtoView(s store.EngineState, logCheckpoint logstore.Checkpoint) (*
 			PendingBuildSince:  pbs,
 			PendingBuildReason: int32(mt.NextBuildReason()),
 			CurrentBuild:       cb,
-			EndpointLinks:      temporaryConvertEndpoints(endpoints),
+			EndpointLinks:      ToProtoLinks(endpoints),
 			PodID:              podID.String(),
 			Specs:              specs,
 			ShowBuildStatus:    len(mt.Manifest.ImageTargets) > 0 || mt.Manifest.IsDC(),
@@ -265,16 +265,4 @@ func LogSegmentToEvent(seg *proto_webview.LogSegment, spans map[string]*proto_we
 	// TODO(maia): actually get level (just spoofing for now)
 	spoofedLevel := logger.InfoLvl
 	return store.NewLogAction(model.ManifestName(span.ManifestName), logstore.SpanID(seg.SpanId), spoofedLevel, seg.Fields, []byte(seg.Text))
-}
-
-// NOTE(maia): for backwards compatibility, will remove once port forward names etc.
-// configurable from Tiltfile
-func temporaryConvertEndpoints(endpoints []string) []*proto_webview.Link {
-	res := make([]*proto_webview.Link, len(endpoints))
-	for i, e := range endpoints {
-		res[i] = &proto_webview.Link{
-			Url: e,
-		}
-	}
-	return res
 }

--- a/internal/hud/webview/convert_test.go
+++ b/internal/hud/webview/convert_test.go
@@ -79,12 +79,16 @@ func TestStateToWebViewPortForwards(t *testing.T) {
 		PortForwards: []model.PortForward{
 			{LocalPort: 8000, ContainerPort: 5000},
 			{LocalPort: 7000, ContainerPort: 5001},
+			{LocalPort: 6000, ContainerPort: 5003, Name: "debugger"},
+			{LocalPort: 5000, ContainerPort: 5002, Host: "127.0.0.2", Name: "dashboard"},
 		},
 	})
 	state := newState([]model.Manifest{m})
 	v := stateToProtoView(t, *state)
 
 	expected := []*proto_webview.Link{
+		&proto_webview.Link{Url: "http://127.0.0.2:5000/", Name: "dashboard"},
+		&proto_webview.Link{Url: "http://localhost:6000/", Name: "debugger"},
 		&proto_webview.Link{Url: "http://localhost:7000/"},
 		&proto_webview.Link{Url: "http://localhost:8000/"},
 	}

--- a/internal/hud/webview/view.go
+++ b/internal/hud/webview/view.go
@@ -155,3 +155,14 @@ func ToProtoBuildRecords(brs []model.BuildRecord, logStore *logstore.LogStore) (
 	}
 	return ret, nil
 }
+
+func ToProtoLinks(lns []model.Link) []*proto_webview.Link {
+	ret := make([]*proto_webview.Link, len(lns))
+	for i, ln := range lns {
+		ret[i] = &proto_webview.Link{
+			Url:  ln.URL,
+			Name: ln.Name,
+		}
+	}
+	return ret
+}

--- a/internal/store/engine_state.go
+++ b/internal/store/engine_state.go
@@ -613,9 +613,9 @@ func (ms *ManifestState) HasPendingChangesBeforeOrEqual(highWaterMark time.Time)
 
 var _ model.TargetStatus = &ManifestState{}
 
-func ManifestTargetEndpoints(mt *ManifestTarget) (endpoints []string) {
+func ManifestTargetEndpoints(mt *ManifestTarget) (endpoints []model.Link) {
 	defer func() {
-		sort.Strings(endpoints)
+		sort.Sort(model.ByURL(endpoints))
 	}()
 
 	// If the user specified port-forwards in the Tiltfile, we
@@ -631,14 +631,14 @@ func ManifestTargetEndpoints(mt *ManifestTarget) (endpoints []string) {
 	publishedPorts := mt.Manifest.DockerComposeTarget().PublishedPorts()
 	if len(publishedPorts) > 0 {
 		for _, p := range publishedPorts {
-			endpoints = append(endpoints, fmt.Sprintf("http://localhost:%d/", p))
+			endpoints = append(endpoints, model.Link{URL: fmt.Sprintf("http://localhost:%d/", p)})
 		}
 		return endpoints
 	}
 
 	for _, u := range mt.State.K8sRuntimeState().LBs {
 		if u != nil {
-			endpoints = append(endpoints, u.String())
+			endpoints = append(endpoints, model.Link{URL: u.String()})
 		}
 	}
 	return endpoints
@@ -711,7 +711,7 @@ func StateToView(s EngineState, mu *sync.RWMutex) view.View {
 			PendingBuildReason: mt.NextBuildReason(),
 			CurrentBuild:       currentBuild,
 			CrashLog:           ms.CrashLog,
-			Endpoints:          endpoints,
+			Endpoints:          model.LinksToURLs(endpoints), // hud can't handle link names, just send URLs
 			ResourceInfo:       resourceInfoView(mt),
 		}
 

--- a/internal/store/engine_state.go
+++ b/internal/store/engine_state.go
@@ -623,11 +623,7 @@ func ManifestTargetEndpoints(mt *ManifestTarget) (endpoints []string) {
 	portForwards := mt.Manifest.K8sTarget().PortForwards
 	if len(portForwards) > 0 {
 		for _, pf := range portForwards {
-			host := pf.Host
-			if host == "" {
-				host = "localhost"
-			}
-			endpoints = append(endpoints, fmt.Sprintf("http://%s:%d/", host, pf.LocalPort))
+			endpoints = append(endpoints, pf.ToLink())
 		}
 		return endpoints
 	}

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -456,12 +456,31 @@ type Link struct {
 	Name string
 }
 
-func (pf PortForward) ToLink() string {
+// ByURL implements sort.Interface based on the URL field.
+type ByURL []Link
+
+func (lns ByURL) Len() int           { return len(lns) }
+func (lns ByURL) Less(i, j int) bool { return lns[i].URL < lns[j].URL }
+func (lns ByURL) Swap(i, j int)      { lns[i], lns[j] = lns[j], lns[i] }
+
+func (pf PortForward) ToLink() Link {
 	host := pf.Host
 	if host == "" {
 		host = "localhost"
 	}
-	return fmt.Sprintf("http://%s:%d/", host, pf.LocalPort)
+	url := fmt.Sprintf("http://%s:%d/", host, pf.LocalPort)
+	return Link{
+		URL:  url,
+		Name: pf.Name,
+	}
+}
+
+func LinksToURLs(lns []Link) []string {
+	res := make([]string, len(lns))
+	for i, ln := range lns {
+		res[i] = ln.URL
+	}
+	return res
 }
 
 var imageTargetAllowUnexported = cmp.AllowUnexported(ImageTarget{})

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -439,6 +439,29 @@ type PortForward struct {
 
 	// Optional host to bind to on the current machine (localhost by default)
 	Host string
+
+	// Optional name of the port forward; if given, used as text of the URL
+	// displayed in the web UI (e.g. <a href="localhost:8888">Debugger</a>)
+	Name string
+}
+
+// A link associated with resource; may represent a port forward, an endpoint
+// derived from a Service/Ingress/etc., or a URL manually associated with a
+// resource via the Tiltfile (TK)
+type Link struct {
+	URL string
+
+	// Optional name of the link; if given, used as text of the URL
+	// displayed in the web UI (e.g. <a href="localhost:8888">Debugger</a>)
+	Name string
+}
+
+func (pf PortForward) ToLink() string {
+	host := pf.Host
+	if host == "" {
+		host = "localhost"
+	}
+	return fmt.Sprintf("http://%s:%d/", host, pf.LocalPort)
 }
 
 var imageTargetAllowUnexported = cmp.AllowUnexported(ImageTarget{})


### PR DESCRIPTION
Hello @nicks, @hyu,

Please review the following commits I made in branch maiamcc/port-forward-name:

f24ca527b74dd40e7fe2da45f3d5c0af0f741a1d (2020-10-01 18:17:28 -0400)
send all info

1b3c5558d7779de793e28cc2ea0005a0d71ce7e8 (2020-10-01 17:54:08 -0400)
current behavior

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics