### PR TITLE
engine: add metric aggregations for k8s deploys

### DIFF
--- a/internal/cli/metrics.go
+++ b/internal/cli/metrics.go
@@ -50,6 +50,9 @@ func initMetrics(ctx context.Context, cmdName model.TiltSubcommand) (context.Con
 		CommandCount,
 		engine.ImageBuildDurationView,
 		engine.ImageBuildCount,
+		engine.K8sDeployDurationView,
+		engine.K8sDeployCount,
+		engine.K8sDeployObjectsCount,
 		tiltfile.TiltfileExecDurationView,
 		tiltfile.TiltfileExecCount)
 	if err != nil {

--- a/internal/engine/image_build_and_deployer.go
+++ b/internal/engine/image_build_and_deployer.go
@@ -193,9 +193,12 @@ func (ibd *ImageBuildAndDeployer) BuildAndDeploy(ctx context.Context, st store.R
 		return newResults, buildcontrol.WrapDontFallBackError(err)
 	}
 
+	startDeployTime := time.Now()
+
 	// (If we pass an empty list of refs here (as we will do if only deploying
 	// yaml), we just don't inject any image refs into the yaml, nbd.
 	k8sResult, err := ibd.deploy(ctx, st, ps, iTargetMap, kTarget, q.AllResults(), anyLiveUpdate)
+	reportK8sDeployMetrics(ctx, kTarget, time.Since(startDeployTime), err != nil)
 	if err != nil {
 		return newResults, buildcontrol.WrapDontFallBackError(err)
 	}

--- a/internal/engine/metrics.go
+++ b/internal/engine/metrics.go
@@ -1,0 +1,71 @@
+package engine
+
+import (
+	"context"
+	"time"
+
+	"go.opencensus.io/stats"
+	"go.opencensus.io/stats/view"
+	"go.opencensus.io/tag"
+	octag "go.opencensus.io/tag"
+
+	"github.com/tilt-dev/tilt/pkg/logger"
+	"github.com/tilt-dev/tilt/pkg/model"
+)
+
+// Metric aggregations
+var keyResourceName = tag.MustNewKey("resource")
+var keyHasError = octag.MustNewKey("error")
+
+var K8sDeployDuration = stats.Float64(
+	"k8s_deploy_duration",
+	"K8s Deploy duration",
+	stats.UnitMilliseconds)
+
+var K8sDeployObjects = stats.Int64("objects", "The number of objects deployed", "1")
+
+var K8sDeployDurationDistribution = view.Distribution(
+	10, 100, 500, 1000, 2000, 5000,
+	10000, 15000, 20000, 30000, 45000, 60000)
+
+var K8sDeployDurationView = &view.View{
+	Name:        "k8s_deploy_duration_dist",
+	Measure:     K8sDeployDuration,
+	Aggregation: K8sDeployDurationDistribution,
+	Description: "K8s Deploy time",
+	TagKeys:     []octag.Key{keyResourceName, keyHasError},
+}
+
+var K8sDeployCount = &view.View{
+	Name:        "k8s_deploy_count",
+	Measure:     K8sDeployDuration,
+	Aggregation: view.Count(),
+	Description: "K8s deploy count",
+	TagKeys:     []octag.Key{keyResourceName, keyHasError},
+}
+
+var K8sDeployObjectsCount = &view.View{
+	Name:        "k8s_deploy_objects_count",
+	Measure:     K8sDeployObjects,
+	Aggregation: view.LastValue(),
+	Description: "K8s objects per resource",
+	TagKeys:     []octag.Key{keyResourceName, keyHasError},
+}
+
+func reportK8sDeployMetrics(ctx context.Context, kTarget model.K8sTarget, dur time.Duration, hasError bool) {
+	latencyMs := float64(dur / time.Millisecond)
+	errorTag := "0"
+	if hasError {
+		errorTag = "1"
+	}
+	recErr := stats.RecordWithTags(ctx,
+		[]octag.Mutator{
+			octag.Upsert(keyResourceName, kTarget.ID().Name.String()),
+			octag.Upsert(keyHasError, errorTag),
+		},
+		K8sDeployDuration.M(latencyMs),
+		K8sDeployObjects.M(int64(len(kTarget.ObjectRefs))))
+	if recErr != nil {
+		logger.Get(ctx).Debugf("k8s deploy stats: %v", recErr)
+	}
+}


### PR DESCRIPTION
Hello @landism,

Please review the following commits I made in branch nicks/deploy:

6fe3dded6d4a627955586df57e05e9bdce5c42ae (2020-11-18 17:40:35 -0500)
engine: add metric aggregations for k8s deploys

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics