### PR TITLE
Tests MVP: a much less hacky way of specifying tests

### DIFF
--- a/internal/tiltfile/local_resource.go
+++ b/internal/tiltfile/local_resource.go
@@ -55,8 +55,11 @@ func (s *tiltfileState) localResource(thread *starlark.Thread, fn *starlark.Buil
 		isTest = true
 
 		// TODO: implement timeout
+		//   (Maybe all local resources should accept a timeout, not just tests?)
 	}
 
+	// TODO: using this func for both `local_resource()` and `test()`, but in future
+	//   we should probably unpack args separately
 	if err := s.unpackArgs(fn.Name(), args, kwargs,
 		"name", &name,
 		"cmd?", &updateCmdVal,
@@ -83,7 +86,7 @@ func (s *tiltfileState) localResource(thread *starlark.Thread, fn *starlark.Buil
 	}
 	tags, err := value.SequenceToStringSlice(tagsVal)
 	if err != nil {
-		return nil, errors.Wrapf(err, "%s: tags", fn.Name())
+		return nil, errors.Wrapf(err, "%s: resource_deps", fn.Name())
 	}
 
 	ignores, err := parseValuesToStrings(ignoresVal, "ignore")

--- a/internal/tiltfile/local_resource.go
+++ b/internal/tiltfile/local_resource.go
@@ -28,6 +28,10 @@ type localResource struct {
 	ignores       []string
 	allowParallel bool
 	links         []model.Link
+
+	// for use in testing mvp
+	tags   []string
+	isTest bool
 }
 
 func (s *tiltfileState) localResource(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
@@ -37,11 +41,21 @@ func (s *tiltfileState) localResource(thread *starlark.Thread, fn *starlark.Buil
 
 	deps := value.NewLocalPathListUnpacker(thread)
 
-	var resourceDepsVal starlark.Sequence
+	var resourceDepsVal, tagsVal starlark.Sequence
 	var ignoresVal starlark.Value
 	var allowParallel bool
 	var links links.LinkList
 	autoInit := true
+
+	var isTest bool
+	if fn.Name() == testN {
+		// If we're initializing a test, by default parallelism is on
+		allowParallel = true
+
+		isTest = true
+
+		// TODO: implement timeout
+	}
 
 	if err := s.unpackArgs(fn.Name(), args, kwargs,
 		"name", &name,
@@ -56,6 +70,7 @@ func (s *tiltfileState) localResource(thread *starlark.Thread, fn *starlark.Buil
 		"serve_cmd_bat?", &serveCmdBatVal,
 		"allow_parallel?", &allowParallel,
 		"links?", &links,
+		"tags?", &tagsVal,
 	); err != nil {
 		return nil, err
 	}
@@ -63,6 +78,10 @@ func (s *tiltfileState) localResource(thread *starlark.Thread, fn *starlark.Buil
 	repos := reposForPaths(deps.Value)
 
 	resourceDeps, err := value.SequenceToStringSlice(resourceDepsVal)
+	if err != nil {
+		return nil, errors.Wrapf(err, "%s: resource_deps", fn.Name())
+	}
+	tags, err := value.SequenceToStringSlice(tagsVal)
 	if err != nil {
 		return nil, errors.Wrapf(err, "%s: resource_deps", fn.Name())
 	}
@@ -98,6 +117,8 @@ func (s *tiltfileState) localResource(thread *starlark.Thread, fn *starlark.Buil
 		ignores:       ignores,
 		allowParallel: allowParallel,
 		links:         links.Links,
+		tags:          tags,
+		isTest:        isTest,
 	}
 
 	//check for duplicate resources by name and throw error if found

--- a/internal/tiltfile/local_resource.go
+++ b/internal/tiltfile/local_resource.go
@@ -83,7 +83,7 @@ func (s *tiltfileState) localResource(thread *starlark.Thread, fn *starlark.Buil
 	}
 	tags, err := value.SequenceToStringSlice(tagsVal)
 	if err != nil {
-		return nil, errors.Wrapf(err, "%s: resource_deps", fn.Name())
+		return nil, errors.Wrapf(err, "%s: tags", fn.Name())
 	}
 
 	ignores, err := parseValuesToStrings(ignoresVal, "ignore")

--- a/internal/tiltfile/tests_test.go
+++ b/internal/tiltfile/tests_test.go
@@ -1,0 +1,51 @@
+package tiltfile
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/tilt-dev/tilt/pkg/model"
+)
+
+func TestTestWithDefaults(t *testing.T) {
+	f := newFixture(t)
+	defer f.TearDown()
+	f.setupFoo()
+
+	f.file("Tiltfile", `
+test("test-foo", "echo hi")
+`)
+
+	f.load()
+
+	foo := f.assertNextManifest("test-foo", localTarget(updateCmd(f.Path(), "echo hi")))
+	assert.True(t, foo.LocalTarget().IsTest, "should be flagged as test manifest")
+}
+
+func TestTestWithExplicit(t *testing.T) {
+	f := newFixture(t)
+	defer f.TearDown()
+	f.setupFoo()
+
+	f.file("Tiltfile", `
+t = test("test-foo", "echo hi",
+		deps=["a.txt", "b.txt"],
+		tags=["beep", "boop"],
+		trigger_mode=TRIGGER_MODE_MANUAL,
+)
+`)
+
+	f.load()
+
+	foo := f.assertNextManifest("test-foo", localTarget(
+		updateCmd(f.Path(), "echo hi"),
+		deps("a.txt", "b.txt")))
+	assert.True(t, foo.LocalTarget().IsTest, "should be flagged as test manifest")
+	assert.Equal(t, []string{"beep", "boop"}, foo.LocalTarget().Tags)
+	assert.Equal(t, model.TriggerModeManualAfterInitial, foo.TriggerMode)
+}
+
+// TODO:
+//   - timeout (once implemented)
+//   - allowParallel defaults to true but can be set to false

--- a/internal/tiltfile/tiltfile_state.go
+++ b/internal/tiltfile/tiltfile_state.go
@@ -304,6 +304,7 @@ const (
 
 	// local resource functions
 	localResourceN = "local_resource"
+	testN          = "test" // test is just a fork of local resource
 
 	// file functions
 	localN     = "local"
@@ -478,6 +479,7 @@ func (s *tiltfileState) OnStart(e *starkit.Environment) error {
 		{filterYamlN, s.filterYaml},
 		{k8sResourceN, s.k8sResource},
 		{localResourceN, s.localResource},
+		{testN, s.localResource},
 		{portForwardN, s.portForward},
 		{k8sKindN, s.k8sKind},
 		{k8sImageJSONPathN, s.k8sImageJsonPath},
@@ -1468,7 +1470,9 @@ func (s *tiltfileState) translateLocal() ([]model.Manifest, error) {
 			WithRepos(reposForPaths(paths)).
 			WithIgnores(ignores).
 			WithAllowParallel(r.allowParallel).
-			WithLinks(r.links)
+			WithLinks(r.links).
+			WithTags(r.tags).
+			WithIsTest(r.isTest)
 		var mds []model.ManifestName
 		for _, md := range r.resourceDeps {
 			mds = append(mds, model.ManifestName(md))

--- a/internal/tiltfile/tiltfile_state.go
+++ b/internal/tiltfile/tiltfile_state.go
@@ -479,7 +479,7 @@ func (s *tiltfileState) OnStart(e *starkit.Environment) error {
 		{filterYamlN, s.filterYaml},
 		{k8sResourceN, s.k8sResource},
 		{localResourceN, s.localResource},
-		{testN, s.localResource},
+		{testN, s.localResource}, // test is just a fork of local resource, w/ some switches based on fn.Name()
 		{portForwardN, s.portForward},
 		{k8sKindN, s.k8sKind},
 		{k8sImageJSONPathN, s.k8sImageJsonPath},

--- a/pkg/model/local_target.go
+++ b/pkg/model/local_target.go
@@ -19,6 +19,10 @@ type LocalTarget struct {
 	// Indicates that we should allow this to run in parallel with other
 	// resources  (by default, this is presumed unsafe and is not allowed).
 	AllowParallel bool
+
+	// For testing MVP
+	Tags   []string // eventually we might want tags to be more widespread -- stored on manifest maybe?
+	IsTest bool     // does this target represent a Test?
 }
 
 var _ TargetSpec = LocalTarget{}
@@ -53,6 +57,16 @@ func (lt LocalTarget) WithIgnores(ignores []Dockerignore) LocalTarget {
 
 func (lt LocalTarget) WithLinks(links []Link) LocalTarget {
 	lt.Links = links
+	return lt
+}
+
+func (lt LocalTarget) WithIsTest(isTest bool) LocalTarget {
+	lt.IsTest = isTest
+	return lt
+}
+
+func (lt LocalTarget) WithTags(tags []string) LocalTarget {
+	lt.Tags = tags
 	return lt
 }
 


### PR DESCRIPTION
I don't know if we want to merge this into master or just leave it in a mega branch but: here's a tiltfile function `test` that just wraps local resource to create a test resource -- again, just a local resource with an `isTest` flag on it. cc @ellenkorbes 