### PR TITLE
web: analytics track number of pinned resources on startup

### DIFF
--- a/web/.eslintrc
+++ b/web/.eslintrc
@@ -4,7 +4,7 @@
     "ecmaVersion": "2018",
     "sourceType": "module"
   },
-  "plugins": ["jest"],
+  "plugins": ["jest", "react-hooks"],
   "rules": {
     "jest/no-disabled-tests": "warn",
     "jest/no-focused-tests": "error"

--- a/web/src/SidebarPin.tsx
+++ b/web/src/SidebarPin.tsx
@@ -52,18 +52,21 @@ export function SidebarPinContextProvider(
 ) {
   let lsc = useContext(localStorageContext)
 
-  function getInitialCount(): string[] {
-    let ret = lsc.get<Array<string>>("pinned-resources") ?? []
+  const [pinnedResources, setPinnedResources] = useState<Array<string>>(
+    () =>
+      props.initialValueForTesting ??
+      lsc.get<Array<string>>("pinned-resources") ??
+      []
+  )
+
+  useEffect(() => {
     incr("ui.web.pin", {
-      pinCount: ret.length.toString(),
+      pinCount: pinnedResources.length.toString(),
       action: "load",
     })
-    return ret
-  }
-
-  const [pinnedResources, setPinnedResources] = useState<Array<string>>(
-    () => props.initialValueForTesting ?? getInitialCount()
-  )
+    // empty deps because we only want to report the loaded pin count once per app load
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   useEffect(() => {
     lsc.set("pinned-resources", pinnedResources)

--- a/web/src/SidebarPin.tsx
+++ b/web/src/SidebarPin.tsx
@@ -52,11 +52,17 @@ export function SidebarPinContextProvider(
 ) {
   let lsc = useContext(localStorageContext)
 
+  function getInitialCount(): string[] {
+    let ret = lsc.get<Array<string>>("pinned-resources") ?? []
+    incr("ui.web.pin", {
+      pinCount: ret.length.toString(),
+      action: "load",
+    })
+    return ret
+  }
+
   const [pinnedResources, setPinnedResources] = useState<Array<string>>(
-    () =>
-      props.initialValueForTesting ??
-      lsc.get<Array<string>>("pinned-resources") ??
-      []
+    () => props.initialValueForTesting ?? getInitialCount()
   )
 
   useEffect(() => {
@@ -67,7 +73,7 @@ export function SidebarPinContextProvider(
     setPinnedResources(prevState => {
       const ret = prevState.includes(name) ? prevState : [...prevState, name]
       incr("ui.web.pin", {
-        newPinCount: ret.length.toString(),
+        pinCount: ret.length.toString(),
         action: "pin",
       })
       return ret
@@ -78,7 +84,7 @@ export function SidebarPinContextProvider(
     setPinnedResources(prevState => {
       const ret = prevState.filter(n => n !== name)
       incr("ui.web.pin", {
-        newPinCount: ret.length.toString(),
+        pinCount: ret.length.toString(),
         action: "unpin",
       })
       return ret

--- a/web/src/SidebarResources.test.tsx
+++ b/web/src/SidebarResources.test.tsx
@@ -67,7 +67,8 @@ describe("SidebarResources", () => {
 
     expect(getPinnedItemNames(root)).toEqual(["snack"])
 
-    expectIncr(0, "ui.web.pin", { newPinCount: "1", action: "pin" })
+    expectIncr(0, "ui.web.pin", { pinCount: "0", action: "load" })
+    expectIncr(1, "ui.web.pin", { pinCount: "1", action: "pin" })
 
     expect(localStorage.getItem(makeKey("test", "pinned-resources"))).toEqual(
       JSON.stringify(["snack"])
@@ -123,7 +124,8 @@ describe("SidebarResources", () => {
 
     expect(getPinnedItemNames(root)).toEqual(["vigoda"])
 
-    expectIncr(0, "ui.web.pin", { newPinCount: "1", action: "unpin" })
+    expectIncr(0, "ui.web.pin", { pinCount: "2", action: "load" })
+    expectIncr(1, "ui.web.pin", { pinCount: "1", action: "unpin" })
 
     expect(localStorage.getItem(makeKey("test", "pinned-resources"))).toEqual(
       JSON.stringify(["vigoda"])


### PR DESCRIPTION
### Problem

Prior to this PR, we only record analytics when a user takes the action of pinning or unpinning a resource. It's possible that most common pinning workflow will be to pin the resources one most cares about and then never touch the pins again. This would mean that in order to evaluate current pin usage, we have to go back through all analytics events looking for when the user pinned items.

### Solution

Also record the number of pinned items when the UI is loaded.