### PR TITLE
use an empty directory for the go cache. this should make things much faster

### DIFF
--- a/scripts/build-tilt-releaser.sh
+++ b/scripts/build-tilt-releaser.sh
@@ -8,19 +8,5 @@ set -ex
 DIR=$(dirname "$0")
 cd "$DIR/.."
 
-docker build -t tilt-releaser-base -f scripts/release.Dockerfile scripts
-docker container rm tilt-releaser-go-cache || true
-
-# We deliberately don't give this container any API keys so it can't
-# accidentally publish.
-docker run --name tilt-releaser-go-cache --privileged \
-       -w /src/tilt \
-       -v "$PWD:/src/tilt:delegated" \
-       -v /var/run/docker.sock:/var/run/docker.sock \
-       tilt-releaser-base \
-       --rm-dist --skip-validate --snapshot --skip-publish
-
-# Commit all the Go cache artifacts we generated
-docker commit tilt-releaser-go-cache gcr.io/windmill-public-containers/tilt-releaser
+docker build -t gcr.io/windmill-public-containers/tilt-releaser -f scripts/release.Dockerfile scripts
 docker push gcr.io/windmill-public-containers/tilt-releaser
-docker container rm tilt-releaser-go-cache

--- a/scripts/goreleaser.sh
+++ b/scripts/goreleaser.sh
@@ -15,10 +15,13 @@ cd "$DIR/.."
 
 docker login
 docker pull gcr.io/windmill-public-containers/tilt-releaser
+mkdir -p ~/.cache/tilt/release/go-build
+
 docker run --rm --privileged \
        -e GITHUB_TOKEN="$GITHUB_TOKEN" \
        -w /src/tilt \
        -v ~/.docker:/root/.docker \
+       -v ~/.cache/tilt/release/go-build:/root/.cache/go-build \
        -v "$PWD:/src/tilt:delegated" \
        -v /var/run/docker.sock:/var/run/docker.sock \
        gcr.io/windmill-public-containers/tilt-releaser \


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/cache:

87805fbe93f6a86d4f16d89b9eae6a949a407196 (2020-10-13 09:44:49 -0400)
use an empty directory for the go cache. this should make things much faster

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics