### PR TITLE
docs: rm synclet release notes from contributing doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -279,19 +279,3 @@ CircleCI will automatically start building your release, and notify the
 For pre-v1.0:
 * If adding backwards-compatible functionality increment the patch version (0.x.Y).
 * If adding backwards-incompatible functionality increment the minor version (0.X.y). We would probably **write a blog post** about this.
-
-### Releasing the Synclet
-
-Releasing a synclet should be very infrequent, because the amount of things it
-does is small. (It's basically an optimization over `kubectl cp`, `kubectl
-exec`, and restarting a container.)
-
-To release a synclet, run `make synclet-release`. This will automatically:
-
-- Publish a new synclet image tagged with the current date
-- Update [sidecar.go](internal/synclet/sidecar/sidecar.go) with the new tag
-
-Then submit the PR. The next time someone releases Tilt, it will use the new image tag.
-
-
-


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch maiamcc/rm-synclet-release:

79413a9862e8c5ca35175fce3c80a279bd42fb38 (2020-12-18 11:44:25 -0500)
docs: rm synclet release notes from contributing doc

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics