### PR TITLE
circleci: add a status notification when the release starts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -157,6 +157,8 @@ jobs:
     steps:
       - setup_remote_docker:
           version: 19.03.12
+      - slack/status:
+          mentions: "nick"
       - checkout
       - gcp-cli/install
       - gcp-cli/initialize


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/circleci:

cd3009b5f74dcccaac1af7235d02b32bbade6ce5 (2021-01-13 16:35:42 -0500)
circleci: add a status notification when the release starts

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics