### PR TITLE
web: add an api for incremental logs to the LogStore

### DIFF
--- a/web/src/LogPane.stories.tsx
+++ b/web/src/LogPane.stories.tsx
@@ -19,7 +19,7 @@ function logPane(lines: LogLine[]) {
 
 function line(manifestName: string, text: string, level?: string): LogLine {
   level = level || "INFO"
-  return { manifestName, text, level, spanId: manifestName }
+  return { manifestName, text, level, spanId: manifestName, storedLineIndex: 0 }
 }
 
 function threeResources() {

--- a/web/src/LogStore.test.ts
+++ b/web/src/LogStore.test.ts
@@ -298,4 +298,93 @@ describe("LogStore", () => {
       "build 1\npod 1"
     )
   })
+
+  it("handles incremental logs", () => {
+    let logs = new LogStore()
+    logs.append({
+      spans: {
+        "": {},
+        "build:1": { manifestName: "fe" },
+      },
+      segments: [
+        newManifestSegment("build:1", "build 1\n"),
+        newManifestSegment("build:1", "build 2\n"),
+        newManifestSegment("build:1", "build 3\n"),
+        newGlobalSegment("global line 1\n"),
+      ],
+      fromCheckpoint: 0,
+      toCheckpoint: 4,
+    })
+
+    let patch = logs.manifestLogPatchSet("fe", 0)
+    expect(logLinesToString(patch.lines, false)).toEqual(
+      "build 1\nbuild 2\nbuild 3"
+    )
+
+    logs.append({
+      spans: {
+        "": {},
+        "build:1": { manifestName: "fe" },
+      },
+      segments: [
+        newGlobalSegment("global line 2\n"),
+        newManifestSegment("build:1", "build 4\n"),
+        newManifestSegment("build:1", "build 5\n"),
+        newManifestSegment("build:1", "build 6\n"),
+      ],
+      fromCheckpoint: 4,
+      toCheckpoint: 8,
+    })
+
+    let patch3 = logs.manifestLogPatchSet("fe", patch.checkpoint)
+    expect(logLinesToString(patch3.lines, false)).toEqual(
+      "build 4\nbuild 5\nbuild 6"
+    )
+  })
+
+  it("handles incremental logs continuation", () => {
+    let logs = new LogStore()
+    logs.append({
+      spans: {
+        "": {},
+        "build:1": { manifestName: "fe" },
+      },
+      segments: [
+        newManifestSegment("build:1", "build 1\n"),
+        newManifestSegment("build:1", "build 2\n"),
+        newManifestSegment("build:1", "build ..."),
+        newGlobalSegment("global line 1\n"),
+      ],
+      fromCheckpoint: 0,
+      toCheckpoint: 4,
+    })
+
+    let patch = logs.manifestLogPatchSet("fe", 0)
+    expect(logLinesToString(patch.lines, false)).toEqual(
+      "build 1\nbuild 2\nbuild ..."
+    )
+
+    let patch2 = logs.manifestLogPatchSet("fe", patch.checkpoint)
+    expect(patch2.lines).toEqual([])
+
+    logs.append({
+      spans: {
+        "": {},
+        "build:1": { manifestName: "fe" },
+      },
+      segments: [
+        newGlobalSegment("global line 2\n"),
+        newManifestSegment("build:1", "... 3\n"),
+        newManifestSegment("build:1", "build 4\n"),
+        newManifestSegment("build:1", "build 5\n"),
+      ],
+      fromCheckpoint: 4,
+      toCheckpoint: 8,
+    })
+
+    let patch3 = logs.manifestLogPatchSet("fe", patch.checkpoint)
+    expect(logLinesToString(patch3.lines, false)).toEqual(
+      "build ...... 3\nbuild 4\nbuild 5"
+    )
+  })
 })

--- a/web/src/logs.ts
+++ b/web/src/logs.ts
@@ -13,6 +13,7 @@ export function logLinesFromString(
       manifestName: manifestName ?? "",
       level: "INFO",
       spanId: "",
+      storedLineIndex: 0,
     }
   })
 }

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -83,6 +83,20 @@ export type LogLine = {
   level: string
   buildEvent?: string
   spanId: string
+
+  // The index of this line in the LogStore StoredLine list.
+  storedLineIndex: number
+}
+
+// Instructions on how to patch an existing log stream with new logs.
+// Includes:
+// - The lines to add. Some of these might patch existing lines.
+// - A client-side checkpoint, for determining the next patch
+//   Users of this API should not modify this. They should just pass it to
+//   the next invocation of the log getter. 0 indicates we will get all logs.
+export type LogPatchSet = {
+  lines: LogLine[]
+  checkpoint: number
 }
 
 // Display data about the current log trace.


### PR DESCRIPTION
Hello @hyu,

Please review the following commits I made in branch nicks/logpane2:

d03bed440557440ff6c830b04bfb8c7c2936a7fd (2021-01-04 16:21:02 -0500)
web: add an api for incremental logs to the LogStore

bfcaac24fb4fc051e454dbc106447cccf77a86e9 (2021-01-04 13:13:54 -0500)
web: redraw the OverviewLogPane when new logs come in

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics