### PR TITLE
tiltfile: port_forward constructor accepts 'name' param [ch9608]

### DIFF
--- a/internal/tiltfile/k8s.go
+++ b/internal/tiltfile/k8s.go
@@ -875,10 +875,8 @@ type portForward struct {
 var _ starlark.Value = portForward{}
 
 func (f portForward) String() string {
-	if f.Name != "" {
-		return fmt.Sprintf("port_forward[%s](%d, %d)", f.Name, f.LocalPort, f.ContainerPort)
-	}
-	return fmt.Sprintf("port_forward(%d, %d)", f.LocalPort, f.ContainerPort)
+	return fmt.Sprintf("port_forward(local_port=%d, container_port=%d, name=%q)",
+		f.LocalPort, f.ContainerPort, f.Name)
 }
 
 func (f portForward) Type() string {


### PR DESCRIPTION
Ha, we already had a `port_forwards` constructor method, who knew??

BTW I verified in [Grafana](https://cloud.tilt.dev/grafana/d/V29UlQIMz/tilt-global-built-ins-usage?orgId=1) that ~no one is currently using that func/it's not documented anywhere, so I feel okay about changing the signature.