### PR TITLE
tiltfile: add more info to docker compose test output

### DIFF
--- a/internal/tiltfile/tiltfile_docker_compose_test.go
+++ b/internal/tiltfile/tiltfile_docker_compose_test.go
@@ -726,15 +726,15 @@ func (f *fixture) assertDcManifest(name model.ManifestName, opts ...interface{})
 	for _, opt := range opts {
 		switch opt := opt.(type) {
 		case dcConfigPathHelper:
-			assert.Equal(f.t, opt.paths, dcInfo.ConfigPaths)
+			assert.Equal(f.t, opt.paths, dcInfo.ConfigPaths, "docker compose config path")
 		case dcLocalPathsHelper:
-			assert.ElementsMatch(f.t, opt.paths, dcInfo.LocalPaths())
+			assert.ElementsMatch(f.t, opt.paths, dcInfo.LocalPaths(), "docker compose local paths")
 		case dcYAMLRawHelper:
-			assert.Equal(f.t, strings.TrimSpace(opt.yaml), strings.TrimSpace(string(dcInfo.YAMLRaw)))
+			assert.Equal(f.t, strings.TrimSpace(opt.yaml), strings.TrimSpace(string(dcInfo.YAMLRaw)), "docker compose YAML raw")
 		case dcDfRawHelper:
-			assert.Equal(f.t, strings.TrimSpace(opt.df), strings.TrimSpace(string(dcInfo.DfRaw)))
+			assert.Equal(f.t, strings.TrimSpace(opt.df), strings.TrimSpace(string(dcInfo.DfRaw)), "docker compose Dockerfile raw")
 		case dcPublishedPortsHelper:
-			assert.Equal(f.t, opt.ports, dcInfo.PublishedPorts())
+			assert.Equal(f.t, opt.ports, dcInfo.PublishedPorts(), "docker compose published ports")
 		default:
 			f.t.Fatalf("unexpected arg to assertDcManifest: %T %v", opt, opt)
 		}


### PR DESCRIPTION
Hello @landism,

Please review the following commits I made in branch maiamcc/dc-tests:

3d070d81c4449407a57f4ac49524e9d0337799a7 (2020-10-02 11:30:40 -0400)
tiltfile: add more info to docker compose test output

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics