### PR TITLE
k8s: use the Helm kube client instead of shelling out to a separate process to apply changes, try #2

### DIFF
--- a/internal/k8s/client_test.go
+++ b/internal/k8s/client_test.go
@@ -1,21 +1,28 @@
 package k8s
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
 	"testing"
 	"time"
 
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"helm.sh/helm/v3/pkg/kube"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/cli-runtime/pkg/resource"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/kubernetes/scheme"
+	restfake "k8s.io/client-go/rest/fake"
 	ktesting "k8s.io/client-go/testing"
 
 	"github.com/tilt-dev/tilt/internal/k8s/testyaml"
@@ -44,8 +51,7 @@ func TestUpsert(t *testing.T) {
 	assert.Nil(t, err)
 	_, err = f.k8sUpsert(f.ctx, postgres)
 	assert.Nil(t, err)
-	assert.Equal(t, 5, len(f.runner.calls))
-	assert.Equal(t, []string{"apply", "-o", "yaml", "-f", "-"}, f.runner.calls[0].argv)
+	assert.Equal(t, 5, len(f.helmKube.updates))
 }
 
 func TestUpsertMutableAndImmutable(t *testing.T) {
@@ -59,56 +65,30 @@ func TestUpsertMutableAndImmutable(t *testing.T) {
 		t.FailNow()
 	}
 
-	// two different calls: one for mutable entities (namespace, deployment),
-	// one for immutable (job)
-	require.Len(t, f.runner.calls, 3)
-
-	call0 := f.runner.calls[0]
-	call1 := f.runner.calls[1]
-	require.Equal(t, []string{"apply", "-o", "yaml", "-f", "-"}, call0.argv, "expected args for call 0")
-	require.Equal(t, []string{"apply", "-o", "yaml", "-f", "-"}, call1.argv, "expected args for call 1")
+	require.Len(t, f.helmKube.updates, 2)
+	require.Len(t, f.helmKube.creates, 1)
 
 	// compare entities instead of strings because str > entity > string gets weird
-	call0Entity := mustParseYAML(t, call0.stdin)[0]
-	call1Entity := mustParseYAML(t, call1.stdin)[0]
+	call0Entity := NewK8sEntity(f.helmKube.updates[0].Object)
+	call1Entity := NewK8sEntity(f.helmKube.updates[1].Object)
 
 	// `apply` should preserve input order of entities (we sort them further upstream)
 	require.Equal(t, eDeploy, call0Entity, "expect call 0 to have applied deployment first (preserve input order)")
 	require.Equal(t, eNamespace, call1Entity, "expect call 0 to have applied namespace second (preserve input order)")
 
-	call2 := f.runner.calls[2]
-	require.Equal(t, []string{"replace", "-o", "yaml", "--force", "-f", "-"}, call2.argv, "expected args for call 1")
-	call2Entities := mustParseYAML(t, call2.stdin)
-	require.Len(t, call2Entities, 1, "expect only one immutable entity applied")
-	require.Equal(t, eJob, call2Entities[0], "expect call 1 to have applied job")
+	call2Entity := NewK8sEntity(f.helmKube.creates[0].Object)
+	require.Equal(t, eJob, call2Entity, "expect create job")
 }
 
 func TestUpsertAnnotationTooLong(t *testing.T) {
 	f := newClientTestFixture(t)
 	postgres := MustParseYAMLFromString(t, testyaml.PostgresYAML)
 
-	f.setStderr(`The ConfigMap "postgres-config" is invalid: metadata.annotations: Too long: must have at most 262144 bytes`)
+	f.helmKube.updateErr = fmt.Errorf(`The ConfigMap "postgres-config" is invalid: metadata.annotations: Too long: must have at most 262144 bytes`)
 	_, err := f.k8sUpsert(f.ctx, postgres)
-	if !assert.Nil(t, err) {
-		t.FailNow()
-	}
-
-	expectedArgs := [][]string{
-		{"apply", "-o", "yaml", "-f", "-"},
-		{"delete", "--ignore-not-found=true", "-f", "-"},
-		{"create", "-o", "yaml", "-f", "-"},
-		{"apply", "-o", "yaml", "-f", "-"},
-		{"apply", "-o", "yaml", "-f", "-"},
-		{"apply", "-o", "yaml", "-f", "-"},
-		{"apply", "-o", "yaml", "-f", "-"},
-	}
-	require.Len(t, f.runner.calls, len(expectedArgs))
-
-	for i, call := range f.runner.calls {
-		require.Equalf(t, expectedArgs[i], call.argv, "expected args for call %d", i)
-		observedEntities := mustParseYAML(t, call.stdin)
-		require.Len(t, observedEntities, 1, "expect 1 entity")
-	}
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(f.helmKube.creates))
+	assert.Equal(t, 4, len(f.helmKube.updates))
 }
 
 func TestUpsertStatefulsetForbidden(t *testing.T) {
@@ -116,17 +96,11 @@ func TestUpsertStatefulsetForbidden(t *testing.T) {
 	postgres, err := ParseYAMLFromString(testyaml.PostgresYAML)
 	assert.Nil(t, err)
 
-	f.setStderr(`The StatefulSet "postgres" is invalid: spec: Forbidden: updates to statefulset spec for fields other than 'replicas', 'template', and 'updateStrategy' are forbidden.`)
+	f.helmKube.updateErr = fmt.Errorf(`The StatefulSet "postgres" is invalid: spec: Forbidden: updates to statefulset spec for fields other than 'replicas', 'template', and 'updateStrategy' are forbidden.`)
 	_, err = f.k8sUpsert(f.ctx, postgres)
-	if assert.Nil(t, err) && assert.Equal(t, 7, len(f.runner.calls)) {
-		assert.Equal(t, []string{"apply", "-o", "yaml", "-f", "-"}, f.runner.calls[0].argv)
-		assert.Equal(t, []string{"delete", "--ignore-not-found=true", "-f", "-"}, f.runner.calls[1].argv)
-		assert.Equal(t, []string{"create", "-o", "yaml", "-f", "-"}, f.runner.calls[2].argv)
-		assert.Equal(t, []string{"apply", "-o", "yaml", "-f", "-"}, f.runner.calls[3].argv)
-		assert.Equal(t, []string{"apply", "-o", "yaml", "-f", "-"}, f.runner.calls[4].argv)
-		assert.Equal(t, []string{"apply", "-o", "yaml", "-f", "-"}, f.runner.calls[5].argv)
-		assert.Equal(t, []string{"apply", "-o", "yaml", "-f", "-"}, f.runner.calls[6].argv)
-	}
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(f.helmKube.creates))
+	assert.Equal(t, 4, len(f.helmKube.updates))
 }
 
 func TestUpsertToTerminatingNamespaceForbidden(t *testing.T) {
@@ -138,16 +112,14 @@ func TestUpsertToTerminatingNamespaceForbidden(t *testing.T) {
 	// field error. Make sure we treat it as what it is and bail out of `kubectl apply`
 	// rather than trying to --force
 	errStr := `Error from server (Forbidden): error when creating "STDIN": deployments.apps "sancho" is forbidden: unable to create new content in namespace sancho-ns because it is being terminated`
-	f.setStderr(errStr)
+	f.helmKube.updateErr = fmt.Errorf(errStr)
 
 	_, err = f.k8sUpsert(f.ctx, postgres)
 	if assert.NotNil(t, err) {
 		assert.Contains(t, err.Error(), errStr)
 	}
-	if assert.Equal(t, 1, len(f.runner.calls)) {
-		assert.Equal(t, []string{"apply", "-o", "yaml", "-f", "-"}, f.runner.calls[0].argv)
-	}
-
+	assert.Equal(t, 0, len(f.helmKube.updates))
+	assert.Equal(t, 0, len(f.helmKube.creates))
 }
 
 func TestGetGroup(t *testing.T) {
@@ -171,25 +143,6 @@ func TestGetGroup(t *testing.T) {
 			assert.Equal(t, test.expectedGroup, ReferenceGVK(obj).Group)
 		})
 	}
-}
-
-func TestUpsertTimeout(t *testing.T) {
-	f := newClientTestFixture(t)
-	postgres := MustParseYAMLFromString(t, testyaml.PostgresYAML)
-
-	f.runner.pauseForever = true
-
-	// we can't use a fake clock with context.Context, so we'll cheat a bit
-	// and just pass Upsert an already expired context.
-	var cancel context.CancelFunc
-	f.ctx, cancel = context.WithDeadline(f.ctx, time.Now().Add(-time.Hour))
-	defer cancel()
-
-	timeout := time.Second * 123
-	_, err := f.client.Upsert(f.ctx, postgres, timeout)
-
-	require.Error(t, err)
-	require.Equal(t, err.Error(), timeoutError(timeout).Error())
 }
 
 type call struct {
@@ -253,6 +206,55 @@ func (f *fakeKubectlRunner) exec(ctx context.Context, args []string) (stdout str
 
 var _ kubectlRunner = &fakeKubectlRunner{}
 
+type fakeHelmKubeClient struct {
+	updates   kube.ResourceList
+	creates   kube.ResourceList
+	deletes   kube.ResourceList
+	updateErr error
+}
+
+func (c *fakeHelmKubeClient) Apply(target kube.ResourceList) (*kube.Result, error) {
+	defer func() {
+		c.updateErr = nil
+	}()
+
+	if c.updateErr != nil {
+		return nil, c.updateErr
+	}
+	c.updates = append(c.updates, target...)
+	return &kube.Result{Updated: target}, nil
+}
+func (c *fakeHelmKubeClient) Delete(l kube.ResourceList) (*kube.Result, []error) {
+	c.deletes = append(c.deletes, l...)
+	return &kube.Result{Deleted: l}, nil
+}
+func (c *fakeHelmKubeClient) Create(l kube.ResourceList) (*kube.Result, error) {
+	c.creates = append(c.creates, l...)
+	return &kube.Result{Created: l}, nil
+}
+func (c *fakeHelmKubeClient) Build(r io.Reader, validate bool) (kube.ResourceList, error) {
+	entities, err := ParseYAML(r)
+	if err != nil {
+		return nil, err
+	}
+	list := kube.ResourceList{}
+	for _, e := range entities {
+		list = append(list, &resource.Info{
+			// Create a fake HTTP client that returns 404 for every request.
+			Client: &restfake.RESTClient{
+				NegotiatedSerializer: scheme.Codecs,
+				Resp:                 &http.Response{StatusCode: http.StatusNotFound, Body: ioutil.NopCloser(&bytes.Buffer{})},
+			},
+			Mapping:   &meta.RESTMapping{Scope: meta.RESTScopeNamespace},
+			Object:    e.Obj,
+			Name:      e.Name(),
+			Namespace: string(e.Namespace()),
+		})
+	}
+
+	return list, nil
+}
+
 type clientTestFixture struct {
 	t           *testing.T
 	ctx         context.Context
@@ -260,6 +262,7 @@ type clientTestFixture struct {
 	runner      *fakeKubectlRunner
 	tracker     ktesting.ObjectTracker
 	watchNotify chan watch.Interface
+	helmKube    *fakeHelmKubeClient
 }
 
 func newClientTestFixture(t *testing.T) *clientTestFixture {
@@ -292,6 +295,9 @@ func newClientTestFixture(t *testing.T) *clientTestFixture {
 	core := cs.CoreV1()
 	runtimeAsync := newRuntimeAsync(core)
 	registryAsync := newRegistryAsync(EnvUnknown, core, runtimeAsync)
+	helmKube := &fakeHelmKubeClient{}
+	ret.helmKube = helmKube
+
 	ret.client = K8sClient{
 		env:               EnvUnknown,
 		kubectlRunner:     ret.runner,
@@ -299,6 +305,8 @@ func newClientTestFixture(t *testing.T) *clientTestFixture {
 		portForwardClient: &FakePortForwardClient{},
 		runtimeAsync:      runtimeAsync,
 		registryAsync:     registryAsync,
+		helmKubeClient:    helmKube,
+		drm:               fakeRESTMapper{},
 	}
 
 	return ret

--- a/internal/k8s/helm.go
+++ b/internal/k8s/helm.go
@@ -1,0 +1,73 @@
+package k8s
+
+import (
+	"io"
+	"io/ioutil"
+	"strings"
+
+	"helm.sh/helm/v3/pkg/kube"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/printers"
+	"k8s.io/kubectl/pkg/cmd/apply"
+	"k8s.io/kubectl/pkg/cmd/delete"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+)
+
+// We've adapted Helm's kubernetes client for our needs
+type HelmKubeClient interface {
+	Apply(target kube.ResourceList) (*kube.Result, error)
+	Delete(existing kube.ResourceList) (*kube.Result, []error)
+	Create(l kube.ResourceList) (*kube.Result, error)
+	Build(r io.Reader, validate bool) (kube.ResourceList, error)
+}
+
+type helmKubeClient struct {
+	*kube.Client
+	factory cmdutil.Factory
+}
+
+// Helm's update function doesn't really work for us,
+// so we use the kubectl apply code directly.
+func (c *helmKubeClient) Apply(target kube.ResourceList) (*kube.Result, error) {
+	f := c.factory
+	o := apply.NewApplyOptions(genericclioptions.IOStreams{
+		In:     strings.NewReader(""),
+		Out:    ioutil.Discard,
+		ErrOut: ioutil.Discard,
+	})
+
+	var err error
+	o.DynamicClient, err = f.DynamicClient()
+	if err != nil {
+		return nil, err
+	}
+
+	o.DeleteOptions = delete.NewDeleteFlags("").ToOptions(o.DynamicClient, o.IOStreams)
+	o.ToPrinter = func(s string) (printers.ResourcePrinter, error) {
+		return genericclioptions.NewPrintFlags("created").ToPrinter()
+	}
+	o.Builder = f.NewBuilder()
+	o.Mapper, err = f.ToRESTMapper()
+	if err != nil {
+		return nil, err
+	}
+
+	o.Namespace, o.EnforceNamespace, err = f.ToRawKubeConfigLoader().Namespace()
+	if err != nil {
+		return nil, err
+	}
+
+	o.SetObjects(target)
+	err = o.Run()
+	if err != nil {
+		return nil, err
+	}
+	return &kube.Result{Updated: target}, nil
+}
+
+func newHelmKubeClient(c K8sClient) HelmKubeClient {
+	return &helmKubeClient{
+		Client:  kube.New(c),
+		factory: cmdutil.NewFactory(c),
+	}
+}

--- a/internal/k8s/serialize_test.go
+++ b/internal/k8s/serialize_test.go
@@ -117,16 +117,6 @@ func TestListYAML(t *testing.T) {
 	}, kinds)
 }
 
-func TestDeleted(t *testing.T) {
-	result, err := parseYAMLFromStringWithDeletedResources(testyaml.OneDeleted)
-	assert.Nil(t, err)
-	assert.Equal(t, 1, len(result))
-
-	result, err = parseYAMLFromStringWithDeletedResources(testyaml.TwoDeleted)
-	assert.Nil(t, err)
-	assert.Equal(t, 2, len(result))
-}
-
 func TestBase64Serialization(t *testing.T) {
 	// json-iterator used to have a bug where it serialized this incorrectly.
 	// https://github.com/json-iterator/go/issues/272

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -46,8 +46,6 @@ github.com/blang/semver
 ## explicit
 # github.com/bugsnag/panicwrap v1.2.0
 ## explicit
-# github.com/cenkalti/backoff v2.2.1+incompatible
-## explicit
 # github.com/census-instrumentation/opencensus-proto v0.2.1
 github.com/census-instrumentation/opencensus-proto/gen-go/agent/common/v1
 github.com/census-instrumentation/opencensus-proto/gen-go/agent/metrics/v1


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/ch10270:

4ea5e09504d71b0a9e13b4954a0d5695ed8dbd6a (2020-11-25 18:56:08 -0500)
k8s: use the Helm kube client instead of shelling out to a separate process to apply changes, try #2

9a9a0d2ddaf701be010c09d99f60c462145530b4 (2020-11-25 17:46:55 -0500)
Revert "k8s: use the Helm kube client instead of shelling out to a separate process to apply changes (#3945)"
This reverts commit f711652e8ad897eef857399f9ae89ebcdb8bec73.

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics