### PR TITLE
web: pull up all the Tab logic into a separate React context

### DIFF
--- a/web/src/HUD.test.tsx
+++ b/web/src/HUD.test.tsx
@@ -5,6 +5,7 @@ import ReactDOM from "react-dom"
 import ReactModal from "react-modal"
 import { MemoryRouter } from "react-router"
 import HUD from "./HUD"
+import SidebarItemView, { SidebarItemAll } from "./SidebarItemView"
 import SocketBar from "./SocketBar"
 import {
   oneResourceNoAlerts,
@@ -127,13 +128,17 @@ it("does re-render the sidebar when the resource list changes", async () => {
 
   let resourceView = oneResourceView()
   hud.setState({ view: resourceView })
-  let sidebarLinks = root.find(".Sidebar-resources Link")
-  expect(sidebarLinks).toHaveLength(2)
+
+  let sidebarLinks = root.find(SidebarItemView)
+  expect(sidebarLinks).toHaveLength(1)
+
+  let allLink = root.find(SidebarItemAll)
+  expect(allLink).toHaveLength(1)
 
   let newResourceView = twoResourceView()
   hud.setState({ view: newResourceView })
-  sidebarLinks = root.find(".Sidebar-resources Link")
-  expect(sidebarLinks).toHaveLength(3)
+  sidebarLinks = root.find(SidebarItemView)
+  expect(sidebarLinks).toHaveLength(2)
 })
 
 it("shows test data in sidebar if test resources present", async () => {

--- a/web/src/HUD.tsx
+++ b/web/src/HUD.tsx
@@ -39,6 +39,7 @@ import SidebarResources from "./SidebarResources"
 import { SnapshotActionProvider } from "./snapshot"
 import SocketBar from "./SocketBar"
 import Statusbar, { StatusItem } from "./Statusbar"
+import { LegacyNavProvider, OverviewNavProvider } from "./TabNav"
 import TestAggregateData from "./TestAggregateData"
 import { traceNav } from "./trace"
 import {
@@ -315,32 +316,54 @@ export default class HUD extends Component<HudProps, HudState> {
       hudClasses.push("is-snapshot")
     }
 
-    let matchTrace = matchPath(String(this.props.history.location.pathname), {
+    let pathname = String(this.props.history.location.pathname)
+    let matchTrace = matchPath(pathname, {
       path: this.path("/r/:name/trace/:span"),
     })
     let matchTraceParams: any = matchTrace?.params
     let isTwoLevelHeader = !!matchTraceParams?.span
-    let matchOverview =
-      matchPath(String(this.props.history.location.pathname), {
-        path: this.path("/overview"),
+    let matchGrid = matchPath(pathname, {
+      path: this.path("/overview"),
+    })
+    let matchOverviewDetail = matchPath(pathname, {
+      path: this.path("/r/:name/overview"),
+    })
+    let matchOverview = matchGrid || matchOverviewDetail
+    let matchAlerts =
+      matchPath(pathname, {
+        path: this.path("/alerts"),
       }) ||
-      matchPath(String(this.props.history.location.pathname), {
-        path: this.path("/r/:name/overview"),
+      matchPath(pathname, {
+        path: this.path("/r/:name/alerts"),
       })
+    let matchFacets = matchPath(pathname, {
+      path: this.path("/r/:name/facets"),
+    })
+    let resourceView = matchFacets
+      ? ResourceView.Facets
+      : matchAlerts
+      ? ResourceView.Alerts
+      : matchOverviewDetail
+      ? ResourceView.OverviewDetail
+      : matchGrid
+      ? ResourceView.Grid
+      : ResourceView.Log
 
     if (matchOverview) {
       return (
         <LocalStorageContextProvider tiltfileKey={view.tiltfileKey}>
           <SidebarPinContextProvider>
-            <div className={hudClasses.join(" ")}>
-              <AnalyticsNudge needsNudge={needsNudge} />
-              <SocketBar state={this.state.socketState} />
-              {fatalErrorModal}
-              {errorModal}
-              {shareSnapshotModal}
+            <OverviewNavProvider resourceView={resourceView}>
+              <div className={hudClasses.join(" ")}>
+                <AnalyticsNudge needsNudge={needsNudge} />
+                <SocketBar state={this.state.socketState} />
+                {fatalErrorModal}
+                {errorModal}
+                {shareSnapshotModal}
 
-              {this.renderOverviewSwitch()}
-            </div>
+                {this.renderOverviewSwitch()}
+              </div>
+            </OverviewNavProvider>
           </SidebarPinContextProvider>
         </LocalStorageContextProvider>
       )
@@ -349,24 +372,26 @@ export default class HUD extends Component<HudProps, HudState> {
     return (
       <LocalStorageContextProvider tiltfileKey={view.tiltfileKey}>
         <SidebarPinContextProvider>
-          <div className={hudClasses.join(" ")}>
-            <AnalyticsNudge needsNudge={needsNudge} />
-            <SocketBar state={this.state.socketState} />
-            {fatalErrorModal}
-            {errorModal}
-            {shareSnapshotModal}
+          <LegacyNavProvider resourceView={resourceView}>
+            <div className={hudClasses.join(" ")}>
+              <AnalyticsNudge needsNudge={needsNudge} />
+              <SocketBar state={this.state.socketState} />
+              {fatalErrorModal}
+              {errorModal}
+              {shareSnapshotModal}
 
-            {this.renderSidebarSwitch()}
-            {statusbar}
+              {this.renderSidebarSwitch()}
+              {statusbar}
 
-            <HUDLayout
-              header={this.renderHUDHeader()}
-              isSidebarClosed={!!this.state.isSidebarClosed}
-              isTwoLevelHeader={isTwoLevelHeader}
-            >
-              {this.renderMainPaneSwitch()}
-            </HUDLayout>
-          </div>
+              <HUDLayout
+                header={this.renderHUDHeader()}
+                isSidebarClosed={!!this.state.isSidebarClosed}
+                isTwoLevelHeader={isTwoLevelHeader}
+              >
+                {this.renderMainPaneSwitch()}
+              </HUDLayout>
+            </div>
+          </LegacyNavProvider>
         </SidebarPinContextProvider>
       </LocalStorageContextProvider>
     )

--- a/web/src/OverviewResourcePane.tsx
+++ b/web/src/OverviewResourcePane.tsx
@@ -5,6 +5,7 @@ import OverviewResourceDetails from "./OverviewResourceDetails"
 import OverviewResourceSidebar from "./OverviewResourceSidebar"
 import OverviewTabBar from "./OverviewTabBar"
 import { Color } from "./style-helpers"
+import { useTabNav } from "./TabNav"
 import { ResourceName } from "./types"
 
 type OverviewResourcePaneProps = {
@@ -30,6 +31,7 @@ let Main = styled.div`
 `
 
 export default function OverviewResourcePane(props: OverviewResourcePaneProps) {
+  let nav = useTabNav()
   let resources = props.view?.resources || []
   let name = props.name
   let r: Proto.webviewResource | undefined

--- a/web/src/OverviewTabBar.stories.tsx
+++ b/web/src/OverviewTabBar.stories.tsx
@@ -1,6 +1,8 @@
 import React from "react"
 import { MemoryRouter } from "react-router"
 import OverviewTabBar from "./OverviewTabBar"
+import { OverviewNavProvider } from "./TabNav"
+import { ResourceView } from "./types"
 
 type Resource = Proto.webviewResource
 
@@ -24,7 +26,11 @@ export const InferOneTab = () => <OverviewTabBar selectedTab={"vigoda"} />
 
 export const TwoTabs = () => {
   let tabs = ["vigoda", "snack"]
-  return <OverviewTabBar selectedTab={""} tabsForTesting={tabs} />
+  return (
+    <OverviewNavProvider resourceView={ResourceView.Grid} tabsForTesting={tabs}>
+      <OverviewTabBar selectedTab={""} />
+    </OverviewNavProvider>
+  )
 }
 
 export const TenTabs = () => {
@@ -40,10 +46,19 @@ export const TenTabs = () => {
     "vigoda_9",
     "vigoda_10",
   ]
-  return <OverviewTabBar selectedTab={"vigoda_2"} tabsForTesting={tabs} />
+  return (
+    <OverviewNavProvider resourceView={ResourceView.Grid} tabsForTesting={tabs}>
+      <OverviewTabBar selectedTab={"vigoda_2"} />
+    </OverviewNavProvider>
+  )
 }
 
 export const LongTabName = () => {
   let tabs = ["extremely-long-tab-name-yes-this-is-very-long"]
-  return <OverviewTabBar selectedTab={""} tabsForTesting={tabs} />
+
+  return (
+    <OverviewNavProvider resourceView={ResourceView.Grid} tabsForTesting={tabs}>
+      <OverviewTabBar selectedTab={""} />
+    </OverviewNavProvider>
+  )
 }

--- a/web/src/OverviewTabBar.test.tsx
+++ b/web/src/OverviewTabBar.test.tsx
@@ -2,14 +2,22 @@ import { mount } from "enzyme"
 import React from "react"
 import { MemoryRouter } from "react-router"
 import OverviewTabBar, { HomeTab, Tab } from "./OverviewTabBar"
+import { OverviewNavProvider, TabNavContextConsumer } from "./TabNav"
+import { ResourceView } from "./types"
 
-it("infers tab from url", () => {
+it("propagate selected tab", () => {
+  let capturedNav: any = null
   const root = mount(
     <MemoryRouter initialEntries={["/r/vigoda/overview"]}>
-      <OverviewTabBar
-        selectedTab="vigoda"
+      <OverviewNavProvider
+        resourceView={ResourceView.Grid}
         tabsForTesting={["vigoda", "snack"]}
-      />
+      >
+        <OverviewTabBar selectedTab="vigoda" />
+        <TabNavContextConsumer>
+          {(nav) => void (capturedNav = nav)}
+        </TabNavContextConsumer>
+      </OverviewNavProvider>
     </MemoryRouter>
   )
 
@@ -22,4 +30,6 @@ it("infers tab from url", () => {
     "/r/vigoda/overview",
     "/r/snack/overview",
   ])
+
+  expect(capturedNav?.selectedTab).toEqual("vigoda")
 })

--- a/web/src/OverviewTabBar.tsx
+++ b/web/src/OverviewTabBar.tsx
@@ -1,9 +1,8 @@
-import React, { useEffect, useState } from "react"
-import { Link, useHistory } from "react-router-dom"
+import React, { useEffect } from "react"
+import { Link } from "react-router-dom"
 import styled from "styled-components"
 import { ReactComponent as CloseSvg } from "./assets/svg/close.svg"
 import { ReactComponent as LogoWordmarkSvg } from "./assets/svg/logo-wordmark-gray.svg"
-import { useLocalStorageContext } from "./LocalStorage"
 import {
   AnimDuration,
   Color,
@@ -13,10 +12,10 @@ import {
   FontSize,
   SizeUnit,
 } from "./style-helpers"
+import { useTabNav } from "./TabNav"
 
 type OverviewTabBarProps = {
   selectedTab: string
-  tabsForTesting?: string[]
 }
 
 let OverviewTabBarRoot = styled.div`
@@ -109,65 +108,26 @@ let CloseButton = styled.button`
 `
 
 export default function OverviewTabBar(props: OverviewTabBarProps) {
-  let lsc = useLocalStorageContext()
-  let history = useHistory()
+  let nav = useTabNav()
+  let tabs = nav.tabs
   let selectedTab = props.selectedTab
 
-  // The list of tabs open. A tab name should never appear twice in the list.
-  const [tabs, setTabs] = useState<Array<string>>(
-    () => props.tabsForTesting ?? lsc.get<Array<string>>("tabs") ?? []
-  )
-
+  // There are two bits of state to determine the selected tab:
+  //
+  // 1) If the user navigates to a url, we need to pull the candidate tab name from the URL.
+  // 2) Then we need to look at the Tilt state to see if that resource exists.
+  //
+  // If the resource exists, then we select that tab. We need propagate it back
+  // up to the context provider. This creates weird data flow, but is probably
+  // ok for this simple case.
   useEffect(() => {
-    lsc.set("tabs", tabs)
-  }, [tabs, lsc])
-
-  // Ensures the tab is in the tab list.
-  function ensureOpenTab(name: string) {
-    if (!name) {
-      return
-    }
-
-    setTabs((prevState) => {
-      if (prevState.includes(name)) {
-        return prevState
-      }
-
-      return [name].concat(prevState)
-    })
-  }
-
-  useEffect(() => {
-    ensureOpenTab(selectedTab)
-  }, [tabs, selectedTab])
-
-  // Deletes the resource in the tab list.
-  // If we're deleting the current tab, navigate to the next reasonable tab.
-  function closeTab(name: string) {
-    let newState = (prevState: string[]) => {
-      return prevState.filter((t) => t !== name)
-    }
-    if (name !== selectedTab) {
-      setTabs(newState)
-      return
-    }
-
-    let index = tabs.indexOf(name)
-    let desired = `/overview`
-    if (index + 1 < tabs.length) {
-      desired = `/r/${tabs[index + 1]}/overview`
-    } else if (index - 1 >= 0) {
-      desired = `/r/${tabs[index - 1]}/overview`
-    }
-
-    setTabs(newState)
-    history.push(desired)
-  }
+    nav.ensureSelectedTab(selectedTab)
+  }, [selectedTab, nav.selectedTab])
 
   let onClose = (e: any, name: string) => {
     e.stopPropagation()
     e.preventDefault()
-    closeTab(name)
+    nav.closeTab(name)
   }
 
   let tabEls = tabs.map((name) => {

--- a/web/src/SidebarItemView.stories.tsx
+++ b/web/src/SidebarItemView.stories.tsx
@@ -6,6 +6,7 @@ import SidebarItemView, {
   SidebarItemAll,
   SidebarItemViewProps,
 } from "./SidebarItemView"
+import { LegacyNavProvider } from "./TabNav"
 import { oneResourceNoAlerts } from "./testdata"
 import {
   ResourceName,
@@ -20,7 +21,9 @@ let pathBuilder = PathBuilder.forTesting("localhost", "/")
 function ItemWrapper(props: { children: React.ReactNode }) {
   return (
     <MemoryRouter initialEntries={["/"]}>
-      <div style={{ width: "336px", margin: "100px" }}>{props.children}</div>
+      <LegacyNavProvider resourceView={ResourceView.Log}>
+        <div style={{ width: "336px", margin: "100px" }}>{props.children}</div>
+      </LegacyNavProvider>
     </MemoryRouter>
   )
 }
@@ -136,7 +139,7 @@ export const Tiltfile = () =>
 export const AllItemSelected = () => {
   return (
     <ItemWrapper>
-      <SidebarItemAll nothingSelected={true} totalAlerts={1} allLink={"/"} />
+      <SidebarItemAll nothingSelected={true} totalAlerts={1} />
     </ItemWrapper>
   )
 }
@@ -144,7 +147,7 @@ export const AllItemSelected = () => {
 export const AllItemUnselected = () => {
   return (
     <ItemWrapper>
-      <SidebarItemAll nothingSelected={false} totalAlerts={1} allLink={"/"} />
+      <SidebarItemAll nothingSelected={false} totalAlerts={1} />
     </ItemWrapper>
   )
 }

--- a/web/src/SidebarItemView.tsx
+++ b/web/src/SidebarItemView.tsx
@@ -1,5 +1,4 @@
 import React from "react"
-import { Link } from "react-router-dom"
 import TimeAgo from "react-timeago"
 import styled, { keyframes } from "styled-components"
 import { incr } from "./analytics"
@@ -18,9 +17,10 @@ import {
   SizeUnit,
   Width,
 } from "./style-helpers"
+import { useTabNav } from "./TabNav"
 import { formatBuildDuration, isZeroTime } from "./time"
 import { timeAgoFormatter } from "./timeFormatters"
-import { ResourceStatus, ResourceView } from "./types"
+import { ResourceName, ResourceStatus, ResourceView } from "./types"
 
 const barberpole = keyframes`
   100% {
@@ -28,7 +28,7 @@ const barberpole = keyframes`
   }
 `
 
-export let SidebarItemBox = styled(Link)`
+export let SidebarItemBox = styled.div`
   color: ${Color.white};
   background-color: ${Color.gray};
   display: flex;
@@ -44,6 +44,7 @@ export let SidebarItemBox = styled(Link)`
   font-size: ${FontSize.small};
   font-family: ${Font.monospace};
   margin-right: ${SizeUnit(0.5)};
+  cursor: pointer;
 
   &:hover {
     background-color: ${ColorRGBA(Color.gray, ColorAlpha.translucent)};
@@ -117,15 +118,16 @@ let SidebarItemText = styled.div`
 type SidebarItemAllProps = {
   nothingSelected: boolean
   totalAlerts: number
-  allLink: string
 }
 
 export function SidebarItemAll(props: SidebarItemAllProps) {
+  let nav = useTabNav()
   return (
     <SidebarItemAllRoot>
       <SidebarItemAllBox
         className={props.nothingSelected ? "isSelected" : ""}
-        to={props.allLink}
+        onClick={() => nav.clickResource(ResourceName.all)}
+        onDoubleClick={() => nav.doubleClickResource(ResourceName.all)}
       >
         <SidebarIcon
           status={ResourceStatus.None}
@@ -246,20 +248,8 @@ function buildTooltipText(status: ResourceStatus): string {
 }
 
 export default function SidebarItemView(props: SidebarItemViewProps) {
+  let nav = useTabNav()
   let item = props.item
-  let link = `/r/${item.name}`
-  switch (props.resourceView) {
-    case ResourceView.Alerts:
-      link += "/alerts"
-      break
-    case ResourceView.Facets:
-      link += "/facets"
-      break
-    case ResourceView.OverviewDetail:
-      link += "/overview"
-      break
-  }
-
   let formatter = timeAgoFormatter
   let hasSuccessfullyDeployed = !isZeroTime(item.lastDeployTime)
   let hasBuilt = item.lastBuild !== null
@@ -284,7 +274,8 @@ export default function SidebarItemView(props: SidebarItemViewProps) {
       )}
       <SidebarItemBox
         className={`${isSelectedClass} ${isBuildingClass}`}
-        to={props.pathBuilder.path(link)}
+        onClick={() => nav.clickResource(item.name)}
+        onDoubleClick={() => nav.doubleClickResource(item.name)}
         data-name={item.name}
       >
         <SidebarItemRuntimeBox>

--- a/web/src/SidebarResources.tsx
+++ b/web/src/SidebarResources.tsx
@@ -9,7 +9,7 @@ import SidebarItemView, {
 import SidebarKeyboardShortcuts from "./SidebarKeyboardShortcuts"
 import { useSidebarPin } from "./SidebarPin"
 import { Color, FontSize, SizeUnit, Width } from "./style-helpers"
-import { ResourceName, ResourceView } from "./types"
+import { ResourceView } from "./types"
 
 let SidebarResourcesRoot = styled.nav`
   flex: 1 0 auto;
@@ -60,15 +60,16 @@ function PinnedItems(props: SidebarProps) {
   let pinnedItems = ctx.pinnedResources?.flatMap((r) =>
     props.items
       .filter((i) => i.name === r)
-      .map((i) =>
-        SidebarItemView({
-          item: i,
-          selected: props.selected === i.name,
-          renderPin: false,
-          pathBuilder: props.pathBuilder,
-          resourceView: props.resourceView,
-        })
-      )
+      .map((i) => (
+        <SidebarItemView
+          key={"sidebarItemPinned-" + i.name}
+          item={i}
+          selected={props.selected === i.name}
+          renderPin={false}
+          pathBuilder={props.pathBuilder}
+          resourceView={props.resourceView}
+        />
+      ))
   )
 
   if (!pinnedItems?.length) {
@@ -94,27 +95,20 @@ export class SidebarResources extends PureComponent<SidebarProps> {
 
   render() {
     let pb = this.props.pathBuilder
-
-    let allLink = pb.path("/")
-    if (this.props.resourceView === ResourceView.Alerts) {
-      allLink = pb.path("/alerts")
-    } else if (this.props.resourceView === ResourceView.OverviewDetail) {
-      allLink = pb.path(`/r/${ResourceName.all}/overview`)
-    }
-
     let totalAlerts = this.props.items
       .map((i) => i.buildAlertCount + i.runtimeAlertCount)
       .reduce((sum, current) => sum + current, 0)
 
-    let listItems = this.props.items.map((item) =>
-      SidebarItemView({
-        item: item,
-        selected: this.props.selected === item.name,
-        renderPin: true,
-        pathBuilder: this.props.pathBuilder,
-        resourceView: this.props.resourceView,
-      })
-    )
+    let listItems = this.props.items.map((item) => (
+      <SidebarItemView
+        key={"sidebarItem-" + item.name}
+        item={item}
+        selected={this.props.selected == item.name}
+        renderPin={true}
+        pathBuilder={this.props.pathBuilder}
+        resourceView={this.props.resourceView}
+      />
+    ))
 
     let nothingSelected = !this.props.selected
     let isOverviewClass =
@@ -128,7 +122,6 @@ export class SidebarResources extends PureComponent<SidebarProps> {
           <SidebarListSection name="">
             <SidebarItemAll
               nothingSelected={nothingSelected}
-              allLink={allLink}
               totalAlerts={totalAlerts}
             />
           </SidebarListSection>

--- a/web/src/TabNav.tsx
+++ b/web/src/TabNav.tsx
@@ -1,0 +1,196 @@
+import React, { useContext, useEffect, useState } from "react"
+import { useHistory } from "react-router-dom"
+import { useLocalStorageContext } from "./LocalStorage"
+import { usePathBuilder } from "./PathBuilder"
+import { ResourceName, ResourceView } from "./types"
+
+// Tav navigation semantics.
+//
+// Different UI controls on the page can have complex interactions
+// with the Tab bar, so we model the TabBar as a React context
+// shared by multiple components.
+type TabNav = {
+  tabs: string[]
+  selectedTab: string
+
+  // Behavior when you click on a link to a resource.
+  clickResource(name: string): void
+
+  // Behavior when you double click on a link to a resource.
+  doubleClickResource(name: string): void
+
+  // Behavior when you close a tab.
+  closeTab(name: string): void
+
+  // Make sure the given tab is open and selected.
+  ensureSelectedTab(name: string): void
+}
+
+const tabNavContext = React.createContext<TabNav>({
+  tabs: [],
+  selectedTab: "",
+  clickResource: (name: string) => {},
+  doubleClickResource: (name: string) => {},
+  ensureSelectedTab: () => {},
+  closeTab: (name: string) => {},
+})
+
+export function useTabNav(): TabNav {
+  return useContext(tabNavContext)
+}
+
+export let TabNavContextConsumer = tabNavContext.Consumer
+
+// In the legacy UI, there are no tabs at all.
+// We only need to make sure we're opening the right link.
+export function LegacyNavProvider(
+  props: React.PropsWithChildren<{ resourceView: ResourceView }>
+) {
+  let history = useHistory()
+  let pb = usePathBuilder()
+  let { resourceView, children } = props
+  let nav = (name: string) => {
+    let all = name === "" || name === ResourceName.all
+    if (all) {
+      switch (resourceView) {
+        case ResourceView.Alerts:
+          history.push(pb.path(`/alerts`))
+          return
+        default:
+          history.push(pb.path(`/`))
+          return
+      }
+    }
+
+    switch (props.resourceView) {
+      case ResourceView.Alerts:
+        history.push(pb.path(`/r/${name}/alerts`))
+        return
+      case ResourceView.Facets:
+        history.push(pb.path(`/r/${name}/facets`))
+        return
+      default:
+        history.push(pb.path(`/r/${name}`))
+        return
+    }
+  }
+
+  let tabNav = {
+    tabs: [],
+    selectedTab: "",
+    clickResource: nav,
+    doubleClickResource: nav,
+    ensureSelectedTab: () => {},
+    closeTab: () => {},
+  }
+
+  return (
+    <tabNavContext.Provider value={tabNav}>{children}</tabNavContext.Provider>
+  )
+}
+
+// New Overview semantics:
+// TODO(nick): Implement these. We've currently ported this straight over from the old semantics.
+//
+// 1. When you single click a resource on the left sidebar,
+//    it changes the current tab to the new resource.
+//
+// 2. When you double click a resource on the left sidebar,
+//    it opens a new tab, and brings the new tab into focus.
+//
+// 3. When you close a tab that is currently selected, the view toggles to the tab on the right
+//
+// 4. When there is only one tab remaining, and you close it, then the overview grid page opens
+//
+// 5. When you open a resource as a new tab (from *resource detail tab view*)
+// - Click on any resource from left sidebar to change logs on right side accordingly
+// - Double click on any resource to open that as a new tab on the immediate right
+//   of current tab
+//   (OR, if the resource is already open in a tab, then view toggles to that open tab)
+//
+// 6. When you open resource in new tab (from *overview grid page*)
+// - Click on a resource card to open preview of that resource inline
+// - Click on "Show details" within card preview, to open that resrouce in the tab view
+// - This new tab opens on the absolute right of all other tabs.
+export function OverviewNavProvider(
+  props: React.PropsWithChildren<{
+    resourceView: ResourceView
+    tabsForTesting?: string[]
+  }>
+) {
+  let { resourceView, children } = props
+  let lsc = useLocalStorageContext()
+  let history = useHistory()
+  let pb = usePathBuilder()
+
+  // The list of tabs open. A tab name should never appear twice in the list.
+  const [tabs, setTabs] = useState<Array<string>>(
+    () => props.tabsForTesting ?? lsc.get<Array<string>>("tabs") ?? []
+  )
+  const [selectedTab, setSelectedTab] = useState("")
+
+  useEffect(() => {
+    lsc.set("tabs", tabs)
+  }, [tabs, lsc])
+
+  // Ensures the tab is in the tab list.
+  function ensureSelectedTab(name: string) {
+    if (!name) {
+      return
+    }
+
+    setTabs((prevState) => {
+      if (prevState.includes(name)) {
+        return prevState
+      }
+
+      return [name].concat(prevState)
+    })
+    setSelectedTab(name)
+  }
+
+  // Deletes the resource in the tab list.
+  // If we're deleting the current tab, navigate to the next reasonable tab.
+  function closeTab(name: string) {
+    let newState = (prevState: string[]) => {
+      return prevState.filter((t) => t !== name)
+    }
+    if (name !== selectedTab) {
+      setTabs(newState)
+      return
+    }
+
+    let index = tabs.indexOf(name)
+    let desired = `/overview`
+    if (index + 1 < tabs.length) {
+      desired = `/r/${tabs[index + 1]}/overview`
+    } else if (index - 1 >= 0) {
+      desired = `/r/${tabs[index - 1]}/overview`
+    }
+
+    setTabs(newState)
+    history.push(desired)
+  }
+
+  let nav = (name: string) => {
+    let all = name === "" || name === ResourceName.all
+    if (all) {
+      history.push(pb.path(`/r/${ResourceName.all}/overview`))
+      return
+    }
+
+    history.push(pb.path(`/r/${name}/overview`))
+  }
+
+  let tabNav = {
+    tabs,
+    selectedTab,
+    ensureSelectedTab,
+    closeTab,
+    clickResource: nav,
+    doubleClickResource: nav,
+  }
+  return (
+    <tabNavContext.Provider value={tabNav}>{children}</tabNavContext.Provider>
+  )
+}

--- a/web/src/__snapshots__/Sidebar.test.tsx.snap
+++ b/web/src/__snapshots__/Sidebar.test.tsx.snap
@@ -19,10 +19,10 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
         <li
           className="sc-bdfBwQ sc-kEjbxe krceUN bmYsyG"
         >
-          <a
-            className="sc-iBPRYJ sc-fubCfw jkXthm hDyxGh isSelected"
-            href="/"
+          <div
+            className="sc-iBPRYJ sc-fubCfw epmLcA hDyxGh isSelected"
             onClick={[Function]}
+            onDoubleClick={[Function]}
           >
             <div
               className="sc-gsTCUz HrTde isNone"
@@ -36,7 +36,7 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
             >
               All
             </div>
-          </a>
+          </div>
         </li>
       </ul>
     </div>
@@ -63,11 +63,11 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
               pin.svg
             </svg>
           </button>
-          <a
-            className="sc-iBPRYJ jkXthm  isBuilding"
+          <div
+            className="sc-iBPRYJ epmLcA  isBuilding"
             data-name="resource4"
-            href="/r/resource4"
             onClick={[Function]}
+            onDoubleClick={[Function]}
           >
             <div
               className="sc-pFZIQ jNegfI"
@@ -139,7 +139,7 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
                 Completed in 12s, with issues
               </div>
             </div>
-          </a>
+          </div>
         </li>
         <li
           className="sc-bdfBwQ krceUN  isBuilding"
@@ -155,11 +155,11 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
               pin.svg
             </svg>
           </button>
-          <a
-            className="sc-iBPRYJ jkXthm  isBuilding"
+          <div
+            className="sc-iBPRYJ epmLcA  isBuilding"
             data-name="resource9"
-            href="/r/resource9"
             onClick={[Function]}
+            onDoubleClick={[Function]}
           >
             <div
               className="sc-pFZIQ jNegfI"
@@ -231,7 +231,7 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
                 Completed in 12s, with issues
               </div>
             </div>
-          </a>
+          </div>
         </li>
         <li
           className="sc-bdfBwQ krceUN  isBuilding"
@@ -247,11 +247,11 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
               pin.svg
             </svg>
           </button>
-          <a
-            className="sc-iBPRYJ jkXthm  isBuilding"
+          <div
+            className="sc-iBPRYJ epmLcA  isBuilding"
             data-name="resource19"
-            href="/r/resource19"
             onClick={[Function]}
+            onDoubleClick={[Function]}
           >
             <div
               className="sc-pFZIQ jNegfI"
@@ -323,7 +323,7 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
                 Completed in 12s, with issues
               </div>
             </div>
-          </a>
+          </div>
         </li>
         <li
           className="sc-bdfBwQ krceUN  isBuilding"
@@ -339,11 +339,11 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
               pin.svg
             </svg>
           </button>
-          <a
-            className="sc-iBPRYJ jkXthm  isBuilding"
+          <div
+            className="sc-iBPRYJ epmLcA  isBuilding"
             data-name="resource29"
-            href="/r/resource29"
             onClick={[Function]}
+            onDoubleClick={[Function]}
           >
             <div
               className="sc-pFZIQ jNegfI"
@@ -415,7 +415,7 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
                 Completed in 12s, with issues
               </div>
             </div>
-          </a>
+          </div>
         </li>
         <li
           className="sc-bdfBwQ krceUN  isBuilding"
@@ -431,11 +431,11 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
               pin.svg
             </svg>
           </button>
-          <a
-            className="sc-iBPRYJ jkXthm  isBuilding"
+          <div
+            className="sc-iBPRYJ epmLcA  isBuilding"
             data-name="resource39"
-            href="/r/resource39"
             onClick={[Function]}
+            onDoubleClick={[Function]}
           >
             <div
               className="sc-pFZIQ jNegfI"
@@ -507,7 +507,7 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
                 Completed in 12s, with issues
               </div>
             </div>
-          </a>
+          </div>
         </li>
         <li
           className="sc-bdfBwQ krceUN  isBuilding"
@@ -523,11 +523,11 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
               pin.svg
             </svg>
           </button>
-          <a
-            className="sc-iBPRYJ jkXthm  isBuilding"
+          <div
+            className="sc-iBPRYJ epmLcA  isBuilding"
             data-name="resource49"
-            href="/r/resource49"
             onClick={[Function]}
+            onDoubleClick={[Function]}
           >
             <div
               className="sc-pFZIQ jNegfI"
@@ -599,7 +599,7 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
                 Completed in 12s, with issues
               </div>
             </div>
-          </a>
+          </div>
         </li>
         <li
           className="sc-bdfBwQ krceUN  isBuilding"
@@ -615,11 +615,11 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
               pin.svg
             </svg>
           </button>
-          <a
-            className="sc-iBPRYJ jkXthm  isBuilding"
+          <div
+            className="sc-iBPRYJ epmLcA  isBuilding"
             data-name="resource54"
-            href="/r/resource54"
             onClick={[Function]}
+            onDoubleClick={[Function]}
           >
             <div
               className="sc-pFZIQ jNegfI"
@@ -691,7 +691,7 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
                 Completed in 12s, with issues
               </div>
             </div>
-          </a>
+          </div>
         </li>
       </ul>
     </div>
@@ -719,10 +719,10 @@ exports[`sidebar renders empty resource list without crashing 1`] = `
         <li
           className="sc-bdfBwQ sc-kEjbxe krceUN bmYsyG"
         >
-          <a
-            className="sc-iBPRYJ sc-fubCfw jkXthm hDyxGh isSelected"
-            href="/"
+          <div
+            className="sc-iBPRYJ sc-fubCfw epmLcA hDyxGh isSelected"
             onClick={[Function]}
+            onDoubleClick={[Function]}
           >
             <div
               className="sc-gsTCUz HrTde isNone"
@@ -736,7 +736,7 @@ exports[`sidebar renders empty resource list without crashing 1`] = `
             >
               All
             </div>
-          </a>
+          </div>
         </li>
       </ul>
     </div>
@@ -774,10 +774,10 @@ exports[`sidebar renders list of resources 1`] = `
         <li
           className="sc-bdfBwQ sc-kEjbxe krceUN bmYsyG"
         >
-          <a
-            className="sc-iBPRYJ sc-fubCfw jkXthm hDyxGh isSelected"
-            href="/"
+          <div
+            className="sc-iBPRYJ sc-fubCfw epmLcA hDyxGh isSelected"
             onClick={[Function]}
+            onDoubleClick={[Function]}
           >
             <div
               className="sc-gsTCUz HrTde isNone"
@@ -791,7 +791,7 @@ exports[`sidebar renders list of resources 1`] = `
             >
               All
             </div>
-          </a>
+          </div>
         </li>
       </ul>
     </div>
@@ -818,11 +818,11 @@ exports[`sidebar renders list of resources 1`] = `
               pin.svg
             </svg>
           </button>
-          <a
-            className="sc-iBPRYJ jkXthm  isBuilding"
+          <div
+            className="sc-iBPRYJ epmLcA  isBuilding"
             data-name="vigoda"
-            href="/r/vigoda"
             onClick={[Function]}
+            onDoubleClick={[Function]}
           >
             <div
               className="sc-pFZIQ jNegfI"
@@ -896,7 +896,7 @@ exports[`sidebar renders list of resources 1`] = `
                 Update error
               </div>
             </div>
-          </a>
+          </div>
         </li>
         <li
           className="sc-bdfBwQ krceUN  isBuilding"
@@ -912,11 +912,11 @@ exports[`sidebar renders list of resources 1`] = `
               pin.svg
             </svg>
           </button>
-          <a
-            className="sc-iBPRYJ jkXthm  isBuilding"
+          <div
+            className="sc-iBPRYJ epmLcA  isBuilding"
             data-name="snack"
-            href="/r/snack"
             onClick={[Function]}
+            onDoubleClick={[Function]}
           >
             <div
               className="sc-pFZIQ jNegfI"
@@ -990,7 +990,7 @@ exports[`sidebar renders list of resources 1`] = `
                 Update error
               </div>
             </div>
-          </a>
+          </div>
         </li>
       </ul>
     </div>
@@ -1018,10 +1018,10 @@ exports[`sidebar renders resources that haven't been built yet 1`] = `
         <li
           className="sc-bdfBwQ sc-kEjbxe krceUN bmYsyG"
         >
-          <a
-            className="sc-iBPRYJ sc-fubCfw jkXthm hDyxGh isSelected"
-            href="/"
+          <div
+            className="sc-iBPRYJ sc-fubCfw epmLcA hDyxGh isSelected"
             onClick={[Function]}
+            onDoubleClick={[Function]}
           >
             <div
               className="sc-gsTCUz HrTde isNone"
@@ -1035,7 +1035,7 @@ exports[`sidebar renders resources that haven't been built yet 1`] = `
             >
               All
             </div>
-          </a>
+          </div>
         </li>
       </ul>
     </div>
@@ -1062,11 +1062,11 @@ exports[`sidebar renders resources that haven't been built yet 1`] = `
               pin.svg
             </svg>
           </button>
-          <a
-            className="sc-iBPRYJ jkXthm  isBuilding"
+          <div
+            className="sc-iBPRYJ epmLcA  isBuilding"
             data-name="vigoda"
-            href="/r/vigoda"
             onClick={[Function]}
+            onDoubleClick={[Function]}
           >
             <div
               className="sc-pFZIQ jNegfI"
@@ -1133,7 +1133,7 @@ exports[`sidebar renders resources that haven't been built yet 1`] = `
                 Updating…
               </div>
             </div>
-          </a>
+          </div>
         </li>
         <li
           className="sc-bdfBwQ krceUN  isBuilding"
@@ -1149,11 +1149,11 @@ exports[`sidebar renders resources that haven't been built yet 1`] = `
               pin.svg
             </svg>
           </button>
-          <a
-            className="sc-iBPRYJ jkXthm  isBuilding"
+          <div
+            className="sc-iBPRYJ epmLcA  isBuilding"
             data-name="snack"
-            href="/r/snack"
             onClick={[Function]}
+            onDoubleClick={[Function]}
           >
             <div
               className="sc-pFZIQ jNegfI"
@@ -1220,7 +1220,7 @@ exports[`sidebar renders resources that haven't been built yet 1`] = `
                 Updating…
               </div>
             </div>
-          </a>
+          </div>
         </li>
       </ul>
     </div>

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -14,6 +14,9 @@ export enum ResourceView {
 
   // The detail view in the Grid-based UI.
   OverviewDetail,
+
+  // The grid UI
+  Grid,
 }
 
 export enum TriggerMode {


### PR DESCRIPTION
Hello @landism, @hyu,

Please review the following commits I made in branch nicks/tabnav:

7082148107d1ba54a6f191f594c052429fda98a6 (2021-01-19 19:59:13 -0500)
web: pull up all the Tab logic into a separate React context
We're moving towards a model where clicking on the Sidebar
can have complex interactions with the Tab bar, so we need
a better way to centralize state between them.

This PR doesn't change any of the semantics. It just moves state around.

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics