### PR TITLE
engine: only mutate PodManagementPolicy for images we build. Fixes https://github.com/tilt-dev/tilt/issues/3906

### DIFF
--- a/internal/engine/image_build_and_deployer.go
+++ b/internal/engine/image_build_and_deployer.go
@@ -360,9 +360,13 @@ func (ibd *ImageBuildAndDeployer) createEntitiesToDeploy(ctx context.Context,
 			}
 		}
 
-		// StatefulSet pods should be managed in parallel. See discussion:
-		// https://github.com/tilt-dev/tilt/issues/1962
-		e = k8s.InjectParallelPodManagementPolicy(e)
+		if len(iTargetMap) > 0 {
+			// StatefulSet pods should be managed in parallel when we're doing iterative
+			// development. See discussion:
+			// https://github.com/tilt-dev/tilt/issues/1962
+			// https://github.com/tilt-dev/tilt/issues/3906
+			e = k8s.InjectParallelPodManagementPolicy(e)
+		}
 
 		// When working with a local k8s cluster, we set the pull policy to Never,
 		// to ensure that k8s fails hard if the image is missing from docker.


### PR DESCRIPTION
Hello @landism,

Please review the following commits I made in branch nicks/ch10137:

76719186f158c8934c70b88e6b2b85570d9ee176 (2020-11-10 16:00:04 -0500)
engine: only mutate PodManagementPolicy for images we build. Fixes https://github.com/tilt-dev/tilt/issues/3906

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics