### PR TITLE
server: api endpoint for setting trigger mode [ch10576]

### DIFF
--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -181,7 +181,7 @@ func upperReducerFn(ctx context.Context, state *store.EngineState, action store.
 		handleMetricsModeAction(state, action)
 	case metrics.MetricsDashboardAction:
 		handleMetricsDashboardAction(state, action)
-	case server.ManifestOverrideAction:
+	case server.OverrideTriggerModeAction:
 		handleManifestOverrideAction(state, action)
 	default:
 		state.FatalError = fmt.Errorf("unrecognized action: %T", action)
@@ -884,7 +884,7 @@ func handleMetricsDashboardAction(state *store.EngineState, action metrics.Metri
 	state.MetricsServing.GrafanaHost = action.GrafanaHost
 }
 
-func handleManifestOverrideAction(state *store.EngineState, action server.ManifestOverrideAction) {
+func handleManifestOverrideAction(state *store.EngineState, action server.OverrideTriggerModeAction) {
 	// TODO(maia): in this implementation, overrides do NOT persist across Tiltfile loads
 	//   (i.e. the next Tiltfile load will wipe out the override we just put in place).
 	//   If we want to keep this functionality, the next step is to store the set of overrides
@@ -895,9 +895,7 @@ func handleManifestOverrideAction(state *store.EngineState, action server.Manife
 		if !ok {
 			panic("well fuck, couldn't find manifest: " + mName)
 		}
-		if action.Overrides.TriggerMode != nil {
-			mt.Manifest.TriggerMode = *action.Overrides.TriggerMode
-		}
+		mt.Manifest.TriggerMode = action.TriggerMode
 	}
 
 }

--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -894,7 +894,7 @@ func handleOverrideTriggerModeAction(ctx context.Context, state *store.EngineSta
 
 	// We validate trigger mode when we receive a request, so this should never happen
 	if !model.ValidTriggerMode(action.TriggerMode) {
-		logger.Get(ctx).Errorf("Error overriding trigger mode: invalid trigger mode %d", action.TriggerMode)
+		logger.Get(ctx).Errorf("INTERNAL ERROR overriding trigger mode: invalid trigger mode %d", action.TriggerMode)
 		return
 	}
 
@@ -902,7 +902,7 @@ func handleOverrideTriggerModeAction(ctx context.Context, state *store.EngineSta
 		mt, ok := state.ManifestTargets[mName]
 		if !ok {
 			// We validate manifest names when we receive a request, so this should never happen
-			logger.Get(ctx).Errorf("Error overriding trigger mode: no such manifest %q", mName)
+			logger.Get(ctx).Errorf("INTERNAL ERROR overriding trigger mode: no such manifest %q", mName)
 			return
 		}
 		mt.Manifest.TriggerMode = action.TriggerMode

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -3651,9 +3651,10 @@ func TestOverrideTriggerModeBadManifestLogsError(t *testing.T) {
 		TriggerMode:   model.TriggerModeManualAfterInitial,
 	})
 
-	f.log.WaitUntilContains("no such manifest", time.Millisecond*100)
+	err := f.log.WaitUntilContains("no such manifest", time.Millisecond*100)
+	require.NoError(t, err)
 
-	err := f.Stop()
+	err = f.Stop()
 	require.NoError(t, err)
 }
 
@@ -3673,8 +3674,10 @@ func TestOverrideTriggerModeBadTriggerModeLogsError(t *testing.T) {
 		TriggerMode:   12345,
 	})
 
-	f.log.WaitUntilContains("invalid trigger mode", time.Millisecond*100)
-	err := f.Stop()
+	err := f.log.WaitUntilContains("invalid trigger mode", time.Millisecond*100)
+	require.NoError(t, err)
+
+	err = f.Stop()
 	require.NoError(t, err)
 }
 

--- a/internal/hud/server/actions.go
+++ b/internal/hud/server/actions.go
@@ -17,9 +17,10 @@ type SetTiltfileArgsAction struct {
 
 func (SetTiltfileArgsAction) Action() {}
 
-type ManifestOverrideAction struct {
+// TODO: a way to clear an override
+type OverrideTriggerModeAction struct {
 	ManifestNames []model.ManifestName
-	Overrides     model.Overrides
+	TriggerMode   model.TriggerMode
 }
 
-func (ManifestOverrideAction) Action() {}
+func (OverrideTriggerModeAction) Action() {}

--- a/internal/hud/server/actions.go
+++ b/internal/hud/server/actions.go
@@ -16,3 +16,10 @@ type SetTiltfileArgsAction struct {
 }
 
 func (SetTiltfileArgsAction) Action() {}
+
+type ManifestOverrideAction struct {
+	ManifestNames []model.ManifestName
+	Overrides     model.Overrides
+}
+
+func (ManifestOverrideAction) Action() {}

--- a/internal/hud/server/server.go
+++ b/internal/hud/server/server.go
@@ -344,6 +344,7 @@ func (s *HeadsUpServer) HandleOverrideTriggerMode(w http.ResponseWriter, req *ht
 	err = checkManifestsExist(s.store, payload.ManifestNames)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
 	}
 
 	s.store.Dispatch(OverrideTriggerModeAction{

--- a/internal/hud/server/server.go
+++ b/internal/hud/server/server.go
@@ -347,6 +347,11 @@ func (s *HeadsUpServer) HandleOverrideTriggerMode(w http.ResponseWriter, req *ht
 		return
 	}
 
+	if !model.ValidTriggerMode(model.TriggerMode(payload.TriggerMode)) {
+		http.Error(w, fmt.Sprintf("invalid trigger mode: %d", payload.TriggerMode), http.StatusBadRequest)
+		return
+	}
+
 	s.store.Dispatch(OverrideTriggerModeAction{
 		ManifestNames: model.ManifestNames(payload.ManifestNames),
 		TriggerMode:   model.TriggerMode(payload.TriggerMode),

--- a/internal/hud/server/server_test.go
+++ b/internal/hud/server/server_test.go
@@ -291,11 +291,22 @@ func TestHandleOverrideTriggerModeMalformedPayload(t *testing.T) {
 	store.AssertNoActionOfType(t, reflect.TypeOf(server.OverrideTriggerModeAction{}), f.getActions)
 }
 
+func TestHandleOverrideTriggerModeInvalidTriggerMode(t *testing.T) {
+	f := newTestFixture(t).withDummyManifests("foo")
+
+	payload := `{"manifest_names":["foo"], "trigger_mode": 12345}`
+	status, respBody := f.makeReq("/api/override/trigger_mode", f.serv.HandleOverrideTriggerMode, http.MethodPost, payload)
+
+	require.Equal(t, http.StatusBadRequest, status, "handler returned wrong status code")
+	require.Contains(t, respBody, "invalid trigger mode: 12345")
+	store.AssertNoActionOfType(t, reflect.TypeOf(server.OverrideTriggerModeAction{}), f.getActions)
+}
+
 func TestHandleOverrideTriggerModeDispatchesEvent(t *testing.T) {
 	f := newTestFixture(t).withDummyManifests("foo", "bar")
 
-	payload := fmt.Sprintf(fmt.Sprintf(`{"manifest_names":["foo", "bar"], "trigger_mode": %d}`,
-		model.TriggerModeManualAfterInitial))
+	payload := fmt.Sprintf(`{"manifest_names":["foo", "bar"], "trigger_mode": %d}`,
+		model.TriggerModeManualAfterInitial)
 	status, _ := f.makeReq("/api/override/trigger_mode", f.serv.HandleOverrideTriggerMode, http.MethodPost, payload)
 
 	require.Equal(t, http.StatusOK, status, "handler returned wrong status code")

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -21,6 +21,14 @@ import (
 type ManifestName string
 type ManifestNameSet map[ManifestName]bool
 
+func ManifestNames(names []string) []ManifestName {
+	mNames := make([]ManifestName, len(names))
+	for i, name := range names {
+		mNames[i] = ManifestName(name)
+	}
+	return mNames
+}
+
 const TiltfileManifestName = ManifestName("(Tiltfile)")
 
 func (m ManifestName) String() string         { return string(m) }
@@ -39,7 +47,7 @@ type Manifest struct {
 
 	// How updates are triggered:
 	// - automatically, when we detect a change
-	// - manually, when the user tells us to
+	// - manually, only when the user tells us to
 	TriggerMode TriggerMode
 
 	// The resource in this manifest will not be built until all of its dependencies have been

--- a/pkg/model/override.go
+++ b/pkg/model/override.go
@@ -1,9 +1,0 @@
-package model
-
-// Manifest properties specified by the user in the UI; these override any properties
-// specified in the Tiltfile  (but do not persist over multiple runs).
-// A `nil` property indicates that it wasn't specified by the user (to differentiate
-// from the user specifying the zero value).
-type Overrides struct {
-	TriggerMode *TriggerMode
-}

--- a/pkg/model/override.go
+++ b/pkg/model/override.go
@@ -1,0 +1,9 @@
+package model
+
+// Manifest properties specified by the user in the UI; these override any properties
+// specified in the Tiltfile  (but do not persist over multiple runs).
+// A `nil` property indicates that it wasn't specified by the user (to differentiate
+// from the user specifying the zero value).
+type Overrides struct {
+	TriggerMode *TriggerMode
+}

--- a/pkg/model/trigger_mode.go
+++ b/pkg/model/trigger_mode.go
@@ -18,6 +18,15 @@ const (
 	TriggerModeManualIncludingInitial TriggerMode = iota
 )
 
+var TriggerModes = map[TriggerMode]bool{
+	TriggerModeAuto:                   true,
+	TriggerModeManualAfterInitial:     true,
+	TriggerModeManualIncludingInitial: true,
+}
+
+func ValidTriggerMode(tm TriggerMode) bool {
+	return TriggerModes[tm]
+}
 func (t TriggerMode) AutoOnChange() bool {
 	return t == TriggerModeAuto
 }


### PR DESCRIPTION
Hello @landism,

Please review the following commits I made in branch maiamcc/override-trigger-mode:

ea43d65b088d8635febe50c88f8ecd958d835c2f (2021-01-07 17:50:02 -0500)
validate trigger mode, double check request in engine

17518058ff8ebd4f0b82c8bf54d3dfa585e9b9d1 (2021-01-07 17:49:58 -0500)
missing return and rename tests

3851de8b81e4e3c8946516c7b96a0fae59b78d03 (2021-01-07 17:49:56 -0500)
more specific implementation

2c7cbfb2507d39c7a870925170301e0a95fbdfa1 (2021-01-07 17:49:52 -0500)
server: first pass at override endpoint

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics