### PR TITLE
circleci: only broadcast storybook deploys on failure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,8 +148,8 @@ jobs:
           name: Setup Docker Credentials
           command: gcloud auth configure-docker
       - run: ./configs/storybook/deploy.sh
-      - slack/status:
-        mentions: "U4H55SA2H" # nicks
+      - slack/notify-on-failure:
+          only_for_branches: master
 
 workflows:
   version: 2


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/circleci:

094e9189256cd5fbc2438f262edaa35928b8885a (2020-10-12 16:54:00 -0400)
circleci: only broadcast storybook deploys on failure

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics