### PR TITLE
k8s: use the metadata client to fetch metadata, instead of full objects

### DIFF
--- a/internal/k8s/entity.go
+++ b/internal/k8s/entity.go
@@ -31,7 +31,7 @@ func NewK8sEntity(obj runtime.Object) K8sEntity {
 	return K8sEntity{Obj: obj}
 }
 
-type k8sMeta interface {
+type ObjectMeta interface {
 	GetName() string
 	GetNamespace() string
 	GetUID() types.UID
@@ -53,8 +53,8 @@ func (emptyMeta) GetOwnerReferences() []metav1.OwnerReference     { return nil }
 func (emptyMeta) SetNamespace(ns string)                          {}
 func (emptyMeta) SetManagedFields(mf []metav1.ManagedFieldsEntry) {}
 
-var _ k8sMeta = emptyMeta{}
-var _ k8sMeta = &metav1.ObjectMeta{}
+var _ ObjectMeta = emptyMeta{}
+var _ ObjectMeta = &metav1.ObjectMeta{}
 
 type entityList []K8sEntity
 
@@ -127,7 +127,7 @@ func (e K8sEntity) Clean() {
 	}
 }
 
-func (e K8sEntity) meta() k8sMeta {
+func (e K8sEntity) meta() ObjectMeta {
 	if unstruct := e.maybeUnstructuredMeta(); unstruct != nil {
 		return unstruct
 	}

--- a/internal/k8s/exploding_client.go
+++ b/internal/k8s/exploding_client.go
@@ -29,8 +29,8 @@ func (ec *explodingClient) Delete(ctx context.Context, entities []K8sEntity) err
 	return errors.Wrap(ec.err, "could not set up k8s client")
 }
 
-func (ec *explodingClient) GetByReference(ctx context.Context, ref v1.ObjectReference) (K8sEntity, error) {
-	return K8sEntity{}, errors.Wrap(ec.err, "could not set up k8s client")
+func (ec *explodingClient) GetMetaByReference(ctx context.Context, ref v1.ObjectReference) (ObjectMeta, error) {
+	return nil, errors.Wrap(ec.err, "could not set up k8s client")
 }
 
 func (ec *explodingClient) PodsWithImage(ctx context.Context, image reference.NamedTagged, n Namespace, lp []model.LabelPair) ([]v1.Pod, error) {

--- a/internal/k8s/fake_client.go
+++ b/internal/k8s/fake_client.go
@@ -313,14 +313,14 @@ func (c *FakeK8sClient) InjectEntityByName(entities ...K8sEntity) {
 	}
 }
 
-func (c *FakeK8sClient) GetByReference(ctx context.Context, ref v1.ObjectReference) (K8sEntity, error) {
+func (c *FakeK8sClient) GetMetaByReference(ctx context.Context, ref v1.ObjectReference) (ObjectMeta, error) {
 	c.getByReferenceCallCount++
 	resp, ok := c.entityByName[ref.Name]
 	if !ok {
-		logger.Get(ctx).Infof("FakeK8sClient.GetByReference: resource not found: %s", ref.Name)
-		return K8sEntity{}, apierrors.NewNotFound(v1.Resource(ref.Kind), ref.Name)
+		logger.Get(ctx).Infof("FakeK8sClient.GetMetaByReference: resource not found: %s", ref.Name)
+		return nil, apierrors.NewNotFound(v1.Resource(ref.Kind), ref.Name)
 	}
-	return resp, nil
+	return resp.meta(), nil
 }
 
 func (c *FakeK8sClient) WatchPod(ctx context.Context, pod *v1.Pod) (watch.Interface, error) {

--- a/vendor/k8s.io/apimachinery/pkg/apis/meta/internalversion/scheme/doc.go
+++ b/vendor/k8s.io/apimachinery/pkg/apis/meta/internalversion/scheme/doc.go
@@ -1,0 +1,17 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheme // import "k8s.io/apimachinery/pkg/apis/meta/internalversion/scheme"

--- a/vendor/k8s.io/apimachinery/pkg/apis/meta/internalversion/scheme/register.go
+++ b/vendor/k8s.io/apimachinery/pkg/apis/meta/internalversion/scheme/register.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheme
+
+import (
+	"k8s.io/apimachinery/pkg/apis/meta/internalversion"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+)
+
+// Scheme is the registry for any type that adheres to the meta API spec.
+var scheme = runtime.NewScheme()
+
+// Codecs provides access to encoding and decoding for the scheme.
+var Codecs = serializer.NewCodecFactory(scheme)
+
+// ParameterCodec handles versioning of objects that are converted to query parameters.
+var ParameterCodec = runtime.NewParameterCodec(scheme)
+
+// Unlike other API groups, meta internal knows about all meta external versions, but keeps
+// the logic for conversion private.
+func init() {
+	utilruntime.Must(internalversion.AddToScheme(scheme))
+}

--- a/vendor/k8s.io/client-go/metadata/interface.go
+++ b/vendor/k8s.io/client-go/metadata/interface.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metadata
+
+import (
+	"context"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+)
+
+// Interface allows a caller to get the metadata (in the form of PartialObjectMetadata objects)
+// from any Kubernetes compatible resource API.
+type Interface interface {
+	Resource(resource schema.GroupVersionResource) Getter
+}
+
+// ResourceInterface contains the set of methods that may be invoked on objects by their metadata.
+// Update is not supported by the server, but Patch can be used for the actions Update would handle.
+type ResourceInterface interface {
+	Delete(ctx context.Context, name string, options metav1.DeleteOptions, subresources ...string) error
+	DeleteCollection(ctx context.Context, options metav1.DeleteOptions, listOptions metav1.ListOptions) error
+	Get(ctx context.Context, name string, options metav1.GetOptions, subresources ...string) (*metav1.PartialObjectMetadata, error)
+	List(ctx context.Context, opts metav1.ListOptions) (*metav1.PartialObjectMetadataList, error)
+	Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error)
+	Patch(ctx context.Context, name string, pt types.PatchType, data []byte, options metav1.PatchOptions, subresources ...string) (*metav1.PartialObjectMetadata, error)
+}
+
+// Getter handles both namespaced and non-namespaced resource types consistently.
+type Getter interface {
+	Namespace(string) ResourceInterface
+	ResourceInterface
+}

--- a/vendor/k8s.io/client-go/metadata/metadata.go
+++ b/vendor/k8s.io/client-go/metadata/metadata.go
@@ -1,0 +1,307 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metadata
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"k8s.io/klog/v2"
+
+	metainternalversionscheme "k8s.io/apimachinery/pkg/apis/meta/internalversion/scheme"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/rest"
+)
+
+var deleteScheme = runtime.NewScheme()
+var parameterScheme = runtime.NewScheme()
+var deleteOptionsCodec = serializer.NewCodecFactory(deleteScheme)
+var dynamicParameterCodec = runtime.NewParameterCodec(parameterScheme)
+
+var versionV1 = schema.GroupVersion{Version: "v1"}
+
+func init() {
+	metav1.AddToGroupVersion(parameterScheme, versionV1)
+	metav1.AddToGroupVersion(deleteScheme, versionV1)
+}
+
+// Client allows callers to retrieve the object metadata for any
+// Kubernetes-compatible API endpoint. The client uses the
+// meta.k8s.io/v1 PartialObjectMetadata resource to more efficiently
+// retrieve just the necessary metadata, but on older servers
+// (Kubernetes 1.14 and before) will retrieve the object and then
+// convert the metadata.
+type Client struct {
+	client *rest.RESTClient
+}
+
+var _ Interface = &Client{}
+
+// ConfigFor returns a copy of the provided config with the
+// appropriate metadata client defaults set.
+func ConfigFor(inConfig *rest.Config) *rest.Config {
+	config := rest.CopyConfig(inConfig)
+	config.AcceptContentTypes = "application/vnd.kubernetes.protobuf,application/json"
+	config.ContentType = "application/vnd.kubernetes.protobuf"
+	config.NegotiatedSerializer = metainternalversionscheme.Codecs.WithoutConversion()
+	if config.UserAgent == "" {
+		config.UserAgent = rest.DefaultKubernetesUserAgent()
+	}
+	return config
+}
+
+// NewForConfigOrDie creates a new metadata client for the given config and
+// panics if there is an error in the config.
+func NewForConfigOrDie(c *rest.Config) Interface {
+	ret, err := NewForConfig(c)
+	if err != nil {
+		panic(err)
+	}
+	return ret
+}
+
+// NewForConfig creates a new metadata client that can retrieve object
+// metadata details about any Kubernetes object (core, aggregated, or custom
+// resource based) in the form of PartialObjectMetadata objects, or returns
+// an error.
+func NewForConfig(inConfig *rest.Config) (Interface, error) {
+	config := ConfigFor(inConfig)
+	// for serializing the options
+	config.GroupVersion = &schema.GroupVersion{}
+	config.APIPath = "/this-value-should-never-be-sent"
+
+	restClient, err := rest.RESTClientFor(config)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Client{client: restClient}, nil
+}
+
+type client struct {
+	client    *Client
+	namespace string
+	resource  schema.GroupVersionResource
+}
+
+// Resource returns an interface that can access cluster or namespace
+// scoped instances of resource.
+func (c *Client) Resource(resource schema.GroupVersionResource) Getter {
+	return &client{client: c, resource: resource}
+}
+
+// Namespace returns an interface that can access namespace-scoped instances of the
+// provided resource.
+func (c *client) Namespace(ns string) ResourceInterface {
+	ret := *c
+	ret.namespace = ns
+	return &ret
+}
+
+// Delete removes the provided resource from the server.
+func (c *client) Delete(ctx context.Context, name string, opts metav1.DeleteOptions, subresources ...string) error {
+	if len(name) == 0 {
+		return fmt.Errorf("name is required")
+	}
+	deleteOptionsByte, err := runtime.Encode(deleteOptionsCodec.LegacyCodec(schema.GroupVersion{Version: "v1"}), &opts)
+	if err != nil {
+		return err
+	}
+
+	result := c.client.client.
+		Delete().
+		AbsPath(append(c.makeURLSegments(name), subresources...)...).
+		Body(deleteOptionsByte).
+		Do(ctx)
+	return result.Error()
+}
+
+// DeleteCollection triggers deletion of all resources in the specified scope (namespace or cluster).
+func (c *client) DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOptions metav1.ListOptions) error {
+	deleteOptionsByte, err := runtime.Encode(deleteOptionsCodec.LegacyCodec(schema.GroupVersion{Version: "v1"}), &opts)
+	if err != nil {
+		return err
+	}
+
+	result := c.client.client.
+		Delete().
+		AbsPath(c.makeURLSegments("")...).
+		Body(deleteOptionsByte).
+		SpecificallyVersionedParams(&listOptions, dynamicParameterCodec, versionV1).
+		Do(ctx)
+	return result.Error()
+}
+
+// Get returns the resource with name from the specified scope (namespace or cluster).
+func (c *client) Get(ctx context.Context, name string, opts metav1.GetOptions, subresources ...string) (*metav1.PartialObjectMetadata, error) {
+	if len(name) == 0 {
+		return nil, fmt.Errorf("name is required")
+	}
+	result := c.client.client.Get().AbsPath(append(c.makeURLSegments(name), subresources...)...).
+		SetHeader("Accept", "application/vnd.kubernetes.protobuf;as=PartialObjectMetadata;g=meta.k8s.io;v=v1,application/json;as=PartialObjectMetadata;g=meta.k8s.io;v=v1,application/json").
+		SpecificallyVersionedParams(&opts, dynamicParameterCodec, versionV1).
+		Do(ctx)
+	if err := result.Error(); err != nil {
+		return nil, err
+	}
+	obj, err := result.Get()
+	if runtime.IsNotRegisteredError(err) {
+		klog.V(5).Infof("Unable to retrieve PartialObjectMetadata: %#v", err)
+		rawBytes, err := result.Raw()
+		if err != nil {
+			return nil, err
+		}
+		var partial metav1.PartialObjectMetadata
+		if err := json.Unmarshal(rawBytes, &partial); err != nil {
+			return nil, fmt.Errorf("unable to decode returned object as PartialObjectMetadata: %v", err)
+		}
+		if !isLikelyObjectMetadata(&partial) {
+			return nil, fmt.Errorf("object does not appear to match the ObjectMeta schema: %#v", partial)
+		}
+		partial.TypeMeta = metav1.TypeMeta{}
+		return &partial, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	partial, ok := obj.(*metav1.PartialObjectMetadata)
+	if !ok {
+		return nil, fmt.Errorf("unexpected object, expected PartialObjectMetadata but got %T", obj)
+	}
+	return partial, nil
+}
+
+// List returns all resources within the specified scope (namespace or cluster).
+func (c *client) List(ctx context.Context, opts metav1.ListOptions) (*metav1.PartialObjectMetadataList, error) {
+	result := c.client.client.Get().AbsPath(c.makeURLSegments("")...).
+		SetHeader("Accept", "application/vnd.kubernetes.protobuf;as=PartialObjectMetadataList;g=meta.k8s.io;v=v1,application/json;as=PartialObjectMetadataList;g=meta.k8s.io;v=v1,application/json").
+		SpecificallyVersionedParams(&opts, dynamicParameterCodec, versionV1).
+		Do(ctx)
+	if err := result.Error(); err != nil {
+		return nil, err
+	}
+	obj, err := result.Get()
+	if runtime.IsNotRegisteredError(err) {
+		klog.V(5).Infof("Unable to retrieve PartialObjectMetadataList: %#v", err)
+		rawBytes, err := result.Raw()
+		if err != nil {
+			return nil, err
+		}
+		var partial metav1.PartialObjectMetadataList
+		if err := json.Unmarshal(rawBytes, &partial); err != nil {
+			return nil, fmt.Errorf("unable to decode returned object as PartialObjectMetadataList: %v", err)
+		}
+		partial.TypeMeta = metav1.TypeMeta{}
+		return &partial, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	partial, ok := obj.(*metav1.PartialObjectMetadataList)
+	if !ok {
+		return nil, fmt.Errorf("unexpected object, expected PartialObjectMetadata but got %T", obj)
+	}
+	return partial, nil
+}
+
+// Watch finds all changes to the resources in the specified scope (namespace or cluster).
+func (c *client) Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
+	var timeout time.Duration
+	if opts.TimeoutSeconds != nil {
+		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
+	}
+	opts.Watch = true
+	return c.client.client.Get().
+		AbsPath(c.makeURLSegments("")...).
+		SetHeader("Accept", "application/vnd.kubernetes.protobuf;as=PartialObjectMetadata;g=meta.k8s.io;v=v1,application/json;as=PartialObjectMetadata;g=meta.k8s.io;v=v1,application/json").
+		SpecificallyVersionedParams(&opts, dynamicParameterCodec, versionV1).
+		Timeout(timeout).
+		Watch(ctx)
+}
+
+// Patch modifies the named resource in the specified scope (namespace or cluster).
+func (c *client) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (*metav1.PartialObjectMetadata, error) {
+	if len(name) == 0 {
+		return nil, fmt.Errorf("name is required")
+	}
+	result := c.client.client.
+		Patch(pt).
+		AbsPath(append(c.makeURLSegments(name), subresources...)...).
+		Body(data).
+		SetHeader("Accept", "application/vnd.kubernetes.protobuf;as=PartialObjectMetadata;g=meta.k8s.io;v=v1,application/json;as=PartialObjectMetadata;g=meta.k8s.io;v=v1,application/json").
+		SpecificallyVersionedParams(&opts, dynamicParameterCodec, versionV1).
+		Do(ctx)
+	if err := result.Error(); err != nil {
+		return nil, err
+	}
+	obj, err := result.Get()
+	if runtime.IsNotRegisteredError(err) {
+		rawBytes, err := result.Raw()
+		if err != nil {
+			return nil, err
+		}
+		var partial metav1.PartialObjectMetadata
+		if err := json.Unmarshal(rawBytes, &partial); err != nil {
+			return nil, fmt.Errorf("unable to decode returned object as PartialObjectMetadata: %v", err)
+		}
+		if !isLikelyObjectMetadata(&partial) {
+			return nil, fmt.Errorf("object does not appear to match the ObjectMeta schema")
+		}
+		partial.TypeMeta = metav1.TypeMeta{}
+		return &partial, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	partial, ok := obj.(*metav1.PartialObjectMetadata)
+	if !ok {
+		return nil, fmt.Errorf("unexpected object, expected PartialObjectMetadata but got %T", obj)
+	}
+	return partial, nil
+}
+
+func (c *client) makeURLSegments(name string) []string {
+	url := []string{}
+	if len(c.resource.Group) == 0 {
+		url = append(url, "api")
+	} else {
+		url = append(url, "apis", c.resource.Group)
+	}
+	url = append(url, c.resource.Version)
+
+	if len(c.namespace) > 0 {
+		url = append(url, "namespaces", c.namespace)
+	}
+	url = append(url, c.resource.Resource)
+
+	if len(name) > 0 {
+		url = append(url, name)
+	}
+
+	return url
+}
+
+func isLikelyObjectMetadata(meta *metav1.PartialObjectMetadata) bool {
+	return len(meta.UID) > 0 || !meta.CreationTimestamp.IsZero() || len(meta.Name) > 0 || len(meta.GenerateName) > 0
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -767,6 +767,7 @@ k8s.io/apimachinery/pkg/api/meta
 k8s.io/apimachinery/pkg/api/resource
 k8s.io/apimachinery/pkg/api/validation
 k8s.io/apimachinery/pkg/apis/meta/internalversion
+k8s.io/apimachinery/pkg/apis/meta/internalversion/scheme
 k8s.io/apimachinery/pkg/apis/meta/v1
 k8s.io/apimachinery/pkg/apis/meta/v1/unstructured
 k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructuredscheme
@@ -1015,6 +1016,7 @@ k8s.io/client-go/listers/settings/v1alpha1
 k8s.io/client-go/listers/storage/v1
 k8s.io/client-go/listers/storage/v1alpha1
 k8s.io/client-go/listers/storage/v1beta1
+k8s.io/client-go/metadata
 k8s.io/client-go/pkg/apis/clientauthentication
 k8s.io/client-go/pkg/apis/clientauthentication/v1alpha1
 k8s.io/client-go/pkg/apis/clientauthentication/v1beta1
@@ -1064,8 +1066,6 @@ k8s.io/client-go/util/workqueue
 ## explicit
 k8s.io/component-base/cli/flag
 k8s.io/component-base/version
-# k8s.io/klog v1.0.0
-## explicit
 # k8s.io/klog/v2 v2.2.0
 ## explicit
 k8s.io/klog/v2


### PR DESCRIPTION
Hello @landism, @maiamcc,

Please review the following commits I made in branch nicks/metadata:

f773fe2f12ad9ccbcb8eddf3ba9c1dbf3e3dbb50 (2020-10-12 16:47:16 -0400)
k8s: use the metadata client to fetch metadata, instead of full objects
I was pulling in the metadata client to help with https://github.com/tilt-dev/tilt/issues/3845,
and this seemed like a good optimization to do while I was here

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics