### PR TITLE
k8s: remove registry instructions until we have a registry for k3d 3.0

### DIFF
--- a/internal/k8s/registry.go
+++ b/internal/k8s/registry.go
@@ -196,10 +196,6 @@ func (r *registryAsync) Registry(ctx context.Context) container.Registry {
 				logger.Get(ctx).Warnf("You are running Kind without a local image registry.\n" +
 					"Tilt can use the local registry to speed up builds.\n" +
 					"Instructions: https://github.com/tilt-dev/kind-local")
-			} else if r.env == EnvK3D {
-				logger.Get(ctx).Warnf("You are running K3D without a local image registry.\n" +
-					"Tilt can use the local registry to speed up builds.\n" +
-					"Instructions: https://github.com/tilt-dev/k3d-local-registry")
 			}
 		}
 	})

--- a/internal/k8s/registry_test.go
+++ b/internal/k8s/registry_test.go
@@ -152,7 +152,7 @@ func TestKINDWarning(t *testing.T) {
 	assert.Contains(t, out.String(), "https://github.com/tilt-dev/kind-local")
 }
 
-func TestK3DWarning(t *testing.T) {
+func TestK3DNoWarning(t *testing.T) {
 	cs := &fake.Clientset{}
 	core := cs.CoreV1()
 	registryAsync := newRegistryAsync(EnvK3D, core, NewNaiveRuntimeSource(container.RuntimeContainerd))
@@ -160,7 +160,7 @@ func TestK3DWarning(t *testing.T) {
 	out := bytes.NewBuffer(nil)
 	registry := registryAsync.Registry(newLoggerCtx(out))
 	assert.True(t, registry.Empty())
-	assert.Contains(t, out.String(), "https://github.com/tilt-dev/k3d-local-registry")
+	assert.Equal(t, out.String(), "")
 }
 
 func TestRegistryFoundInLabelsWithLocalOnly(t *testing.T) {


### PR DESCRIPTION
Hello @maiamcc,

Please review the following commits I made in branch nicks/k3dregistry:

596a34cc99699a9ec470b9d2eefacbd0b602d435 (2020-12-22 12:31:26 -0500)
k8s: remove registry instructions until we have a registry for k3d 3.0

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics