### PR TITLE
engine: add a controller that deploys a local metrics stack

### DIFF
--- a/internal/cli/wire.go
+++ b/internal/cli/wire.go
@@ -77,6 +77,7 @@ var BaseWireSet = wire.NewSet(
 
 	ProvideDeferredExporter,
 	metrics.NewController,
+	metrics.NewModeController,
 	dockercompose.NewDockerComposeClient,
 
 	clockwork.NewRealClock,

--- a/internal/cli/wire_gen.go
+++ b/internal/cli/wire_gen.go
@@ -272,13 +272,14 @@ func wireCmdUp(ctx context.Context, analytics3 *analytics.TiltAnalytics, cmdTags
 	deferredExporter := ProvideDeferredExporter()
 	gitRemote := git.ProvideGitRemote()
 	metricsController := metrics.NewController(deferredExporter, tiltBuild, gitRemote)
-	v2 := engine.ProvideSubscribers(headsUpDisplay, terminalStream, terminalPrompt, podWatcher, serviceWatcher, podLogManager, controller, watchManager, gitManager, buildController, configsController, eventWatcher, dockerComposeLogManager, profilerManager, syncletManager, analyticsReporter, headsUpServerController, analyticsUpdater, eventWatchManager, cloudStatusManager, dockerPruner, telemetryController, localController, podMonitor, exitController, metricsController)
+	modeController := metrics.NewModeController(modelWebHost)
+	v2 := engine.ProvideSubscribers(headsUpDisplay, terminalStream, terminalPrompt, podWatcher, serviceWatcher, podLogManager, controller, watchManager, gitManager, buildController, configsController, eventWatcher, dockerComposeLogManager, profilerManager, syncletManager, analyticsReporter, headsUpServerController, analyticsUpdater, eventWatchManager, cloudStatusManager, dockerPruner, telemetryController, localController, podMonitor, exitController, metricsController, modeController)
 	upper := engine.NewUpper(ctx, storeStore, v2)
-	windmillDir, err := dirs.UseTiltDevDir()
+	tiltDevDir, err := dirs.UseTiltDevDir()
 	if err != nil {
 		return CmdUpDeps{}, err
 	}
-	tokenToken, err := token.GetOrCreateToken(windmillDir)
+	tokenToken, err := token.GetOrCreateToken(tiltDevDir)
 	if err != nil {
 		return CmdUpDeps{}, err
 	}
@@ -433,13 +434,14 @@ func wireCmdCI(ctx context.Context, analytics3 *analytics.TiltAnalytics, subcomm
 	deferredExporter := ProvideDeferredExporter()
 	gitRemote := git.ProvideGitRemote()
 	metricsController := metrics.NewController(deferredExporter, tiltBuild, gitRemote)
-	v2 := engine.ProvideSubscribers(headsUpDisplay, terminalStream, terminalPrompt, podWatcher, serviceWatcher, podLogManager, controller, watchManager, gitManager, buildController, configsController, eventWatcher, dockerComposeLogManager, profilerManager, syncletManager, analyticsReporter, headsUpServerController, analyticsUpdater, eventWatchManager, cloudStatusManager, dockerPruner, telemetryController, localController, podMonitor, exitController, metricsController)
+	modeController := metrics.NewModeController(modelWebHost)
+	v2 := engine.ProvideSubscribers(headsUpDisplay, terminalStream, terminalPrompt, podWatcher, serviceWatcher, podLogManager, controller, watchManager, gitManager, buildController, configsController, eventWatcher, dockerComposeLogManager, profilerManager, syncletManager, analyticsReporter, headsUpServerController, analyticsUpdater, eventWatchManager, cloudStatusManager, dockerPruner, telemetryController, localController, podMonitor, exitController, metricsController, modeController)
 	upper := engine.NewUpper(ctx, storeStore, v2)
-	windmillDir, err := dirs.UseTiltDevDir()
+	tiltDevDir, err := dirs.UseTiltDevDir()
 	if err != nil {
 		return CmdCIDeps{}, err
 	}
-	tokenToken, err := token.GetOrCreateToken(windmillDir)
+	tokenToken, err := token.GetOrCreateToken(tiltDevDir)
 	if err != nil {
 		return CmdCIDeps{}, err
 	}
@@ -729,7 +731,7 @@ func wireAnalytics(l logger.Logger, cmdName model.TiltSubcommand) (*analytics.Ti
 var K8sWireSet = wire.NewSet(k8s.ProvideEnv, k8s.ProvideClusterName, k8s.ProvideKubeContext, k8s.ProvideKubeConfig, k8s.ProvideClientConfig, k8s.ProvideClientset, k8s.ProvideRESTConfig, k8s.ProvidePortForwardClient, k8s.ProvideConfigNamespace, k8s.ProvideKubectlRunner, k8s.ProvideContainerRuntime, k8s.ProvideServerVersion, k8s.ProvideK8sClient, k8s.ProvideOwnerFetcher, ProvideKubeContextOverride)
 
 var BaseWireSet = wire.NewSet(
-	K8sWireSet, tiltfile.WireSet, provideKubectlLogLevel, git.ProvideGitRemote, docker.SwitchWireSet, ProvideDeferredExporter, metrics.NewController, dockercompose.NewDockerComposeClient, clockwork.NewRealClock, engine.DeployerWireSet, runtimelog.NewPodLogManager, portforward.NewController, engine.NewBuildController, local.ProvideExecer, local.NewController, k8swatch.NewPodWatcher, k8swatch.NewServiceWatcher, k8swatch.NewEventWatchManager, configs.NewConfigsController, telemetry.NewController, dcwatch.NewEventWatcher, runtimelog.NewDockerComposeLogManager, engine.NewProfilerManager, cloud.WireSet, cloudurl.ProvideAddress, k8srollout.NewPodMonitor, telemetry.NewStartTracker, exit.NewController, provideClock, hud.WireSet, prompt.WireSet, provideLogActions, store.NewStore, wire.Bind(new(store.RStore), new(*store.Store)), dockerprune.NewDockerPruner, provideTiltInfo, engine.ProvideSubscribers, engine.NewUpper, analytics2.NewAnalyticsUpdater, analytics2.ProvideAnalyticsReporter, provideUpdateModeFlag, fswatch.NewGitManager, fswatch.NewWatchManager, fswatch.ProvideFsWatcherMaker, fswatch.ProvideTimerMaker, provideWebVersion,
+	K8sWireSet, tiltfile.WireSet, provideKubectlLogLevel, git.ProvideGitRemote, docker.SwitchWireSet, ProvideDeferredExporter, metrics.NewController, metrics.NewModeController, dockercompose.NewDockerComposeClient, clockwork.NewRealClock, engine.DeployerWireSet, runtimelog.NewPodLogManager, portforward.NewController, engine.NewBuildController, local.ProvideExecer, local.NewController, k8swatch.NewPodWatcher, k8swatch.NewServiceWatcher, k8swatch.NewEventWatchManager, configs.NewConfigsController, telemetry.NewController, dcwatch.NewEventWatcher, runtimelog.NewDockerComposeLogManager, engine.NewProfilerManager, cloud.WireSet, cloudurl.ProvideAddress, k8srollout.NewPodMonitor, telemetry.NewStartTracker, exit.NewController, provideClock, hud.WireSet, prompt.WireSet, provideLogActions, store.NewStore, wire.Bind(new(store.RStore), new(*store.Store)), dockerprune.NewDockerPruner, provideTiltInfo, engine.ProvideSubscribers, engine.NewUpper, analytics2.NewAnalyticsUpdater, analytics2.ProvideAnalyticsReporter, provideUpdateModeFlag, fswatch.NewGitManager, fswatch.NewWatchManager, fswatch.ProvideFsWatcherMaker, fswatch.ProvideTimerMaker, provideWebVersion,
 	provideWebMode,
 	provideWebURL,
 	provideWebPort,

--- a/internal/engine/metrics/actions.go
+++ b/internal/engine/metrics/actions.go
@@ -1,0 +1,14 @@
+package metrics
+
+import (
+	"github.com/tilt-dev/tilt/internal/store"
+	"github.com/tilt-dev/tilt/pkg/model"
+)
+
+type MetricsModeAction struct {
+	Mode      store.MetricsMode
+	Settings  model.MetricsSettings
+	Manifests []model.Manifest
+}
+
+func (MetricsModeAction) Action() {}

--- a/internal/engine/metrics/controller.go
+++ b/internal/engine/metrics/controller.go
@@ -25,7 +25,13 @@ type MetricsState struct {
 }
 
 func (s MetricsState) Enabled() bool {
-	return s.settings.Enabled && s.username != "" && s.token != ""
+	if !s.settings.Enabled {
+		return false
+	}
+	if s.settings.AllowAnonymous {
+		return true
+	}
+	return s.username != "" && s.token != ""
 }
 
 type Controller struct {

--- a/internal/engine/metrics/mode_controller.go
+++ b/internal/engine/metrics/mode_controller.go
@@ -1,0 +1,127 @@
+package metrics
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+
+	"github.com/tilt-dev/tilt/internal/k8s"
+	"github.com/tilt-dev/tilt/internal/store"
+	"github.com/tilt-dev/tilt/pkg/logger"
+	"github.com/tilt-dev/tilt/pkg/model"
+)
+
+const grafanaManifestName = model.ManifestName("(tilt-grafana)")
+const collectorManifestName = model.ManifestName("(tilt-collector)")
+const promManifestName = model.ManifestName("(tilt-prometheus)")
+const collectorHostPort = 10351
+const grafanaHostPort = 10352
+
+func IsLocalMetricsStack(name model.ManifestName) bool {
+	return name == grafanaManifestName ||
+		name == collectorManifestName ||
+		name == promManifestName
+}
+
+type ModeController struct {
+	host        model.WebHost
+	initialized bool
+}
+
+func NewModeController(host model.WebHost) *ModeController {
+	return &ModeController{host: host}
+}
+
+func (c *ModeController) currentMode(rStore store.RStore) store.MetricsMode {
+	state := rStore.RLockState()
+	defer rStore.RUnlockState()
+	return state.MetricsMode
+}
+
+func (c *ModeController) OnChange(ctx context.Context, rStore store.RStore) {
+	if c.initialized {
+		return
+	}
+	c.initialized = true
+
+	// NOTE(nick): This is a hack until we have a real flow for
+	// letting the user set the metrics mode from the UI, or letting
+	// their team lead set it from a dashboard.
+	localMetricsEnv := os.Getenv("TILT_LOCAL_METRICS")
+	if localMetricsEnv != "1" {
+		return
+	}
+
+	stack, err := c.localMetricsStack()
+	if err != nil {
+		logger.Get(ctx).Warnf("metrics mode: %v", err)
+		return
+	}
+
+	rStore.Dispatch(MetricsModeAction{
+		Mode: store.MetricsLocal,
+		Settings: model.MetricsSettings{
+			Enabled:         true,
+			Address:         fmt.Sprintf("%s:%d", c.host, grafanaHostPort),
+			Insecure:        true,
+			ReportingPeriod: 5 * time.Second,
+			AllowAnonymous:  true,
+		},
+		Manifests: stack,
+	})
+}
+
+// The metrics stack consists of 3 servers: a collector (for ingestion),
+// prometheus (for querying/indexing timeseries data),
+// and grafana (for displaying the timeseries).
+//
+// In an ideal world, this would be only one manifest (or a resource group),
+// but our port-forwarding system only supports 1 pod per manifest.
+func (c *ModeController) localMetricsStack() ([]model.Manifest, error) {
+	collector, err := c.localMetricsManifest(collectorManifestName, []string{
+		collector,
+		collectorConfig,
+	}, []model.PortForward{{ContainerPort: 55678, LocalPort: collectorHostPort, Host: string(c.host)}})
+	if err != nil {
+		return nil, errors.Wrap(err, "init metrics collector")
+	}
+
+	prometheus, err := c.localMetricsManifest(promManifestName, []string{
+		prometheus,
+		prometheusConfig,
+	}, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, "init metrics prometheus")
+	}
+
+	grafana, err := c.localMetricsManifest(grafanaManifestName, []string{
+		grafana,
+		grafanaConfig,
+		grafanaDashboardConfig,
+	}, []model.PortForward{{ContainerPort: 9090, LocalPort: grafanaHostPort, Host: string(c.host)}})
+	if err != nil {
+		return nil, errors.Wrap(err, "init metrics grafana")
+	}
+	return []model.Manifest{collector, prometheus, grafana}, nil
+}
+
+func (c *ModeController) localMetricsManifest(name model.ManifestName, yaml []string, ports []model.PortForward) (model.Manifest, error) {
+	entities := []k8s.K8sEntity{}
+	for _, c := range yaml {
+		newEs, err := k8s.ParseYAML(strings.NewReader(c))
+		if err != nil {
+			return model.Manifest{}, fmt.Errorf("init local metrics: %v", err)
+		}
+		entities = append(entities, newEs...)
+	}
+	kTarget, err := k8s.NewTarget(model.TargetName(name), entities, ports,
+		nil, nil, nil, model.PodReadinessIgnore, nil, nil)
+	if err != nil {
+		return model.Manifest{}, fmt.Errorf("init local metrics: %v", err)
+	}
+	return model.Manifest{Name: name}.WithDeployTarget(kTarget), nil
+}

--- a/internal/engine/metrics/mode_controller_test.go
+++ b/internal/engine/metrics/mode_controller_test.go
@@ -1,0 +1,63 @@
+package metrics
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/tilt-dev/tilt/internal/store"
+	"github.com/tilt-dev/tilt/internal/testutils/tempdir"
+	"github.com/tilt-dev/tilt/pkg/logger"
+)
+
+func TestEnableLocalMetrics(t *testing.T) {
+	f := newModeFixture(t)
+	os.Setenv("TILT_LOCAL_METRICS", "1")
+	defer os.Unsetenv("TILT_LOCAL_METRICS")
+
+	f.mc.OnChange(f.ctx, f.st)
+	if assert.NotNil(t, f.st.action) {
+		assert.Equal(t, store.MetricsLocal, f.st.action.Mode)
+		assert.Equal(t, 3, len(f.st.action.Manifests))
+	}
+}
+
+type modeStore struct {
+	*store.TestingStore
+
+	action MetricsModeAction
+}
+
+func (s *modeStore) Dispatch(action store.Action) {
+	mma, ok := action.(MetricsModeAction)
+	if ok {
+		s.action = mma
+	}
+	s.TestingStore.Dispatch(mma)
+}
+
+type modeFixture struct {
+	*tempdir.TempDirFixture
+	ctx context.Context
+	st  *modeStore
+	mc  *ModeController
+}
+
+func newModeFixture(t *testing.T) *modeFixture {
+	f := tempdir.NewTempDirFixture(t)
+
+	st := &modeStore{TestingStore: store.NewTestingStore()}
+
+	l := logger.NewLogger(logger.DebugLvl, os.Stdout)
+	ctx := logger.WithLogger(context.Background(), l)
+
+	mc := NewModeController("localhost")
+	return &modeFixture{
+		TempDirFixture: f,
+		ctx:            ctx,
+		st:             st,
+		mc:             mc,
+	}
+}

--- a/internal/engine/metrics/yaml.go
+++ b/internal/engine/metrics/yaml.go
@@ -1,0 +1,464 @@
+package metrics
+
+// YAML copied from
+// https://github.com/tilt-dev/tilt-local-metrics
+
+const collector = `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tilt-local-metrics-collector
+  labels:
+    app.kubernetes.io/name: otel-collector
+    app.kubernetes.io/part-of: tilt-local-metrics
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: otel-collector
+      app.kubernetes.io/part-of: tilt-local-metrics
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: otel-collector
+        app.kubernetes.io/part-of: tilt-local-metrics
+    spec:
+      volumes:
+        - name: config-vol
+          configMap:
+            name: tilt-otel-collector-config
+            items:
+              - key: otel-collector-config
+                path: otel-collector-config.yaml
+
+      containers:
+        - name: otel-collector
+          image: otel/opentelemetry-collector:0.14.0
+          command:
+          - "/otelcol"
+          - "--config=/conf/otel-collector-config.yaml"
+
+          ports:
+            - name: pprof
+              containerPort: 1777
+              protocol: TCP
+            - name: zpages
+              containerPort: 55679
+              protocol: TCP
+            - name: receiver
+              containerPort: 55678
+              protocol: TCP
+            - name: prom-exporter
+              containerPort: 55681
+              protocol: TCP
+            - name: healthcheck
+              containerPort: 13133
+              protocol: TCP
+          volumeMounts:
+            - name: config-vol
+              mountPath: /conf
+
+          readinessProbe:
+            httpGet:
+              port: 13133
+            initialDelaySeconds: 5
+            periodSeconds: 10
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: tilt-local-metrics-collector
+  labels:
+    app.kubernetes.io/name: otel-collector
+    app.kubernetes.io/part-of: tilt-local-metrics
+spec:
+  ports:
+  - name: receiver
+    port: 55678
+    protocol: TCP
+    targetPort: 55678
+  - name: exporter
+    port: 55681
+    protocol: TCP
+    targetPort: 55681
+  selector:
+    app.kubernetes.io/name: otel-collector
+    app.kubernetes.io/part-of: tilt-local-metrics
+`
+
+const collectorConfig = `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: tilt-otel-collector-config
+  labels:
+    app.kubernetes.io/name: otel-collector
+    app.kubernetes.io/part-of: tilt-local-metrics
+data:
+  otel-collector-config: |
+    extensions:
+      health_check:
+      pprof:
+        endpoint: 0.0.0.0:1777
+      zpages:
+        endpoint: 0.0.0.0:55679
+
+    receivers:
+      opencensus:
+        endpoint: "0.0.0.0:55678"
+
+    processors:
+      memory_limiter:
+        check_interval: 5s
+        limit_mib: 4000
+        spike_limit_mib: 500
+      batch:
+
+    exporters:
+      logging:
+        loglevel: info
+      prometheus:
+        endpoint: "0.0.0.0:55681"
+
+    service:
+      extensions: [health_check, pprof, zpages]
+      pipelines:
+        metrics:
+          receivers: [opencensus]
+          exporters: [logging, prometheus]
+`
+
+const prometheus = `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tilt-local-metrics-prometheus
+  labels:
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/part-of: tilt-local-metrics
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus
+      app.kubernetes.io/part-of: tilt-local-metrics
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: prometheus
+        app.kubernetes.io/part-of: tilt-local-metrics
+    spec:
+      volumes:
+        - name: config-vol
+          configMap:
+            name: tilt-prometheus-config
+            items:
+              - key: prometheus-config
+                path: prometheus.yml
+
+      containers:
+        - name: prometheus
+          image: prom/prometheus:v2.22.2
+
+          ports:
+            - name: http
+              containerPort: 9090
+              protocol: TCP
+
+          volumeMounts:
+            - name: config-vol
+              mountPath: /etc/prometheus
+
+          readinessProbe:
+            httpGet:
+              port: 9090
+            initialDelaySeconds: 5
+            periodSeconds: 10
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: tilt-local-metrics-prometheus
+  labels:
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/part-of: tilt-local-metrics
+spec:
+  ports:
+  - name: http
+    port: 9090
+    protocol: TCP
+    targetPort: 9090
+  selector:
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/part-of: tilt-local-metrics
+`
+
+const prometheusConfig = `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: tilt-prometheus-config
+  labels:
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/part-of: tilt-local-metrics
+data:
+  prometheus-config: |
+    global:
+      scrape_interval: 15s
+
+    scrape_configs:
+    - job_name: 'otel-collector'
+      scrape_interval: 5s
+      static_configs:
+        - targets: ['tilt-local-metrics-collector:55681']
+`
+
+const grafana = `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tilt-local-metrics-grafana
+  labels:
+    app.kubernetes.io/name: grafana
+    app.kubernetes.io/part-of: tilt-local-metrics
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: grafana
+      app.kubernetes.io/part-of: tilt-local-metrics
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: grafana
+        app.kubernetes.io/part-of: tilt-local-metrics
+    spec:
+      volumes:
+        - name: ini-vol
+          configMap:
+            name: tilt-grafana-config
+            items:
+            - key: grafana.ini
+              path: grafana.ini
+        - name: provision-dashboards-vol
+          configMap:
+            name: tilt-grafana-config
+            items:
+            - key: dashboards.yaml
+              path: dashboards.yaml
+        - name: provision-datasources-vol
+          configMap:
+            name: tilt-grafana-config
+            items:
+            - key: datasource-prometheus.yaml
+              path: datasource-prometheus.yaml
+        - name: dashboard-vol
+          configMap:
+            name: tilt-grafana-dashboards
+
+      containers:
+        - name: grafana
+          image: grafana/grafana:7.3.3
+
+          ports:
+            - name: http
+              containerPort: 3000
+              protocol: TCP
+
+          volumeMounts:
+            - name: ini-vol
+              mountPath: /etc/grafana/grafana.ini
+              subPath: grafana.ini
+            - name: provision-dashboards-vol
+              mountPath: /etc/grafana/provisioning/dashboards/dashboards.yaml
+              subPath: dashboards.yaml
+            - name: provision-datasources-vol
+              mountPath: /etc/grafana/provisioning/datasources/datasource-prometheus.yaml
+              subPath: datasource-prometheus.yaml
+            - name: dashboard-vol
+              mountPath: /var/lib/grafana/dashboards
+
+          readinessProbe:
+            httpGet:
+              port: 3000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+`
+
+const grafanaConfig = `
+kind: ConfigMap
+apiVersion: v1
+data:
+  dashboards.yaml: |
+    apiVersion: 1
+
+    providers:
+    - name: 'default-dashboards'
+      orgId: 1
+      type: file
+      disableDeletion: true
+      updateIntervalSeconds: 1000
+      allowUiUpdates: true
+      options:
+        path: /var/lib/grafana/dashboards
+        foldersFromFilesStructure: true
+  datasource-prometheus.yaml: |
+    apiVersion: 1
+
+    datasources:
+    - name: Prometheus
+      type: prometheus
+      url: http://tilt-local-metrics-prometheus:9090/
+      default: true
+  grafana.ini: |+
+    [auth.anonymous]
+    enabled = true
+`
+
+const grafanaDashboardConfig = `
+kind: ConfigMap
+apiVersion: v1
+data:
+  tiltfile-execution.json: |
+    {
+      "annotations": {
+        "list": [
+          {
+            "builtIn": 1,
+            "datasource": "-- Grafana --",
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "name": "Annotations & Alerts",
+            "type": "dashboard"
+          }
+        ]
+      },
+      "editable": true,
+      "gnetId": null,
+      "graphTooltip": 0,
+      "id": 1,
+      "links": [],
+      "panels": [
+        {
+          "aliasColors": {
+            "Rolling 15 minute average ": "yellow"
+          },
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 0,
+            "y": 0
+          },
+          "hiddenSeries": false,
+          "id": 2,
+          "legend": {
+            "alignAsTable": false,
+            "avg": false,
+            "current": false,
+            "hideEmpty": false,
+            "hideZero": true,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "connected",
+          "options": {
+            "alertThreshold": false
+          },
+          "percentage": false,
+          "pluginVersion": "7.3.3",
+          "pointradius": 2,
+          "points": true,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(tiltfile_exec_duration_dist_sum[60s]) / rate(tiltfile_exec_duration_dist_count[60s])",
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "Rolling 5 min avg (Error: {{error}})",
+              "refId": "B"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Tiltfile Execution (ms)",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "ms",
+              "label": "",
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": true,
+            "alignLevel": null
+          }
+        }
+      ],
+      "schemaVersion": 26,
+      "style": "dark",
+      "tags": [],
+      "templating": {
+        "list": []
+      },
+      "time": {
+        "from": "now-15m",
+        "to": "now"
+      },
+      "timepicker": {},
+      "timezone": "",
+      "title": "Tilt Local Metrics",
+      "uid": "nIq4P-TMz",
+      "version": 2
+    }
+`

--- a/internal/engine/subscribers.go
+++ b/internal/engine/subscribers.go
@@ -49,6 +49,7 @@ func ProvideSubscribers(
 	podm *k8srollout.PodMonitor,
 	ec *exit.Controller,
 	mc *metrics.Controller,
+	mmc *metrics.ModeController,
 ) []store.Subscriber {
 	return []store.Subscriber{
 		hud,
@@ -77,5 +78,6 @@ func ProvideSubscribers(
 		podm,
 		ec,
 		mc,
+		mmc,
 	}
 }

--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -22,6 +22,7 @@ import (
 	"github.com/tilt-dev/tilt/internal/engine/fswatch"
 	"github.com/tilt-dev/tilt/internal/engine/k8swatch"
 	"github.com/tilt-dev/tilt/internal/engine/local"
+	"github.com/tilt-dev/tilt/internal/engine/metrics"
 	"github.com/tilt-dev/tilt/internal/engine/runtimelog"
 	"github.com/tilt-dev/tilt/internal/hud"
 	"github.com/tilt-dev/tilt/internal/hud/prompt"
@@ -176,6 +177,8 @@ func upperReducerFn(ctx context.Context, state *store.EngineState, action store.
 		handleExitAction(state, action)
 	case prompt.SwitchTerminalModeAction:
 		handleSwitchTerminalModeAction(state, action)
+	case metrics.MetricsModeAction:
+		// TODO(nick): Fill this in
 	default:
 		state.FatalError = fmt.Errorf("unrecognized action: %T", action)
 	}

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -3724,8 +3724,9 @@ func newTestFixture(t *testing.T) *testFixture {
 
 	de := metrics.NewDeferredExporter()
 	mc := metrics.NewController(de, model.TiltBuild{}, "")
+	mcc := metrics.NewModeController("localhost")
 
-	subs := ProvideSubscribers(h, ts, tp, pw, sw, plm, pfc, fwm, gm, bc, cc, dcw, dclm, pm, sm, ar, hudsc, au, ewm, tcum, dp, tc, lc, podm, ec, mc)
+	subs := ProvideSubscribers(h, ts, tp, pw, sw, plm, pfc, fwm, gm, bc, cc, dcw, dclm, pm, sm, ar, hudsc, au, ewm, tcum, dp, tc, lc, podm, ec, mc, mcc)
 	ret.upper = NewUpper(ctx, st, subs)
 
 	go func() {

--- a/internal/store/engine_state.go
+++ b/internal/store/engine_state.go
@@ -113,6 +113,7 @@ type EngineState struct {
 	TelemetrySettings model.TelemetrySettings
 
 	MetricsSettings model.MetricsSettings
+	MetricsMode     MetricsMode
 
 	UserConfigState model.UserConfigState
 }

--- a/internal/store/metrics.go
+++ b/internal/store/metrics.go
@@ -1,0 +1,8 @@
+package store
+
+// User-specified presets for creating metrics.
+type MetricsMode string
+
+const MetricsNone MetricsMode = ""
+const MetricsLocal MetricsMode = "local"
+const MetricsProd MetricsMode = "prod"

--- a/pkg/model/metrics.go
+++ b/pkg/model/metrics.go
@@ -14,6 +14,11 @@ type MetricsSettings struct {
 	// How often Tilt reports its metrics. Useful for testing.
 	// https://pkg.go.dev/go.opencensus.io/stats/view?tab=doc#SetReportingPeriod
 	ReportingPeriod time.Duration
+
+	// Whether anonymous metrics are allowed.
+	// The normal tilt prod metrics processor requires the
+	// user to be logged in.
+	AllowAnonymous bool
 }
 
 func DefaultMetricsSettings() MetricsSettings {


### PR DESCRIPTION
Hello @landism, @maiamcc,

Please review the following commits I made in branch nicks/localmetrics:

80df10eee3bac18e78412619a142ac21b5c2e6bc (2020-11-20 12:02:38 -0500)
engine: add a controller that deploys a local metrics stack

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics