### PR TITLE
tiltfile: make a link object a struct

### DIFF
--- a/internal/tiltfile/links/links.go
+++ b/internal/tiltfile/links/links.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/pkg/errors"
 	"go.starlark.net/starlark"
+	"go.starlark.net/starlarkstruct"
 
 	"github.com/tilt-dev/tilt/pkg/model"
 
@@ -14,28 +15,11 @@ import (
 )
 
 type Link struct {
+	*starlarkstruct.Struct
 	model.Link
 }
 
 var _ starlark.Value = Link{}
-
-func (l Link) String() string {
-	return fmt.Sprintf("Link(url=%q, name=%q)", l.URL, l.Name)
-}
-
-func (l Link) Type() string {
-	return "Link"
-}
-
-func (l Link) Freeze() {}
-
-func (l Link) Truth() starlark.Bool {
-	return l.Link != model.Link{}
-}
-
-func (l Link) Hash() (uint32, error) {
-	return 0, fmt.Errorf("unhashable type: port_forward")
-}
 
 // Parse resource links (string or `link`) into model.Link
 // Not to be confused with a LinkED List :P
@@ -117,6 +101,10 @@ func (e Extension) link(thread *starlark.Thread, fn *starlark.Builtin, args star
 	}
 
 	return Link{
+		Struct: starlarkstruct.FromStringDict(starlark.String("link"), starlark.StringDict{
+			"url":  starlark.String(withScheme),
+			"name": starlark.String(name),
+		}),
 		Link: model.Link{
 			URL:  withScheme,
 			Name: name,

--- a/internal/tiltfile/links/links_test.go
+++ b/internal/tiltfile/links/links_test.go
@@ -3,7 +3,10 @@ package links
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/tilt-dev/tilt/internal/tiltfile/starkit"
 )
 
 func TestMaybeAddScheme(t *testing.T) {
@@ -41,4 +44,32 @@ func TestMaybeAddScheme(t *testing.T) {
 			require.Equal(t, c.expectURL, actual, "expected URL != actual URL")
 		})
 	}
+}
+
+func TestLinkProps(t *testing.T) {
+	f := starkit.NewFixture(t, NewExtension())
+	defer f.TearDown()
+
+	f.File("Tiltfile", `
+l = link("localhost:4000", "web")
+print(l.url)
+print(l.name)
+`)
+
+	_, err := f.ExecFile("Tiltfile")
+	require.NoError(t, err)
+	assert.Equal(t, "localhost:4000\nweb\n", f.PrintOutput())
+}
+func TestLinkPropsImmutable(t *testing.T) {
+	f := starkit.NewFixture(t, NewExtension())
+	defer f.TearDown()
+
+	f.File("Tiltfile", `
+l = link("localhost:4000", "web")
+l.url = "XXX"
+`)
+
+	_, err := f.ExecFile("Tiltfile")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "can't assign to .url field of struct")
 }


### PR DESCRIPTION
Hello @maiamcc, @landism,

Please review the following commits I made in branch nicks/struct:

eee98cf3b6efe0603035287c5fdbfb9716958cf6 (2020-10-08 16:37:01 -0400)
tiltfile: make a link object a struct

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics