### PR TITLE
circleci: add tilt deploy context to publish-assets

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -193,6 +193,7 @@ workflows:
           requires:
             - build-linux
       - publish-assets:
+          context: Tilt Deploy Context
           filters:
             branches:
               only: master


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/publish:

9622b57005497bc4047791139a2a113922dff0b0 (2020-12-17 16:10:55 -0500)
circleci: add tilt deploy context to publish-assets

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics