### PR TITLE
tiltfile: change os.path.exists to not watch files. Fixes https://github.com/tilt-dev/tilt/issues/4062

### DIFF
--- a/internal/tiltfile/os/os.go
+++ b/internal/tiltfile/os/os.go
@@ -8,7 +8,6 @@ import (
 
 	"go.starlark.net/starlark"
 
-	"github.com/tilt-dev/tilt/internal/tiltfile/io"
 	"github.com/tilt-dev/tilt/internal/tiltfile/starkit"
 	"github.com/tilt-dev/tilt/internal/tiltfile/value"
 )
@@ -177,23 +176,12 @@ func exists(t *starlark.Thread, path string) (starlark.Value, error) {
 	absPath := starkit.AbsPath(t, path)
 
 	_, err := os.Stat(absPath)
-	if os.IsNotExist(err) {
-		err := io.RecordReadPath(t, io.WatchFileOnly, absPath)
-		if err != nil {
-			return nil, err
-		}
-
-		return starlark.Bool(false), nil
-	} else if err != nil {
-		// Return false on error (e.g., permission denied errors),
-		// for consistency with the python version, but don't watch.
-		return starlark.Bool(false), nil
-	}
-
-	err = io.RecordReadPath(t, io.WatchFileOnly, absPath)
 	if err != nil {
-		return nil, err
+		// Return false on error (either not found errors or permission denied
+		// errors), for consistency with the python version.
+		return starlark.Bool(false), nil
 	}
+
 	return starlark.Bool(true), nil
 }
 

--- a/internal/tiltfile/os/os_test.go
+++ b/internal/tiltfile/os/os_test.go
@@ -251,12 +251,9 @@ print(result4)
 print(result5)
 `)
 
-	model, err := f.ExecFile("Tiltfile")
+	_, err := f.ExecFile("Tiltfile")
 	require.NoError(t, err)
 	assert.Equal(t, "False\nTrue\nTrue\nTrue\nFalse\n", f.PrintOutput())
-
-	readState := io.MustState(model)
-	assert.Equal(t, f.JoinPath("foo", "foo", "Tiltfile"), readState.Paths[2])
 }
 
 func TestPermissionDenied(t *testing.T) {


### PR DESCRIPTION
Hello @maiamcc, @landism,

Please review the following commits I made in branch nicks/ch10676:

69f390375c330c2cfb9f32c329d4fc0bf272158a (2021-01-08 15:13:42 -0500)
tiltfile: change os.path.exists to not watch files. Fixes https://github.com/tilt-dev/tilt/issues/4062

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics