### PR TITLE
k8s: set the informer resync period to something more reasonable

### DIFF
--- a/internal/k8s/watch.go
+++ b/internal/k8s/watch.go
@@ -24,6 +24,10 @@ var PodGVR = v1.SchemeGroupVersion.WithResource("pods")
 var ServiceGVR = v1.SchemeGroupVersion.WithResource("services")
 var EventGVR = v1.SchemeGroupVersion.WithResource("events")
 
+// Inspired by:
+// https://groups.google.com/g/kubernetes-sig-api-machinery/c/PbSCXdLDno0/m/v9gH3HXVDAAJ
+const resyncPeriod = 15 * time.Minute
+
 // A wrapper object around SharedInformer objects, to make them
 // a bit easier to use correctly.
 type ObjectUpdate struct {
@@ -152,7 +156,7 @@ func (kCli K8sClient) makeInformer(
 		options = append(options, informers.WithNamespace(ns.String()))
 	}
 
-	factory := informers.NewSharedInformerFactoryWithOptions(kCli.clientset, 5*time.Second, options...)
+	factory := informers.NewSharedInformerFactoryWithOptions(kCli.clientset, resyncPeriod, options...)
 	resFactory, err := factory.ForResource(gvr)
 	if err != nil {
 		return nil, errors.Wrap(err, "makeInformer")


### PR DESCRIPTION
Hello @maiamcc, @landism,

Please review the following commits I made in branch nicks/resync-period:

9fa8fdc56a492a8f2ef460a73f0a71d3acae5e34 (2020-10-12 15:43:42 -0400)
k8s: set the informer resync period to something more reasonable

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics