### PR TITLE
k8swatch: fix a bug where a manifest is removed then re-added, but we never find the pod

### DIFF
--- a/internal/engine/k8swatch/watcher.go
+++ b/internal/engine/k8swatch/watcher.go
@@ -86,6 +86,14 @@ func (ks *watcherKnownState) createTaskList(state store.EngineState) watcherTask
 		}
 	}
 
+	// If we're no longer deploying a manifest, delete it from the known deployed UIDs.
+	// This ensures that if it shows up again, we process it correctly.
+	for uid := range ks.knownDeployedUIDs {
+		if !seenUIDs[uid] {
+			delete(ks.knownDeployedUIDs, uid)
+		}
+	}
+
 	var watchableNamespaces []k8s.Namespace
 	var setupNamespaces []k8s.Namespace
 	var teardownNamespaces []k8s.Namespace

--- a/internal/store/engine_state.go
+++ b/internal/store/engine_state.go
@@ -195,6 +195,18 @@ func (e *EngineState) UpsertManifestTarget(mt *ManifestTarget) {
 	e.ManifestTargets[mn] = mt
 }
 
+func (e *EngineState) RemoveManifestTarget(mn model.ManifestName) {
+	delete(e.ManifestTargets, mn)
+	newOrder := []model.ManifestName{}
+	for _, n := range e.ManifestDefinitionOrder {
+		if n == mn {
+			continue
+		}
+		newOrder = append(newOrder, n)
+	}
+	e.ManifestDefinitionOrder = newOrder
+}
+
 func (e EngineState) Manifest(mn model.ManifestName) (model.Manifest, bool) {
 	m, ok := e.ManifestTargets[mn]
 	if !ok {


### PR DESCRIPTION
Hello @maiamcc, @landism,

Please review the following commits I made in branch nicks/watchbug:

828404bab78263eb3b97349db61cc642083a64b7 (2020-12-01 10:27:13 -0500)
k8swatch: fix a bug where a manifest is removed then re-added, but we never find the pod

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics