### PR TITLE
web: Add OverviewLogPane, a fork of LogPane

### DIFF
--- a/web/src/AnsiLine.scss
+++ b/web/src/AnsiLine.scss
@@ -1,27 +1,35 @@
 @import "constants.scss";
 
 // Use Tilt brand colors
-.ansi-black {
+.ansi-black,
+.ansi-black-fg {
   color: $color-black;
 }
-.ansi-red {
+.ansi-red,
+.ansi-red-fg {
   color: $color-red;
 }
-.ansi-green {
+.ansi-green,
+.ansi-green-fg {
   color: $color-green;
 }
-.ansi-yellow {
+.ansi-yellow,
+.ansi-yellow-fg {
   color: $color-yellow;
 }
-.ansi-blue {
+.ansi-blue,
+.ansi-blue-fg {
   color: $color-blue;
 }
-.ansi-magenta {
+.ansi-magenta,
+.ansi-magenta-fg {
   color: $color-purple;
 }
-.ansi-cyan {
+.ansi-cyan,
+.ansi-cyan-fg {
   color: $color-blue-light;
 }
-.ansi-white {
+.ansi-white,
+.ansi-white-fg {
   color: $color-white;
 }

--- a/web/src/HUD.tsx
+++ b/web/src/HUD.tsx
@@ -20,7 +20,7 @@ import K8sViewPane from "./K8sViewPane"
 import { LocalStorageContextProvider } from "./LocalStorage"
 import LogPane from "./LogPane"
 import { logLinesFromString } from "./logs"
-import LogStore from "./LogStore"
+import LogStore, { LogStoreProvider } from "./LogStore"
 import MetricsPane from "./MetricsPane"
 import NoMatch from "./NoMatch"
 import NotFound from "./NotFound"
@@ -106,6 +106,7 @@ class HUD extends Component<HudProps, HudState> {
       socketState: SocketState.Closed,
       showErrorModal: ShowErrorModal.Default,
       error: undefined,
+      logStore: new LogStore(),
     }
 
     this.toggleSidebar = this.toggleSidebar.bind(this)
@@ -348,18 +349,20 @@ class HUD extends Component<HudProps, HudState> {
   renderOverviewSwitch() {
     return (
       <PathBuilderProvider value={this.pathBuilder}>
-        <Switch>
-          <Route
-            path={this.path("/r/:name/overview")}
-            render={(props: RouteComponentProps<any>) => (
-              <OverviewResourcePane
-                name={props.match.params?.name || ""}
-                view={this.state.view}
-              />
-            )}
-          />
-          <Route render={() => <OverviewPane view={this.state.view} />} />
-        </Switch>
+        <LogStoreProvider value={this.state.logStore || new LogStore()}>
+          <Switch>
+            <Route
+              path={this.path("/r/:name/overview")}
+              render={(props: RouteComponentProps<any>) => (
+                <OverviewResourcePane
+                  name={props.match.params?.name || ""}
+                  view={this.state.view}
+                />
+              )}
+            />
+            <Route render={() => <OverviewPane view={this.state.view} />} />
+          </Switch>
+        </LogStoreProvider>
       </PathBuilderProvider>
     )
   }

--- a/web/src/LogStore.ts
+++ b/web/src/LogStore.ts
@@ -4,6 +4,7 @@
 // pkg/model/logstore/logstore.go
 // but with better support for incremental updates and rendering.
 
+import React, { useContext } from "react"
 import { isBuildSpanId } from "./logs"
 import { LogLine } from "./types"
 
@@ -419,3 +420,11 @@ class LogStore {
 }
 
 export default LogStore
+
+const logStoreContext = React.createContext<LogStore>(new LogStore())
+
+export function useLogStore(): LogStore {
+  return useContext(logStoreContext)
+}
+
+export let LogStoreProvider = logStoreContext.Provider

--- a/web/src/OverviewLogPane.stories.tsx
+++ b/web/src/OverviewLogPane.stories.tsx
@@ -1,0 +1,124 @@
+import React from "react"
+import { MemoryRouter } from "react-router"
+import LogStore, { LogStoreProvider } from "./LogStore"
+import OverviewLogPane from "./OverviewLogPane"
+
+function now() {
+  return new Date().toString()
+}
+
+type Line = string | { text: string; fields?: any }
+
+function appendLines(logStore: LogStore, name: string, ...lines: Line[]) {
+  let spans = {} as any
+  let spanId = name || "_"
+  spans[spanId] = { manifestName: name }
+
+  let segments = []
+  for (let line of lines) {
+    let obj = { time: now(), spanId: spanId, text: "" } as any
+    if (typeof line == "string") {
+      obj.text = line
+    } else {
+      for (let key in line) {
+        obj[key] = (line as any)[key]
+      }
+    }
+    segments.push(obj)
+  }
+
+  logStore.append({ spans, segments })
+}
+
+export default {
+  title: "OverviewLogPane",
+  decorators: [
+    (Story: any) => (
+      <MemoryRouter initialEntries={["/"]}>
+        <div
+          style={{
+            margin: "-1rem",
+            height: "80vh",
+            width: "80vw",
+            border: "thin solid #ccc",
+          }}
+        >
+          <Story />
+        </div>
+      </MemoryRouter>
+    ),
+  ],
+}
+
+export const ThreeLines = () => {
+  let logStore = new LogStore()
+  appendLines(logStore, "fe", "line 1\n", "line2\n", "line3\n")
+  return (
+    <LogStoreProvider value={logStore}>
+      <OverviewLogPane manifestName="fe" />
+    </LogStoreProvider>
+  )
+}
+
+export const ThreeLinesAllLog = () => {
+  let logStore = new LogStore()
+  appendLines(logStore, "", "line 1\n", "line2\n", "line3\n")
+  return (
+    <LogStoreProvider value={logStore}>
+      <OverviewLogPane manifestName="" />
+    </LogStoreProvider>
+  )
+}
+
+export const OneThousandLines = () => {
+  let logStore = new LogStore()
+  let lines = []
+  for (let i = 0; i < 1000; i++) {
+    lines.push(`line ${i}\n`)
+  }
+  appendLines(logStore, "fe", ...lines)
+  return (
+    <LogStoreProvider value={logStore}>
+      <OverviewLogPane manifestName="fe" />
+    </LogStoreProvider>
+  )
+}
+
+export const StyledLines = () => {
+  let logStore = new LogStore()
+  let lines = [
+    "Black: \u001b[30m text \u001b[0m\n",
+    "Red: \u001b[31m text \u001b[0m\n",
+    "Green: \u001b[32m text \u001b[0m\n",
+    "Yellow: \u001b[33m text \u001b[0m\n",
+    "Blue: \u001b[34m text \u001b[0m\n",
+    "Magenta: \u001b[35m text \u001b[0m\n",
+    "Cyan: \u001b[36m text \u001b[0m\n",
+    "White: \u001b[37m text \u001b[0m\n",
+    "Link: https://tilt.dev/\n",
+    'Escaped Link: <a href="https://tilt.dev/" >Tilt</a>\n',
+    'Escaped Button: <button onClick="alert(\\"you are p0wned\\")" >Tilt</button>\n',
+  ]
+  appendLines(logStore, "fe", ...lines)
+  return (
+    <LogStoreProvider value={logStore}>
+      <OverviewLogPane manifestName="fe" />
+    </LogStoreProvider>
+  )
+}
+
+export const BuildEventLines = () => {
+  let logStore = new LogStore()
+  let lines = [
+    { text: "Start build\n", fields: { buildEvent: "init" } },
+    { text: "Fallback build\n", fields: { buildEvent: "fallback" } },
+    "Build log 1\n",
+    "Build log 2\n",
+  ]
+  appendLines(logStore, "fe", ...lines)
+  return (
+    <LogStoreProvider value={logStore}>
+      <OverviewLogPane manifestName="fe" />
+    </LogStoreProvider>
+  )
+}

--- a/web/src/OverviewLogPane.test.tsx
+++ b/web/src/OverviewLogPane.test.tsx
@@ -1,0 +1,25 @@
+import { mount } from "enzyme"
+import {
+  StyledLines,
+  ThreeLines,
+  ThreeLinesAllLog,
+} from "./OverviewLogPane.stories"
+
+it("renders 3 lines in resource view", () => {
+  let root = mount(ThreeLines())
+  let el = root.getDOMNode()
+  expect(el.querySelectorAll(".LogPaneLine")).toHaveLength(3)
+})
+
+it("renders 3 lines in all log view", () => {
+  let root = mount(ThreeLinesAllLog())
+  let el = root.getDOMNode()
+  expect(el.querySelectorAll(".LogPaneLine")).toHaveLength(3)
+})
+
+it("escapes html and linkifies", () => {
+  let root = mount(StyledLines())
+  let el = root.getDOMNode()
+  expect(el.querySelectorAll(".LogPaneLine a")).toHaveLength(2)
+  expect(el.querySelectorAll(".LogPaneLine button")).toHaveLength(0)
+})

--- a/web/src/OverviewLogPane.tsx
+++ b/web/src/OverviewLogPane.tsx
@@ -1,0 +1,282 @@
+import Anser from "anser"
+import React, { Component } from "react"
+import styled, { keyframes } from "styled-components"
+import "./LogPane.scss"
+import "./LogPaneLine.scss"
+import LogStore, { useLogStore } from "./LogStore"
+import PathBuilder, { usePathBuilder } from "./PathBuilder"
+import { SizeUnit } from "./style-helpers"
+import { LogLine } from "./types"
+
+type OverviewLogComponentProps = {
+  manifestName: string
+  pathBuilder: PathBuilder
+  logStore: LogStore
+}
+
+let LogPaneRoot = styled.section`
+  padding-top: ${SizeUnit(0.5)};
+  padding-bottom: ${SizeUnit(0.5)};
+  width: 100%;
+  height: 100%;
+  overflow-y: auto;
+  box-sizing: border-box;
+`
+
+const blink = keyframes`
+0% {
+  opacity: 1;
+}
+50% {
+  opacity: 0;
+}
+100% {
+  opacity: 1;
+}
+`
+
+let LogEnd = styled.div`
+  animation: ${blink} 1s infinite;
+  animation-timing-function: ease;
+  padding-topt: ${SizeUnit(0.25)};
+  padding-left: ${SizeUnit(0.625)};
+`
+
+let anser = new Anser()
+
+function newLineEl(line: LogLine, isContextChange: boolean): Element {
+  let text = line.text
+  let level = line.level
+  let buildEvent = line.buildEvent
+  let classes = ["LogPaneLine"]
+  if (level === "WARN") {
+    classes.push("is-warning")
+  } else if (level === "ERROR") {
+    classes.push("is-error")
+  }
+  if (isContextChange) {
+    classes.push("is-contextChange")
+  }
+  if (buildEvent === "init") {
+    classes.push("is-buildEvent-init")
+  }
+  if (buildEvent === "fallback") {
+    classes.push("is-buildEvent-fallback")
+  }
+  let span = document.createElement("span")
+  span.classList.add(...classes)
+  let code = document.createElement("code")
+  code.classList.add("LogPaneLine-content")
+  code.innerHTML = anser.linkify(
+    anser.ansiToHtml(anser.escapeForHtml(line.text), {
+      use_classes: true,
+    })
+  )
+  span.appendChild(code)
+  return span
+}
+
+// React is not a great system for rendering logs.
+// React has to build a virtual DOM, diffs the virtual DOM, and does
+// spot updates of the actual DOM.
+//
+// But logs are append-only, so this wastes a lot of CPU doing diffs
+// for things that never change. Other components (like xtermjs) manage
+// rendering directly, but have a thin React wrapper to mount the component.
+// So we use that rendering strategy here.
+//
+// This means that we can't use other react components (like styled-components)
+// and have to use plain css + HTML.
+class OverviewLogComponent extends Component<OverviewLogComponentProps> {
+  private autoscroll: boolean = false
+
+  // The element containing all the log lines.
+  private rootRef: React.RefObject<any> = React.createRef()
+
+  // The blinking cursor at the end fo the component.
+  private cursorRef: React.RefObject<HTMLParagraphElement> = React.createRef()
+
+  // Track the scrollY of the root element to see if the user is scrolling upwards.
+  private scrollY: number = -1
+
+  // Timer for tracking autoscroll.
+  private autoscrollRafID: number | null = null
+
+  constructor(props: OverviewLogComponentProps) {
+    super(props)
+
+    this.onScroll = this.onScroll.bind(this)
+  }
+
+  scrollCursorIntoView() {
+    if (this.cursorRef.current?.scrollIntoView) {
+      this.cursorRef.current.scrollIntoView()
+    }
+  }
+
+  componentDidUpdate(prevProps: OverviewLogComponentProps) {
+    if (prevProps.logStore !== this.props.logStore) {
+      // TODO(nick): setup/teardown logstore listeners.
+    }
+
+    if (prevProps.manifestName !== this.props.manifestName) {
+      this.autoscroll = true
+      this.scrollY = -1
+      if (this.props.pathBuilder.isSnapshot()) {
+        this.autoscroll = false
+      }
+
+      this.renderFreshLogs()
+    } else if (prevProps.logStore !== this.props.logStore) {
+      this.renderFreshLogs()
+    }
+  }
+
+  componentDidMount() {
+    if (this.props.pathBuilder.isSnapshot()) {
+      this.autoscroll = false
+    }
+
+    window.addEventListener("scroll", this.onScroll, {
+      passive: true,
+    })
+    this.renderFreshLogs()
+
+    // TODO(nick): setup logstore listeners
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener("scroll", this.onScroll)
+    if (this.autoscrollRafID) {
+      cancelAnimationFrame(this.autoscrollRafID)
+    }
+    // TODO(nick): teardown logstore listeners
+  }
+
+  onScroll() {
+    let rootEl = this.rootRef.current
+    if (!rootEl) {
+      return
+    }
+
+    let scrollY = rootEl.scrollY
+    let oldScrollY = this.scrollY
+    let autoscroll = this.autoscroll
+
+    this.scrollY = scrollY
+    if (oldScrollY === -1 || oldScrollY === scrollY) {
+      return
+    }
+
+    // If we're scrolled horizontally, cancel the autoscroll.
+    if (rootEl.scrollX > 0) {
+      this.autoscroll = false
+      return
+    }
+
+    // If we're autoscrolling, and the user scrolled up,
+    // cancel the autoscroll.
+    if (autoscroll && scrollY < oldScrollY) {
+      this.autoscroll = false
+      return
+    }
+
+    // If we're not autoscrolling, and the user scrolled down,
+    // we may have to re-engage the autoscroll.
+    if (!autoscroll && scrollY > oldScrollY) {
+      this.maybeEngageAutoscroll()
+    }
+  }
+
+  private maybeEngageAutoscroll() {
+    if (this.props.pathBuilder.isSnapshot()) {
+      return
+    }
+
+    if (this.autoscrollRafID) {
+      cancelAnimationFrame(this.autoscrollRafID)
+    }
+
+    this.autoscrollRafID = requestAnimationFrame(() => {
+      let autoscroll = this.computeAutoScroll()
+      if (autoscroll) {
+        this.autoscroll = true
+      }
+    })
+  }
+
+  // Compute whether we should auto-scroll from the state of the DOM.
+  // This forces a layout, so should be used sparingly.
+  private computeAutoScroll() {
+    let rootEl = this.rootRef.current
+    if (!rootEl) {
+      return
+    }
+
+    // Always auto-scroll when we're recovering from a loading screen.
+    if (!this.cursorRef.current) {
+      return true
+    }
+
+    // Never auto-scroll if we're horizontally scrolled.
+    if (rootEl.scrollX) {
+      return false
+    }
+
+    let lastElInView =
+      this.cursorRef.current.getBoundingClientRect().bottom < window.innerHeight
+    return lastElInView
+  }
+
+  // Re-render all the logs from scratch.
+  renderFreshLogs() {
+    let root = this.rootRef.current
+    let cursor = this.cursorRef.current
+    let mn = this.props.manifestName
+    let logStore = this.props.logStore
+
+    let lines = mn ? logStore.manifestLog(mn) : logStore.allLog()
+
+    while (root.firstChild != cursor) {
+      root.removeChild(root.firstChild)
+    }
+
+    let lastManifestName = ""
+    for (let i = 0; i < lines.length; i++) {
+      let line = lines[i]
+      let isContextChange = i > 0 && line.manifestName !== lastManifestName
+      let lineEl = newLineEl(line, false)
+      root.insertBefore(lineEl, cursor)
+
+      lastManifestName = line.manifestName
+    }
+
+    this.scrollCursorIntoView()
+  }
+
+  render() {
+    return (
+      <LogPaneRoot ref={this.rootRef}>
+        <LogEnd key="logEnd" className="logEnd" ref={this.cursorRef}>
+          &#9608;
+        </LogEnd>
+      </LogPaneRoot>
+    )
+  }
+}
+
+type OverviewLogPaneProps = {
+  manifestName: string
+}
+
+export default function OverviewLogPane(props: { manifestName: string }) {
+  let pathBuilder = usePathBuilder()
+  let logStore = useLogStore()
+  return (
+    <OverviewLogComponent
+      manifestName={props.manifestName}
+      pathBuilder={pathBuilder}
+      logStore={logStore}
+    />
+  )
+}

--- a/web/src/OverviewResourceDetails.stories.tsx
+++ b/web/src/OverviewResourceDetails.stories.tsx
@@ -18,4 +18,6 @@ export default {
   ],
 }
 
-export const Vigoda = () => <OverviewResourceDetails view={oneResource()} />
+export const Vigoda = () => (
+  <OverviewResourceDetails view={oneResource()} name="vigoda" />
+)

--- a/web/src/OverviewResourceDetails.tsx
+++ b/web/src/OverviewResourceDetails.tsx
@@ -1,7 +1,9 @@
 import React from "react"
 import styled from "styled-components"
+import OverviewLogPane from "./OverviewLogPane"
 
 type OverviewResourceDetailsProps = {
+  name: string
   view: Proto.webviewResource
 }
 
@@ -33,14 +35,7 @@ export default function OverviewResourceDetails(
         <div>links</div>
         <div>copy pod</div>
       </ActionBar>
-      <LogPane>
-        <div>log line 1</div>
-        <div>log line 2</div>
-        <div>log line 3</div>
-        <div>log line 4</div>
-        <div>log line 5</div>
-        <div>log line 6</div>
-      </LogPane>
+      <OverviewLogPane manifestName={name} />
     </OverviewResourceDetailsRoot>
   )
 }


### PR DESCRIPTION
Hello @hyu,

Please review the following commits I made in branch nicks/ch10498:

06851e637895dcc66d2d9639a4df5b92b6b35dae (2020-12-23 12:25:13 -0500)
web: Add OverviewLogPane, a fork of LogPane
LogPane is pretty closely coupled with window-based scrolling and the particular
DOM layout of the old view, so probably we were going to need to fork it either way.

Meanwhile, I'm pretty unhappy with both the performance and flexibility of the old log pane.
It doesn't really fit in well with React's view of the world. React is optimized
so that any component can be live updated. But most logs need to be rendered once and
never touched again.

OverviewLogPane uses a lot of the existing CSS from LogPane, but substantially
changes rendering to vanilla JS, and gets rid of the concept of a render window.

2b50abf937ca1326415b57abb2c882f9ce6d9781 (2020-12-22 12:33:01 -0500)
web: Use contexts to provide PathBuilder

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics