### PR TITLE
web: clean up design for tabs UI

### DIFF
--- a/web/src/FloatDialog.tsx
+++ b/web/src/FloatDialog.tsx
@@ -46,6 +46,10 @@ let CloseButton = styled.button`
   border-radius: 32px 32px;
   padding: 0;
 
+  svg {
+    fill: ${Color.grayDark};
+  }
+
   &:hover,
   &:active {
     background-color: ${Color.grayLightest};

--- a/web/src/OverviewResourcePane.tsx
+++ b/web/src/OverviewResourcePane.tsx
@@ -25,7 +25,8 @@ let OverviewResourcePaneRoot = styled.div`
 let Main = styled.div`
   display: flex;
   width: 100%;
-  flex: 1 1 auto;
+  // In Safari, flex-basis "auto" squishes OverviewTabBar + OverviewResourceBar
+  flex: 1 1 100%;
   overflow: hidden;
 `
 

--- a/web/src/OverviewTabBar.test.tsx
+++ b/web/src/OverviewTabBar.test.tsx
@@ -1,7 +1,7 @@
 import { mount } from "enzyme"
 import React from "react"
 import { MemoryRouter } from "react-router"
-import OverviewTabBar, { Tab } from "./OverviewTabBar"
+import OverviewTabBar, { HomeTab, Tab } from "./OverviewTabBar"
 
 it("infers tab from url", () => {
   const root = mount(
@@ -10,10 +10,12 @@ it("infers tab from url", () => {
     </MemoryRouter>
   )
 
+  let homeTab = root.find(HomeTab)
   let tabs = root.find(Tab)
-  expect(tabs).toHaveLength(3)
+
+  expect(homeTab).toHaveLength(1)
+  expect(tabs).toHaveLength(2)
   expect(tabs.map((tab) => tab.props().to)).toEqual([
-    "/overview",
     "/r/vigoda/overview",
     "/r/snack/overview",
   ])

--- a/web/src/OverviewTabBar.tsx
+++ b/web/src/OverviewTabBar.tsx
@@ -2,29 +2,110 @@ import React, { useEffect, useState } from "react"
 import { matchPath } from "react-router"
 import { Link, useHistory } from "react-router-dom"
 import styled from "styled-components"
+import { ReactComponent as CloseSvg } from "./assets/svg/close.svg"
+import { ReactComponent as LogoWordmarkSvg } from "./assets/svg/logo-wordmark-gray.svg"
 import { useLocalStorageContext } from "./LocalStorage"
-import { Color } from "./style-helpers"
+import {
+  AnimDuration,
+  Color,
+  ColorAlpha,
+  ColorRGBA,
+  Font,
+  FontSize,
+  SizeUnit,
+} from "./style-helpers"
 
 type OverviewTabBarProps = {
   tabsForTesting?: string[]
 }
 
 let OverviewTabBarRoot = styled.div`
+  padding-top: ${SizeUnit(0.5)};
   display: flex;
   width: 100%;
-  height: 68px;
-  background-color: ${Color.gray};
+  height: 60px;
+  box-sizing: border-box;
+  background-color: ${Color.grayDarkest};
   border-bottom: 1px solid ${Color.grayLight};
+  align-items: stretch;
 `
 
 export let Tab = styled(Link)`
+  cursor: pointer;
   display: flex;
-  border: 1px solid ${Color.grayLight};
-  border-radius: 4px 4px 0px 0px;
-  margin: 12px;
+  font-family: ${Font.sansSerif};
+  font-size: ${FontSize.smallest};
   flex-grow: 0;
-  padding: 8px;
+  color: ${Color.grayLightest};
+  align-items: stretch;
   text-decoration: none;
+  padding-left: ${SizeUnit(0.5)};
+  box-sizing: border-box;
+  // "Remove" the Tab's bottom border (i.e., OverviewTabBarRoot's border)
+  margin-bottom: -1px;
+  // Define borders now so it doesn't "jump" when selected
+  border-top: 1px solid ${ColorRGBA(Color.black, 0)};
+  border-left: 1px solid ${ColorRGBA(Color.black, 0)};
+  border-right: 1px solid ${ColorRGBA(Color.black, 0)};
+
+  transition: background-color ${AnimDuration.short} linear,
+    color ${AnimDuration.default} linear,
+    border-color ${AnimDuration.short} linear;
+
+  &:focus {
+    outline: 0;
+    border-top-color: ${Color.gray};
+  }
+
+  &:hover {
+    color: ${Color.white};
+  }
+
+  &.isSelected {
+    color: ${Color.white};
+    background-color: ${Color.grayDark};
+    border-top-color: ${Color.grayLight};
+    border-left-color: ${Color.grayLight};
+    border-right-color: ${Color.grayLight};
+    border-radius: 4px 4px 0px 0px;
+  }
+`
+
+let TabName = styled.div`
+  display: flex;
+  align-items: center;
+`
+
+export let HomeTab = styled(Link)`
+  border: none;
+  padding-left: ${SizeUnit(1)};
+  padding-right: ${SizeUnit(1)};
+  background-color: transparent;
+  display: flex;
+  align-items: center;
+  opacity: ${ColorAlpha.almostOpaque};
+  transition: opacity ${AnimDuration.short} ease;
+
+  &:hover {
+    opacity: 1;
+  }
+`
+
+let CloseButton = styled.button`
+  cursor: pointer;
+  background-color: transparent;
+  border: 0 none;
+  padding-left: ${SizeUnit(0.25)};
+  padding-right: ${SizeUnit(0.25)};
+
+  svg {
+    fill: none;
+  }
+
+  ${Tab}:hover & svg,
+  ${Tab}.isSelected & svg {
+    fill: ${Color.grayLightest};
+  }
 `
 
 export default function OverviewTabBar(props: OverviewTabBarProps) {
@@ -100,20 +181,23 @@ export default function OverviewTabBar(props: OverviewTabBarProps) {
   let tabEls = tabs.map((name) => {
     let href = `/r/${name}/overview`
     let text = name
+    let isSelectedTab = false
     if (selectedTab === name) {
-      text += " (current)"
+      isSelectedTab = true
     }
     return (
-      <Tab key={name} to={href}>
-        <div>{text}</div>
-        <button onClick={(e) => onClose(e, name)}>close</button>
+      <Tab key={name} to={href} className={isSelectedTab ? "isSelected" : ""}>
+        <TabName>{text}</TabName>
+        <CloseButton onClick={(e) => onClose(e, name)}>
+          <CloseSvg />
+        </CloseButton>
       </Tab>
     )
   })
   tabEls.unshift(
-    <Tab key="logo" to={"/overview"}>
-      Logo
-    </Tab>
+    <HomeTab key="logo" to={"/overview"} className={selectedTab}>
+      <LogoWordmarkSvg width="57px" />
+    </HomeTab>
   )
   return <OverviewTabBarRoot>{tabEls}</OverviewTabBarRoot>
 }

--- a/web/src/assets/svg/close.svg
+++ b/web/src/assets/svg/close.svg
@@ -1,4 +1,4 @@
 <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-<rect x="3.43506" y="2" width="15" height="2" rx="1" transform="rotate(45 3.43506 2)" fill="#073642"/>
-<rect x="14.021" y="3.41418" width="15" height="2" rx="1" transform="rotate(135 14.021 3.41418)" fill="#073642"/>
+<rect x="3.43506" y="2" width="15" height="2" rx="1" transform="rotate(45 3.43506 2)"/>
+<rect x="14.021" y="3.41418" width="15" height="2" rx="1" transform="rotate(135 14.021 3.41418)" />
 </svg>


### PR DESCRIPTION
<img width="755" alt="Screen Shot 2021-01-07 at 7 54 54 PM" src="https://user-images.githubusercontent.com/20349/103961336-4b5c2500-5122-11eb-9154-cca24462d70c.png">

Interaction:
![2021-01-07 20 10 54](https://user-images.githubusercontent.com/20349/103962258-8f502980-5124-11eb-9e4b-d6254902a73a.gif)

Note: This PR didn't introduce it, but there's a weird effect where trying to close the only remaining tab doesn't actually remove the tab. (It does take you to Overview, though.)
