### PR TITLE
k8s: add down policy annotation

### DIFF
--- a/internal/cli/down.go
+++ b/internal/cli/down.go
@@ -82,6 +82,14 @@ func (c *downCmd) down(ctx context.Context, downDeps DownDeps, args []string) er
 		return errors.Wrap(err, "Parsing manifest YAML")
 	}
 
+	entities, _, err = k8s.Filter(entities, func(e k8s.K8sEntity) (b bool, err error) {
+		downPolicy, exists := e.Annotations()["tilt.dev/down-policy"]
+		return !exists || downPolicy != "keep", nil
+	})
+	if err != nil {
+		return errors.Wrap(err, "Filtering entities by down policy")
+	}
+
 	if !c.deleteNamespaces {
 		var namespaces []k8s.K8sEntity
 		entities, namespaces, err = k8s.Filter(entities, func(e k8s.K8sEntity) (b bool, err error) {

--- a/internal/k8s/entity.go
+++ b/internal/k8s/entity.go
@@ -233,6 +233,10 @@ func (e K8sEntity) UID() types.UID {
 	return e.meta().GetUID()
 }
 
+func (e K8sEntity) Annotations() map[string]string {
+	return e.meta().GetAnnotations()
+}
+
 func (e K8sEntity) Labels() map[string]string {
 	return e.meta().GetLabels()
 }


### PR DESCRIPTION
Inspired by the issue linked at the bottom of this PR I added support for keeping k8s entities based on an annotation. This mirrors the behavior also found in other k8s-adjacent tools like Helm.

For example, you could define a persistent volume to be kept, so that users can `down` everything when done but keep the database contents saved. To achieve the same behavior right now you can use an if based on `tilt_subcommand`, but that doesn't play well with e.g. the `helm_remote` extension.

The annotation is called `tilt.dev/down-policy` and supports the value `keep` (everything else is ignored). YAML usage example:

```yaml
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: mysql-pvc
  annotations:
    tilt.dev/down-policy: keep
spec:
  accessModes:
    - ReadWriteOnce
  resources:
    requests:
      storage: 20Gi
```

Fixes #3755.