### PR TITLE
Allow install script to work on Alpine

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -26,7 +26,7 @@ function copy_binary() {
 }
 
 function install_tilt() {
-  if [[ "$OSTYPE" == "linux-gnu" ]]; then
+  if [[ "$OSTYPE" == "linux"* ]]; then
       if [[ "$BREW" != "" ]]; then
           set -x
           brew tap tilt-dev/tap


### PR DESCRIPTION
On Alpine Linux, the bash variable `$OSTYPE` is `linux-musl`
instead of `linux-gnu`. But since the `tilt` binary is
statically linked, it will work anyway, so we can let the
script do its thing on Alpine.

“I'd just like to interject for a moment. What you're referring
to as Linux, is in fact, GNU/Linux, or–
— Well, actually, I'm running Alpine Linux on this system, so–
— I think you mean musl/Linux. It's only called Alpine Linux when
  it comes from the Alps region of France.”

See #3883.