### PR TITLE
server: add an api for turning on metrics from local

### DIFF
--- a/internal/cli/wire.go
+++ b/internal/cli/wire.go
@@ -46,6 +46,7 @@ import (
 	"github.com/tilt-dev/tilt/internal/tiltfile"
 	"github.com/tilt-dev/tilt/internal/token"
 	"github.com/tilt-dev/tilt/internal/tracer"
+	"github.com/tilt-dev/tilt/internal/user"
 	"github.com/tilt-dev/tilt/pkg/logger"
 	"github.com/tilt-dev/tilt/pkg/model"
 )
@@ -76,8 +77,8 @@ var BaseWireSet = wire.NewSet(
 	docker.SwitchWireSet,
 
 	ProvideDeferredExporter,
-	metrics.NewController,
-	metrics.NewModeController,
+	metrics.WireSet,
+	user.WireSet,
 	dockercompose.NewDockerComposeClient,
 
 	clockwork.NewRealClock,

--- a/internal/engine/analytics/doc.go
+++ b/internal/engine/analytics/doc.go
@@ -1,0 +1,4 @@
+// Package analytics handles reporting of anonymized usage statistics
+// about what features of Tilt are in use. Analytics does not report
+// identifiable information about user code.
+package analytics

--- a/internal/engine/metrics/doc.go
+++ b/internal/engine/metrics/doc.go
@@ -1,0 +1,3 @@
+// Package metrics handles reporting of identifable metrics about user code
+// for personal and team consumption.
+package metrics

--- a/internal/engine/metrics/mode_controller_test.go
+++ b/internal/engine/metrics/mode_controller_test.go
@@ -9,17 +9,19 @@ import (
 
 	"github.com/tilt-dev/tilt/internal/store"
 	"github.com/tilt-dev/tilt/internal/testutils/tempdir"
+	"github.com/tilt-dev/tilt/internal/user"
 	"github.com/tilt-dev/tilt/pkg/logger"
+	"github.com/tilt-dev/tilt/pkg/model"
 )
 
 func TestEnableLocalMetrics(t *testing.T) {
 	f := newModeFixture(t)
-	os.Setenv("TILT_LOCAL_METRICS", "1")
-	defer os.Unsetenv("TILT_LOCAL_METRICS")
+	os.Setenv("TILT_METRICS", "local")
+	defer os.Unsetenv("TILT_METRICS")
 
 	f.mc.OnChange(f.ctx, f.st)
 	if assert.NotNil(t, f.st.action) {
-		assert.Equal(t, store.MetricsLocal, f.st.action.Serving.Mode)
+		assert.Equal(t, model.MetricsLocal, f.st.action.Serving.Mode)
 		assert.Equal(t, 3, len(f.st.action.Manifests))
 	}
 }
@@ -53,7 +55,7 @@ func newModeFixture(t *testing.T) *modeFixture {
 	l := logger.NewLogger(logger.DebugLvl, os.Stdout)
 	ctx := logger.WithLogger(context.Background(), l)
 
-	mc := NewModeController("localhost")
+	mc := NewModeController("localhost", user.NewFakePrefs())
 	return &modeFixture{
 		TempDirFixture: f,
 		ctx:            ctx,

--- a/internal/engine/metrics/wire.go
+++ b/internal/engine/metrics/wire.go
@@ -1,0 +1,10 @@
+package metrics
+
+import (
+	"github.com/google/wire"
+)
+
+var WireSet = wire.NewSet(
+	NewController,
+	NewModeController,
+)

--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -565,7 +565,7 @@ func handleConfigsReloaded(
 
 	// Only set the metrics settings from the tiltfile if the mode
 	// hasn't been configured from elsewhere.
-	if state.MetricsServing.Mode == store.MetricsNone {
+	if state.MetricsServing.Mode == model.MetricsDefault {
 		// Add metrics if it exists, even if execution failed.
 		if event.MetricsSettings.Enabled || event.Err == nil {
 			state.MetricsSettings = event.MetricsSettings

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -72,6 +72,7 @@ import (
 	"github.com/tilt-dev/tilt/internal/tiltfile/version"
 	"github.com/tilt-dev/tilt/internal/token"
 	"github.com/tilt-dev/tilt/internal/tracer"
+	"github.com/tilt-dev/tilt/internal/user"
 	"github.com/tilt-dev/tilt/internal/watch"
 	"github.com/tilt-dev/tilt/pkg/assets"
 	"github.com/tilt-dev/tilt/pkg/logger"
@@ -3601,7 +3602,7 @@ func TestMetricsModeAction(t *testing.T) {
 
 	m2 := f.newManifest("collector")
 	f.store.Dispatch(metrics.MetricsModeAction{
-		Serving:   store.MetricsServing{Mode: store.MetricsLocal},
+		Serving:   store.MetricsServing{Mode: model.MetricsLocal},
 		Settings:  model.MetricsSettings{Address: "localhost:10352"},
 		Manifests: []model.Manifest{m2},
 	})
@@ -3744,7 +3745,7 @@ func newTestFixture(t *testing.T) *testFixture {
 
 	de := metrics.NewDeferredExporter()
 	mc := metrics.NewController(de, model.TiltBuild{}, "")
-	mcc := metrics.NewModeController("localhost")
+	mcc := metrics.NewModeController("localhost", user.NewFakePrefs())
 
 	subs := ProvideSubscribers(h, ts, tp, pw, sw, plm, pfc, fwm, gm, bc, cc, dcw, dclm, pm, sm, ar, hudsc, au, ewm, tcum, dp, tc, lc, podm, ec, mc, mcc)
 	ret.upper = NewUpper(ctx, st, subs)

--- a/internal/store/metrics.go
+++ b/internal/store/metrics.go
@@ -1,13 +1,8 @@
 package store
 
-// How metrics are served to the user.
-type MetricsMode string
-
-const MetricsNone = MetricsMode("")
-const MetricsLocal = MetricsMode("local")
-const MetricsProd = MetricsMode("prod")
+import "github.com/tilt-dev/tilt/pkg/model"
 
 type MetricsServing struct {
-	Mode        MetricsMode
+	Mode        model.MetricsMode
 	GrafanaHost string
 }

--- a/internal/user/api.go
+++ b/internal/user/api.go
@@ -1,0 +1,18 @@
+package user
+
+import "github.com/tilt-dev/tilt/pkg/model"
+
+// TODO(nick): Eventually would like this interface to help with
+// 1) other kinds of user preferences (token? analytics opt-in/opt-out?)
+// 2) server-based preferences
+type Prefs struct {
+	// The kind of metrics stack the user is talking to.
+	MetricsMode model.MetricsMode `json:"metricsMode,omitempty" yaml:"metricsMode,omitempty"`
+}
+
+// Read/write metrics setting from a store.
+// Inspired loosely by https://pkg.go.dev/k8s.io/client-go/kubernetes/typed/core/v1#PodInterface
+type PrefsInterface interface {
+	Get() (Prefs, error)
+	Update(newPrefs Prefs) error
+}

--- a/internal/user/api_test.go
+++ b/internal/user/api_test.go
@@ -1,0 +1,29 @@
+package user
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tilt-dev/wmclient/pkg/dirs"
+
+	"github.com/tilt-dev/tilt/internal/testutils/tempdir"
+	"github.com/tilt-dev/tilt/pkg/model"
+)
+
+func TestWriteMode(t *testing.T) {
+	f := tempdir.NewTempDirFixture(t)
+	defer f.TearDown()
+
+	dir := dirs.NewTiltDevDirAt(f.Path())
+	up := NewFilePrefs(dir)
+	prefs, err := up.Get()
+	assert.NoError(t, err)
+	assert.Equal(t, model.MetricsDefault, prefs.MetricsMode)
+
+	err = UpdateMetricsMode(up, model.MetricsLocal)
+	assert.NoError(t, err)
+
+	prefs, err = up.Get()
+	assert.NoError(t, err)
+	assert.Equal(t, model.MetricsLocal, prefs.MetricsMode)
+}

--- a/internal/user/fake.go
+++ b/internal/user/fake.go
@@ -1,0 +1,18 @@
+package user
+
+func NewFakePrefs() *FakePrefs {
+	return &FakePrefs{}
+}
+
+type FakePrefs struct {
+	Prefs Prefs
+}
+
+func (i *FakePrefs) Get() (Prefs, error) {
+	return i.Prefs, nil
+}
+
+func (i *FakePrefs) Update(newPrefs Prefs) error {
+	i.Prefs = newPrefs
+	return nil
+}

--- a/internal/user/file.go
+++ b/internal/user/file.go
@@ -1,0 +1,49 @@
+package user
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/tilt-dev/wmclient/pkg/dirs"
+	"gopkg.in/yaml.v3"
+)
+
+const userPrefsFileName = "tilt_user_prefs.yaml"
+
+type filePrefs struct {
+	dir *dirs.TiltDevDir
+}
+
+func NewFilePrefs(dir *dirs.TiltDevDir) *filePrefs {
+	return &filePrefs{dir: dir}
+}
+
+func (f *filePrefs) Get() (Prefs, error) {
+	contents, err := f.dir.ReadFile(userPrefsFileName)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return Prefs{}, nil
+		}
+		return Prefs{}, fmt.Errorf("get user prefs: %v", err)
+	}
+
+	prefs := Prefs{}
+	err = yaml.Unmarshal([]byte(contents), &prefs)
+	if err != nil {
+		return Prefs{}, fmt.Errorf("get user prefs: %v", err)
+	}
+
+	return prefs, nil
+}
+
+func (f *filePrefs) Update(newPrefs Prefs) error {
+	contents, err := yaml.Marshal(newPrefs)
+	if err != nil {
+		return fmt.Errorf("update user prefs: %v", err)
+	}
+	err = f.dir.WriteFile(userPrefsFileName, string(contents))
+	if err != nil {
+		return fmt.Errorf("update user prefs: %v", err)
+	}
+	return nil
+}

--- a/internal/user/helpers.go
+++ b/internal/user/helpers.go
@@ -1,0 +1,12 @@
+package user
+
+import "github.com/tilt-dev/tilt/pkg/model"
+
+func UpdateMetricsMode(pi PrefsInterface, mode model.MetricsMode) error {
+	prefs, err := pi.Get()
+	if err != nil {
+		return err
+	}
+	prefs.MetricsMode = mode
+	return pi.Update(prefs)
+}

--- a/internal/user/wire.go
+++ b/internal/user/wire.go
@@ -1,0 +1,10 @@
+package user
+
+import (
+	"github.com/google/wire"
+)
+
+var WireSet = wire.NewSet(
+	NewFilePrefs,
+	wire.Bind(new(PrefsInterface), new(*filePrefs)),
+)

--- a/pkg/model/metrics.go
+++ b/pkg/model/metrics.go
@@ -28,3 +28,11 @@ func DefaultMetricsSettings() MetricsSettings {
 		ReportingPeriod: DefaultReportingPeriod,
 	}
 }
+
+// User metrics preferences
+type MetricsMode string
+
+const MetricsDefault = MetricsMode("")
+const MetricsDisabled = MetricsMode("disabled")
+const MetricsLocal = MetricsMode("local")
+const MetricsProd = MetricsMode("prod")


### PR DESCRIPTION
Hello @landism, @maiamcc,

Please review the following commits I made in branch nicks/localmetrics5:

1e84937932f5633abc503ac17d0ab128e059634c (2020-11-30 13:30:29 -0500)
server: add an api for turning on metrics from local

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics