### PR TITLE
webview: Tiltfile has no runtime status

### DIFF
--- a/internal/cloud/io_test.go
+++ b/internal/cloud/io_test.go
@@ -32,7 +32,7 @@ func TestWriteSnapshotTo(t *testing.T) {
           "startTime": "0001-01-01T00:00:00Z",
           "finishTime": "0001-01-01T00:00:00Z"
         },
-        "runtimeStatus": "ok",
+        "runtimeStatus": "not_applicable",
         "isTiltfile": true
       }
     ],

--- a/internal/hud/webview/convert.go
+++ b/internal/hud/webview/convert.go
@@ -204,7 +204,7 @@ func tiltfileResourceProtoView(s store.EngineState) (*proto_webview.Resource, er
 		BuildHistory: []*proto_webview.BuildRecord{
 			pltfb,
 		},
-		RuntimeStatus: string(model.RuntimeStatusOK),
+		RuntimeStatus: string(model.RuntimeStatusNotApplicable),
 	}
 	start, err := timeToProto(ctfb.StartTime)
 	if err != nil {


### PR DESCRIPTION
Hello @hyu,

Please review the following commits I made in branch nicks/ch10422:

b934afd0aa0d60c7e2ecdd9110be0802ef0dc251 (2020-12-08 13:16:11 -0500)
webview: Tiltfile has no runtime status

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics