### PR TITLE
web: redraw the OverviewLogPane when new logs come in

### DIFF
--- a/web/src/OverviewLogPane.stories.tsx
+++ b/web/src/OverviewLogPane.stories.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import React, { useEffect, useState } from "react"
 import { MemoryRouter } from "react-router"
 import LogStore, { LogStoreProvider } from "./LogStore"
 import OverviewLogPane from "./OverviewLogPane"
@@ -10,6 +10,9 @@ function now() {
 type Line = string | { text: string; fields?: any }
 
 function appendLines(logStore: LogStore, name: string, ...lines: Line[]) {
+  let fromCheckpoint = logStore.checkpoint
+  let toCheckpoint = fromCheckpoint + lines.length
+
   let spans = {} as any
   let spanId = name || "_"
   spans[spanId] = { manifestName: name }
@@ -27,7 +30,7 @@ function appendLines(logStore: LogStore, name: string, ...lines: Line[]) {
     segments.push(obj)
   }
 
-  logStore.append({ spans, segments })
+  logStore.append({ spans, segments, fromCheckpoint, toCheckpoint })
 }
 
 export default {
@@ -48,6 +51,12 @@ export default {
       </MemoryRouter>
     ),
   ],
+  argTypes: {
+    layer1: { control: { type: "number", min: 0, max: 100 } },
+    layer2: { control: { type: "number", min: 0, max: 100 } },
+    layer3: { control: { type: "number", min: 0, max: 100 } },
+    layer4: { control: { type: "number", min: 0, max: 100 } },
+  },
 }
 
 export const ThreeLines = () => {
@@ -121,4 +130,40 @@ export const BuildEventLines = () => {
       <OverviewLogPane manifestName="fe" />
     </LogStoreProvider>
   )
+}
+
+export const ProgressLines = (args: any) => {
+  let [logStore, setLogStore] = useState(new LogStore())
+  let lines = [
+    { text: "Start build\n", fields: { progressID: "start" } },
+    { text: `Layer 1: 0%\n`, fields: { progressID: "layer1" } },
+    { text: `Layer 2: 0%\n`, fields: { progressID: "layer2" } },
+    { text: `Layer 3: 0%\n`, fields: { progressID: "layer3" } },
+    { text: `Layer 4: 0%\n`, fields: { progressID: "layer4" } },
+  ]
+  appendLines(logStore, "fe", ...lines)
+
+  useEffect(() => {
+    let lines = [
+      { text: "Start build\n", fields: { progressID: "start" } },
+      { text: `Layer 1: ${args.layer1}%\n`, fields: { progressID: "layer1" } },
+      { text: `Layer 2: ${args.layer2}%\n`, fields: { progressID: "layer2" } },
+      { text: `Layer 3: ${args.layer3}%\n`, fields: { progressID: "layer3" } },
+      { text: `Layer 4: ${args.layer4}%\n`, fields: { progressID: "layer4" } },
+    ]
+    appendLines(logStore, "fe", ...lines)
+  }, [args])
+
+  return (
+    <LogStoreProvider value={logStore}>
+      <OverviewLogPane manifestName="fe" />
+    </LogStoreProvider>
+  )
+}
+
+ProgressLines.args = {
+  layer1: 50,
+  layer2: 40,
+  layer3: 30,
+  layer4: 20,
 }

--- a/web/src/OverviewLogPane.tsx
+++ b/web/src/OverviewLogPane.tsx
@@ -106,6 +106,7 @@ class OverviewLogComponent extends Component<OverviewLogComponentProps> {
     super(props)
 
     this.onScroll = this.onScroll.bind(this)
+    this.onLogUpdate = this.onLogUpdate.bind(this)
   }
 
   scrollCursorIntoView() {
@@ -114,9 +115,19 @@ class OverviewLogComponent extends Component<OverviewLogComponentProps> {
     }
   }
 
+  onLogUpdate() {
+    if (!this.rootRef.current || !this.cursorRef.current) {
+      return
+    }
+
+    // TODO(nick): Make this more progressive instead of re-rendering every time.
+    this.renderFreshLogs()
+  }
+
   componentDidUpdate(prevProps: OverviewLogComponentProps) {
     if (prevProps.logStore !== this.props.logStore) {
-      // TODO(nick): setup/teardown logstore listeners.
+      prevProps.logStore.removeUpdateListener(this.onLogUpdate)
+      this.props.logStore.addUpdateListener(this.onLogUpdate)
     }
 
     if (prevProps.manifestName !== this.props.manifestName) {
@@ -142,15 +153,15 @@ class OverviewLogComponent extends Component<OverviewLogComponentProps> {
     })
     this.renderFreshLogs()
 
-    // TODO(nick): setup logstore listeners
+    this.props.logStore.addUpdateListener(this.onLogUpdate)
   }
 
   componentWillUnmount() {
+    this.props.logStore.removeUpdateListener(this.onLogUpdate)
     window.removeEventListener("scroll", this.onScroll)
     if (this.autoscrollRafID) {
       cancelAnimationFrame(this.autoscrollRafID)
     }
-    // TODO(nick): teardown logstore listeners
   }
 
   onScroll() {


### PR DESCRIPTION
Hello @hyu,

Please review the following commits I made in branch nicks/logpane3:

c8dbb2163f068089e4cdaad9a1714469bb1c6cda (2021-01-04 13:13:15 -0500)
web: redraw the OverviewLogPane when new logs come in

fa99ea3bb4f02fec9eac06ab131f168eaaf19415 (2021-01-04 11:25:34 -0500)
web: Add OverviewLogPane, a fork of LogPane
LogPane is pretty closely coupled with window-based scrolling and the particular
DOM layout of the old view, so probably we were going to need to fork it either way.

Meanwhile, I'm pretty unhappy with both the performance and flexibility of the old log pane.
It doesn't really fit in well with React's view of the world. React is optimized
so that any component can be live updated. But most logs need to be rendered once and
never touched again.

OverviewLogPane uses a lot of the existing CSS from LogPane, but substantially
changes rendering to vanilla JS, and gets rid of the concept of a render window.

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics