### PR TITLE
local_resource/store: can attach links to a local_resource, they are returned as endpoints/sent tto frontend views [ch9660]

### DIFF
--- a/internal/hud/webview/convert_test.go
+++ b/internal/hud/webview/convert_test.go
@@ -96,6 +96,26 @@ func TestStateToWebViewPortForwards(t *testing.T) {
 	assert.Equal(t, expected, res.EndpointLinks)
 }
 
+func TestStateToWebViewLocalResourceLink(t *testing.T) {
+	m := model.Manifest{
+		Name: "foo",
+	}.WithDeployTarget(model.LocalTarget{
+		Links: []model.Link{
+			{URL: "www.zombo.com", Name: "zombo"},
+			{URL: "www.apple.edu", Name: "apple"},
+		},
+	})
+	state := newState([]model.Manifest{m})
+	v := stateToProtoView(t, *state)
+
+	expected := []*proto_webview.Link{
+		&proto_webview.Link{Url: "www.apple.edu", Name: "apple"},
+		&proto_webview.Link{Url: "www.zombo.com", Name: "zombo"},
+	}
+	res, _ := findResource(m.Name, v)
+	assert.Equal(t, expected, res.EndpointLinks)
+}
+
 func TestStateToViewUnresourcedYAMLManifest(t *testing.T) {
 	m, err := k8s.NewK8sOnlyManifestFromYAML(testyaml.SanchoYAML)
 	assert.NoError(t, err)

--- a/internal/store/engine_state.go
+++ b/internal/store/engine_state.go
@@ -628,6 +628,11 @@ func ManifestTargetEndpoints(mt *ManifestTarget) (endpoints []model.Link) {
 		return endpoints
 	}
 
+	localResourceLinks := mt.Manifest.LocalTarget().Links
+	if len(localResourceLinks) > 0 {
+		return localResourceLinks
+	}
+
 	publishedPorts := mt.Manifest.DockerComposeTarget().PublishedPorts()
 	if len(publishedPorts) > 0 {
 		for _, p := range publishedPorts {

--- a/internal/store/engine_state_test.go
+++ b/internal/store/engine_state_test.go
@@ -99,6 +99,23 @@ func TestStateToViewPortForwards(t *testing.T) {
 		res.Endpoints)
 }
 
+func TestStateToViewLocalResourceLinks(t *testing.T) {
+	m := model.Manifest{
+		Name: "foo",
+	}.WithDeployTarget(model.LocalTarget{
+		Links: []model.Link{
+			{URL: "www.zombo.com", Name: "zombo"},
+			{URL: "www.apple.edu", Name: "apple"},
+		},
+	})
+	state := newState([]model.Manifest{m})
+	v := StateToView(*state, &sync.RWMutex{})
+	res, _ := v.Resource(m.Name)
+	assert.Equal(t,
+		[]string{"www.apple.edu", "www.zombo.com"},
+		res.Endpoints)
+}
+
 func TestRuntimeStateNonWorkload(t *testing.T) {
 	f := tempdir.NewTempDirFixture(t)
 	defer f.TearDown()

--- a/pkg/model/local_target.go
+++ b/pkg/model/local_target.go
@@ -11,6 +11,7 @@ type LocalTarget struct {
 	UpdateCmd Cmd      // e.g. `make proto`
 	ServeCmd  Cmd      // e.g. `python main.py`
 	Workdir   string   // directory from which the commands should be run
+	Links     []Link   // (optional) one+ links assoc'd with this resource (to be displayed in UIs)
 	Deps      []string // a list of ABSOLUTE file paths that are dependencies of this target
 	ignores   []Dockerignore
 


### PR DESCRIPTION
Hello @nicks, @landism,

Please review the following commits I made in branch maiamcc/local-resource-links:

a44f1e247f2ab96d3c01d307d8ed6a0f599f8dff (2020-10-02 17:34:02 -0400)
convert tests

42ea3e67ceb7525cc104f9bb6bec8ce954916543 (2020-10-02 17:31:09 -0400)
store links on local resource, return as endpoints

6adda95b040223292123961d30b772f05c2dc95c (2020-10-02 17:21:28 -0400)
test framework

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics