### PR TITLE
logger: default env variables for logging

### DIFF
--- a/internal/build/custom_builder.go
+++ b/internal/build/custom_builder.go
@@ -76,6 +76,7 @@ func (b *ExecCustomBuilder) Build(ctx context.Context, refs container.RefSet, cb
 
 	cmd := exec.CommandContext(ctx, command.Argv[0], command.Argv[1:]...)
 	cmd.Dir = workDir
+	cmd.Env = logger.DefaultEnv(ctx)
 
 	l := logger.Get(ctx)
 

--- a/internal/engine/local/execer.go
+++ b/internal/engine/local/execer.go
@@ -151,6 +151,7 @@ func (e *processExecer) processRun(ctx context.Context, cmd model.Cmd, w io.Writ
 	c.Stderr = w
 	c.Stdout = w
 	c.Dir = cmd.Dir
+	c.Env = logger.DefaultEnv(ctx)
 
 	err := c.Start()
 	if err != nil {

--- a/internal/engine/local_target_build_and_deployer.go
+++ b/internal/engine/local_target_build_and_deployer.go
@@ -105,6 +105,7 @@ func (bd *LocalTargetBuildAndDeployer) run(ctx context.Context, c model.Cmd) err
 	cmd.Stdout = writer
 	cmd.Stderr = writer
 	cmd.Dir = c.Dir
+	cmd.Env = logger.DefaultEnv(ctx)
 
 	ps := build.NewPipelineState(ctx, 1, bd.clock)
 	ps.StartPipelineStep(ctx, "Running command: %v (in %q)", c.Argv, c.Dir)

--- a/pkg/logger/env.go
+++ b/pkg/logger/env.go
@@ -1,0 +1,38 @@
+package logger
+
+import (
+	"context"
+	"os"
+	"strings"
+)
+
+// A set of environment variables to make sure that
+// subprocesses log correctly.
+func DefaultEnv(ctx context.Context) []string {
+	supportsColor := Get(ctx).SupportsColor()
+	env := os.Environ()
+	hasLines := false
+	hasColumns := false
+	hasForceColor := false
+
+	for _, e := range env {
+		// LINES and COLUMNS are posix standards.
+		// https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap08.html
+		hasLines = hasLines || strings.HasPrefix("LINES=", e)
+		hasColumns = hasColumns || strings.HasPrefix("COLUMNS=", e)
+
+		// FORCE_COLOR is common in nodejs https://github.com/tilt-dev/tilt/issues/3038
+		hasForceColor = hasForceColor || strings.HasPrefix("FORCE_COLOR=", e)
+	}
+
+	if !hasLines {
+		env = append(env, "LINES=24")
+	}
+	if !hasColumns {
+		env = append(env, "COLUMNS=80")
+	}
+	if !hasForceColor && supportsColor {
+		env = append(env, "FORCE_COLOR=1")
+	}
+	return env
+}

--- a/web/storybook.tiltfile
+++ b/web/storybook.tiltfile
@@ -1,0 +1,16 @@
+local_resource(
+  'storybook',
+  'yarn run storybook -- --ci',
+  links=['http://localhost:9009'])
+
+local_resource(
+  'prettier',
+  'cd .. && make prettier',
+  auto_init=False,
+  trigger_mode=TRIGGER_MODE_MANUAL)
+
+local_resource(
+  'tsc',
+  'node_modules/.bin/tsc -p .',
+  auto_init=False,
+  trigger_mode=TRIGGER_MODE_MANUAL)


### PR DESCRIPTION
Hello @landism,

Please review the following commits I made in branch nicks/lines:

acd5a0ceb0e63d01dc8d102b3adf81008c365827 (2020-12-21 12:33:54 -0500)
logger: default env variables for logging
This makes Tilt more robust when subprocesses try to adjust their output
for the current terminal.

Fixes https://github.com/tilt-dev/tilt/issues/4007

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics