### PR TITLE
Revert "k8s: use the Helm kube client instead of shelling out to a separate process to apply changes (#3945)"

### DIFF
--- a/internal/k8s/serialize.go
+++ b/internal/k8s/serialize.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"io"
+	"strings"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -17,6 +18,18 @@ import (
 func ParseYAMLFromString(yaml string) ([]K8sEntity, error) {
 	buf := bytes.NewBuffer([]byte(yaml))
 	return ParseYAML(buf)
+}
+
+func parseYAMLFromStringWithDeletedResources(yamlWithDeletedResources string) ([]K8sEntity, error) {
+	lines := strings.Split(yamlWithDeletedResources, "\n")
+	for len(lines) > 0 {
+		line := lines[0]
+		if !strings.HasSuffix(line, "deleted") {
+			break
+		}
+		lines = lines[1:]
+	}
+	return ParseYAMLFromString(strings.Join(lines, "\n"))
 }
 
 func decodeMetaList(list *metav1.List) ([]K8sEntity, error) {
@@ -133,14 +146,6 @@ func serializeSpec(obj runtime.Object, w io.Writer) error {
 // By convention, all K8s objects contain ObjectMetadata, Spec, and Status.
 // This only serializes the metadata and spec, skipping the status.
 func SerializeSpecYAML(decoded []K8sEntity) (string, error) {
-	buf, err := SerializeSpecYAMLToBuffer(decoded)
-	if err != nil {
-		return "", err
-	}
-	return buf.String(), nil
-}
-
-func SerializeSpecYAMLToBuffer(decoded []K8sEntity) (*bytes.Buffer, error) {
 	buf := bytes.NewBuffer(nil)
 	for i, obj := range decoded {
 		if i != 0 {
@@ -148,8 +153,8 @@ func SerializeSpecYAMLToBuffer(decoded []K8sEntity) (*bytes.Buffer, error) {
 		}
 		err := serializeSpec(obj.Obj, buf)
 		if err != nil {
-			return nil, err
+			return "", err
 		}
 	}
-	return buf, nil
+	return buf.String(), nil
 }

--- a/internal/k8s/serialize_test.go
+++ b/internal/k8s/serialize_test.go
@@ -117,6 +117,16 @@ func TestListYAML(t *testing.T) {
 	}, kinds)
 }
 
+func TestDeleted(t *testing.T) {
+	result, err := parseYAMLFromStringWithDeletedResources(testyaml.OneDeleted)
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(result))
+
+	result, err = parseYAMLFromStringWithDeletedResources(testyaml.TwoDeleted)
+	assert.Nil(t, err)
+	assert.Equal(t, 2, len(result))
+}
+
 func TestBase64Serialization(t *testing.T) {
 	// json-iterator used to have a bug where it serialized this incorrectly.
 	// https://github.com/json-iterator/go/issues/272

--- a/internal/k8s/watch_test.go
+++ b/internal/k8s/watch_test.go
@@ -355,13 +355,6 @@ func TestSupportsPartialMeta(t *testing.T) {
 	}
 }
 
-type fakeDiscovery struct {
-	*difake.FakeDiscovery
-}
-
-func (fakeDiscovery) Fresh() bool { return true }
-func (fakeDiscovery) Invalidate() {}
-
 type watchTestFixture struct {
 	t    *testing.T
 	kCli K8sClient
@@ -424,11 +417,9 @@ func newWatchTestFixture(t *testing.T) *watchTestFixture {
 	ret.metadata = mcs
 
 	version := &version.Info{Major: "1", Minor: "19", GitVersion: "v1.19.1"}
-	di := fakeDiscovery{
-		FakeDiscovery: &difake.FakeDiscovery{
-			Fake:               &ktesting.Fake{},
-			FakedServerVersion: version,
-		},
+	di := &difake.FakeDiscovery{
+		Fake:               &ktesting.Fake{},
+		FakedServerVersion: version,
 	}
 
 	ret.kCli = K8sClient{
@@ -632,13 +623,11 @@ func (tf *watchTestFixture) testServiceLabels(input labels.Set, expectedLabels l
 }
 
 type fakeRESTMapper struct {
-	*meta.DefaultRESTMapper
 }
 
 func (f fakeRESTMapper) RESTMapping(gk schema.GroupKind, versions ...string) (*meta.RESTMapping, error) {
 	return &meta.RESTMapping{
 		Resource: PodGVR,
-		Scope:    meta.RESTScopeNamespace,
 	}, nil
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -46,6 +46,8 @@ github.com/blang/semver
 ## explicit
 # github.com/bugsnag/panicwrap v1.2.0
 ## explicit
+# github.com/cenkalti/backoff v2.2.1+incompatible
+## explicit
 # github.com/census-instrumentation/opencensus-proto v0.2.1
 github.com/census-instrumentation/opencensus-proto/gen-go/agent/common/v1
 github.com/census-instrumentation/opencensus-proto/gen-go/agent/metrics/v1


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/update-error:

9a9a0d2ddaf701be010c09d99f60c462145530b4 (2020-11-25 17:46:55 -0500)
Revert "k8s: use the Helm kube client instead of shelling out to a separate process to apply changes (#3945)"
This reverts commit f711652e8ad897eef857399f9ae89ebcdb8bec73.

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics