### PR TITLE
engine: merge local metrics services into the engine state

### DIFF
--- a/internal/engine/image_builder.go
+++ b/internal/engine/image_builder.go
@@ -91,7 +91,7 @@ func (icb *imageBuilder) Build(ctx context.Context, iTarget model.ImageTarget,
 
 	defer func() {
 		latencyMs := float64(time.Since(startTime)) / float64(time.Millisecond)
-		errorTag := ""
+		errorTag := "0"
 		if err != nil {
 			errorTag = "1"
 		}

--- a/internal/engine/metrics/mode_controller.go
+++ b/internal/engine/metrics/mode_controller.go
@@ -66,7 +66,7 @@ func (c *ModeController) OnChange(ctx context.Context, rStore store.RStore) {
 		Mode: store.MetricsLocal,
 		Settings: model.MetricsSettings{
 			Enabled:         true,
-			Address:         fmt.Sprintf("%s:%d", c.host, grafanaHostPort),
+			Address:         fmt.Sprintf("%s:%d", c.host, collectorHostPort),
 			Insecure:        true,
 			ReportingPeriod: 5 * time.Second,
 			AllowAnonymous:  true,
@@ -102,7 +102,7 @@ func (c *ModeController) localMetricsStack() ([]model.Manifest, error) {
 		grafana,
 		grafanaConfig,
 		grafanaDashboardConfig,
-	}, []model.PortForward{{ContainerPort: 9090, LocalPort: grafanaHostPort, Host: string(c.host)}})
+	}, []model.PortForward{{ContainerPort: 3000, LocalPort: grafanaHostPort, Host: string(c.host)}})
 	if err != nil {
 		return nil, errors.Wrap(err, "init metrics grafana")
 	}
@@ -123,5 +123,8 @@ func (c *ModeController) localMetricsManifest(name model.ManifestName, yaml []st
 	if err != nil {
 		return model.Manifest{}, fmt.Errorf("init local metrics: %v", err)
 	}
-	return model.Manifest{Name: name}.WithDeployTarget(kTarget), nil
+	return model.Manifest{
+		Name:   name,
+		Source: model.ManifestSourceMetrics,
+	}.WithDeployTarget(kTarget), nil
 }

--- a/internal/engine/metrics/yaml.go
+++ b/internal/engine/metrics/yaml.go
@@ -288,6 +288,8 @@ spec:
 const grafanaConfig = `
 kind: ConfigMap
 apiVersion: v1
+metadata:
+  name: tilt-grafana-config
 data:
   dashboards.yaml: |
     apiVersion: 1
@@ -318,6 +320,8 @@ data:
 const grafanaDashboardConfig = `
 kind: ConfigMap
 apiVersion: v1
+metadata:
+  name: tilt-grafana-dashboards
 data:
   tiltfile-execution.json: |
     {

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -3592,6 +3592,26 @@ func TestHandleTiltfileTriggerQueue(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestMetricsModeAction(t *testing.T) {
+	f := newTestFixture(t)
+	defer f.TearDown()
+
+	m1 := f.newManifest("fe")
+	f.Start([]model.Manifest{m1})
+
+	m2 := f.newManifest("collector")
+	f.store.Dispatch(metrics.MetricsModeAction{
+		Mode:      store.MetricsLocal,
+		Settings:  model.MetricsSettings{Address: "localhost:10352"},
+		Manifests: []model.Manifest{m2},
+	})
+
+	f.waitForCompletedBuildCount(2)
+	f.withState(func(state store.EngineState) {
+		assert.Equal(t, []model.ManifestName{"fe", "collector"}, state.ManifestDefinitionOrder)
+	})
+}
+
 type testFixture struct {
 	*tempdir.TempDirFixture
 	t                          *testing.T

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -46,6 +46,8 @@ type Manifest struct {
 	// The resource in this manifest will not be built until all of its dependencies have been
 	// ready at least once.
 	ResourceDependencies []ManifestName
+
+	Source ManifestSource
 }
 
 func (m Manifest) ID() TargetID {
@@ -594,3 +596,8 @@ func equalForBuildInvalidation(x, y interface{}) bool {
 		ignoreDockerBuildCacheFrom,
 	)
 }
+
+type ManifestSource string
+
+const ManifestSourceTiltfile = ManifestSource("")
+const ManifestSourceMetrics = ManifestSource("metrics")


### PR DESCRIPTION
Hello @landism,

Please review the following commits I made in branch nicks/localmetrics2:

19a52f3909508db9a66165e99f0ba46ae1cb5bff (2020-11-24 11:49:30 -0500)
engine: merge local metrics services into the engine state

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics