### PR TITLE
engine: add initial touch points for local readiness probe

### DIFF
--- a/internal/hud/webview/convert_test.go
+++ b/internal/hud/webview/convert_test.go
@@ -277,9 +277,9 @@ func TestLocalResource(t *testing.T) {
 	}.WithDeployTarget(lt)
 
 	state := newState([]model.Manifest{m})
-	state.ManifestTargets[m.Name].State.RuntimeState = store.LocalRuntimeState{
-		State: model.ProcessStateRunning,
-	}
+	lrs := store.NewLocalRuntimeState(m)
+	lrs.State = model.ProcessStateRunning
+	state.ManifestTargets[m.Name].State.RuntimeState = lrs
 	v := stateToProtoView(t, *state)
 
 	assert.Equal(t, 2, len(v.Resources))

--- a/internal/store/engine_state.go
+++ b/internal/store/engine_state.go
@@ -491,7 +491,7 @@ func newManifestState(m model.Manifest) *ManifestState {
 	if m.IsK8s() {
 		ms.RuntimeState = NewK8sRuntimeState(m)
 	} else if m.IsLocal() {
-		ms.RuntimeState = LocalRuntimeState{}
+		ms.RuntimeState = NewLocalRuntimeState(m)
 	}
 
 	// For historical reasons, DC state is initialized differently.


### PR DESCRIPTION
Currently a noop in that the readiness probe status is simply
initialized to successful and then never touched. In the future,
this will continue to be the behavior for local resources without
a readiness probe defined, while local resources with a readiness
probe will start off in a failing state until the process is up &
probe passes. (This aligns with the behavior of readiness probes
in K8s.)