### PR TITLE
Do not mutate objects from informer cache

### DIFF
--- a/internal/k8s/container.go
+++ b/internal/k8s/container.go
@@ -134,6 +134,15 @@ func FixContainerStatusImages(pod *v1.Pod) {
 	}
 }
 
+// FixContainerStatusImagesNoMutation is the same as FixContainerStatusImages but it does not mutate the input.
+// It instead makes a deep copy and returns that with the updated status.
+// It should be used over FixContainerStatusImages when the source of the pod is shared such as an informer.
+func FixContainerStatusImagesNoMutation(pod *v1.Pod) *v1.Pod {
+	pod = pod.DeepCopy()
+	FixContainerStatusImages(pod)
+	return pod
+}
+
 func ContainerMatching(pod *v1.Pod, ref container.RefSelector) (v1.ContainerStatus, error) {
 	for _, c := range pod.Status.ContainerStatuses {
 		cRef, err := container.ParseNamed(c.Image)

--- a/internal/k8s/container_test.go
+++ b/internal/k8s/container_test.go
@@ -33,6 +33,41 @@ func TestFixContainerStatusImages(t *testing.T) {
 		pod.Status.ContainerStatuses[0].Image)
 }
 
+func TestFixContainerStatusImagesNoMutation(t *testing.T) {
+	origPod := fakePod(expectedPod, blorgDevImgStr)
+	origPod.Status = v1.PodStatus{
+		ContainerStatuses: []v1.ContainerStatus{
+			{
+				Name:  "default",
+				Image: blorgDevImgStr + "v2",
+				Ready: true,
+			},
+		},
+	}
+
+	assert.NotEqual(t,
+		origPod.Spec.Containers[0].Image,
+		origPod.Status.ContainerStatuses[0].Image)
+
+	podCopy := origPod.DeepCopy()
+	newPod := FixContainerStatusImagesNoMutation(origPod)
+
+	assert.Equal(t, podCopy, origPod)
+	assert.NotEqual(t, newPod, origPod)
+
+	assert.NotEqual(t,
+		origPod.Spec.Containers[0].Image,
+		origPod.Status.ContainerStatuses[0].Image)
+
+	assert.Equal(t,
+		origPod.Spec.Containers[0].Image,
+		newPod.Status.ContainerStatuses[0].Image)
+
+	assert.Equal(t,
+		newPod.Spec.Containers[0].Image,
+		newPod.Status.ContainerStatuses[0].Image)
+}
+
 func TestWaitForContainerAlreadyAlive(t *testing.T) {
 	f := newClientTestFixture(t)
 

--- a/internal/k8s/watch.go
+++ b/internal/k8s/watch.go
@@ -214,14 +214,14 @@ func (kCli K8sClient) WatchPods(ctx context.Context, ns Namespace, ls labels.Sel
 		AddFunc: func(obj interface{}) {
 			mObj, ok := obj.(*v1.Pod)
 			if ok {
-				FixContainerStatusImages(mObj)
+				obj = FixContainerStatusImagesNoMutation(mObj)
 			}
 			ch <- ObjectUpdate{obj: obj}
 		},
 		DeleteFunc: func(obj interface{}) {
 			mObj, ok := obj.(*v1.Pod)
 			if ok {
-				FixContainerStatusImages(mObj)
+				obj = FixContainerStatusImagesNoMutation(mObj)
 			}
 			ch <- ObjectUpdate{obj: obj, isDelete: true}
 		},
@@ -236,7 +236,7 @@ func (kCli K8sClient) WatchPods(ctx context.Context, ns Namespace, ls labels.Sel
 				return
 			}
 
-			FixContainerStatusImages(newPod)
+			newPod = FixContainerStatusImagesNoMutation(newPod)
 			ch <- ObjectUpdate{obj: newPod}
 		},
 	})


### PR DESCRIPTION
This change updates the `WatchPods` code to not mutate objects from an informer cache.  These objects are meant to be shared across go routines and are read-only.

Before this change, running tilt as follows would crash:

```shell
export KUBE_CACHE_MUTATION_DETECTOR=true
tilt up
```
```
Tilt started on http://localhost:10350/
v0.17.8, built 2020-10-13

(space) to open the browser
(s) to stream logs (--stream=true)
(t) to open legacy terminal mode (--legacy=true)
(ctrl-c) to exit

CACHE *v1.Pod[3] ALTERED!
(*v1.Pod)(0xc0005d8bb8)({                                  (*v1.Pod)(0xc0004f5000)({
...
    Image: (string) (len=22) "kindest/kindnetd:0.5.4",         Image: (string) (len=32) "docker.io/kindest/kindnetd:0.5.4",
...
})                                                         })

panic: cache *v1.Pod modified

goroutine 1123 [running]: ...
```

Signed-off-by: Monis Khan <mok@vmware.com>

---

A follow-up change should look into turning on the cache mutation detector via `export KUBE_CACHE_MUTATION_DETECTOR=true` by default in all testing environments.  Note that it should not be turned on in production environments as it leaks memory.