### PR TITLE
cli: improve documentation in 'tilt down'

### DIFF
--- a/internal/cli/down.go
+++ b/internal/cli/down.go
@@ -36,18 +36,15 @@ func (c *downCmd) register() *cobra.Command {
 		Long: `
 Deletes resources specified in the Tiltfile
 
+Specify additional flags and arguments to control which resources are deleted.
+
 Namespaces are not deleted by default. Use --delete-namespaces to change that.
 
-There are two types of args:
-1) Tilt flags, listed below, which are handled entirely by Tilt.
-2) Tiltfile args, which can be anything, and are potentially accessed by config.parse in your Tiltfile.
+Kubernetes resources with the annotation 'tilt.dev/down-policy: keep' are not deleted.
 
-By default:
-1) Tiltfile args are interpreted as the list of services to delete, e.g. tilt down frontend backend.
-2) Running with no Tiltfile args deletes all services defined in the Tiltfile
-
-This default behavior does not apply if the Tiltfile uses config.parse or config.set_enabled_resources.
-In that case, see https://tilt.dev/user_config.html and/or comments in your Tiltfile
+For more complex cases, the Tiltfile has APIs to add additional flags and arguments to the Tilt CLI.
+These arguments can be scripted to define custom subsets of resources to delete.
+See https://docs.tilt.dev/tiltfile_config.html for examples.
 `,
 	}
 


### PR DESCRIPTION
Hello @landism,

Please review the following commits I made in branch nicks/down:

2cc5a340cfdcb1706f1a045d1f0e9a987c5f9084 (2021-01-20 11:25:09 -0500)
cli: improve documentation in 'tilt down'
- Add notes on down-policy
- Fix the link to the tiltfile config docs

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics