### PR TITLE
cli: add TILT_HOST and TILT_PORT env variables

### DIFF
--- a/integration/crash_test.go
+++ b/integration/crash_test.go
@@ -22,6 +22,6 @@ func TestCrash(t *testing.T) {
 	res, err := f.tilt.Up([]string{"--watch=false"}, out)
 	assert.NoError(t, err)
 	<-res.Done()
-	assert.Contains(t, out.String(), "Cannot start Tilt")
+	assert.Contains(t, out.String(), "Tilt cannot start")
 	assert.NotContains(t, out.String(), "Usage:")
 }

--- a/internal/cli/ci.go
+++ b/internal/cli/ci.go
@@ -42,7 +42,7 @@ While Tilt is running, you can view the UI at %s:%d
 (configurable with --host and --port).
 
 See blog post for additional information: https://blog.tilt.dev/2020/04/16/how-to-not-break-server-startup.html
-`, DefaultWebHost, DefaultWebPort),
+`, defaultWebHost, defaultWebPort),
 	}
 
 	addStartServerFlags(cmd)

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -33,6 +33,12 @@ func logLevel(verbose, debug bool) logger.Level {
 }
 
 func Execute() {
+	err := readEnvDefaults()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
 	rootCmd := &cobra.Command{
 		Use:   "tilt",
 		Short: "Multi-service development with no stress",

--- a/internal/cli/flags.go
+++ b/internal/cli/flags.go
@@ -1,11 +1,37 @@
 package cli
 
 import (
+	"os"
+	"strconv"
+
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	"github.com/tilt-dev/tilt/internal/k8s"
 	"github.com/tilt-dev/tilt/internal/tiltfile"
 )
+
+var defaultWebHost = "localhost"
+var defaultWebPort = 10350
+var webHostFlag = ""
+var webPortFlag = 0
+
+func readEnvDefaults() error {
+	envPort := os.Getenv("TILT_PORT")
+	if envPort != "" {
+		port, err := strconv.Atoi(envPort)
+		if err != nil {
+			return errors.Wrap(err, "parsing env TILT_PORT")
+		}
+		defaultWebPort = port
+	}
+
+	envHost := os.Getenv("TILT_HOST")
+	if envHost != "" {
+		defaultWebHost = envHost
+	}
+	return nil
+}
 
 // Common flags used across multiple commands.
 
@@ -20,14 +46,14 @@ func addKubeContextFlag(cmd *cobra.Command) {
 
 // For commands that talk to the web server.
 func addConnectServerFlags(cmd *cobra.Command) {
-	cmd.Flags().IntVar(&webPort, "port", DefaultWebPort, "Port for the Tilt HTTP server. Only necessary if you started Tilt with --port.")
-	cmd.Flags().StringVar(&webHost, "host", DefaultWebHost, "Host for the Tilt HTTP server. Only necessary if you started Tilt with --host.")
+	cmd.Flags().IntVar(&webPortFlag, "port", defaultWebPort, "Port for the Tilt HTTP server. Only necessary if you started Tilt with --port. Overrides TILT_PORT env variable.")
+	cmd.Flags().StringVar(&webHostFlag, "host", defaultWebHost, "Host for the Tilt HTTP server. Only necessary if you started Tilt with --host. Overrides TILT_HOST env variable.")
 }
 
 // For commands that start a web server.
 func addStartServerFlags(cmd *cobra.Command) {
-	cmd.Flags().IntVar(&webPort, "port", DefaultWebPort, "Port for the Tilt HTTP server. Set to 0 to disable.")
-	cmd.Flags().StringVar(&webHost, "host", DefaultWebHost, "Host for the Tilt HTTP server and default host for any port-forwards. Set to 0.0.0.0 to listen on all interfaces.")
+	cmd.Flags().IntVar(&webPortFlag, "port", defaultWebPort, "Port for the Tilt HTTP server. Set to 0 to disable. Overrides TILT_PORT env variable.")
+	cmd.Flags().StringVar(&webHostFlag, "host", defaultWebHost, "Host for the Tilt HTTP server and default host for any port-forwards. Set to 0.0.0.0 to listen on all interfaces. Overrides TILT_HOST env variable.")
 }
 
 func addDevServerFlags(cmd *cobra.Command) {

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -25,14 +25,11 @@ import (
 	"github.com/tilt-dev/tilt/web"
 )
 
-const DefaultWebHost = "localhost"
-const DefaultWebPort = 10350
+var webModeFlag model.WebMode = model.DefaultWebMode
+
 const DefaultWebDevPort = 46764
 
 var updateModeFlag string = string(buildcontrol.UpdateModeAuto)
-var webModeFlag model.WebMode = model.DefaultWebMode
-var webPort = 0
-var webHost = DefaultWebHost
 var webDevPort = 0
 var logActionsFlag bool = false
 
@@ -221,11 +218,11 @@ func provideWebMode(b model.TiltBuild) (model.WebMode, error) {
 }
 
 func provideWebHost() model.WebHost {
-	return model.WebHost(webHost)
+	return model.WebHost(webHostFlag)
 }
 
 func provideWebPort() model.WebPort {
-	return model.WebPort(webPort)
+	return model.WebPort(webPortFlag)
 }
 
 func provideWebURL(webHost model.WebHost, webPort model.WebPort) (model.WebURL, error) {
@@ -235,7 +232,7 @@ func provideWebURL(webHost model.WebHost, webPort model.WebPort) (model.WebURL, 
 
 	if webHost == "0.0.0.0" {
 		// 0.0.0.0 means "listen on all hosts"
-		// For UI displays, we use 127.0.0.01 (loopback)
+		// For UI displays, we use 127.0.0.1 (loopback)
 		webHost = "127.0.0.1"
 	}
 

--- a/internal/cli/utils.go
+++ b/internal/cli/utils.go
@@ -11,12 +11,12 @@ import (
 )
 
 func apiHost() string {
-	return fmt.Sprintf("%s:%d", webHost, webPort)
+	return fmt.Sprintf("%s:%d", provideWebHost(), provideWebPort())
 }
 
 func apiURL(path string) string {
 	path = strings.TrimLeft(path, "/")
-	return fmt.Sprintf("http://%s:%d/api/%s", webHost, webPort, path)
+	return fmt.Sprintf("http://%s:%d/api/%s", provideWebHost(), provideWebPort(), path)
 }
 
 func apiGet(path string) (body io.ReadCloser) {

--- a/internal/hud/server/controller.go
+++ b/internal/hud/server/controller.go
@@ -8,8 +8,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/pkg/errors"
-
 	"github.com/tilt-dev/tilt/internal/store"
 	"github.com/tilt-dev/tilt/pkg/assets"
 	"github.com/tilt-dev/tilt/pkg/model"
@@ -60,7 +58,10 @@ func (s *HeadsUpServerController) OnChange(ctx context.Context, st store.RStore)
 	if err != nil {
 		st.Dispatch(
 			store.NewErrorAction(
-				errors.Wrapf(err, "Cannot start Tilt. Maybe another process is already running on port %d? Use --port to set a custom port", s.port)))
+				fmt.Errorf("Tilt cannot start because you already have another process on port %d\n"+
+					"If you want to run multiple Tilt instances simultaneously,\n"+
+					"use the --port flag or TILT_PORT env variable to set a custom port\nOriginal error: %v",
+					s.port, err)))
 		return
 	}
 


### PR DESCRIPTION
Hello @maiamcc,

Please review the following commits I made in branch nicks/ch10491:

d86aa5bb40ccd7b155e616144c6da966ae3acf8c (2020-12-10 18:03:18 -0500)
cli: add TILT_HOST and TILT_PORT env variables
Clarify that --port and TILT_PORT are both Officially Endorsed
ways to run two Tilts simultaneously.

Fixes https://github.com/tilt-dev/tilt/issues/3948

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics