### PR TITLE
tiltfile: implement load_dynamic.

### DIFF
--- a/internal/tiltfile/include/include.go
+++ b/internal/tiltfile/include/include.go
@@ -11,6 +11,9 @@ import (
 // The main difference is that include() doesn't bind any arguments into the
 // global scope, whereas load() forces you to bind at least one argument into the global
 // scope (i.e., you can't load() a Tilfile for its side-effects).
+//
+// Users should generally be discouraged from using this function. They should use
+// load_dynamic instead, which has a more self-descriptive name and can load symbols.
 type IncludeFn struct {
 }
 

--- a/internal/tiltfile/include_test.go
+++ b/internal/tiltfile/include_test.go
@@ -147,6 +147,21 @@ local('exit 1')
 		"exit status 1")
 }
 
+func TestLoadDynamic(t *testing.T) {
+	f := newFixture(t)
+	defer f.TearDown()
+
+	f.file("foo/Tiltfile", `
+x = 1
+`)
+	f.file("Tiltfile", `
+print(load_dynamic('./foo/Tiltfile'))
+`)
+
+	f.load()
+	assert.Contains(t, f.out.String(), `{"x": 1}`)
+}
+
 func assertContainsOnce(t *testing.T, s, contains string) {
 	assert.Contains(t, s, contains)
 	assert.Equal(t, 1, strings.Count(s, contains))

--- a/internal/tiltfile/loaddynamic/load.go
+++ b/internal/tiltfile/loaddynamic/load.go
@@ -1,0 +1,59 @@
+package loaddynamic
+
+import (
+	"go.starlark.net/starlark"
+
+	"github.com/tilt-dev/tilt/internal/tiltfile/starkit"
+	"github.com/tilt-dev/tilt/internal/tiltfile/value"
+)
+
+// Implements the load_dynamic() built-in.
+//
+// Most programming languages only support static import - where the module
+// being loaded and the local variables being bound must be determinable at
+// compile-time (i.e., without executing the code).
+//
+// Dynamic import tends to be fairly contentious. Here's a good discussion on the topic:
+//
+// https://github.com/tc39/proposal-dynamic-import
+//
+// (TC39 - the JavaScript committee - is a generally good resource for
+// programming language theory discussion, because there are so many open-source
+// implementations of the core language.)
+//
+// load_dynamic() provides a dynamic import, with semantics similar to nodejs
+// require(), where it returns a dictionary of symbols that can be introspected
+// on. It does no binding of local variables.
+type LoadDynamicFn struct {
+}
+
+func NewExtension() LoadDynamicFn {
+	return LoadDynamicFn{}
+}
+
+func (LoadDynamicFn) OnStart(e *starkit.Environment) error {
+	return e.AddBuiltin("load_dynamic", loadDynamic)
+}
+
+func loadDynamic(t *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var p value.Stringable
+	err := starkit.UnpackArgs(t, fn.Name(), args, kwargs, "path", &p)
+	if err != nil {
+		return nil, err
+	}
+
+	module, err := t.Load(t, p.Value)
+	if err != nil {
+		return nil, err
+	}
+
+	dict := starlark.NewDict(len(module))
+	for key, val := range module {
+		err = dict.SetKey(starlark.String(key), val)
+		if err != nil {
+			return nil, err
+		}
+	}
+	dict.Freeze()
+	return dict, err
+}

--- a/internal/tiltfile/loaddynamic/load_test.go
+++ b/internal/tiltfile/loaddynamic/load_test.go
@@ -1,0 +1,91 @@
+package loaddynamic
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.starlark.net/starlark"
+
+	"github.com/tilt-dev/tilt/internal/tiltfile/starkit"
+)
+
+func TestLoadDynamicOK(t *testing.T) {
+	f := NewFixture(t)
+
+	f.File("Tiltfile", `
+stuff = load_dynamic('./foo/Tiltfile')
+print('stuff.x=' + str(stuff['x']))
+`)
+	f.File("foo/Tiltfile", `
+x = 1
+print('x=' + str(x))
+`)
+
+	_, err := f.ExecFile("Tiltfile")
+	require.NoError(t, err)
+	assert.Equal(t, "x=1\nstuff.x=1\n", f.PrintOutput())
+}
+
+func TestLoadDynamicCachedLoad(t *testing.T) {
+	f := NewFixture(t)
+
+	f.File("Tiltfile", `
+stuff1 = load_dynamic('./foo/Tiltfile')
+print('stuff1.x=' + str(stuff1['x']))
+stuff2 = load_dynamic('./foo/Tiltfile')
+print('stuff2.x=' + str(stuff2['x']))
+`)
+	f.File("foo/Tiltfile", `
+x = 1
+print('x=' + str(x))
+`)
+
+	_, err := f.ExecFile("Tiltfile")
+	require.NoError(t, err)
+	assert.Equal(t, "x=1\nstuff1.x=1\nstuff2.x=1\n", f.PrintOutput())
+}
+
+func TestLoadDynamicFrozen(t *testing.T) {
+	f := NewFixture(t)
+
+	f.File("Tiltfile", `
+stuff = load_dynamic('./foo/Tiltfile')
+stuff['x'] = 2
+`)
+	f.File("foo/Tiltfile", `
+x = 1
+print('x=' + str(x))
+`)
+
+	_, err := f.ExecFile("Tiltfile")
+	if assert.Error(t, err) {
+		backtrace := err.(*starlark.EvalError).Backtrace()
+		assert.Contains(t, backtrace, fmt.Sprintf("%s:3:6: in <toplevel>", f.JoinPath("Tiltfile")))
+		assert.Contains(t, backtrace, "cannot insert into frozen hash table")
+	}
+}
+
+func TestLoadDynamicError(t *testing.T) {
+	f := NewFixture(t)
+
+	f.File("Tiltfile", `
+load_dynamic('./foo/Tiltfile')
+`)
+	f.File("foo/Tiltfile", `
+x = 1
+y = x // 0
+`)
+
+	_, err := f.ExecFile("Tiltfile")
+	if assert.Error(t, err) {
+		backtrace := err.(*starlark.EvalError).Backtrace()
+		assert.Contains(t, backtrace, fmt.Sprintf("%s:2:13: in <toplevel>", f.JoinPath("Tiltfile")))
+		assert.Contains(t, backtrace, fmt.Sprintf("%s:3:7: in <toplevel>", f.JoinPath("foo", "Tiltfile")))
+	}
+}
+
+func NewFixture(tb testing.TB) *starkit.Fixture {
+	return starkit.NewFixture(tb, &LoadDynamicFn{})
+}

--- a/internal/tiltfile/tiltfile_state.go
+++ b/internal/tiltfile/tiltfile_state.go
@@ -29,6 +29,7 @@ import (
 	"github.com/tilt-dev/tilt/internal/tiltfile/io"
 	tiltfile_k8s "github.com/tilt-dev/tilt/internal/tiltfile/k8s"
 	"github.com/tilt-dev/tilt/internal/tiltfile/k8scontext"
+	"github.com/tilt-dev/tilt/internal/tiltfile/loaddynamic"
 	"github.com/tilt-dev/tilt/internal/tiltfile/metrics"
 	"github.com/tilt-dev/tilt/internal/tiltfile/os"
 	"github.com/tilt-dev/tilt/internal/tiltfile/secretsettings"
@@ -214,6 +215,7 @@ func (s *tiltfileState) loadManifests(absFilename string, userConfigState model.
 		encoding.NewExtension(),
 		shlex.NewExtension(),
 		watch.NewExtension(),
+		loaddynamic.NewExtension(),
 		tiltextension.NewExtension(fetcher, tiltextension.NewLocalStore(filepath.Dir(absFilename))),
 		links.NewExtension(),
 	)


### PR DESCRIPTION
Hello @landism,

Please review the following commits I made in branch nicks/include:

ecb9e44b3c954247483ad57252abd7dadee0479c (2020-10-27 14:54:06 -0400)
tiltfile: implement load_dynamic.
Intended as a replacement for include(), but with a more self-descriptive name
and better semantics for loading symbols.

Fixes https://github.com/tilt-dev/tilt/issues/3433

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics