### PR TITLE
web/resourceInfo: trim the URL we display for endpoints (and some renaming for consistency) [ch9652]

### DIFF
--- a/web/src/ResourceInfo.test.tsx
+++ b/web/src/ResourceInfo.test.tsx
@@ -93,3 +93,28 @@ it("displays mixed named/unnamed endpoints", () => {
   expect(links.at(1).prop("href")).toEqual(namedEndpointLink.url)
   expect(links.at(1).text()).toEqual(namedEndpointLink.name)
 })
+
+it("trims URLs for unnamed endpoints", () => {
+  let ep1 = { url: "http://www.apple.com", expectedText: "apple.com" }
+  let ep2 = { url: "https://www.banana.com", expectedText: "banana.com" }
+  let ep3 = { url: "http://cherry.com", expectedText: "cherry.com" }
+  let ep4 = { url: "www.durian.com", expectedText: "durian.com" }
+  let endpoints = [ep1, ep2, ep3, ep4]
+
+  const root = mount(
+    <ResourceInfo
+      showSnapshotButton={false}
+      handleOpenModal={fakeHandleOpenModal}
+      highlight={null}
+      endpoints={endpoints}
+    />
+  )
+
+  let links = root.find("span#endpoints a")
+  expect(links).toHaveLength(4)
+
+  for (let i = 0; i < 4; i++) {
+    expect(links.at(i).prop("href")).toEqual(endpoints[i].url)
+    expect(links.at(i).text()).toEqual(endpoints[i].expectedText)
+  }
+})

--- a/web/src/ResourceInfo.test.tsx
+++ b/web/src/ResourceInfo.test.tsx
@@ -113,8 +113,8 @@ it("trims URLs for unnamed endpoints", () => {
   let links = root.find("span#endpoints a")
   expect(links).toHaveLength(4)
 
-  for (let i = 0; i < 4; i++) {
-    expect(links.at(i).prop("href")).toEqual(endpoints[i].url)
-    expect(links.at(i).text()).toEqual(endpoints[i].expectedText)
-  }
+  endpoints.forEach((ep, i) => {
+    expect(links.at(i).prop("href")).toEqual(ep.url)
+    expect(links.at(i).text()).toEqual(ep.expectedText)
+  })
 })

--- a/web/src/ResourceInfo.tsx
+++ b/web/src/ResourceInfo.tsx
@@ -36,7 +36,7 @@ let PodStatus = styled.span`
 
 let PodId = styled.span``
 
-let PortForward = styled.span`
+let Endpoints = styled.span`
   ${PodId} + & {
     margin-left: ${s.SizeUnit(0.5)};
     border-left: 1px solid ${s.Color.gray};
@@ -44,14 +44,14 @@ let PortForward = styled.span`
   }
 `
 
-let ResourceLinkLabel = styled.span`
+let EndpointsLabel = styled.span`
   color: ${s.Color.grayLight};
   margin-right: ${s.SizeUnit(0.25)};
 
   ${s.mixinHideOnSmallScreen}
 `
 
-let ResourceLink = styled.a`
+let Endpoint = styled.a`
   & + & {
     padding-left: ${s.SizeUnit(0.25)};
     border-left: 1px dotted ${s.Color.grayLight};
@@ -116,22 +116,22 @@ class ResourceInfo extends PureComponent<HUDHeaderProps> {
 
     let endpoints = this.props.endpoints ?? []
     let endpointsEl = endpoints?.length > 0 && (
-      <PortForward id="endpoints">
-        <ResourceLinkLabel>
-          Port-Forward{endpoints?.length > 1 ? "s" : ""}:
-        </ResourceLinkLabel>
+      <Endpoints id="endpoints">
+        <EndpointsLabel>
+          Endpoint{endpoints?.length > 1 ? "s" : ""}:
+        </EndpointsLabel>
 
         {endpoints?.map(ep => (
-          <ResourceLink
+          <Endpoint
             href={ep.url}
             target="_blank"
             rel="noopener noreferrer"
             key={ep.url}
           >
-            {ep.name || ep.url}
-          </ResourceLink>
+            {ep.name || displayURL(ep)}
+          </Endpoint>
         ))}
-      </PortForward>
+      </Endpoints>
     )
 
     return (
@@ -145,6 +145,13 @@ class ResourceInfo extends PureComponent<HUDHeaderProps> {
       </Root>
     )
   }
+}
+
+function displayURL(li: Link): string {
+  let url = li.url?.replace(/^(http:\/\/)/, "")
+  url = url?.replace(/^(https:\/\/)/, "")
+  url = url?.replace(/^(www\.)/, "")
+  return url || ""
 }
 
 export default ResourceInfo


### PR DESCRIPTION
Hello @nicks, @hyu,

Please review the following commits I made in branch maiamcc/endpoints-in-web:

7989df67f0659bc001518118a1008eec6fbfc8c1 (2020-10-06 17:04:31 -0400)
web/resourceInfo: trim the URL we display for endpoints (and some renaming for consistency) [ch9652]

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics