### PR TITLE
cli: Remove [redacted] in tilt doctor

### DIFF
--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -8,8 +8,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	wmanalytics "github.com/tilt-dev/wmclient/pkg/analytics"
-
 	"github.com/tilt-dev/tilt/internal/analytics"
 	"github.com/tilt-dev/tilt/pkg/logger"
 	"github.com/tilt-dev/tilt/pkg/model"

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -142,15 +142,8 @@ func (c *doctorCmd) run(ctx context.Context, args []string) error {
 	opt := a.UserOpt()
 	fmt.Printf("- User Mode: %s\n", opt)
 
-	machineHash := "[redacted]"
-	gitRepoHash := "[redacted]"
-	if opt == wmanalytics.OptIn {
-		machineHash = a.MachineHash()
-		gitRepoHash = a.GitRepoHash()
-	}
-
-	fmt.Printf("- Machine: %s\n", machineHash)
-	fmt.Printf("- Repo: %s\n", gitRepoHash)
+	fmt.Printf("- Machine: %s\n", a.MachineHash())
+	fmt.Printf("- Repo: %s\n", a.GitRepoHash())
 
 	return nil
 }


### PR DESCRIPTION
Verified that whether I've opted in or out (i.e. with `tilt analytics opt in` or `tilt analytics opt out`),`tilt doctor` now shows both fields not redacted.