### PR TITLE
tiltfile/model: can attach arbitrary links to k8s resource [ch8238]

### DIFF
--- a/internal/k8s/target.go
+++ b/internal/k8s/target.go
@@ -17,7 +17,7 @@ func MustTarget(name model.TargetName, yaml string) model.K8sTarget {
 	if err != nil {
 		panic(fmt.Errorf("MustTarget: %v", err))
 	}
-	target, err := NewTarget(name, entities, nil, nil, nil, nil, model.PodReadinessIgnore, nil)
+	target, err := NewTarget(name, entities, nil, nil, nil, nil, model.PodReadinessIgnore, nil, nil)
 	if err != nil {
 		panic(fmt.Errorf("MustTarget: %v", err))
 	}
@@ -32,7 +32,8 @@ func NewTarget(
 	dependencyIDs []model.TargetID,
 	refInjectCounts map[string]int,
 	podReadinessMode model.PodReadinessMode,
-	allLocators []ImageLocator) (model.K8sTarget, error) {
+	allLocators []ImageLocator,
+	links []model.Link) (model.K8sTarget, error) {
 	sorted := SortedEntities(entities)
 	yaml, err := SerializeSpecYAML(sorted)
 	if err != nil {
@@ -63,11 +64,12 @@ func NewTarget(
 		ObjectRefs:        objectRefs,
 		PodReadinessMode:  podReadinessMode,
 		ImageLocators:     myLocators,
+		Links:             links,
 	}.WithDependencyIDs(dependencyIDs).WithRefInjectCounts(refInjectCounts), nil
 }
 
 func NewK8sOnlyManifest(name model.ManifestName, entities []K8sEntity, allLocators []ImageLocator) (model.Manifest, error) {
-	kTarget, err := NewTarget(name.TargetName(), entities, nil, nil, nil, nil, model.PodReadinessIgnore, allLocators)
+	kTarget, err := NewTarget(name.TargetName(), entities, nil, nil, nil, nil, model.PodReadinessIgnore, allLocators, nil)
 	if err != nil {
 		return model.Manifest{}, err
 	}

--- a/internal/k8s/target_test.go
+++ b/internal/k8s/target_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestNewTargetSortsK8sEntities(t *testing.T) {
 	entities := MustParseYAMLFromString(t, testyaml.OutOfOrderYaml)
-	targ, err := NewTarget("foo", entities, nil, nil, nil, nil, model.PodReadinessWait, nil)
+	targ, err := NewTarget("foo", entities, nil, nil, nil, nil, model.PodReadinessWait, nil, nil)
 	require.NoError(t, err)
 
 	expectedKindOrder := []string{"PersistentVolume", "PersistentVolumeClaim", "ConfigMap", "Service", "StatefulSet", "Job", "Pod"}

--- a/internal/tiltfile/k8s.go
+++ b/internal/tiltfile/k8s.go
@@ -14,6 +14,8 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 
+	"github.com/tilt-dev/tilt/internal/tiltfile/links"
+
 	"github.com/tilt-dev/tilt/internal/container"
 	"github.com/tilt-dev/tilt/internal/k8s"
 	"github.com/tilt-dev/tilt/internal/tiltfile/io"
@@ -58,6 +60,8 @@ type k8sResource struct {
 	resourceDeps []string
 
 	manuallyGrouped bool
+
+	links []model.Link
 }
 
 const deprecatedResourceAssemblyV1Warning = "This Tiltfile is using k8s resource assembly version 1, which has been " +
@@ -78,6 +82,7 @@ type k8sResourceOptions struct {
 	objects           []string
 	manuallyGrouped   bool
 	podReadinessMode  model.PodReadinessMode
+	links             []model.Link
 }
 
 func (r *k8sResource) addRefSelector(selector container.RefSelector) {
@@ -408,6 +413,7 @@ func (s *tiltfileState) k8sResourceV2(thread *starlark.Thread, fn *starlark.Buil
 	var resourceDepsVal starlark.Sequence
 	var objectsVal starlark.Sequence
 	var podReadinessMode tiltfile_k8s.PodReadinessMode
+	var links links.LinkList
 	autoInit := true
 
 	if err := s.unpackArgs(fn.Name(), args, kwargs,
@@ -420,6 +426,7 @@ func (s *tiltfileState) k8sResourceV2(thread *starlark.Thread, fn *starlark.Buil
 		"objects?", &objectsVal,
 		"auto_init?", &autoInit,
 		"pod_readiness?", &podReadinessMode,
+		"links?", &links,
 	); err != nil {
 		return nil, err
 	}
@@ -477,6 +484,7 @@ func (s *tiltfileState) k8sResourceV2(thread *starlark.Thread, fn *starlark.Buil
 		objects:           objects,
 		manuallyGrouped:   manuallyGrouped,
 		podReadinessMode:  podReadinessMode.Value,
+		links:             links.Links,
 	}
 
 	return starlark.None, nil

--- a/internal/tiltfile/tiltfile_state.go
+++ b/internal/tiltfile/tiltfile_state.go
@@ -719,6 +719,7 @@ func (s *tiltfileState) assembleK8sV2() error {
 			r.triggerMode = opts.triggerMode
 			r.autoInit = opts.autoInit
 			r.resourceDeps = opts.resourceDeps
+			r.links = opts.links
 			if opts.newName != "" && opts.newName != r.name {
 				if _, ok := s.k8sByName[opts.newName]; ok {
 					return fmt.Errorf("k8s_resource at %s specified to rename %q to %q, but there already exists a resource with that name", opts.tiltfilePosition.String(), r.name, opts.newName)
@@ -1168,8 +1169,10 @@ func (s *tiltfileState) translateK8s(resources []*k8sResource) ([]model.Manifest
 			ResourceDependencies: mds,
 		}
 
-		k8sTarget, err := k8s.NewTarget(mn.TargetName(), r.entities, s.defaultedPortForwards(r.portForwards),
-			r.extraPodSelectors, r.dependencyIDs, r.imageRefMap, s.inferPodReadinessMode(r), locators)
+		k8sTarget, err := k8s.NewTarget(mn.TargetName(), r.entities,
+			s.defaultedPortForwards(r.portForwards), r.extraPodSelectors,
+			r.dependencyIDs, r.imageRefMap, s.inferPodReadinessMode(r),
+			locators, r.links)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/model/k8s_target.go
+++ b/pkg/model/k8s_target.go
@@ -62,7 +62,7 @@ type K8sTarget struct {
 	// given image in a k8s entity.
 	refInjectCounts map[string]int
 
-	// (optional) one+ links assoc'd with this resource (to be displayed in UIs,
+	// zero+ links assoc'd with this resource (to be displayed in UIs,
 	// in addition to any port forwards/LB endpoints)
 	Links []Link
 }

--- a/pkg/model/k8s_target.go
+++ b/pkg/model/k8s_target.go
@@ -61,6 +61,10 @@ type K8sTarget struct {
 	// (right now, Tiltfile and Engine have two different ways of finding a
 	// given image in a k8s entity.
 	refInjectCounts map[string]int
+
+	// (optional) one+ links assoc'd with this resource (to be displayed in UIs,
+	// in addition to any port forwards/LB endpoints)
+	Links []Link
 }
 
 func (k8s K8sTarget) Empty() bool { return reflect.DeepEqual(k8s, K8sTarget{}) }


### PR DESCRIPTION
This was originally out of scope for the Endpoints epic, but turns out
one of our customers wants this specifically and it was fast, so!