### PR TITLE
tiltfile: add env support for local + local_resource

### DIFF
--- a/internal/engine/local/execer.go
+++ b/internal/engine/local/execer.go
@@ -222,4 +222,3 @@ func (e *processExecer) killProcess(ctx context.Context, c *exec.Cmd, processExi
 		return
 	}
 }
-

--- a/internal/engine/local/execer.go
+++ b/internal/engine/local/execer.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"os"
 	"os/exec"
 	"sync"
 	"syscall"
@@ -13,6 +12,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/tilt-dev/tilt/internal/localexec"
 	"github.com/tilt-dev/tilt/pkg/logger"
 	"github.com/tilt-dev/tilt/pkg/model"
 	"github.com/tilt-dev/tilt/pkg/procutil"
@@ -145,7 +145,7 @@ func (e *processExecer) processRun(ctx context.Context, cmd model.Cmd, w io.Writ
 	defer close(statusCh)
 
 	logger.Get(ctx).Infof("Running serve cmd: %s", cmd.String())
-	c := ExecCmd(cmd, logger.Get(ctx))
+	c := localexec.ExecCmd(cmd, logger.Get(ctx))
 
 	c.SysProcAttr = &syscall.SysProcAttr{}
 	procutil.SetOptNewProcessGroup(c.SysProcAttr)
@@ -223,33 +223,3 @@ func (e *processExecer) killProcess(ctx context.Context, c *exec.Cmd, processExi
 	}
 }
 
-// ExecCmd creates a stdlib exec.Cmd instance suitable for execution by the local engine.
-//
-// The resulting command will inherit the parent process (i.e. `tilt`) environment, then
-// have command specific environment overrides applied, and finally, additional conditional
-// environment to improve logging output.
-//
-// NOTE: To avoid confusion with ExecCmdContext, this method accepts a logger instance
-// directly rather than using logger.Get(ctx); the returned exec.Cmd from this function
-// will NOT be associated with any context.
-func ExecCmd(cmd model.Cmd, l logger.Logger) *exec.Cmd {
-	c := exec.Command(cmd.Argv[0], cmd.Argv[1:]...)
-	populateExecCmd(c, cmd, l)
-	return c
-}
-
-// ExecCmdContext is like ExecCmd but uses exec.CommandContext to associate a context with
-// the returned exec.Cmd.
-func ExecCmdContext(ctx context.Context, cmd model.Cmd) *exec.Cmd {
-	c := exec.CommandContext(ctx, cmd.Argv[0], cmd.Argv[1:]...)
-	populateExecCmd(c, cmd, logger.Get(ctx))
-	return c
-}
-
-func populateExecCmd(c *exec.Cmd, cmd model.Cmd, l logger.Logger) {
-	c.Dir = cmd.Dir
-	// env from command definition takes precedence over parent env (exec.Cmd takes last in case of dupes)
-	execEnv := os.Environ()
-	execEnv = append(execEnv, cmd.Env...)
-	c.Env = logger.PrepareEnv(l, execEnv)
-}

--- a/internal/engine/local/execer.go
+++ b/internal/engine/local/execer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
 	"sync"
 	"syscall"
@@ -144,14 +145,12 @@ func (e *processExecer) processRun(ctx context.Context, cmd model.Cmd, w io.Writ
 	defer close(statusCh)
 
 	logger.Get(ctx).Infof("Running serve cmd: %s", cmd.String())
-	c := exec.Command(cmd.Argv[0], cmd.Argv[1:]...)
+	c := ExecCmd(cmd, logger.Get(ctx))
 
 	c.SysProcAttr = &syscall.SysProcAttr{}
 	procutil.SetOptNewProcessGroup(c.SysProcAttr)
 	c.Stderr = w
 	c.Stdout = w
-	c.Dir = cmd.Dir
-	c.Env = logger.DefaultEnv(ctx)
 
 	err := c.Start()
 	if err != nil {
@@ -222,4 +221,35 @@ func (e *processExecer) killProcess(ctx context.Context, c *exec.Cmd, processExi
 	case <-processExitCh:
 		return
 	}
+}
+
+// ExecCmd creates a stdlib exec.Cmd instance suitable for execution by the local engine.
+//
+// The resulting command will inherit the parent process (i.e. `tilt`) environment, then
+// have command specific environment overrides applied, and finally, additional conditional
+// environment to improve logging output.
+//
+// NOTE: To avoid confusion with ExecCmdContext, this method accepts a logger instance
+// directly rather than using logger.Get(ctx); the returned exec.Cmd from this function
+// will NOT be associated with any context.
+func ExecCmd(cmd model.Cmd, l logger.Logger) *exec.Cmd {
+	c := exec.Command(cmd.Argv[0], cmd.Argv[1:]...)
+	populateExecCmd(c, cmd, l)
+	return c
+}
+
+// ExecCmdContext is like ExecCmd but uses exec.CommandContext to associate a context with
+// the returned exec.Cmd.
+func ExecCmdContext(ctx context.Context, cmd model.Cmd) *exec.Cmd {
+	c := exec.CommandContext(ctx, cmd.Argv[0], cmd.Argv[1:]...)
+	populateExecCmd(c, cmd, logger.Get(ctx))
+	return c
+}
+
+func populateExecCmd(c *exec.Cmd, cmd model.Cmd, l logger.Logger) {
+	c.Dir = cmd.Dir
+	// env from command definition takes precedence over parent env (exec.Cmd takes last in case of dupes)
+	execEnv := os.Environ()
+	execEnv = append(execEnv, cmd.Env...)
+	c.Env = logger.PrepareEnv(l, execEnv)
 }

--- a/internal/engine/local/execer_test.go
+++ b/internal/engine/local/execer_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/tilt-dev/tilt/internal/localexec"
 	"github.com/tilt-dev/tilt/internal/testutils"
 	"github.com/tilt-dev/tilt/internal/testutils/bufsync"
 	"github.com/tilt-dev/tilt/internal/testutils/tempdir"
@@ -153,7 +154,7 @@ func TestExecCmd(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			c := ExecCmd(tc.cmd, l)
+			c := localexec.ExecCmd(tc.cmd, l)
 			assertCommandEqual(t, tc.cmd, c)
 		})
 	}
@@ -167,7 +168,7 @@ func TestExecCmdContext(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			c := ExecCmdContext(ctx, tc.cmd)
+			c := localexec.ExecCmdContext(ctx, tc.cmd)
 			assertCommandEqual(t, tc.cmd, c)
 		})
 	}

--- a/internal/engine/local/execer_test.go
+++ b/internal/engine/local/execer_test.go
@@ -2,16 +2,20 @@ package local
 
 import (
 	"context"
+	"io/ioutil"
+	"os/exec"
 	"runtime"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/tilt-dev/tilt/internal/testutils"
 	"github.com/tilt-dev/tilt/internal/testutils/bufsync"
 	"github.com/tilt-dev/tilt/internal/testutils/tempdir"
+	"github.com/tilt-dev/tilt/pkg/logger"
 	"github.com/tilt-dev/tilt/pkg/model"
 )
 
@@ -140,6 +144,60 @@ func TestHandlesProcessThatFailsToStart(t *testing.T) {
 	f.startMalformedCommand()
 	f.waitForError()
 	f.assertLogContains("failed to start: ")
+}
+
+func TestExecCmd(t *testing.T) {
+	testCases := execTestCases()
+
+	l := logger.NewLogger(logger.NoneLvl, ioutil.Discard)
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := ExecCmd(tc.cmd, l)
+			assertCommandEqual(t, tc.cmd, c)
+		})
+	}
+}
+
+func TestExecCmdContext(t *testing.T) {
+	testCases := execTestCases()
+
+	l := logger.NewLogger(logger.NoneLvl, ioutil.Discard)
+	ctx := logger.WithLogger(context.Background(), l)
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := ExecCmdContext(ctx, tc.cmd)
+			assertCommandEqual(t, tc.cmd, c)
+		})
+	}
+}
+
+type execTestCase struct {
+	name string
+	cmd  model.Cmd
+}
+
+func execTestCases() []execTestCase {
+	// these need to appear as actual paths or exec.Command will attempt to resolve them
+	// (their actual existence is irrelevant since they won't actually execute; similarly,
+	// it won't matter that they're unix paths even on Windows)
+	return []execTestCase{
+		{"command only", model.Cmd{Argv: []string{"/bin/ls"}}},
+		{"command array", model.Cmd{Argv: []string{"/bin/echo", "hi"}}},
+		{"current working directory", model.Cmd{Argv: []string{"/bin/echo", "hi"}, Dir: "/foo"}},
+		{"env", model.Cmd{Argv: []string{"/bin/echo", "hi"}, Env: []string{"FOO=bar"}}},
+	}
+}
+
+func assertCommandEqual(t *testing.T, expected model.Cmd, actual *exec.Cmd) {
+	t.Helper()
+	assert.Equal(t, expected.Argv[0], actual.Path)
+	assert.Equal(t, expected.Argv, actual.Args)
+	assert.Equal(t, expected.Dir, actual.Dir)
+	for _, e := range expected.Env {
+		assert.Contains(t, actual.Env, e)
+	}
 }
 
 type processExecFixture struct {

--- a/internal/engine/local_target_build_and_deployer.go
+++ b/internal/engine/local_target_build_and_deployer.go
@@ -8,7 +8,7 @@ import (
 	"github.com/tilt-dev/tilt/internal/analytics"
 	"github.com/tilt-dev/tilt/internal/build"
 	"github.com/tilt-dev/tilt/internal/engine/buildcontrol"
-	"github.com/tilt-dev/tilt/internal/engine/local"
+	"github.com/tilt-dev/tilt/internal/localexec"
 	"github.com/tilt-dev/tilt/internal/store"
 	"github.com/tilt-dev/tilt/pkg/logger"
 	"github.com/tilt-dev/tilt/pkg/model"
@@ -103,7 +103,7 @@ func (bd *LocalTargetBuildAndDeployer) extract(specs []model.TargetSpec) []model
 func (bd *LocalTargetBuildAndDeployer) run(ctx context.Context, c model.Cmd) error {
 	l := logger.Get(ctx)
 	writer := l.Writer(logger.InfoLvl)
-	cmd := local.ExecCmdContext(ctx, c)
+	cmd := localexec.ExecCmdContext(ctx, c)
 	cmd.Stdout = writer
 	cmd.Stderr = writer
 

--- a/internal/engine/local_target_build_and_deployer.go
+++ b/internal/engine/local_target_build_and_deployer.go
@@ -3,12 +3,12 @@ package engine
 import (
 	"context"
 	"fmt"
-	"os/exec"
 	"time"
 
 	"github.com/tilt-dev/tilt/internal/analytics"
 	"github.com/tilt-dev/tilt/internal/build"
 	"github.com/tilt-dev/tilt/internal/engine/buildcontrol"
+	"github.com/tilt-dev/tilt/internal/engine/local"
 	"github.com/tilt-dev/tilt/internal/store"
 	"github.com/tilt-dev/tilt/pkg/logger"
 	"github.com/tilt-dev/tilt/pkg/model"
@@ -103,11 +103,9 @@ func (bd *LocalTargetBuildAndDeployer) extract(specs []model.TargetSpec) []model
 func (bd *LocalTargetBuildAndDeployer) run(ctx context.Context, c model.Cmd) error {
 	l := logger.Get(ctx)
 	writer := l.Writer(logger.InfoLvl)
-	cmd := exec.CommandContext(ctx, c.Argv[0], c.Argv[1:]...)
+	cmd := local.ExecCmdContext(ctx, c)
 	cmd.Stdout = writer
 	cmd.Stderr = writer
-	cmd.Dir = c.Dir
-	cmd.Env = logger.DefaultEnv(ctx)
 
 	ps := build.NewPipelineState(ctx, 1, bd.clock)
 	ps.StartPipelineStep(ctx, "Running command: %v (in %q)", c.Argv, c.Dir)

--- a/internal/localexec/localexec.go
+++ b/internal/localexec/localexec.go
@@ -36,6 +36,7 @@ func populateExecCmd(c *exec.Cmd, cmd model.Cmd, l logger.Logger) {
 	c.Dir = cmd.Dir
 	// env from command definition takes precedence over parent env (exec.Cmd takes last in case of dupes)
 	execEnv := os.Environ()
+	execEnv = logger.PrepareEnv(l, execEnv)
 	execEnv = append(execEnv, cmd.Env...)
-	c.Env = logger.PrepareEnv(l, execEnv)
+	c.Env = execEnv
 }

--- a/internal/localexec/localexec.go
+++ b/internal/localexec/localexec.go
@@ -1,3 +1,5 @@
+// Package localexec provides constructs for uniform execution of local processes,
+// specifically conversion from model.Cmd to exec.Cmd.
 package localexec
 
 import (
@@ -34,7 +36,8 @@ func ExecCmdContext(ctx context.Context, cmd model.Cmd) *exec.Cmd {
 
 func populateExecCmd(c *exec.Cmd, cmd model.Cmd, l logger.Logger) {
 	c.Dir = cmd.Dir
-	// env from command definition takes precedence over parent env (exec.Cmd takes last in case of dupes)
+	// env precedence: parent process (i.e. tilt) -> logger -> command
+	// dupes are left for Go stdlib to handle (API guarantees last wins)
 	execEnv := os.Environ()
 	execEnv = logger.PrepareEnv(l, execEnv)
 	execEnv = append(execEnv, cmd.Env...)

--- a/internal/localexec/localexec.go
+++ b/internal/localexec/localexec.go
@@ -1,0 +1,41 @@
+package localexec
+
+import (
+	"context"
+	"os"
+	"os/exec"
+
+	"github.com/tilt-dev/tilt/pkg/logger"
+	"github.com/tilt-dev/tilt/pkg/model"
+)
+
+// ExecCmd creates a stdlib exec.Cmd instance suitable for execution by the local engine.
+//
+// The resulting command will inherit the parent process (i.e. `tilt`) environment, then
+// have command specific environment overrides applied, and finally, additional conditional
+// environment to improve logging output.
+//
+// NOTE: To avoid confusion with ExecCmdContext, this method accepts a logger instance
+// directly rather than using logger.Get(ctx); the returned exec.Cmd from this function
+// will NOT be associated with any context.
+func ExecCmd(cmd model.Cmd, l logger.Logger) *exec.Cmd {
+	c := exec.Command(cmd.Argv[0], cmd.Argv[1:]...)
+	populateExecCmd(c, cmd, l)
+	return c
+}
+
+// ExecCmdContext is like ExecCmd but uses exec.CommandContext to associate a context with
+// the returned exec.Cmd.
+func ExecCmdContext(ctx context.Context, cmd model.Cmd) *exec.Cmd {
+	c := exec.CommandContext(ctx, cmd.Argv[0], cmd.Argv[1:]...)
+	populateExecCmd(c, cmd, logger.Get(ctx))
+	return c
+}
+
+func populateExecCmd(c *exec.Cmd, cmd model.Cmd, l logger.Logger) {
+	c.Dir = cmd.Dir
+	// env from command definition takes precedence over parent env (exec.Cmd takes last in case of dupes)
+	execEnv := os.Environ()
+	execEnv = append(execEnv, cmd.Env...)
+	c.Env = logger.PrepareEnv(l, execEnv)
+}

--- a/internal/tiltfile/docker.go
+++ b/internal/tiltfile/docker.go
@@ -194,7 +194,7 @@ func (s *tiltfileState) dockerBuild(thread *starlark.Thread, fn *starlark.Builti
 		return nil, err
 	}
 
-	entrypointCmd, err := value.ValueToUnixCmd(thread, entrypoint)
+	entrypointCmd, err := value.ValueToUnixCmd(thread, entrypoint, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -312,7 +312,7 @@ func (s *tiltfileState) customBuild(thread *starlark.Thread, fn *starlark.Builti
 		return nil, err
 	}
 
-	entrypointCmd, err := value.ValueToUnixCmd(thread, entrypoint)
+	entrypointCmd, err := value.ValueToUnixCmd(thread, entrypoint, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -330,7 +330,7 @@ func (s *tiltfileState) customBuild(thread *starlark.Thread, fn *starlark.Builti
 		commandBat = commandBatVal
 	}
 
-	command, err := value.ValueGroupToCmdHelper(thread, commandVal, commandBat)
+	command, err := value.ValueGroupToCmdHelper(thread, commandVal, commandBat, nil)
 	if err != nil {
 		return nil, fmt.Errorf("Argument 2 (command): %v", err)
 	} else if command.Empty() {

--- a/internal/tiltfile/files.go
+++ b/internal/tiltfile/files.go
@@ -10,11 +10,13 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/tilt-dev/tilt/internal/engine/local"
 	"github.com/tilt-dev/tilt/internal/k8s"
 	tiltfile_io "github.com/tilt-dev/tilt/internal/tiltfile/io"
 	"github.com/tilt-dev/tilt/internal/tiltfile/starkit"
 	"github.com/tilt-dev/tilt/internal/tiltfile/value"
 	"github.com/tilt-dev/tilt/pkg/logger"
+	"github.com/tilt-dev/tilt/pkg/model"
 
 	"github.com/pkg/errors"
 	"go.starlark.net/starlark"
@@ -26,6 +28,7 @@ const localLogPrefix = " → "
 
 func (s *tiltfileState) local(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	var commandValue, commandBatValue starlark.Value
+	var commandEnv value.StringStringMap
 	quiet := false
 	echoOff := false
 	err := s.unpackArgs(fn.Name(), args, kwargs,
@@ -33,12 +36,13 @@ func (s *tiltfileState) local(thread *starlark.Thread, fn *starlark.Builtin, arg
 		"quiet?", &quiet,
 		"command_bat", &commandBatValue,
 		"echo_off", &echoOff,
+		"env", &commandEnv,
 	)
 	if err != nil {
 		return nil, err
 	}
 
-	cmd, err := value.ValueGroupToCmdHelper(thread, commandValue, commandBatValue)
+	cmd, err := value.ValueGroupToCmdHelper(thread, commandValue, commandBatValue, commandEnv)
 	if err != nil {
 		return nil, err
 	}
@@ -47,7 +51,7 @@ func (s *tiltfileState) local(thread *starlark.Thread, fn *starlark.Builtin, arg
 		s.logger.Infof("local: %s", cmd)
 	}
 
-	out, err := s.execLocalCmd(thread, exec.Command(cmd.Argv[0], cmd.Argv[1:]...), !quiet)
+	out, err := s.execLocalCmd(thread, cmd, !quiet)
 	if err != nil {
 		return nil, err
 	}
@@ -55,7 +59,7 @@ func (s *tiltfileState) local(thread *starlark.Thread, fn *starlark.Builtin, arg
 	return tiltfile_io.NewBlob(out, fmt.Sprintf("local: %s", cmd)), nil
 }
 
-func (s *tiltfileState) execLocalCmd(t *starlark.Thread, c *exec.Cmd, logOutput bool) (string, error) {
+func (s *tiltfileState) execLocalCmd(t *starlark.Thread, cmd model.Cmd, logOutput bool) (string, error) {
 	stdout := bytes.NewBuffer(nil)
 	stderr := bytes.NewBuffer(nil)
 	ctx, err := starkit.ContextFromThread(t)
@@ -63,11 +67,11 @@ func (s *tiltfileState) execLocalCmd(t *starlark.Thread, c *exec.Cmd, logOutput 
 		return "", err
 	}
 
+	c := local.ExecCmd(cmd, logger.Get(ctx))
+
 	// TODO(nick): Should this also inject any docker.Env overrides?
-	c.Dir = starkit.AbsWorkingDir(t)
 	c.Stdout = stdout
 	c.Stderr = stderr
-	c.Env = logger.DefaultEnv(ctx)
 
 	if logOutput {
 		logOutput := logger.NewMutexWriter(logger.NewPrefixedLogger(localLogPrefix, s.logger).Writer(logger.InfoLvl))
@@ -113,15 +117,15 @@ func (s *tiltfileState) kustomize(thread *starlark.Thread, fn *starlark.Builtin,
 		return nil, err
 	}
 
-	cmd := []string{"kustomize", "build", relKustomizePath}
+	cmd := model.Cmd{Argv: []string{"kustomize", "build", relKustomizePath}, Dir: starkit.AbsWorkingDir(thread)}
 
-	_, err = exec.LookPath(cmd[0])
+	_, err = exec.LookPath(cmd.Argv[0])
 	if err != nil {
-		s.logger.Infof("Falling back to `kubectl kustomize` since `%s` was not found in PATH", cmd[0])
-		cmd = []string{"kubectl", "kustomize", relKustomizePath}
+		s.logger.Infof("Falling back to `kubectl kustomize` since `%s` was not found in PATH", cmd.Argv[0])
+		cmd.Argv = []string{"kubectl", "kustomize", relKustomizePath}
 	}
 
-	yaml, err := s.execLocalCmd(thread, exec.Command(cmd[0], cmd[1:]...), false)
+	yaml, err := s.execLocalCmd(thread, cmd, false)
 	if err != nil {
 		return nil, err
 	}
@@ -225,7 +229,7 @@ func (s *tiltfileState) helm(thread *starlark.Thread, fn *starlark.Builtin, args
 
 	s.logger.Infof("Running: %s", cmd)
 
-	stdout, err := s.execLocalCmd(thread, exec.Command(cmd[0], cmd[1:]...), false)
+	stdout, err := s.execLocalCmd(thread, model.Cmd{Argv: cmd, Dir: starkit.AbsWorkingDir(thread)}, false)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/tiltfile/files.go
+++ b/internal/tiltfile/files.go
@@ -10,8 +10,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/tilt-dev/tilt/internal/engine/local"
 	"github.com/tilt-dev/tilt/internal/k8s"
+	"github.com/tilt-dev/tilt/internal/localexec"
 	tiltfile_io "github.com/tilt-dev/tilt/internal/tiltfile/io"
 	"github.com/tilt-dev/tilt/internal/tiltfile/starkit"
 	"github.com/tilt-dev/tilt/internal/tiltfile/value"
@@ -67,7 +67,7 @@ func (s *tiltfileState) execLocalCmd(t *starlark.Thread, cmd model.Cmd, logOutpu
 		return "", err
 	}
 
-	c := local.ExecCmd(cmd, logger.Get(ctx))
+	c := localexec.ExecCmd(cmd, logger.Get(ctx))
 
 	// TODO(nick): Should this also inject any docker.Env overrides?
 	c.Stdout = stdout

--- a/internal/tiltfile/live_update.go
+++ b/internal/tiltfile/live_update.go
@@ -167,7 +167,7 @@ func (s *tiltfileState) liveUpdateRun(thread *starlark.Thread, fn *starlark.Buil
 		return nil, err
 	}
 
-	command, err := value.ValueToUnixCmd(thread, commandVal)
+	command, err := value.ValueToUnixCmd(thread, commandVal, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/tiltfile/local_resource.go
+++ b/internal/tiltfile/local_resource.go
@@ -64,19 +64,19 @@ func (s *tiltfileState) localResource(thread *starlark.Thread, fn *starlark.Buil
 	if err := s.unpackArgs(fn.Name(), args, kwargs,
 		"name", &name,
 		"cmd?", &updateCmdVal,
-		"env?", &updateEnv,
 		"deps?", &deps,
 		"trigger_mode?", &triggerMode,
 		"resource_deps?", &resourceDepsVal,
 		"ignore?", &ignoresVal,
 		"auto_init?", &autoInit,
 		"serve_cmd?", &serveCmdVal,
-		"serve_env?", &serveEnv,
 		"cmd_bat?", &updateCmdBatVal,
 		"serve_cmd_bat?", &serveCmdBatVal,
 		"allow_parallel?", &allowParallel,
 		"links?", &links,
 		"tags?", &tagsVal,
+		"env?", &updateEnv,
+		"serve_env?", &serveEnv,
 	); err != nil {
 		return nil, err
 	}

--- a/internal/tiltfile/local_resource.go
+++ b/internal/tiltfile/local_resource.go
@@ -37,6 +37,7 @@ type localResource struct {
 func (s *tiltfileState) localResource(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	var name string
 	var updateCmdVal, updateCmdBatVal, serveCmdVal, serveCmdBatVal starlark.Value
+	var updateEnv, serveEnv value.StringStringMap
 	var triggerMode triggerMode
 
 	deps := value.NewLocalPathListUnpacker(thread)
@@ -63,12 +64,14 @@ func (s *tiltfileState) localResource(thread *starlark.Thread, fn *starlark.Buil
 	if err := s.unpackArgs(fn.Name(), args, kwargs,
 		"name", &name,
 		"cmd?", &updateCmdVal,
+		"env?", &updateEnv,
 		"deps?", &deps,
 		"trigger_mode?", &triggerMode,
 		"resource_deps?", &resourceDepsVal,
 		"ignore?", &ignoresVal,
 		"auto_init?", &autoInit,
 		"serve_cmd?", &serveCmdVal,
+		"serve_env?", &serveEnv,
 		"cmd_bat?", &updateCmdBatVal,
 		"serve_cmd_bat?", &serveCmdBatVal,
 		"allow_parallel?", &allowParallel,
@@ -94,11 +97,11 @@ func (s *tiltfileState) localResource(thread *starlark.Thread, fn *starlark.Buil
 		return nil, err
 	}
 
-	updateCmd, err := value.ValueGroupToCmdHelper(thread, updateCmdVal, updateCmdBatVal)
+	updateCmd, err := value.ValueGroupToCmdHelper(thread, updateCmdVal, updateCmdBatVal, updateEnv)
 	if err != nil {
 		return nil, err
 	}
-	serveCmd, err := value.ValueGroupToCmdHelper(thread, serveCmdVal, serveCmdBatVal)
+	serveCmd, err := value.ValueGroupToCmdHelper(thread, serveCmdVal, serveCmdBatVal, serveEnv)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/tiltfile/telemetry/telemetry.go
+++ b/internal/tiltfile/telemetry/telemetry.go
@@ -38,7 +38,7 @@ func setTelemetryCmd(thread *starlark.Thread, fn *starlark.Builtin, args starlar
 		return starlark.None, err
 	}
 
-	cmd, err := value.ValueGroupToCmdHelper(thread, cmdVal, cmdBatVal)
+	cmd, err := value.ValueGroupToCmdHelper(thread, cmdVal, cmdBatVal, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/tiltfile/tests_test.go
+++ b/internal/tiltfile/tests_test.go
@@ -19,7 +19,7 @@ test("test-foo", "echo hi")
 
 	f.load()
 
-	foo := f.assertNextManifest("test-foo", localTarget(updateCmd(f.Path(), "echo hi")))
+	foo := f.assertNextManifest("test-foo", localTarget(updateCmd(f.Path(), "echo hi", nil)))
 	assert.True(t, foo.LocalTarget().IsTest, "should be flagged as test manifest")
 }
 
@@ -39,7 +39,7 @@ t = test("test-foo", "echo hi",
 	f.load()
 
 	foo := f.assertNextManifest("test-foo", localTarget(
-		updateCmd(f.Path(), "echo hi"),
+		updateCmd(f.Path(), "echo hi", nil),
 		deps("a.txt", "b.txt")))
 	assert.True(t, foo.LocalTarget().IsTest, "should be flagged as test manifest")
 	assert.Equal(t, []string{"beep", "boop"}, foo.LocalTarget().Tags)

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -279,7 +279,7 @@ func TestLocalEnv(t *testing.T) {
 	// contrived example to ensure that the environment is correctly passed to local -- an env var is echoed back out
 	// which then gets passed as an ignore so that it's visible in the load result for assertion
 	f.file("Tiltfile", `
-ignore = str(local('echo $FOO', env={'FOO': 'bar'})).rstrip('\n')
+ignore = str(local('echo $FOO', command_bat='echo %FOO%', env={'FOO': 'bar'})).rstrip('\n')
 watch_settings(ignore=ignore)
 `)
 

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -279,7 +279,7 @@ func TestLocalEnv(t *testing.T) {
 	// contrived example to ensure that the environment is correctly passed to local -- an env var is echoed back out
 	// which then gets passed as an ignore so that it's visible in the load result for assertion
 	f.file("Tiltfile", `
-ignore = str(local('echo $FOO', command_bat='echo %FOO%', env={'FOO': 'bar'})).rstrip('\n')
+ignore = str(local('echo $FOO', command_bat='echo %FOO%', env={'FOO': 'bar'})).rstrip('\r\n')
 watch_settings(ignore=ignore)
 `)
 

--- a/internal/tiltfile/value/value.go
+++ b/internal/tiltfile/value/value.go
@@ -2,8 +2,8 @@ package value
 
 import (
 	"fmt"
-	"path/filepath"
 	"runtime"
+	"sort"
 
 	"github.com/pkg/errors"
 	"go.starlark.net/starlark"
@@ -80,31 +80,36 @@ func StringSliceToList(slice []string) *starlark.List {
 // there's a "main" command, and then various per-platform overrides.
 // https://docs.bazel.build/versions/master/be/general.html#genrule.cmd_bat
 // This helper function abstracts out the precedence rules.
-func ValueGroupToCmdHelper(t *starlark.Thread, cmdVal, cmdBatVal starlark.Value) (model.Cmd, error) {
+func ValueGroupToCmdHelper(t *starlark.Thread, cmdVal, cmdBatVal starlark.Value, env map[string]string) (model.Cmd, error) {
 	if cmdBatVal != nil && runtime.GOOS == "windows" {
-		return ValueToBatCmd(t, cmdBatVal)
+		return ValueToBatCmd(t, cmdBatVal, env)
 	}
-	return ValueToHostCmd(t, cmdVal)
+	return ValueToHostCmd(t, cmdVal, env)
 }
 
 // provides dockerfile-style behavior of:
 // a string gets interpreted as a shell command (like, sh -c 'foo bar $X')
 // an array of strings gets interpreted as a raw argv to exec
-func ValueToHostCmd(t *starlark.Thread, v starlark.Value) (model.Cmd, error) {
-	return valueToCmdHelper(t, v, model.ToHostCmd)
+func ValueToHostCmd(t *starlark.Thread, v starlark.Value, env map[string]string) (model.Cmd, error) {
+	return valueToCmdHelper(t, v, env, model.ToHostCmd)
 }
 
-func ValueToBatCmd(t *starlark.Thread, v starlark.Value) (model.Cmd, error) {
-	return valueToCmdHelper(t, v, model.ToBatCmd)
+func ValueToBatCmd(t *starlark.Thread, v starlark.Value, env map[string]string) (model.Cmd, error) {
+	return valueToCmdHelper(t, v, env, model.ToBatCmd)
 }
 
-func ValueToUnixCmd(t *starlark.Thread, v starlark.Value) (model.Cmd, error) {
-	return valueToCmdHelper(t, v, model.ToUnixCmd)
+func ValueToUnixCmd(t *starlark.Thread, v starlark.Value, env map[string]string) (model.Cmd, error) {
+	return valueToCmdHelper(t, v, env, model.ToUnixCmd)
 }
 
-func valueToCmdHelper(t *starlark.Thread, v starlark.Value, stringToCmd func(string) model.Cmd) (model.Cmd, error) {
-	dir := filepath.Dir(starkit.CurrentExecPath(t))
-	switch x := v.(type) {
+func valueToCmdHelper(t *starlark.Thread, cmdVal starlark.Value, cmdEnv map[string]string, stringToCmd func(string) model.Cmd) (model.Cmd, error) {
+	dir := starkit.AbsWorkingDir(t)
+	env, err := envTuples(cmdEnv)
+	if err != nil {
+		return model.Cmd{}, err
+	}
+
+	switch x := cmdVal.(type) {
 	// If a starlark function takes an optional command argument, then UnpackArgs will set its starlark.Value to nil
 	// we convert nils here to an empty Cmd, since otherwise every callsite would have to do a nil check with presumably
 	// the same outcome
@@ -113,14 +118,30 @@ func valueToCmdHelper(t *starlark.Thread, v starlark.Value, stringToCmd func(str
 	case starlark.String:
 		cmd := stringToCmd(string(x))
 		cmd.Dir = dir
+		cmd.Env = env
 		return cmd, nil
 	case starlark.Sequence:
 		argv, err := SequenceToStringSlice(x)
 		if err != nil {
 			return model.Cmd{}, errors.Wrap(err, "a command must be a string or a list of strings")
 		}
-		return model.Cmd{Argv: argv, Dir: dir}, nil
+		return model.Cmd{Argv: argv, Dir: dir, Env: env}, nil
 	default:
 		return model.Cmd{}, fmt.Errorf("a command must be a string or list of strings. found %T", x)
 	}
+}
+
+func envTuples(env map[string]string) ([]string, error) {
+	var kv []string
+	for k, v := range env {
+		if k == "" {
+			return nil, fmt.Errorf("environment has empty key for value %q", v)
+		}
+		kv = append(kv, k+"="+v)
+	}
+	// sorting here is for consistency/predictability; since the input is a map, uniqueness
+	// is guaranteed so order is not actually relevant, but this simplifies usage in tests,
+	// for example
+	sort.Strings(kv)
+	return kv, nil
 }

--- a/pkg/logger/env.go
+++ b/pkg/logger/env.go
@@ -6,11 +6,18 @@ import (
 	"strings"
 )
 
-// A set of environment variables to make sure that
-// subprocesses log correctly.
+// DefaultEnv returns a set of strings in the form of "key=value"
+// based on the current process' environment with additional entries
+// to improve subprocess log output.
 func DefaultEnv(ctx context.Context) []string {
-	supportsColor := Get(ctx).SupportsColor()
-	env := os.Environ()
+	return PrepareEnv(Get(ctx), os.Environ())
+}
+
+// PrepareEnv returns a set of strings in the form of "key=value"
+// based on a provided set of strings in the same format with additional
+// entries to improve subprocess log output.
+func PrepareEnv(l Logger, env []string) []string {
+	supportsColor := l.SupportsColor()
 	hasLines := false
 	hasColumns := false
 	hasForceColor := false

--- a/pkg/model/cmd.go
+++ b/pkg/model/cmd.go
@@ -9,6 +9,7 @@ import (
 type Cmd struct {
 	Argv []string
 	Dir  string
+	Env  []string
 }
 
 func (c Cmd) IsShellStandardForm() bool {
@@ -89,6 +90,12 @@ func ToHostCmd(cmd string) Cmd {
 func ToHostCmdInDir(cmd string, dir string) Cmd {
 	c := ToHostCmd(cmd)
 	c.Dir = dir
+	return c
+}
+
+func ToHostCmdInDirWithEnv(cmd string, dir string, env []string) Cmd {
+	c := ToHostCmdInDir(cmd, dir)
+	c.Env = env
 	return c
 }
 


### PR DESCRIPTION
New, optional argument(s) for `local` and `local_resource` to pass
environment variables to the invoked command. In all cases, the
argument is a `dict` and must have both string keys and values:
no type conversion will take place.

For `local`, there is a single `env` argument.
For `local_resource`, there is `env`, which is used for the update
command (`cmd`) and `serve_env`, which is used for the serve command
(`serve_cmd`).

Any environment variables that are passed will take precedence over
the parent process' (i.e. `tilt`) environment. However, it's possible
to read from the environment in `Tiltfile`, so in the event that a
default is desired, a practical approach is to combine with `os.getenv`:

```python
local_resource('mycmd', './mycmd', env={'KEY': os.getenv('KEY', 'default')})
```

Closes #3767.