### PR TITLE
engine: refactor process state representation

### DIFF
--- a/internal/engine/local/actions.go
+++ b/internal/engine/local/actions.go
@@ -6,7 +6,7 @@ import (
 
 type LocalServeStatusAction struct {
 	ManifestName model.ManifestName
-	Status       model.RuntimeStatus
+	State        model.ProcessState
 	PID          int // 0 if there's no process running
 	SpanID       model.LogSpanID
 }

--- a/internal/engine/local/controller.go
+++ b/internal/engine/local/controller.go
@@ -163,12 +163,12 @@ func processStatuses(
 		if !stillHasSameProcNum() {
 			continue
 		}
-		runtimeStatus := sm.status.ToRuntime()
-		if runtimeStatus != "" {
+		procState := sm.status.ToProcessState()
+		if procState != "" {
 			// TODO(matt) when we get an error, the dot is red in the web ui, but green in the TUI
 			st.Dispatch(LocalServeStatusAction{
 				ManifestName: manifestName,
-				Status:       runtimeStatus,
+				State:        procState,
 				PID:          sm.pid,
 				SpanID:       sm.spanID,
 			})
@@ -247,12 +247,14 @@ const (
 	Error   status = iota
 )
 
-func (s status) ToRuntime() model.RuntimeStatus {
+func (s status) ToProcessState() model.ProcessState {
 	switch s {
 	case Running:
-		return model.RuntimeStatusOK
+		return model.ProcessStateRunning
+	case Done:
+		return model.ProcessStateTerminated
 	case Error:
-		return model.RuntimeStatusError
+		return model.ProcessStateTerminated
 	default:
 		return ""
 	}

--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -461,7 +461,6 @@ func handleBuildCompleted(ctx context.Context, engineState *store.EngineState, c
 
 	if mt.Manifest.IsLocal() {
 		lrs := ms.LocalRuntimeState()
-		lrs.Status = model.RuntimeStatusNotApplicable
 		if err == nil {
 			lrs.HasSucceededAtLeastOnce = true
 		}
@@ -771,7 +770,7 @@ func handleLocalServeStatusAction(ctx context.Context, state *store.EngineState,
 	}
 
 	lrs := ms.LocalRuntimeState()
-	lrs.Status = action.Status
+	lrs.State = action.State
 	lrs.PID = action.PID
 	lrs.SpanID = action.SpanID
 	ms.RuntimeState = lrs

--- a/internal/hud/webview/convert_test.go
+++ b/internal/hud/webview/convert_test.go
@@ -278,14 +278,14 @@ func TestLocalResource(t *testing.T) {
 
 	state := newState([]model.Manifest{m})
 	state.ManifestTargets[m.Name].State.RuntimeState = store.LocalRuntimeState{
-		Status: model.RuntimeStatusNotApplicable,
+		State: model.ProcessStateRunning,
 	}
 	v := stateToProtoView(t, *state)
 
 	assert.Equal(t, 2, len(v.Resources))
 	r := v.Resources[1]
 	assert.Equal(t, "test", r.Name)
-	assert.Equal(t, model.RuntimeStatusNotApplicable, model.RuntimeStatus(r.RuntimeStatus))
+	assert.Equal(t, model.RuntimeStatusOK, model.RuntimeStatus(r.RuntimeStatus))
 	require.Len(t, r.Specs, 1)
 	spec := r.Specs[0]
 	require.Equal(t, proto_webview.TargetType_TARGET_TYPE_LOCAL, spec.Type)

--- a/pkg/model/process_state.go
+++ b/pkg/model/process_state.go
@@ -1,0 +1,12 @@
+package model
+
+// ProcessState represents the current execution state of a local process.
+type ProcessState string
+
+const (
+	// ProcessStateRunning indicates that a process is alive and executing.
+	ProcessStateRunning ProcessState = "running"
+	// ProcessStateTerminated indicates that a process is no longer executing
+	// either because it exited or was terminated.
+	ProcessStateTerminated ProcessState = "terminated"
+)


### PR DESCRIPTION
In preparation for `local_resource` readiness checks, represent
the process state via a specific type (modeled after the K8s
`ContainerState`).

This disambiguates it from the higher-level `RuntimeStatus` which
will be the synthesis of the process state + readiness probe.