### PR TITLE
web: add support for latest node LTS (v14)

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -84,7 +84,7 @@
     "react-test-renderer": "^16.9.0"
   },
   "engines": {
-    "node": ">=12.0.0 <13.0.0"
+    "node": ">=12.0.0 <13.0.0 || >=14.0.0 <15.0.0"
   },
   "jest": {
     "snapshotSerializers": [


### PR DESCRIPTION
I ended up with latest node LTS in my env - webpack config & everything seems happy with v14 as well. This doesn't change what CI will actually use to build the app, but just makes it so yarn won't give up installing deps in a local dev env that's not on node v12.