### PR TITLE
k8s: add missing polyfill over metadata watch on k8s 1.14-. Fixes https://github.com/tilt-dev/tilt/issues/3870

### DIFF
--- a/internal/k8s/exploding_client.go
+++ b/internal/k8s/exploding_client.go
@@ -8,7 +8,6 @@ import (
 	"github.com/docker/distribution/reference"
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/watch"
@@ -75,7 +74,7 @@ func (ec *explodingClient) WatchEvents(ctx context.Context, ns Namespace) (<-cha
 	return nil, errors.Wrap(ec.err, "could not set up k8s client")
 }
 
-func (ec *explodingClient) WatchMeta(ctx context.Context, gvk schema.GroupVersionKind, ns Namespace) (<-chan *metav1.ObjectMeta, error) {
+func (ec *explodingClient) WatchMeta(ctx context.Context, gvk schema.GroupVersionKind, ns Namespace) (<-chan ObjectMeta, error) {
 	return nil, errors.Wrap(ec.err, "could not set up k8s client")
 }
 

--- a/internal/k8s/fake_client.go
+++ b/internal/k8s/fake_client.go
@@ -13,7 +13,6 @@ import (
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/watch"
@@ -165,8 +164,8 @@ func (c *FakeK8sClient) WatchEvents(ctx context.Context, ns Namespace) (<-chan *
 	return ch, nil
 }
 
-func (c *FakeK8sClient) WatchMeta(ctx context.Context, gvk schema.GroupVersionKind, ns Namespace) (<-chan *metav1.ObjectMeta, error) {
-	return make(chan *metav1.ObjectMeta), nil
+func (c *FakeK8sClient) WatchMeta(ctx context.Context, gvk schema.GroupVersionKind, ns Namespace) (<-chan ObjectMeta, error) {
+	return make(chan ObjectMeta), nil
 }
 
 func (c *FakeK8sClient) EmitEvent(ctx context.Context, evt *v1.Event) {

--- a/internal/k8s/owner_fetcher.go
+++ b/internal/k8s/owner_fetcher.go
@@ -111,6 +111,12 @@ func (v OwnerFetcher) ensureResourceFetched(gvk schema.GroupVersionKind, ns Name
 
 		go func() {
 			for meta := range ch {
+				// NOTE(nick): I don't think we can ever get a blank UID, but want to protect
+				// us from weird k8s bugs.
+				if meta.GetUID() == "" {
+					continue
+				}
+
 				v.mu.Lock()
 				v.metaCache[meta.GetUID()] = meta
 				v.mu.Unlock()


### PR DESCRIPTION
Hello @landism,

Please review the following commits I made in branch nicks/ch9946:

555d24e4bc4164c95e49348bbf733768e09dd083 (2020-10-23 13:51:38 -0400)
k8s: add missing polyfill over metadata watch on k8s 1.14-. Fixes https://github.com/tilt-dev/tilt/issues/3870

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics