### PR TITLE
model: docker_build.cache_from changes don't invalidate manifest

### DIFF
--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -553,6 +553,7 @@ var registryAllowUnexported = cmp.AllowUnexported(container.Registry{})
 var portForwardPathAllowUnexported = cmp.AllowUnexported(PortForward{})
 var ignoreCustomBuildDepsField = cmpopts.IgnoreFields(CustomBuild{}, "Deps")
 var ignoreLocalTargetDepsField = cmpopts.IgnoreFields(LocalTarget{}, "Deps")
+var ignoreDockerBuildCacheFrom = cmpopts.IgnoreFields(DockerBuild{}, "CacheFrom")
 
 var dockerRefEqual = cmp.Comparer(func(a, b reference.Named) bool {
 	aNil := a == nil
@@ -591,5 +592,9 @@ func equalForBuildInvalidation(x, y interface{}) bool {
 		// deps changes don't invalidate a build, so don't compare fields used only for deps
 		ignoreCustomBuildDepsField,
 		ignoreLocalTargetDepsField,
+
+		// DockerBuild.CacheFrom doesn't invalidate a build (b/c it affects HOW we build but
+		// shouldn't affect the result of the build), so don't compare these fields
+		ignoreDockerBuildCacheFrom,
 	)
 }

--- a/pkg/model/manifest_test.go
+++ b/pkg/model/manifest_test.go
@@ -279,6 +279,12 @@ var equalitytests = []struct {
 		Manifest{}.WithImageTarget(ImageTarget{}.WithBuildDetails(CustomBuild{Deps: []string{"bar", "quux"}})),
 		false,
 	},
+	{
+		"DockerBuild.CacheFrom unequal and doesn't invalidate",
+		Manifest{}.WithImageTarget(ImageTarget{}.WithBuildDetails(DockerBuild{CacheFrom: []string{"foo", "bar"}})),
+		Manifest{}.WithImageTarget(ImageTarget{}.WithBuildDetails(DockerBuild{CacheFrom: []string{"bar", "quux"}})),
+		false,
+	},
 }
 
 func TestManifestEquality(t *testing.T) {


### PR DESCRIPTION
in response to [user issue raised in slack](https://kubernetes.slack.com/archives/CESBL84MV/p1603387895199600?thread_ts=1603295786.187500&cid=CESBL84MV)

at least theoretically, changes to `cache_from` shouldn't cause the image to change (if we assume that a cache of statement X always gives output Y -- which is the point of a cache, right?). seems possible that in practice it won't work quite like that e.g. you don't actually want to rely on a cached result of `git clone xyz`--but ideally for that you wouldn't be using the cache at all.

anyway, that seems like a rare enough situation AND `docker_build.cache_from` is very infrequently used--according to our graphs, one repo used that arg in the last 30 days--so this seems safe to try and we can roll it back if we get complaints. wdyt?