### PR TITLE
web: fix sidebar wrapping

### DIFF
--- a/web/src/SidebarItem.tsx
+++ b/web/src/SidebarItem.tsx
@@ -10,6 +10,7 @@ export const SidebarItemStyle = styled.li`
     margin-top: ${SizeUnit(0.2)};
   }
   clear: both;
+  display: flex;
 `
 
 const moment = require("moment")

--- a/web/src/SidebarPin.tsx
+++ b/web/src/SidebarPin.tsx
@@ -22,8 +22,8 @@ let PinnedPinIcon = styled(PinResourceFilledSvg)`
   fill: ${Color.yellowLight};
 `
 let PinButton = styled.button`
-  float: left;
   cursor: pointer;
+  padding: 0;
   background-position: center center;
   background-repeat: no-repeat;
   background-color: transparent;
@@ -119,3 +119,7 @@ export function SidebarPinButton(props: { resourceName: string }): JSX.Element {
     </PinButton>
   )
 }
+
+export const SidebarPinButtonSpacer = styled.div`
+  width: ${Width.sidebarPinButton}px;
+`

--- a/web/src/SidebarResources.tsx
+++ b/web/src/SidebarResources.tsx
@@ -22,6 +22,7 @@ import {
 import SidebarItem, { SidebarItemStyle } from "./SidebarItem"
 import {
   SidebarPinButton,
+  SidebarPinButtonSpacer,
   sidebarPinContext,
   SidebarPinContextProvider,
 } from "./SidebarPin"
@@ -39,14 +40,16 @@ let SidebarResourcesRoot = styled.nav`
   margin-left: ${SizeUnit(0.2)};
   margin-right: ${SizeUnit(0.2)};
 `
-let SidebarList = styled.span``
-let SidebarItemBox = styled.span`
+let SidebarList = styled.div``
+let SidebarItemBox = styled.div`
   color: ${Color.white};
   background-color: ${Color.gray};
   display: flex;
   align-items: stretch;
-  float: right;
-  width: ${Width.sidebar - Width.sidebarTriggerButton - 1}px;
+  width: ${Width.sidebar -
+    Width.sidebarTriggerButton -
+    Width.sidebarPinButton -
+    1}px;
   height: ${Height.sidebarItem}px;
   transition: color ${AnimDuration.default} linear,
     background-color ${AnimDuration.default} linear;
@@ -126,9 +129,9 @@ let SidebarItemDuration = styled.span`
 let SidebarItemTimeAgo = styled.span`
   color: inherit;
 `
-let SidebarListSectionName = styled.span`
-  float: right;
+let SidebarListSectionName = styled.div`
   width: ${Width.sidebar - Width.sidebarTriggerButton - 1}px;
+  margin-left: ${Width.sidebarPinButton}px;
   text-transform: uppercase;
   color: ${Color.grayLight};
   font-size: ${FontSize.small};
@@ -141,10 +144,10 @@ export function SidebarListSection(
   props: React.PropsWithChildren<{ name: string }>
 ): JSX.Element {
   return (
-    <span>
+    <div>
       <SidebarListSectionName>{props.name}</SidebarListSectionName>
       <SidebarListSectionItems>{props.children}</SidebarListSectionItems>
-    </span>
+    </div>
   )
 }
 
@@ -219,7 +222,11 @@ function renderSidebarItem(
       key={item.name}
       className={`${isSelectedClass} ${isBuildingClass}`}
     >
-      {renderPin ? <SidebarPinButton resourceName={item.name} /> : null}
+      {renderPin ? (
+        <SidebarPinButton resourceName={item.name} />
+      ) : (
+        <SidebarPinButtonSpacer />
+      )}
       <SidebarItemBox className={`${isSelectedClass} ${isBuildingClass}`}>
         <SidebarItemLink
           className="SidebarItem-link"

--- a/web/src/__snapshots__/Sidebar.test.tsx.snap
+++ b/web/src/__snapshots__/Sidebar.test.tsx.snap
@@ -2,28 +2,28 @@
 
 exports[`sidebar abbreviates durations under a minute 1`] = `
 <nav
-  className="sc-iCoHVE kCEswU Sidebar-resources"
+  className="sc-fujyUd gWHmpD Sidebar-resources"
 >
-  <span
-    className="sc-fujyUd"
+  <div
+    className="sc-pNWxx"
   >
-    <span>
-      <span
-        className="sc-hBMVcZ cXgYCe"
+    <div>
+      <div
+        className="sc-fnVYJo kCixeB"
       >
         
-      </span>
+      </div>
       <ul
-        className="sc-fnVYJo kmqYjA"
+        className="sc-fFSRdu eLEDce"
       >
         <li
-          className="sc-bdnylx sc-kEqYlL WGzQp kpzMuW"
+          className="sc-bdnylx sc-iqAbSa hXxjVf iEaWtt"
         >
-          <span
-            className="sc-pNWxx gmmoRv isSelected"
+          <div
+            className="sc-jrsJCI kkHxjM isSelected"
           >
             <a
-              className="sc-jrsJCI sPll"
+              className="sc-kEqYlL eSYWEc"
               href="/"
               onClick={[Function]}
             >
@@ -37,29 +37,29 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
                 </span>
               </div>
               <p
-                className="sc-iqAbSa bjqwqr"
+                className="sc-crzoUp fBHrqP"
               >
                 All
               </p>
             </a>
-          </span>
+          </div>
         </li>
       </ul>
-    </span>
-    <span>
-      <span
-        className="sc-hBMVcZ cXgYCe"
+    </div>
+    <div>
+      <div
+        className="sc-fnVYJo kCixeB"
       >
         resources
-      </span>
+      </div>
       <ul
-        className="sc-fnVYJo kmqYjA"
+        className="sc-fFSRdu eLEDce"
       >
         <li
-          className="sc-bdnylx WGzQp  isBuilding"
+          className="sc-bdnylx hXxjVf  isBuilding"
         >
           <button
-            className="sc-gKAblj hSXSpm"
+            className="sc-gKAblj jOjMZw"
             onClick={[Function]}
             title="pin"
           >
@@ -69,11 +69,11 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
               pin-resource-filled.svg
             </svg>
           </button>
-          <span
-            className="sc-pNWxx gmmoRv  isBuilding"
+          <div
+            className="sc-jrsJCI kkHxjM  isBuilding"
           >
             <a
-              className="sc-jrsJCI sPll SidebarItem-link"
+              className="sc-kEqYlL eSYWEc SidebarItem-link"
               href="/r/resource4"
               onClick={[Function]}
               title="resource4"
@@ -88,19 +88,19 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
                 </span>
               </div>
               <p
-                className="sc-iqAbSa bjqwqr"
+                className="sc-crzoUp fBHrqP"
               >
                 <span
-                  className="sc-crzoUp kpwCjx"
+                  className="sc-dIsAE cjTFAy"
                 >
                   resource4
                 </span>
               </p>
               <div
-                className="sc-dIsAE gmgHtR"
+                className="sc-bqGHjH kFumNN"
               >
                 <span
-                  className="sc-ksluoS bAUftp"
+                  className="sc-hBMVcZ fGQFaE"
                 >
                   <time
                     dateTime="2017-12-21T15:36:03.000Z"
@@ -110,7 +110,7 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
                   </time>
                 </span>
                 <span
-                  className="sc-bqGHjH hdRcqG"
+                  className="sc-ksluoS huVVNh"
                 >
                   12s
                 </span>
@@ -123,13 +123,13 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
               onClick={[Function]}
               title="Cannot trigger an update while resource is updating or update is pending."
             />
-          </span>
+          </div>
         </li>
         <li
-          className="sc-bdnylx WGzQp  isBuilding"
+          className="sc-bdnylx hXxjVf  isBuilding"
         >
           <button
-            className="sc-gKAblj hSXSpm"
+            className="sc-gKAblj jOjMZw"
             onClick={[Function]}
             title="pin"
           >
@@ -139,11 +139,11 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
               pin-resource-filled.svg
             </svg>
           </button>
-          <span
-            className="sc-pNWxx gmmoRv  isBuilding"
+          <div
+            className="sc-jrsJCI kkHxjM  isBuilding"
           >
             <a
-              className="sc-jrsJCI sPll SidebarItem-link"
+              className="sc-kEqYlL eSYWEc SidebarItem-link"
               href="/r/resource9"
               onClick={[Function]}
               title="resource9"
@@ -158,19 +158,19 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
                 </span>
               </div>
               <p
-                className="sc-iqAbSa bjqwqr"
+                className="sc-crzoUp fBHrqP"
               >
                 <span
-                  className="sc-crzoUp kpwCjx"
+                  className="sc-dIsAE cjTFAy"
                 >
                   resource9
                 </span>
               </p>
               <div
-                className="sc-dIsAE gmgHtR"
+                className="sc-bqGHjH kFumNN"
               >
                 <span
-                  className="sc-ksluoS bAUftp"
+                  className="sc-hBMVcZ fGQFaE"
                 >
                   <time
                     dateTime="2017-12-21T15:35:58.000Z"
@@ -180,7 +180,7 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
                   </time>
                 </span>
                 <span
-                  className="sc-bqGHjH hdRcqG"
+                  className="sc-ksluoS huVVNh"
                 >
                   12s
                 </span>
@@ -193,13 +193,13 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
               onClick={[Function]}
               title="Cannot trigger an update while resource is updating or update is pending."
             />
-          </span>
+          </div>
         </li>
         <li
-          className="sc-bdnylx WGzQp  isBuilding"
+          className="sc-bdnylx hXxjVf  isBuilding"
         >
           <button
-            className="sc-gKAblj hSXSpm"
+            className="sc-gKAblj jOjMZw"
             onClick={[Function]}
             title="pin"
           >
@@ -209,11 +209,11 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
               pin-resource-filled.svg
             </svg>
           </button>
-          <span
-            className="sc-pNWxx gmmoRv  isBuilding"
+          <div
+            className="sc-jrsJCI kkHxjM  isBuilding"
           >
             <a
-              className="sc-jrsJCI sPll SidebarItem-link"
+              className="sc-kEqYlL eSYWEc SidebarItem-link"
               href="/r/resource19"
               onClick={[Function]}
               title="resource19"
@@ -228,19 +228,19 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
                 </span>
               </div>
               <p
-                className="sc-iqAbSa bjqwqr"
+                className="sc-crzoUp fBHrqP"
               >
                 <span
-                  className="sc-crzoUp kpwCjx"
+                  className="sc-dIsAE cjTFAy"
                 >
                   resource19
                 </span>
               </p>
               <div
-                className="sc-dIsAE gmgHtR"
+                className="sc-bqGHjH kFumNN"
               >
                 <span
-                  className="sc-ksluoS bAUftp"
+                  className="sc-hBMVcZ fGQFaE"
                 >
                   <time
                     dateTime="2017-12-21T15:35:48.000Z"
@@ -250,7 +250,7 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
                   </time>
                 </span>
                 <span
-                  className="sc-bqGHjH hdRcqG"
+                  className="sc-ksluoS huVVNh"
                 >
                   12s
                 </span>
@@ -263,13 +263,13 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
               onClick={[Function]}
               title="Cannot trigger an update while resource is updating or update is pending."
             />
-          </span>
+          </div>
         </li>
         <li
-          className="sc-bdnylx WGzQp  isBuilding"
+          className="sc-bdnylx hXxjVf  isBuilding"
         >
           <button
-            className="sc-gKAblj hSXSpm"
+            className="sc-gKAblj jOjMZw"
             onClick={[Function]}
             title="pin"
           >
@@ -279,11 +279,11 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
               pin-resource-filled.svg
             </svg>
           </button>
-          <span
-            className="sc-pNWxx gmmoRv  isBuilding"
+          <div
+            className="sc-jrsJCI kkHxjM  isBuilding"
           >
             <a
-              className="sc-jrsJCI sPll SidebarItem-link"
+              className="sc-kEqYlL eSYWEc SidebarItem-link"
               href="/r/resource29"
               onClick={[Function]}
               title="resource29"
@@ -298,19 +298,19 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
                 </span>
               </div>
               <p
-                className="sc-iqAbSa bjqwqr"
+                className="sc-crzoUp fBHrqP"
               >
                 <span
-                  className="sc-crzoUp kpwCjx"
+                  className="sc-dIsAE cjTFAy"
                 >
                   resource29
                 </span>
               </p>
               <div
-                className="sc-dIsAE gmgHtR"
+                className="sc-bqGHjH kFumNN"
               >
                 <span
-                  className="sc-ksluoS bAUftp"
+                  className="sc-hBMVcZ fGQFaE"
                 >
                   <time
                     dateTime="2017-12-21T15:35:38.000Z"
@@ -320,7 +320,7 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
                   </time>
                 </span>
                 <span
-                  className="sc-bqGHjH hdRcqG"
+                  className="sc-ksluoS huVVNh"
                 >
                   12s
                 </span>
@@ -333,13 +333,13 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
               onClick={[Function]}
               title="Cannot trigger an update while resource is updating or update is pending."
             />
-          </span>
+          </div>
         </li>
         <li
-          className="sc-bdnylx WGzQp  isBuilding"
+          className="sc-bdnylx hXxjVf  isBuilding"
         >
           <button
-            className="sc-gKAblj hSXSpm"
+            className="sc-gKAblj jOjMZw"
             onClick={[Function]}
             title="pin"
           >
@@ -349,11 +349,11 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
               pin-resource-filled.svg
             </svg>
           </button>
-          <span
-            className="sc-pNWxx gmmoRv  isBuilding"
+          <div
+            className="sc-jrsJCI kkHxjM  isBuilding"
           >
             <a
-              className="sc-jrsJCI sPll SidebarItem-link"
+              className="sc-kEqYlL eSYWEc SidebarItem-link"
               href="/r/resource39"
               onClick={[Function]}
               title="resource39"
@@ -368,19 +368,19 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
                 </span>
               </div>
               <p
-                className="sc-iqAbSa bjqwqr"
+                className="sc-crzoUp fBHrqP"
               >
                 <span
-                  className="sc-crzoUp kpwCjx"
+                  className="sc-dIsAE cjTFAy"
                 >
                   resource39
                 </span>
               </p>
               <div
-                className="sc-dIsAE gmgHtR"
+                className="sc-bqGHjH kFumNN"
               >
                 <span
-                  className="sc-ksluoS bAUftp"
+                  className="sc-hBMVcZ fGQFaE"
                 >
                   <time
                     dateTime="2017-12-21T15:35:28.000Z"
@@ -390,7 +390,7 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
                   </time>
                 </span>
                 <span
-                  className="sc-bqGHjH hdRcqG"
+                  className="sc-ksluoS huVVNh"
                 >
                   12s
                 </span>
@@ -403,13 +403,13 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
               onClick={[Function]}
               title="Cannot trigger an update while resource is updating or update is pending."
             />
-          </span>
+          </div>
         </li>
         <li
-          className="sc-bdnylx WGzQp  isBuilding"
+          className="sc-bdnylx hXxjVf  isBuilding"
         >
           <button
-            className="sc-gKAblj hSXSpm"
+            className="sc-gKAblj jOjMZw"
             onClick={[Function]}
             title="pin"
           >
@@ -419,11 +419,11 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
               pin-resource-filled.svg
             </svg>
           </button>
-          <span
-            className="sc-pNWxx gmmoRv  isBuilding"
+          <div
+            className="sc-jrsJCI kkHxjM  isBuilding"
           >
             <a
-              className="sc-jrsJCI sPll SidebarItem-link"
+              className="sc-kEqYlL eSYWEc SidebarItem-link"
               href="/r/resource49"
               onClick={[Function]}
               title="resource49"
@@ -438,19 +438,19 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
                 </span>
               </div>
               <p
-                className="sc-iqAbSa bjqwqr"
+                className="sc-crzoUp fBHrqP"
               >
                 <span
-                  className="sc-crzoUp kpwCjx"
+                  className="sc-dIsAE cjTFAy"
                 >
                   resource49
                 </span>
               </p>
               <div
-                className="sc-dIsAE gmgHtR"
+                className="sc-bqGHjH kFumNN"
               >
                 <span
-                  className="sc-ksluoS bAUftp"
+                  className="sc-hBMVcZ fGQFaE"
                 >
                   <time
                     dateTime="2017-12-21T15:35:18.000Z"
@@ -460,7 +460,7 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
                   </time>
                 </span>
                 <span
-                  className="sc-bqGHjH hdRcqG"
+                  className="sc-ksluoS huVVNh"
                 >
                   12s
                 </span>
@@ -473,13 +473,13 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
               onClick={[Function]}
               title="Cannot trigger an update while resource is updating or update is pending."
             />
-          </span>
+          </div>
         </li>
         <li
-          className="sc-bdnylx WGzQp  isBuilding"
+          className="sc-bdnylx hXxjVf  isBuilding"
         >
           <button
-            className="sc-gKAblj hSXSpm"
+            className="sc-gKAblj jOjMZw"
             onClick={[Function]}
             title="pin"
           >
@@ -489,11 +489,11 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
               pin-resource-filled.svg
             </svg>
           </button>
-          <span
-            className="sc-pNWxx gmmoRv  isBuilding"
+          <div
+            className="sc-jrsJCI kkHxjM  isBuilding"
           >
             <a
-              className="sc-jrsJCI sPll SidebarItem-link"
+              className="sc-kEqYlL eSYWEc SidebarItem-link"
               href="/r/resource54"
               onClick={[Function]}
               title="resource54"
@@ -508,19 +508,19 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
                 </span>
               </div>
               <p
-                className="sc-iqAbSa bjqwqr"
+                className="sc-crzoUp fBHrqP"
               >
                 <span
-                  className="sc-crzoUp kpwCjx"
+                  className="sc-dIsAE cjTFAy"
                 >
                   resource54
                 </span>
               </p>
               <div
-                className="sc-dIsAE gmgHtR"
+                className="sc-bqGHjH kFumNN"
               >
                 <span
-                  className="sc-ksluoS bAUftp"
+                  className="sc-hBMVcZ fGQFaE"
                 >
                   <time
                     dateTime="2017-12-21T15:35:13.000Z"
@@ -530,7 +530,7 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
                   </time>
                 </span>
                 <span
-                  className="sc-bqGHjH hdRcqG"
+                  className="sc-ksluoS huVVNh"
                 >
                   12s
                 </span>
@@ -543,39 +543,39 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
               onClick={[Function]}
               title="Cannot trigger an update while resource is updating or update is pending."
             />
-          </span>
+          </div>
         </li>
       </ul>
-    </span>
-  </span>
+    </div>
+  </div>
   <span />
 </nav>
 `;
 
 exports[`sidebar renders empty resource list without crashing 1`] = `
 <nav
-  className="sc-iCoHVE kCEswU Sidebar-resources"
+  className="sc-fujyUd gWHmpD Sidebar-resources"
 >
-  <span
-    className="sc-fujyUd"
+  <div
+    className="sc-pNWxx"
   >
-    <span>
-      <span
-        className="sc-hBMVcZ cXgYCe"
+    <div>
+      <div
+        className="sc-fnVYJo kCixeB"
       >
         
-      </span>
+      </div>
       <ul
-        className="sc-fnVYJo kmqYjA"
+        className="sc-fFSRdu eLEDce"
       >
         <li
-          className="sc-bdnylx sc-kEqYlL WGzQp kpzMuW"
+          className="sc-bdnylx sc-iqAbSa hXxjVf iEaWtt"
         >
-          <span
-            className="sc-pNWxx gmmoRv isSelected"
+          <div
+            className="sc-jrsJCI kkHxjM isSelected"
           >
             <a
-              className="sc-jrsJCI sPll"
+              className="sc-kEqYlL eSYWEc"
               href="/"
               onClick={[Function]}
             >
@@ -587,54 +587,54 @@ exports[`sidebar renders empty resource list without crashing 1`] = `
                 </span>
               </div>
               <p
-                className="sc-iqAbSa bjqwqr"
+                className="sc-crzoUp fBHrqP"
               >
                 All
               </p>
             </a>
-          </span>
+          </div>
         </li>
       </ul>
-    </span>
-    <span>
-      <span
-        className="sc-hBMVcZ cXgYCe"
+    </div>
+    <div>
+      <div
+        className="sc-fnVYJo kCixeB"
       >
         resources
-      </span>
+      </div>
       <ul
-        className="sc-fnVYJo kmqYjA"
+        className="sc-fFSRdu eLEDce"
       />
-    </span>
-  </span>
+    </div>
+  </div>
   <span />
 </nav>
 `;
 
 exports[`sidebar renders list of resources 1`] = `
 <nav
-  className="sc-iCoHVE kCEswU Sidebar-resources"
+  className="sc-fujyUd gWHmpD Sidebar-resources"
 >
-  <span
-    className="sc-fujyUd"
+  <div
+    className="sc-pNWxx"
   >
-    <span>
-      <span
-        className="sc-hBMVcZ cXgYCe"
+    <div>
+      <div
+        className="sc-fnVYJo kCixeB"
       >
         
-      </span>
+      </div>
       <ul
-        className="sc-fnVYJo kmqYjA"
+        className="sc-fFSRdu eLEDce"
       >
         <li
-          className="sc-bdnylx sc-kEqYlL WGzQp kpzMuW"
+          className="sc-bdnylx sc-iqAbSa hXxjVf iEaWtt"
         >
-          <span
-            className="sc-pNWxx gmmoRv isSelected"
+          <div
+            className="sc-jrsJCI kkHxjM isSelected"
           >
             <a
-              className="sc-jrsJCI sPll"
+              className="sc-kEqYlL eSYWEc"
               href="/"
               onClick={[Function]}
             >
@@ -648,29 +648,29 @@ exports[`sidebar renders list of resources 1`] = `
                 </span>
               </div>
               <p
-                className="sc-iqAbSa bjqwqr"
+                className="sc-crzoUp fBHrqP"
               >
                 All
               </p>
             </a>
-          </span>
+          </div>
         </li>
       </ul>
-    </span>
-    <span>
-      <span
-        className="sc-hBMVcZ cXgYCe"
+    </div>
+    <div>
+      <div
+        className="sc-fnVYJo kCixeB"
       >
         resources
-      </span>
+      </div>
       <ul
-        className="sc-fnVYJo kmqYjA"
+        className="sc-fFSRdu eLEDce"
       >
         <li
-          className="sc-bdnylx WGzQp  isBuilding"
+          className="sc-bdnylx hXxjVf  isBuilding"
         >
           <button
-            className="sc-gKAblj hSXSpm"
+            className="sc-gKAblj jOjMZw"
             onClick={[Function]}
             title="pin"
           >
@@ -680,11 +680,11 @@ exports[`sidebar renders list of resources 1`] = `
               pin-resource-filled.svg
             </svg>
           </button>
-          <span
-            className="sc-pNWxx gmmoRv  isBuilding"
+          <div
+            className="sc-jrsJCI kkHxjM  isBuilding"
           >
             <a
-              className="sc-jrsJCI sPll SidebarItem-link"
+              className="sc-kEqYlL eSYWEc SidebarItem-link"
               href="/r/vigoda"
               onClick={[Function]}
               title="vigoda"
@@ -699,19 +699,19 @@ exports[`sidebar renders list of resources 1`] = `
                 </span>
               </div>
               <p
-                className="sc-iqAbSa bjqwqr"
+                className="sc-crzoUp fBHrqP"
               >
                 <span
-                  className="sc-crzoUp kpwCjx"
+                  className="sc-dIsAE cjTFAy"
                 >
                   vigoda
                 </span>
               </p>
               <div
-                className="sc-dIsAE gmgHtR"
+                className="sc-bqGHjH kFumNN"
               >
                 <span
-                  className="sc-ksluoS bAUftp"
+                  className="sc-hBMVcZ fGQFaE"
                 >
                   <time
                     dateTime="2017-12-21T15:36:07.000Z"
@@ -721,7 +721,7 @@ exports[`sidebar renders list of resources 1`] = `
                   </time>
                 </span>
                 <span
-                  className="sc-bqGHjH hdRcqG"
+                  className="sc-ksluoS huVVNh"
                 >
                   12s
                 </span>
@@ -734,13 +734,13 @@ exports[`sidebar renders list of resources 1`] = `
               onClick={[Function]}
               title="Cannot trigger an update while resource is updating or update is pending."
             />
-          </span>
+          </div>
         </li>
         <li
-          className="sc-bdnylx WGzQp  isBuilding"
+          className="sc-bdnylx hXxjVf  isBuilding"
         >
           <button
-            className="sc-gKAblj hSXSpm"
+            className="sc-gKAblj jOjMZw"
             onClick={[Function]}
             title="pin"
           >
@@ -750,11 +750,11 @@ exports[`sidebar renders list of resources 1`] = `
               pin-resource-filled.svg
             </svg>
           </button>
-          <span
-            className="sc-pNWxx gmmoRv  isBuilding"
+          <div
+            className="sc-jrsJCI kkHxjM  isBuilding"
           >
             <a
-              className="sc-jrsJCI sPll SidebarItem-link"
+              className="sc-kEqYlL eSYWEc SidebarItem-link"
               href="/r/snack"
               onClick={[Function]}
               title="snack"
@@ -769,19 +769,19 @@ exports[`sidebar renders list of resources 1`] = `
                 </span>
               </div>
               <p
-                className="sc-iqAbSa bjqwqr"
+                className="sc-crzoUp fBHrqP"
               >
                 <span
-                  className="sc-crzoUp kpwCjx"
+                  className="sc-dIsAE cjTFAy"
                 >
                   snack
                 </span>
               </p>
               <div
-                className="sc-dIsAE gmgHtR"
+                className="sc-bqGHjH kFumNN"
               >
                 <span
-                  className="sc-ksluoS bAUftp"
+                  className="sc-hBMVcZ fGQFaE"
                 >
                   <time
                     dateTime="2017-12-21T15:35:57.000Z"
@@ -791,7 +791,7 @@ exports[`sidebar renders list of resources 1`] = `
                   </time>
                 </span>
                 <span
-                  className="sc-bqGHjH hdRcqG"
+                  className="sc-ksluoS huVVNh"
                 >
                   -10.0s
                 </span>
@@ -804,39 +804,39 @@ exports[`sidebar renders list of resources 1`] = `
               onClick={[Function]}
               title="Cannot trigger an update while resource is updating or update is pending."
             />
-          </span>
+          </div>
         </li>
       </ul>
-    </span>
-  </span>
+    </div>
+  </div>
   <span />
 </nav>
 `;
 
 exports[`sidebar renders resources that haven't been built yet 1`] = `
 <nav
-  className="sc-iCoHVE kCEswU Sidebar-resources"
+  className="sc-fujyUd gWHmpD Sidebar-resources"
 >
-  <span
-    className="sc-fujyUd"
+  <div
+    className="sc-pNWxx"
   >
-    <span>
-      <span
-        className="sc-hBMVcZ cXgYCe"
+    <div>
+      <div
+        className="sc-fnVYJo kCixeB"
       >
         
-      </span>
+      </div>
       <ul
-        className="sc-fnVYJo kmqYjA"
+        className="sc-fFSRdu eLEDce"
       >
         <li
-          className="sc-bdnylx sc-kEqYlL WGzQp kpzMuW"
+          className="sc-bdnylx sc-iqAbSa hXxjVf iEaWtt"
         >
-          <span
-            className="sc-pNWxx gmmoRv isSelected"
+          <div
+            className="sc-jrsJCI kkHxjM isSelected"
           >
             <a
-              className="sc-jrsJCI sPll"
+              className="sc-kEqYlL eSYWEc"
               href="/"
               onClick={[Function]}
             >
@@ -850,29 +850,29 @@ exports[`sidebar renders resources that haven't been built yet 1`] = `
                 </span>
               </div>
               <p
-                className="sc-iqAbSa bjqwqr"
+                className="sc-crzoUp fBHrqP"
               >
                 All
               </p>
             </a>
-          </span>
+          </div>
         </li>
       </ul>
-    </span>
-    <span>
-      <span
-        className="sc-hBMVcZ cXgYCe"
+    </div>
+    <div>
+      <div
+        className="sc-fnVYJo kCixeB"
       >
         resources
-      </span>
+      </div>
       <ul
-        className="sc-fnVYJo kmqYjA"
+        className="sc-fFSRdu eLEDce"
       >
         <li
-          className="sc-bdnylx WGzQp  isBuilding"
+          className="sc-bdnylx hXxjVf  isBuilding"
         >
           <button
-            className="sc-gKAblj hSXSpm"
+            className="sc-gKAblj jOjMZw"
             onClick={[Function]}
             title="pin"
           >
@@ -882,11 +882,11 @@ exports[`sidebar renders resources that haven't been built yet 1`] = `
               pin-resource-filled.svg
             </svg>
           </button>
-          <span
-            className="sc-pNWxx gmmoRv  isBuilding"
+          <div
+            className="sc-jrsJCI kkHxjM  isBuilding"
           >
             <a
-              className="sc-jrsJCI sPll SidebarItem-link"
+              className="sc-kEqYlL eSYWEc SidebarItem-link"
               href="/r/vigoda"
               onClick={[Function]}
               title="vigoda"
@@ -901,24 +901,24 @@ exports[`sidebar renders resources that haven't been built yet 1`] = `
                 </span>
               </div>
               <p
-                className="sc-iqAbSa bjqwqr"
+                className="sc-crzoUp fBHrqP"
               >
                 <span
-                  className="sc-crzoUp kpwCjx"
+                  className="sc-dIsAE cjTFAy"
                 >
                   vigoda
                 </span>
               </p>
               <div
-                className="sc-dIsAE gmgHtR"
+                className="sc-bqGHjH kFumNN"
               >
                 <span
-                  className="sc-ksluoS bAUftp isEmpty"
+                  className="sc-hBMVcZ fGQFaE isEmpty"
                 >
                   —
                 </span>
                 <span
-                  className="sc-bqGHjH hdRcqG isEmpty"
+                  className="sc-ksluoS huVVNh isEmpty"
                 >
                   —
                 </span>
@@ -931,13 +931,13 @@ exports[`sidebar renders resources that haven't been built yet 1`] = `
               onClick={[Function]}
               title="Cannot trigger an update while resource is updating or update is pending."
             />
-          </span>
+          </div>
         </li>
         <li
-          className="sc-bdnylx WGzQp  isBuilding"
+          className="sc-bdnylx hXxjVf  isBuilding"
         >
           <button
-            className="sc-gKAblj hSXSpm"
+            className="sc-gKAblj jOjMZw"
             onClick={[Function]}
             title="pin"
           >
@@ -947,11 +947,11 @@ exports[`sidebar renders resources that haven't been built yet 1`] = `
               pin-resource-filled.svg
             </svg>
           </button>
-          <span
-            className="sc-pNWxx gmmoRv  isBuilding"
+          <div
+            className="sc-jrsJCI kkHxjM  isBuilding"
           >
             <a
-              className="sc-jrsJCI sPll SidebarItem-link"
+              className="sc-kEqYlL eSYWEc SidebarItem-link"
               href="/r/snack"
               onClick={[Function]}
               title="snack"
@@ -966,24 +966,24 @@ exports[`sidebar renders resources that haven't been built yet 1`] = `
                 </span>
               </div>
               <p
-                className="sc-iqAbSa bjqwqr"
+                className="sc-crzoUp fBHrqP"
               >
                 <span
-                  className="sc-crzoUp kpwCjx"
+                  className="sc-dIsAE cjTFAy"
                 >
                   snack
                 </span>
               </p>
               <div
-                className="sc-dIsAE gmgHtR"
+                className="sc-bqGHjH kFumNN"
               >
                 <span
-                  className="sc-ksluoS bAUftp isEmpty"
+                  className="sc-hBMVcZ fGQFaE isEmpty"
                 >
                   —
                 </span>
                 <span
-                  className="sc-bqGHjH hdRcqG isEmpty"
+                  className="sc-ksluoS huVVNh isEmpty"
                 >
                   —
                 </span>
@@ -996,11 +996,11 @@ exports[`sidebar renders resources that haven't been built yet 1`] = `
               onClick={[Function]}
               title="Cannot trigger an update while resource is updating or update is pending."
             />
-          </span>
+          </div>
         </li>
       </ul>
-    </span>
-  </span>
+    </div>
+  </div>
   <span />
 </nav>
 `;


### PR DESCRIPTION
Fixes #3903

That issue has one repro for the issue, but I've seen similar unpredictable behavior when iterating on the sidebar, and it feels kind of house-of-cardsy. @hyu suggested making it work without the `float`s so that we have one fewer layout system competing for control, which seems to have done the trick.