### PR TITLE
web: display the pod ID, and truncate the text

### DIFF
--- a/web/src/OverviewItemView.stories.tsx
+++ b/web/src/OverviewItemView.stories.tsx
@@ -123,3 +123,13 @@ export const CompleteDetails = () => {
   item.podId = "my-pod-deadbeef"
   return <OverviewItemDetails item={item} />
 }
+
+export const LongDetails = () => {
+  let item = new OverviewItem(oneResourceNoAlerts())
+  item.endpoints = [
+    { url: "http://my-pod-grafana-long-service-name-deadbeef:4001" },
+    { url: "http://my-pod-grafana-long-service-name-deadbeef:4002" },
+  ]
+  item.podId = "my-pod-grafana-long-service-name-deadbeef"
+  return <OverviewItemDetails item={item} />
+}

--- a/web/src/OverviewItemView.tsx
+++ b/web/src/OverviewItemView.tsx
@@ -377,6 +377,13 @@ let ShowDetailsBox = styled(Link)`
   ${detailsRow}
 `
 
+let DetailText = styled.div`
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  margin-left: 10px;
+`
+
 async function copyTextToClipboard(text: string, cb: () => void) {
   await navigator.clipboard.writeText(text)
   cb()
@@ -395,7 +402,7 @@ export function OverviewItemDetails(props: OverviewItemDetailsProps) {
         key={ep.url}
       >
         <LinkSvg />
-        <div style={{ marginLeft: "10px" }}>{ep.name || displayURL(ep)}</div>
+        <DetailText>{ep.name || displayURL(ep)}</DetailText>
       </Endpoint>
     )
   })
@@ -423,7 +430,9 @@ export function OverviewItemDetails(props: OverviewItemDetailsProps) {
     copy = (
       <Copy onClick={copyClick}>
         {icon}
-        <div style={{ marginLeft: "8px" }}>Copy Pod ID</div>
+        <DetailText style={{ marginLeft: "8px" }}>
+          {item.podId} Pod ID
+        </DetailText>
       </Copy>
     )
   }
@@ -438,7 +447,7 @@ export function OverviewItemDetails(props: OverviewItemDetailsProps) {
         <ShowDetailsBox to={pathBuilder.path(link)}>
           <MaximizeSvg />
 
-          <div style={{ marginLeft: "8px" }}>Show details</div>
+          <DetailText>Show details</DetailText>
         </ShowDetailsBox>
         <BuildBox item={props.item} />
       </OverviewItemDetailsBox>

--- a/web/src/OverviewResourceDetails.stories.tsx
+++ b/web/src/OverviewResourceDetails.stories.tsx
@@ -21,6 +21,16 @@ export default {
   ],
 }
 
+export const OverflowTextBar = () => {
+  let res = oneResource()
+  res.endpointLinks = [
+    { url: "http://my-pod-grafana-long-service-name-deadbeef:4001" },
+    { url: "http://my-pod-grafana-long-service-name-deadbeef:4002" },
+  ]
+  res.podID = "my-pod-grafana-long-service-name-deadbeef"
+  return <OverviewResourceDetails resource={res} />
+}
+
 export const FullBar = () => {
   let res = oneResource()
   res.endpointLinks = [
@@ -30,6 +40,7 @@ export const FullBar = () => {
   res.podID = "my-pod-deadbeef"
   return <OverviewResourceDetails resource={res} />
 }
+
 export const EmptyBar = () => {
   let res = oneResource()
   res.endpointLinks = []

--- a/web/src/OverviewResourceDetails.tsx
+++ b/web/src/OverviewResourceDetails.tsx
@@ -63,6 +63,13 @@ async function copyTextToClipboard(text: string, cb: () => void) {
   cb()
 }
 
+let TruncateText = styled.div`
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 250px;
+`
+
 function CopyButton(props: CopyButtonProps) {
   let [showCopySuccess, setShowCopySuccess] = useState(false)
 
@@ -85,7 +92,9 @@ function CopyButton(props: CopyButtonProps) {
   return (
     <CopyButtonRoot onClick={copyClick}>
       {icon}
-      <div style={{ marginLeft: "8px" }}>Copy Pod ID</div>
+      <TruncateText style={{ marginLeft: "8px" }}>
+        {props.podId} Pod ID
+      </TruncateText>
     </CopyButtonRoot>
   )
 }
@@ -139,7 +148,7 @@ function ActionBar(props: ActionBarProps) {
         target={ep.url}
         key={ep.url}
       >
-        {ep.name || displayURL(ep)}
+        <TruncateText>{ep.name || displayURL(ep)}</TruncateText>
       </Endpoint>
     )
   })


### PR DESCRIPTION
Hello @hyu,

Please review the following commits I made in branch nicks/podid:

46d628b7d9ea787b81a94d399a06c909b325b481 (2021-01-14 11:43:22 -0500)
web: display the pod ID, and truncate the text

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics