### PR TITLE
engine: fix a bug in the log rotation handler where sometimes it would erroneously duplicate a log

### DIFF
--- a/internal/engine/runtimelog/podlogmanager_test.go
+++ b/internal/engine/runtimelog/podlogmanager_test.go
@@ -301,7 +301,7 @@ func TestLogReconnection(t *testing.T) {
 	f.AssertOutputContains("goodbye world!")
 
 	// Make sure the start time was adjusted for when the last read happened.
-	assert.Equal(t, lastRead, f.kClient.LastPodLogStartTime)
+	assert.Equal(t, lastRead.Add(podLogReconnectGap), f.kClient.LastPodLogStartTime)
 }
 
 func TestInitContainerLogs(t *testing.T) {


### PR DESCRIPTION
Hello @maiamcc, @landism,

Please review the following commits I made in branch nicks/logdupe:

c8c3f71f4fa40e02df115a56272d55e5430d8fce (2021-01-05 16:21:33 -0500)
engine: fix a bug in the log rotation handler where sometimes it would erroneously duplicate a log

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics