### PR TITLE
tilt: add .swp to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ tilt_option.json
 
 # Text editor stuff
 .idea/*
+.*.swp
 
 
 # Generated yaml (from synclet deploy)


### PR DESCRIPTION
My global .gitignore ignores .swp, but now that the release build happens in a container, my global .gitignore doesn't apply.