### PR TITLE
tiltfile: fix some error reporting in setStateFn

### DIFF
--- a/internal/tiltfile/starkit/set_state.go
+++ b/internal/tiltfile/starkit/set_state.go
@@ -59,7 +59,7 @@ func setStateFn(model Model, typ reflect.Type, fn interface{}) error {
 	// Overwrite the value in the state store.
 	existing, ok := model.state[inTyp]
 	if !ok {
-		return fmt.Errorf("Internal error: Type not found in state store: %T", inTyp)
+		return fmt.Errorf("Internal error: Type not found in state store: %s", inTyp)
 	}
 
 	outs := reflect.ValueOf(fn).Call([]reflect.Value{reflect.ValueOf(existing)})


### PR DESCRIPTION
lol I think this was copypasta, `inTyp` is already a type, this
string formatting just prints `*reflectType` always, which is not very helpful

cc @ellenkorbes in case you're curious :P