### PR TITLE
tiltfile: port_forward constructor supports host param

### DIFF
--- a/internal/tiltfile/k8s.go
+++ b/internal/tiltfile/k8s.go
@@ -862,14 +862,15 @@ func convertPortForwards(val starlark.Value) ([]model.PortForward, error) {
 
 func (s *tiltfileState) portForward(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	var local, container int
-	var name, path string
+	var name, path, host string
 
 	// TODO: can specify host (see `stringToPortForward` for host validation logic)
 	if err := s.unpackArgs(fn.Name(), args, kwargs,
 		"local_port", &local,
 		"container_port?", &container,
 		"name?", &name,
-		"link_path?", &path); err != nil {
+		"link_path?", &path,
+		"host?", &host); err != nil {
 		return nil, err
 	}
 
@@ -882,7 +883,7 @@ func (s *tiltfileState) portForward(thread *starlark.Thread, fn *starlark.Builti
 		}
 	}
 	return portForward{
-		model.PortForward{LocalPort: local, ContainerPort: container, Name: name}.WithPath(parsedPath),
+		model.PortForward{LocalPort: local, ContainerPort: container, Host: host, Name: name}.WithPath(parsedPath),
 	}, nil
 }
 

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -681,12 +681,15 @@ func TestPortForward(t *testing.T) {
 			[]model.PortForward{model.MustPortForward(8001, 0, "", "", "v1/ui")}),
 		newPortForwardSuccessCase("value_constructor_both", "port_forward(8001, 443)", []model.PortForward{{LocalPort: 8001, ContainerPort: 443}}),
 		newPortForwardSuccessCase("value_constructor_both_named", "port_forward(8001, 443, name='foo')", []model.PortForward{{LocalPort: 8001, ContainerPort: 443, Name: "foo"}}),
-		newPortForwardSuccessCase("value_constructor_all_positional", "port_forward(8001, 443, 'foo', 'v1/ui')",
-			[]model.PortForward{model.MustPortForward(8001, 443, "", "foo", "v1/ui")}),
+		newPortForwardSuccessCase("value_constructor_all_positional", "port_forward(8001, 443, 'foo', 'v1/ui', 'elasticsearch:9200')",
+			[]model.PortForward{model.MustPortForward(8001, 443, "elasticsearch:9200", "foo", "v1/ui")}),
 		newPortForwardErrorCase("value_constructor_no_local_port", "port_forward(container_port=443)", "missing argument for local_port"),
 		newPortForwardErrorCase("value_constructor_local_port_wrong_type", "port_forward('8001')", "for parameter local_port: got string, want int"),
 		newPortForwardErrorCase("value_constructor_bad_path", "port_forward(8001, 443, link_path='invalid_escape%')", "invalid URL escape"),
 		newPortForwardErrorCase("value_constructor_name_wrong_type", "port_forward(8001, 443, 54321)", "for parameter name: got int, want string"),
+		newPortForwardSuccessCase("value_constructor_host", "port_forward(8001, 443, host='elasticsearch:9200')",
+			[]model.PortForward{{LocalPort: 8001, ContainerPort: 443, Host: "elasticsearch:9200"}}),
+		newPortForwardErrorCase("value_constructor_host_wrong_type", "port_forward(8001, 443, host=54321)", "for parameter \"host\": got int, want string"),
 
 		// list values
 		newPortForwardSuccessCase("list_mixed", "[8000, port_forward(8001, 443), '8002', '8003:444'],", []model.PortForward{{LocalPort: 8000}, {LocalPort: 8001, ContainerPort: 443}, {LocalPort: 8002}, {LocalPort: 8003, ContainerPort: 444}}),

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -681,14 +681,14 @@ func TestPortForward(t *testing.T) {
 			[]model.PortForward{model.MustPortForward(8001, 0, "", "", "v1/ui")}),
 		newPortForwardSuccessCase("value_constructor_both", "port_forward(8001, 443)", []model.PortForward{{LocalPort: 8001, ContainerPort: 443}}),
 		newPortForwardSuccessCase("value_constructor_both_named", "port_forward(8001, 443, name='foo')", []model.PortForward{{LocalPort: 8001, ContainerPort: 443, Name: "foo"}}),
-		newPortForwardSuccessCase("value_constructor_all_positional", "port_forward(8001, 443, 'foo', 'v1/ui', 'elasticsearch:9200')",
-			[]model.PortForward{model.MustPortForward(8001, 443, "elasticsearch:9200", "foo", "v1/ui")}),
+		newPortForwardSuccessCase("value_constructor_all_positional", "port_forward(8001, 443, 'foo', 'v1/ui', 'elastic.local')",
+			[]model.PortForward{model.MustPortForward(8001, 443, "elastic.local", "foo", "v1/ui")}),
 		newPortForwardErrorCase("value_constructor_no_local_port", "port_forward(container_port=443)", "missing argument for local_port"),
 		newPortForwardErrorCase("value_constructor_local_port_wrong_type", "port_forward('8001')", "for parameter local_port: got string, want int"),
 		newPortForwardErrorCase("value_constructor_bad_path", "port_forward(8001, 443, link_path='invalid_escape%')", "invalid URL escape"),
 		newPortForwardErrorCase("value_constructor_name_wrong_type", "port_forward(8001, 443, 54321)", "for parameter name: got int, want string"),
-		newPortForwardSuccessCase("value_constructor_host", "port_forward(8001, 443, host='elasticsearch:9200')",
-			[]model.PortForward{{LocalPort: 8001, ContainerPort: 443, Host: "elasticsearch:9200"}}),
+		newPortForwardSuccessCase("value_constructor_host", "port_forward(8001, 443, host='elastic.local')",
+			[]model.PortForward{{LocalPort: 8001, ContainerPort: 443, Host: "elastic.local"}}),
 		newPortForwardErrorCase("value_constructor_host_wrong_type", "port_forward(8001, 443, host=54321)", "for parameter \"host\": got int, want string"),
 
 		// list values


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch maiamcc/port-forward-host:

dd4ae1c6bac6ad7c08ea2cb19b58ec08439ced0f (2020-12-07 14:16:05 -0500)
tiltfile: port_forward constructor supports host param

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics