### PR TITLE
release: put the token in the legacy token dir

### DIFF
--- a/scripts/release-ci.sh
+++ b/scripts/release-ci.sh
@@ -26,7 +26,7 @@ cd "$DIR/.."
 echo "$DOCKER_TOKEN" | docker login --username "$DOCKER_USERNAME" --password-stdin
 
 mkdir -p ~/.tilt-dev
-echo "$TILT_CLOUD_TOKEN" > ~/.tilt-dev/token
+echo "$TILT_CLOUD_TOKEN" > ~/.windmill/token
 
 git fetch --tags
 ./scripts/upload-assets.py latest


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/tokendir:

020a9ff8a5280106be8d8a0538c28f42c21af50b (2020-11-12 23:41:43 -0500)
release: put the token in the legacy token dir

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics