### PR TITLE
tilt: include deploy targets in tiltfile-result

### DIFF
--- a/internal/store/manifest_target_test.go
+++ b/internal/store/manifest_target_test.go
@@ -16,7 +16,7 @@ func TestManifestTarget_FacetsSecretsScrubbed(t *testing.T) {
 
 	s := "password1"
 	b64 := base64.StdEncoding.EncodeToString([]byte(s))
-	mt.State.BuildStatuses[m.DeployTarget().ID()] = &BuildStatus{
+	mt.State.BuildStatuses[m.DeployTarget.ID()] = &BuildStatus{
 		LastResult: K8sBuildResult{AppliedEntitiesText: fmt.Sprintf("text %s moretext", b64)},
 	}
 	secrets := model.SecretSet{}

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -2052,7 +2052,7 @@ k8s_yaml('snack.yaml')
 	}, f.idNames(m.DependencyIDs()))
 	assert.Equal(t, []string{}, f.idNames(m.ImageTargets[0].DependencyIDs()))
 	assert.Equal(t, []string{"gcr.io/image-a"}, f.idNames(m.ImageTargets[1].DependencyIDs()))
-	assert.Equal(t, []string{"gcr.io/image-b"}, f.idNames(m.DeployTarget().DependencyIDs()))
+	assert.Equal(t, []string{"gcr.io/image-b"}, f.idNames(m.DeployTarget.DependencyIDs()))
 }
 
 func TestImageDependencyNormalization(t *testing.T) {
@@ -6155,7 +6155,7 @@ func (f *fixture) assertManifestConsistency(m model.Manifest) {
 		iTargetIDs[iTarget.ID()] = true
 	}
 
-	deployTarget := m.DeployTarget()
+	deployTarget := m.DeployTarget
 	for _, depID := range deployTarget.DependencyIDs() {
 		if !iTargetIDs[depID] {
 			f.t.Fatalf("Image Target needed by deploy target is missing: %s", depID)


### PR DESCRIPTION
Fixes an issue reported in [#3815](https://github.com/tilt-dev/tilt/issues/3815#issuecomment-731091427).

### Problem

in `tilt alpha tiltfile-result`, local resources look like this:
```
    {
      "Name": "frontend-yarn",
      "ImageTargets": null,
      "TriggerMode": 0,
      "ResourceDependencies": null
    },
```

Or, more generally, we aren't outputting the manifests' deploy targets at all, which also means yaml contents can't be verified.

### Solution

Make DeployTarget public, and therefore serialized.

This could also be done by providing a `MarshalJSON` instead of making the field public. I went this way because the other way creates an opportunity for devs to add fields to `Manifest` without realizing they also need to be in `MarshalJSON`, and leaving them out of `tiltfile-result`.
I'm unaware of a reason that this field is private and the others public. I'm guessing they were added at different times by different devs. Happy to hear otherwise.

I spent half an hour trying to set up testing infrastructure for `alpha tiltfile-result` (which currently has no tests) and hit some annoyances and decided this change isn't risky enough and that command changed often enough for that to be a good investment at the moment.