### PR TITLE
web: don't show the metrics tab in snapshot mode

### DIFF
--- a/web/src/HUD.tsx
+++ b/web/src/HUD.tsx
@@ -438,7 +438,9 @@ class HUD extends Component<HudProps, HudState> {
 
       let facetsUrl = name !== "" ? this.path(`/r/${name}/facets`) : null
       let metricsUrl = ""
-      let showMetricsTab = name === "" && (hasK8s || view?.metricsServing?.mode)
+      let isSnapshot = this.pathBuilder.isSnapshot()
+      let showMetricsTab =
+        name === "" && !isSnapshot && (hasK8s || view?.metricsServing?.mode)
       if (showMetricsTab) {
         metricsUrl = this.path("/metrics")
       }


### PR DESCRIPTION
Hello @maiamcc,

Please review the following commits I made in branch nicks/ch10548:

4b1b16067b686b073a96c244a19393284ba2f3be (2020-12-17 14:47:54 -0500)
web: don't show the metrics tab in snapshot mode

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics