### PR TITLE
web: replace react-modal with Popover in dialogs

### DIFF
--- a/web/src/FloatDialog.tsx
+++ b/web/src/FloatDialog.tsx
@@ -1,26 +1,21 @@
+import Popover from "@material-ui/core/Popover"
+import { makeStyles } from "@material-ui/core/styles"
 import React from "react"
-import Modal from "react-modal"
 import styled from "styled-components"
 import { ReactComponent as CloseSvg } from "./assets/svg/close.svg"
 import { Color, Font, FontSize } from "./style-helpers"
 
 type props = {
+  id: string
   title: string | React.ReactElement
-  isOpen: boolean
-  onRequestClose: () => void
+  open: boolean
+  anchorEl: Element | null
+  onClose: () => void
   children: any
   style?: any
+  anchorOrigin?: any
+  transformOrigin?: any
 }
-
-let FloatDialogRoot = styled(Modal)`
-  display: flex;
-  flex-direction: column;
-  background: #ffffff;
-  color: ${Color.grayDarkest};
-  box-shadow: 3px 3px 4px rgba(0, 0, 0, 0.5);
-  border-radius: 8px;
-  padding: 16px 20px;
-`
 
 let TitleBar = styled.div`
   display: flex;
@@ -63,21 +58,52 @@ let Content = styled.div`
   line-height: 28px;
 `
 
+let useStyles = makeStyles((theme) => ({
+  paper: {
+    display: "flex",
+    flexDirection: "column",
+    background: "#fff",
+    color: Color.grayDarkest,
+    boxShadow: "3px 3px 4px rgba(0, 0, 0, 0.5)",
+    borderRadius: "8px",
+    padding: "16px 20px",
+    width: "400px",
+  },
+}))
+
 // A generic dialog that floats in a part of the screen.
 // Intended to be attached to a menu button.
 export default function FloatDialog(props: props) {
+  const popoverClasses = useStyles()
+
   let title = props.title
   let titleEl = typeof title == "string" ? <Title>{title}</Title> : title
+  let anchorOrigin = props.anchorOrigin ?? {
+    vertical: "bottom",
+    horizontal: "right",
+  }
+  let transformOrigin = props.transformOrigin ?? {
+    vertical: "top",
+    horizontal: "right",
+  }
   return (
-    <FloatDialogRoot shouldCloseOnEsc={true} {...props}>
+    <Popover
+      id={props.id}
+      classes={popoverClasses}
+      open={props.open}
+      onClose={props.onClose}
+      anchorEl={props.anchorEl}
+      anchorOrigin={anchorOrigin}
+      transformOrigin={transformOrigin}
+    >
       <TitleBar>
         {titleEl}
-        <CloseButton onClick={props.onRequestClose}>
+        <CloseButton onClick={props.onClose}>
           <CloseSvg />
         </CloseButton>
       </TitleBar>
       <HR />
       <Content>{props.children}</Content>
-    </FloatDialogRoot>
+    </Popover>
   )
 }

--- a/web/src/ShortcutsDialog.stories.tsx
+++ b/web/src/ShortcutsDialog.stories.tsx
@@ -10,5 +10,9 @@ export default {
 }
 
 export const Dialog = () => (
-  <ShortcutsDialog isOpen={true} onRequestClose={onRequestClose} />
+  <ShortcutsDialog
+    open={true}
+    onClose={onRequestClose}
+    anchorEl={document.body}
+  />
 )

--- a/web/src/ShortcutsDialog.tsx
+++ b/web/src/ShortcutsDialog.tsx
@@ -3,9 +3,9 @@ import styled from "styled-components"
 import FloatDialog from "./FloatDialog"
 
 type props = {
-  isOpen: boolean
-  onRequestClose: () => void
-  style?: any
+  open: boolean
+  onClose: () => void
+  anchorEl: Element | null
 }
 
 let ShortcutRoot = styled.div`
@@ -36,7 +36,7 @@ function Shortcut(props: { keys: string; label: string }) {
 
 export default function ShortcutsDialog(props: props) {
   return (
-    <FloatDialog title="Keyboard Shortcuts" {...props}>
+    <FloatDialog id="shortcuts" title="Keyboard Shortcuts" {...props}>
       <Shortcut keys="j, k" label="Navigate Resource" />
       <Shortcut keys="r" label="Trigger rebuild for a resource" />
       <Shortcut keys="Shift+1, 2..." label="Open Endpoint" />

--- a/web/src/SidebarAccount.stories.tsx
+++ b/web/src/SidebarAccount.stories.tsx
@@ -6,7 +6,7 @@ export default {
 }
 
 export const Default = () => (
-  <div style={{ width: "350px" }}>
+  <div style={{ width: "600px" }}>
     <SidebarAccount
       isSnapshot={false}
       tiltCloudUsername={""}
@@ -18,7 +18,7 @@ export const Default = () => (
 )
 
 export const LoggedIn = () => (
-  <div style={{ width: "350px" }}>
+  <div style={{ width: "600px" }}>
     <SidebarAccount
       isSnapshot={false}
       tiltCloudUsername={"pusheen"}

--- a/web/src/SidebarAccount.test.tsx
+++ b/web/src/SidebarAccount.test.tsx
@@ -41,8 +41,9 @@ it("renders shortcuts dialog on ?", () => {
     </MemoryRouter>
   )
 
-  expect(root.find(ShortcutsDialog).props().isOpen).toEqual(false)
+  expect(root.find(ShortcutsDialog).props().open).toEqual(false)
   act(() => void fireEvent.keyDown(document.body, { key: "?" }))
-  expect(root.find(ShortcutsDialog).props().isOpen).toEqual(false)
+  root.update()
+  expect(root.find(ShortcutsDialog).props().open).toEqual(true)
   root.unmount()
 })

--- a/web/src/SidebarAccount.tsx
+++ b/web/src/SidebarAccount.tsx
@@ -1,4 +1,4 @@
-import React, { Component, useState } from "react"
+import React, { Component, useRef, useState } from "react"
 import ReactOutlineManager from "react-outline-manager"
 import styled from "styled-components"
 import { AccountMenuContent, AccountMenuHeader } from "./AccountMenu"
@@ -91,75 +91,71 @@ class SidebarAccountShortcuts extends Component<{
 }
 
 function SidebarAccount(props: SidebarAccountProps) {
-  const [shortcutsDialogOpen, setShortcutsDialogOpen] = useState(false)
-  const [accountMenuOpen, setAccountMenuOpen] = useState(false)
+  const shortcutButton = useRef(null as any)
+  const accountButton = useRef(null as any)
+  const [shortcutsDialogAnchor, setShortcutsDialogAnchor] = useState(
+    null as Element | null
+  )
+  const [accountMenuAnchor, setAccountMenuAnchor] = useState(
+    null as Element | null
+  )
+  const shortcutsDialogOpen = !!shortcutsDialogAnchor
+  const accountMenuOpen = !!accountMenuAnchor
+  if (props.isSnapshot) {
+    return null
+  }
 
   let toggleAccountMenu = (action: string) => {
     if (!accountMenuOpen) {
       incr("ui.web.menu", { type: "account", action: action })
     }
-    setAccountMenuOpen(!accountMenuOpen)
+    setAccountMenuAnchor(
+      accountMenuOpen ? null : (accountButton.current as Element)
+    )
   }
 
   let toggleShortcutsDialog = (action: string) => {
     if (!shortcutsDialogOpen) {
       incr("ui.web.menu", { type: "shortcuts", action: action })
     }
-    setShortcutsDialogOpen(!shortcutsDialogOpen)
-  }
-
-  if (props.isSnapshot) {
-    return null
+    setShortcutsDialogAnchor(
+      shortcutsDialogOpen ? null : (shortcutButton.current as Element)
+    )
   }
 
   let accountMenuHeader = <AccountMenuHeader {...props} />
   let accountMenuContent = <AccountMenuContent {...props} />
 
-  // NOTE(nick): A better way to position these would be to re-parent them under
-  // SidebarAccountHeader, but to do that we'd need to do some react wiring that
-  // I'm not enthusiastic about.
-  let accountMenuStyle = {
-    content: {
-      top: SizeUnit(3),
-      right: SizeUnit(0.5),
-      position: "absolute",
-      width: "400px",
-    },
-    overlay: { display: "block" },
-  }
-  let shortcutsDialogStyle = {
-    content: {
-      top: SizeUnit(3),
-      right: SizeUnit(1.5),
-      position: "absolute",
-      width: "400px",
-    },
-    overlay: { display: "block" },
-  }
-
   return (
     <SidebarAccountRoot>
       <ReactOutlineManager>
         <SidebarAccountHeader>
-          <SidebarAccountButton onClick={() => toggleShortcutsDialog("click")}>
+          <SidebarAccountButton
+            ref={shortcutButton}
+            onClick={() => toggleShortcutsDialog("click")}
+          >
             <SidebarHelpIcon />
           </SidebarAccountButton>
-          <SidebarAccountButton onClick={() => toggleAccountMenu("click")}>
+          <SidebarAccountButton
+            ref={accountButton}
+            onClick={() => toggleAccountMenu("click")}
+          >
             <SidebarAccountIcon />
           </SidebarAccountButton>
         </SidebarAccountHeader>
         <FloatDialog
+          id="accountMenu"
           title={accountMenuHeader}
-          isOpen={accountMenuOpen}
-          onRequestClose={() => toggleAccountMenu("close")}
-          style={accountMenuStyle}
+          open={accountMenuOpen}
+          anchorEl={accountMenuAnchor}
+          onClose={() => toggleAccountMenu("close")}
         >
           {accountMenuContent}
         </FloatDialog>
         <ShortcutsDialog
-          isOpen={shortcutsDialogOpen}
-          onRequestClose={() => toggleShortcutsDialog("close")}
-          style={shortcutsDialogStyle}
+          open={shortcutsDialogOpen}
+          anchorEl={shortcutsDialogAnchor}
+          onClose={() => toggleShortcutsDialog("close")}
         />
         <SidebarAccountShortcuts
           toggleShortcutsDialog={() => toggleShortcutsDialog("shortcut")}


### PR DESCRIPTION
Hello @hyu,

Please review the following commits I made in branch nicks/menus:

7a463482c31273220575c54038d5ccdf6865e421 (2020-12-18 17:01:06 -0500)
web: replace react-modal with Popover in dialogs
With react-modal, we had to manually position the dialogs
to anchor them to the trigger buttons.

With the new system, the Popover library handles the anchor.

This will make it much easier to use the dialogs in different UIs

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics