### PR TITLE
engine: handle readiness probes for local resources

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 	github.com/grpc-ecosystem/grpc-opentracing v0.0.0-20180507213350-8e809c8a8645
 	github.com/hailocab/go-hostpool v0.0.0-20160125115350-e80d13ce29ed // indirect
 	github.com/jinzhu/gorm v1.9.12 // indirect
-	github.com/jonboulle/clockwork v0.1.0
+	github.com/jonboulle/clockwork v0.2.2
 	github.com/json-iterator/go v1.1.10
 	github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0 // indirect
 	github.com/looplab/tarjan v0.0.0-20161115091335-9cc6d6cebfb5
@@ -62,13 +62,14 @@ require (
 	github.com/schollz/closestmatch v2.1.0+incompatible
 	github.com/spf13/cobra v1.1.1
 	github.com/spf13/pflag v1.0.5
-	github.com/stretchr/testify v1.6.1
+	github.com/stretchr/testify v1.7.0
 	github.com/theupdateframework/notary v0.6.1 // indirect
 	github.com/tilt-dev/dockerignore v0.0.0-20200910202654-0d8c17a73277
 	github.com/tilt-dev/fsevents v0.0.0-20200515134857-2efe37af20de
 	github.com/tilt-dev/fsnotify v1.4.8-0.20200727200623-991e307aab7f
 	github.com/tilt-dev/go-get v0.0.0-20200911222649-1acd29546527
 	github.com/tilt-dev/localregistry-go v0.0.0-20200615231835-07e386f4ebd7
+	github.com/tilt-dev/probe v0.1.0
 	github.com/tilt-dev/wmclient v0.0.0-20201109174454-1839d0355fbc
 	github.com/tonistiigi/units v0.0.0-20180711220420-6950e57a87ea
 	github.com/whilp/git-urls v0.0.0-20160530060445-31bac0d230fa

--- a/go.sum
+++ b/go.sum
@@ -724,6 +724,8 @@ github.com/joefitzgerald/rainbow-reporter v0.1.0/go.mod h1:481CNgqmVHQZzdIbN52Cu
 github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
 github.com/jonboulle/clockwork v0.1.0 h1:VKV+ZcuP6l3yW9doeqz6ziZGgcynBVQO+obU0+0hcPo=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
+github.com/jonboulle/clockwork v0.2.2 h1:UOGuzwb1PwsrDAObMuhUnj0p5ULPj8V/xJ7Kx9qUBdQ=
+github.com/jonboulle/clockwork v0.2.2/go.mod h1:Pkfl5aHPm1nk2H9h0bjmnJD/BcgbGXUBGnn1kMkgxc8=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/json-iterator/go v0.0.0-20180612202835-f2b4162afba3/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
@@ -1118,6 +1120,7 @@ github.com/streadway/handy v0.0.0-20190108123426-d5acb3125c2a/go.mod h1:qNTQ5P5J
 github.com/stretchr/objx v0.0.0-20180129172003-8a3f7159479f/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.2.0 h1:Hbg2NidpLE8veEBkEZTL3CvlkUIVzuU9jDplZO54c48=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/testify v0.0.0-20151208002404-e3a8ff8ce365/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v0.0.0-20180303142811-b89eecf5ca5d/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
@@ -1129,6 +1132,8 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/syndtr/gocapability v0.0.0-20170704070218-db04d3cc01c8/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
@@ -1152,6 +1157,8 @@ github.com/tilt-dev/localregistry-go v0.0.0-20200615231835-07e386f4ebd7 h1:ysHGL
 github.com/tilt-dev/localregistry-go v0.0.0-20200615231835-07e386f4ebd7/go.mod h1:bZecZHy8tHzZWeF+MEQMugKbGhi9cF1A7tuaZNIxoDs=
 github.com/tilt-dev/opencensus-go v0.22.5-0.20200904175236-275b1754f353 h1:lxM1v8P9oYChoHZjnno3s8FlH0w3h2nWeq86FH4sAag=
 github.com/tilt-dev/opencensus-go v0.22.5-0.20200904175236-275b1754f353/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
+github.com/tilt-dev/probe v0.1.0 h1:mEQhtV/M1VjV/sY2TZ89FVE3u+rFSWV9gtT8KzHAn54=
+github.com/tilt-dev/probe v0.1.0/go.mod h1:N4FSqESyYQuc9GwIaIoHS5cIUDznIUwDkG6y4kQVXQY=
 github.com/tilt-dev/wmclient v0.0.0-20201109174454-1839d0355fbc h1:wGkAoZhrvnmq93B4W2v+agiPl7xzqUaxXkxmKrwJ6bc=
 github.com/tilt-dev/wmclient v0.0.0-20201109174454-1839d0355fbc/go.mod h1:n01fG3LbImzxBP3GGCTHkgXuPeJusWg6xv0QYGm9HtE=
 github.com/timakin/bodyclose v0.0.0-20190930140734-f7f2e9bca95e/go.mod h1:Qimiffbc6q9tBWlVV6x0P9sat/ao1xEkREYPPj9hphk=
@@ -1686,6 +1693,8 @@ k8s.io/utils v0.0.0-20200729134348-d5654de09c73 h1:uJmqzgNWG7XyClnU/mLPBWwfKKF1K
 k8s.io/utils v0.0.0-20200729134348-d5654de09c73/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 k8s.io/utils v0.0.0-20201110183641-67b214c5f920 h1:CbnUZsM497iRC5QMVkHwyl8s2tB3g7yaSHkYPkpgelw=
 k8s.io/utils v0.0.0-20201110183641-67b214c5f920/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
+k8s.io/utils v0.0.0-20210111153108-fddb29f9d009 h1:0T5IaWHO3sJTEmCP6mUlBvMukxPKUQWqiI/YuiBNMiQ=
+k8s.io/utils v0.0.0-20210111153108-fddb29f9d009/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 modernc.org/cc v1.0.0/go.mod h1:1Sk4//wdnYJiUIxnW8ddKpaOJCF37yAdqYnkxUpaYxw=
 modernc.org/golex v1.0.0/go.mod h1:b/QX9oBD/LhixY6NDh+IdGv17hgB+51fET1i2kPSmvk=
 modernc.org/mathutil v1.0.0/go.mod h1:wU0vUrJsVWBZ4P6e7xtFJEhFSNsfRLJ8H458uRjg03k=

--- a/internal/cli/wire.go
+++ b/internal/cli/wire.go
@@ -85,6 +85,7 @@ var BaseWireSet = wire.NewSet(
 	portforward.NewController,
 	engine.NewBuildController,
 	local.ProvideExecer,
+	local.ProvideProberManager,
 	local.NewController,
 	k8swatch.NewPodWatcher,
 	k8swatch.NewServiceWatcher,

--- a/internal/cli/wire_gen.go
+++ b/internal/cli/wire_gen.go
@@ -259,7 +259,8 @@ func wireCmdUp(ctx context.Context, analytics3 *analytics.TiltAnalytics, cmdTags
 	dockerPruner := dockerprune.NewDockerPruner(switchCli)
 	telemetryController := telemetry.NewController(clock, spanCollector)
 	execer := local.ProvideExecer()
-	localController := local.NewController(execer)
+	proberManager := local.ProvideProberManager()
+	localController := local.NewController(execer, proberManager)
 	podMonitor := k8srollout.NewPodMonitor()
 	exitController := exit.NewController()
 	deferredExporter := ProvideDeferredExporter()
@@ -413,7 +414,8 @@ func wireCmdCI(ctx context.Context, analytics3 *analytics.TiltAnalytics, subcomm
 	dockerPruner := dockerprune.NewDockerPruner(switchCli)
 	telemetryController := telemetry.NewController(clock, spanCollector)
 	execer := local.ProvideExecer()
-	localController := local.NewController(execer)
+	proberManager := local.ProvideProberManager()
+	localController := local.NewController(execer, proberManager)
 	podMonitor := k8srollout.NewPodMonitor()
 	exitController := exit.NewController()
 	deferredExporter := ProvideDeferredExporter()
@@ -699,7 +701,7 @@ func wireAnalytics(l logger.Logger, cmdName model.TiltSubcommand) (*analytics.Ti
 var K8sWireSet = wire.NewSet(k8s.ProvideEnv, k8s.ProvideClusterName, k8s.ProvideKubeContext, k8s.ProvideKubeConfig, k8s.ProvideClientConfig, k8s.ProvideClientset, k8s.ProvideRESTConfig, k8s.ProvidePortForwardClient, k8s.ProvideConfigNamespace, k8s.ProvideContainerRuntime, k8s.ProvideServerVersion, k8s.ProvideK8sClient, k8s.ProvideOwnerFetcher, ProvideKubeContextOverride)
 
 var BaseWireSet = wire.NewSet(
-	K8sWireSet, tiltfile.WireSet, git.ProvideGitRemote, docker.SwitchWireSet, ProvideDeferredExporter, metrics.WireSet, user.WireSet, dockercompose.NewDockerComposeClient, clockwork.NewRealClock, engine.DeployerWireSet, runtimelog.NewPodLogManager, portforward.NewController, engine.NewBuildController, local.ProvideExecer, local.NewController, k8swatch.NewPodWatcher, k8swatch.NewServiceWatcher, k8swatch.NewEventWatchManager, configs.NewConfigsController, telemetry.NewController, dcwatch.NewEventWatcher, runtimelog.NewDockerComposeLogManager, engine.NewProfilerManager, cloud.WireSet, cloudurl.ProvideAddress, k8srollout.NewPodMonitor, telemetry.NewStartTracker, exit.NewController, provideClock, hud.WireSet, prompt.WireSet, provideLogActions, store.NewStore, wire.Bind(new(store.RStore), new(*store.Store)), dockerprune.NewDockerPruner, provideTiltInfo, engine.ProvideSubscribers, engine.NewUpper, analytics2.NewAnalyticsUpdater, analytics2.ProvideAnalyticsReporter, provideUpdateModeFlag, fswatch.NewGitManager, fswatch.NewWatchManager, fswatch.ProvideFsWatcherMaker, fswatch.ProvideTimerMaker, provideWebVersion,
+	K8sWireSet, tiltfile.WireSet, git.ProvideGitRemote, docker.SwitchWireSet, ProvideDeferredExporter, metrics.WireSet, user.WireSet, dockercompose.NewDockerComposeClient, clockwork.NewRealClock, engine.DeployerWireSet, runtimelog.NewPodLogManager, portforward.NewController, engine.NewBuildController, local.ProvideExecer, local.ProvideProberManager, local.NewController, k8swatch.NewPodWatcher, k8swatch.NewServiceWatcher, k8swatch.NewEventWatchManager, configs.NewConfigsController, telemetry.NewController, dcwatch.NewEventWatcher, runtimelog.NewDockerComposeLogManager, engine.NewProfilerManager, cloud.WireSet, cloudurl.ProvideAddress, k8srollout.NewPodMonitor, telemetry.NewStartTracker, exit.NewController, provideClock, hud.WireSet, prompt.WireSet, provideLogActions, store.NewStore, wire.Bind(new(store.RStore), new(*store.Store)), dockerprune.NewDockerPruner, provideTiltInfo, engine.ProvideSubscribers, engine.NewUpper, analytics2.NewAnalyticsUpdater, analytics2.ProvideAnalyticsReporter, provideUpdateModeFlag, fswatch.NewGitManager, fswatch.NewWatchManager, fswatch.ProvideFsWatcherMaker, fswatch.ProvideTimerMaker, provideWebVersion,
 	provideWebMode,
 	provideWebURL,
 	provideWebPort,

--- a/internal/engine/buildcontrol/build_control_test.go
+++ b/internal/engine/buildcontrol/build_control_test.go
@@ -79,7 +79,7 @@ func TestK8sDependsOnLocal(t *testing.T) {
 		FinishTime: time.Now(),
 	})
 	lrs := local1.State.LocalRuntimeState()
-	lrs.HasSucceededAtLeastOnce = true
+	lrs.LastReadyOrSucceededTime = time.Now()
 	local1.State.RuntimeState = lrs
 
 	f.assertNextTargetToBuild("k8s1")

--- a/internal/engine/buildcontrol/build_control_test.go
+++ b/internal/engine/buildcontrol/build_control_test.go
@@ -78,7 +78,9 @@ func TestK8sDependsOnLocal(t *testing.T) {
 		StartTime:  time.Now(),
 		FinishTime: time.Now(),
 	})
-	local1.State.RuntimeState = store.LocalRuntimeState{HasSucceededAtLeastOnce: true}
+	lrs := local1.State.LocalRuntimeState()
+	lrs.HasSucceededAtLeastOnce = true
+	local1.State.RuntimeState = lrs
 
 	f.assertNextTargetToBuild("k8s1")
 	k8s1.State.CurrentBuild = model.BuildRecord{StartTime: time.Now()}

--- a/internal/engine/local/actions.go
+++ b/internal/engine/local/actions.go
@@ -12,3 +12,10 @@ type LocalServeStatusAction struct {
 }
 
 func (LocalServeStatusAction) Action() {}
+
+type LocalServeReadinessProbeAction struct {
+	ManifestName model.ManifestName
+	Ready        bool
+}
+
+func (LocalServeReadinessProbeAction) Action() {}

--- a/internal/engine/local/controller.go
+++ b/internal/engine/local/controller.go
@@ -21,18 +21,17 @@ type Controller struct {
 	execer       Execer
 	procs        map[model.ManifestName]*currentProcess
 	procCount    int
-	probeManager probeManager
+	probeManager ProberManager
 }
 
 var _ store.Subscriber = &Controller{}
 var _ store.TearDowner = &Controller{}
 
-func NewController(execer Execer) *Controller {
+func NewController(execer Execer, manager ProberManager) *Controller {
 	return &Controller{
-		execer: execer,
-		procs:  make(map[model.ManifestName]*currentProcess),
-		// TODO: inject with wire
-		probeManager: prober.NewManager(),
+		execer:       execer,
+		procs:        make(map[model.ManifestName]*currentProcess),
+		probeManager: manager,
 	}
 }
 
@@ -172,7 +171,7 @@ func (c *Controller) start(ctx context.Context, spec ServeSpec, st store.RStore)
 			spec.ReadinessProbe,
 			probe.WorkerOnStatusChange(statusChangeFunc))
 		if err != nil {
-			logger.Get(ctx).Warnf("invalid readiness probe: %v", err)
+			logger.Get(ctx).Warnf("Invalid readiness probe: %v", err)
 		} else {
 			proc.probeWorker = probeWorker
 			go proc.probeWorker.Run(ctx)

--- a/internal/engine/local/controller.go
+++ b/internal/engine/local/controller.go
@@ -189,7 +189,7 @@ func processReadinessProbeUpdate(
 			return
 		}
 		if status != prober.Success && output != "" {
-			w := logger.Get(ctx).Writer(logger.DebugLvl)
+			w := logger.Get(ctx).Writer(logger.VerboseLvl)
 			_, _ = io.WriteString(w, output)
 		}
 		ready := status == prober.Success || status == prober.Warning

--- a/internal/engine/local/controller.go
+++ b/internal/engine/local/controller.go
@@ -169,7 +169,7 @@ func (c *Controller) start(ctx context.Context, spec ServeSpec, st store.RStore)
 		probeWorker, err := probeWorkerFromSpec(
 			c.proberManager,
 			spec.ReadinessProbe,
-			probe.WorkerOnStatusChange(statusChangeFunc))
+			statusChangeFunc)
 		if err != nil {
 			logger.Get(ctx).Warnf("Invalid readiness probe: %v", err)
 		} else {

--- a/internal/engine/local/controller.go
+++ b/internal/engine/local/controller.go
@@ -18,20 +18,20 @@ import (
 )
 
 type Controller struct {
-	execer       Execer
-	procs        map[model.ManifestName]*currentProcess
-	procCount    int
-	probeManager ProberManager
+	execer        Execer
+	procs         map[model.ManifestName]*currentProcess
+	procCount     int
+	proberManager ProberManager
 }
 
 var _ store.Subscriber = &Controller{}
 var _ store.TearDowner = &Controller{}
 
-func NewController(execer Execer, manager ProberManager) *Controller {
+func NewController(execer Execer, proberManager ProberManager) *Controller {
 	return &Controller{
-		execer:       execer,
-		procs:        make(map[model.ManifestName]*currentProcess),
-		probeManager: manager,
+		execer:        execer,
+		procs:         make(map[model.ManifestName]*currentProcess),
+		proberManager: proberManager,
 	}
 }
 
@@ -167,7 +167,7 @@ func (c *Controller) start(ctx context.Context, spec ServeSpec, st store.RStore)
 	if spec.ReadinessProbe != nil {
 		statusChangeFunc := processReadinessProbeUpdate(ctx, st, spec.ManifestName, proc.stillHasSameProcNum())
 		probeWorker, err := probeWorkerFromSpec(
-			c.probeManager,
+			c.proberManager,
 			spec.ReadinessProbe,
 			probe.WorkerOnStatusChange(statusChangeFunc))
 		if err != nil {

--- a/internal/engine/local/controller.go
+++ b/internal/engine/local/controller.go
@@ -190,6 +190,7 @@ func processReadinessProbeUpdate(
 		}
 		if status != prober.Success && output != "" {
 			w := logger.Get(ctx).Writer(logger.VerboseLvl)
+			// TODO(milas): improve output to distinguish from process stdout/stderr logs
 			_, _ = io.WriteString(w, output)
 		}
 		ready := status == prober.Success || status == prober.Warning

--- a/internal/engine/local/probe.go
+++ b/internal/engine/local/probe.go
@@ -104,11 +104,14 @@ func extractURL(httpGet *v1.HTTPGetAction) (*url.URL, error) {
 // (note: this implementation is substantially simplified from K8s - it does not handle "named" ports nor implicit
 //  string conversion, as these are not relevant concerns here)
 func extractPort(v intstr.IntOrString) (int, error) {
-	var port int
+	port := -1
 	if v.Type == intstr.Int {
 		port = v.IntValue()
 	}
 	if port <= 0 || port > 65535 {
+		// this will handle both intstr.Int values that are out of range as well
+		// as intstr.String values (which aren't supported); the raw value of the
+		// parameter will be included in the error message
 		return 0, fmt.Errorf("invalid port number: %s", v.String())
 	}
 	return port, nil

--- a/internal/engine/local/probe.go
+++ b/internal/engine/local/probe.go
@@ -18,13 +18,17 @@ import (
 
 var ErrUnsupportedProbeType = errors.New("unsupported probe type")
 
-type probeManager interface {
+func ProvideProberManager() ProberManager {
+	return prober.NewManager()
+}
+
+type ProberManager interface {
 	HTTPGet(u *url.URL, headers http.Header) prober.ProberFunc
 	TCPSocket(host string, port int) prober.ProberFunc
 	Exec(name string, args ...string) prober.ProberFunc
 }
 
-func probeWorkerFromSpec(manager probeManager, probeSpec *v1.Probe, opts ...probe.WorkerOption) (*probe.Worker, error) {
+func probeWorkerFromSpec(manager ProberManager, probeSpec *v1.Probe, opts ...probe.WorkerOption) (*probe.Worker, error) {
 	probeFunc, err := proberFromSpec(manager, probeSpec)
 	if err != nil {
 		return nil, err
@@ -51,7 +55,7 @@ func probeWorkerFromSpec(manager probeManager, probeSpec *v1.Probe, opts ...prob
 	return w, nil
 }
 
-func proberFromSpec(manager probeManager, probeSpec *v1.Probe) (prober.Prober, error) {
+func proberFromSpec(manager ProberManager, probeSpec *v1.Probe) (prober.Prober, error) {
 	if probeSpec == nil {
 		return nil, nil
 	} else if probeSpec.Exec != nil {

--- a/internal/engine/local/probe.go
+++ b/internal/engine/local/probe.go
@@ -1,0 +1,121 @@
+package local
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/tilt-dev/probe/pkg/probe"
+	"github.com/tilt-dev/probe/pkg/prober"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+var ErrUnsupportedProbeType = errors.New("unsupported probe type")
+
+type probeManager interface {
+	HTTPGet(u *url.URL, headers http.Header) prober.ProberFunc
+	TCPSocket(host string, port int) prober.ProberFunc
+	Exec(name string, args ...string) prober.ProberFunc
+}
+
+func probeWorkerFromSpec(manager probeManager, probeSpec *v1.Probe, opts ...probe.WorkerOption) (*probe.Worker, error) {
+	probeFunc, err := proberFromSpec(manager, probeSpec)
+	if err != nil {
+		return nil, err
+	}
+
+	if probeSpec.InitialDelaySeconds >= 0 {
+		opts = append(opts, probe.WorkerInitialDelay(time.Duration(probeSpec.InitialDelaySeconds)*time.Second))
+	}
+	if probeSpec.TimeoutSeconds > 0 {
+		opts = append(opts, probe.WorkerTimeout(time.Duration(probeSpec.TimeoutSeconds)*time.Second))
+	}
+	if probeSpec.PeriodSeconds > 0 {
+		opts = append(opts, probe.WorkerPeriod(time.Duration(probeSpec.PeriodSeconds)*time.Second))
+	}
+
+	if probeSpec.SuccessThreshold > 0 {
+		opts = append(opts, probe.WorkerSuccessThreshold(int(probeSpec.SuccessThreshold)))
+	}
+	if probeSpec.FailureThreshold > 0 {
+		opts = append(opts, probe.WorkerFailureThreshold(int(probeSpec.FailureThreshold)))
+	}
+
+	w := probe.NewWorker(probeFunc, opts...)
+	return w, nil
+}
+
+func proberFromSpec(manager probeManager, probeSpec *v1.Probe) (prober.Prober, error) {
+	if probeSpec == nil {
+		return nil, nil
+	} else if probeSpec.Exec != nil {
+		return manager.Exec(probeSpec.Exec.Command[0], probeSpec.Exec.Command[1:]...), nil
+	} else if probeSpec.HTTPGet != nil {
+		u, err := extractURL(probeSpec.HTTPGet)
+		if err != nil {
+			return nil, err
+		}
+		return manager.HTTPGet(u, convertHeaders(probeSpec.HTTPGet.HTTPHeaders)), nil
+	} else if probeSpec.TCPSocket != nil {
+		port, err := extractPort(probeSpec.TCPSocket.Port)
+		if err != nil {
+			return nil, err
+		}
+		return manager.TCPSocket(probeSpec.TCPSocket.Host, port), nil
+	}
+
+	return nil, ErrUnsupportedProbeType
+}
+
+// extractURL converts a K8s HTTP GET probe spec to a Go URL
+// adapted from https://github.com/kubernetes/kubernetes/blob/v1.20.2/pkg/kubelet/prober/prober.go#L163-L186
+func extractURL(httpGet *v1.HTTPGetAction) (*url.URL, error) {
+	port, err := extractPort(httpGet.Port)
+	if err != nil {
+		return nil, err
+	}
+	u, err := url.Parse(httpGet.Path)
+	if err != nil {
+		return nil, err
+	}
+	u.Scheme = strings.ToLower(string(httpGet.Scheme))
+	if u.Scheme == "" {
+		u.Scheme = "http"
+	}
+	if httpGet.Host == "" {
+		return nil, errors.New("no host specified")
+	}
+	u.Host = net.JoinHostPort(httpGet.Host, strconv.Itoa(port))
+	return u, nil
+}
+
+// extractPort converts a K8s multi-type value to a valid port number or returns an error.
+// adapted from https://github.com/kubernetes/kubernetes/blob/v1.20.2/pkg/kubelet/prober/prober.go#L203-L223
+// (note: this implementation is substantially simplified from K8s - it does not handle "named" ports nor implicit
+//  string conversion, as these are not relevant concerns here)
+func extractPort(v intstr.IntOrString) (int, error) {
+	var port int
+	if v.Type == intstr.Int {
+		port = v.IntValue()
+	}
+	if port <= 0 || port > 65535 {
+		return 0, fmt.Errorf("invalid port number: %s", v.String())
+	}
+	return port, nil
+}
+
+// convertHeaders creates a stdlib http.Header map from a collection of HTTP header key-value pairs
+// adapted from https://github.com/kubernetes/kubernetes/blob/v1.20.2/pkg/kubelet/prober/prober.go#L146-L154
+func convertHeaders(headerList []v1.HTTPHeader) http.Header {
+	headers := make(http.Header)
+	for _, header := range headerList {
+		headers[header.Name] = append(headers[header.Name], header.Value)
+	}
+	return headers
+}

--- a/internal/engine/local/probe_fake.go
+++ b/internal/engine/local/probe_fake.go
@@ -1,0 +1,56 @@
+package local
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"sync/atomic"
+
+	"github.com/tilt-dev/probe/pkg/prober"
+)
+
+func NewFakeProberManager() *FakeProberManager {
+	return &FakeProberManager{}
+}
+
+type FakeProberManager struct {
+	probeCount int32
+
+	httpURL     *url.URL
+	httpHeaders http.Header
+
+	tcpHost string
+	tcpPort int
+
+	execName string
+	execArgs []string
+}
+
+func (m *FakeProberManager) HTTPGet(u *url.URL, headers http.Header) prober.ProberFunc {
+	m.httpURL = u
+	m.httpHeaders = headers
+	atomic.AddInt32(&m.probeCount, 1)
+	return successProbe
+}
+
+func (m *FakeProberManager) TCPSocket(host string, port int) prober.ProberFunc {
+	m.tcpHost = host
+	m.tcpPort = port
+	atomic.AddInt32(&m.probeCount, 1)
+	return successProbe
+}
+
+func (m *FakeProberManager) Exec(name string, args ...string) prober.ProberFunc {
+	m.execName = name
+	m.execArgs = args
+	atomic.AddInt32(&m.probeCount, 1)
+	return successProbe
+}
+
+func (m *FakeProberManager) ProbeCount() int {
+	return int(atomic.LoadInt32(&m.probeCount))
+}
+
+func successProbe(_ context.Context) (prober.Result, string, error) {
+	return prober.Success, "", nil
+}

--- a/internal/engine/local/probe_test.go
+++ b/internal/engine/local/probe_test.go
@@ -1,0 +1,191 @@
+package local
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tilt-dev/probe/pkg/prober"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+type mockProbeManager struct {
+	httpURL     *url.URL
+	httpHeaders http.Header
+
+	tcpHost string
+	tcpPort int
+
+	execName string
+	execArgs []string
+}
+
+func (m *mockProbeManager) HTTPGet(u *url.URL, headers http.Header) prober.ProberFunc {
+	m.httpURL = u
+	m.httpHeaders = headers
+	return noopProbe
+}
+
+func (m *mockProbeManager) TCPSocket(host string, port int) prober.ProberFunc {
+	m.tcpHost = host
+	m.tcpPort = port
+	return noopProbe
+}
+
+func (m *mockProbeManager) Exec(name string, args ...string) prober.ProberFunc {
+	m.execName = name
+	m.execArgs = args
+	return noopProbe
+}
+
+func noopProbe(_ context.Context) (prober.Result, string, error) {
+	return prober.Unknown, "", nil
+}
+
+func TestProbeFromSpecUnsupported(t *testing.T) {
+	// empty probe spec
+	probeSpec := &v1.Probe{}
+	p, err := proberFromSpec(&mockProbeManager{}, probeSpec)
+	assert.Nil(t, p)
+	assert.ErrorIs(t, err, ErrUnsupportedProbeType)
+}
+
+func TestProbeFromSpecTCP(t *testing.T) {
+	type tc struct {
+		host        string
+		port        intstr.IntOrString
+		expectedErr string
+	}
+	cases := []tc{
+		{"localhost", intstr.FromInt(8080), ""},
+		{"localhost", intstr.IntOrString{}, "invalid port number: 0"},
+		{"localhost", intstr.FromString("http"), "invalid port number: http"},
+		{"localhost", intstr.FromInt(-1), "invalid port number: -1"},
+		{"localhost", intstr.FromInt(65536), "invalid port number: 65536"},
+	}
+	for i, tc := range cases {
+		t.Run(fmt.Sprintf("[%d] %s:%s", i, tc.host, tc.port.String()), func(t *testing.T) {
+			probeSpec := &v1.Probe{
+				Handler: v1.Handler{
+					TCPSocket: &v1.TCPSocketAction{
+						Host: tc.host,
+						Port: tc.port,
+					},
+				},
+			}
+			manager := &mockProbeManager{}
+			p, err := proberFromSpec(manager, probeSpec)
+			if tc.expectedErr != "" {
+				require.EqualError(t, err, tc.expectedErr)
+			} else {
+				assert.Nil(t, err)
+				assert.NotNil(t, p)
+				assert.Equal(t, tc.host, manager.tcpHost)
+				assert.Equal(t, tc.port.IntValue(), manager.tcpPort)
+			}
+		})
+	}
+}
+
+func TestProbeFromSpecHTTP(t *testing.T) {
+	type tc struct {
+		httpGet     *v1.HTTPGetAction
+		expectedErr string
+	}
+	cases := []tc{
+		{
+			&v1.HTTPGetAction{
+				Host: "localhost",
+				Port: intstr.FromInt(80),
+			},
+			"",
+		},
+		{
+			&v1.HTTPGetAction{
+				Host: "localhost",
+				Port: intstr.FromInt(-1),
+			},
+			"invalid port number: -1",
+		},
+		{
+			&v1.HTTPGetAction{
+				Host:   "localhost",
+				Port:   intstr.FromInt(8080),
+				Scheme: v1.URISchemeHTTPS,
+			},
+			"",
+		},
+		{
+			&v1.HTTPGetAction{
+				Host: "localhost",
+				Port: intstr.FromInt(8888),
+				HTTPHeaders: []v1.HTTPHeader{
+					{Name: "X-Fake-Header", Value: "value-1"},
+					{Name: "X-Fake-Header", Value: "value-2"},
+					{Name: "Content-Type", Value: "application/json"},
+				},
+			},
+			"",
+		},
+	}
+	for i, tc := range cases {
+		t.Run(fmt.Sprintf("[%d] %s", i, tc.httpGet.String()), func(t *testing.T) {
+			probeSpec := &v1.Probe{
+				Handler: v1.Handler{
+					HTTPGet: tc.httpGet,
+				},
+			}
+			manager := &mockProbeManager{}
+			p, err := proberFromSpec(manager, probeSpec)
+			if tc.expectedErr != "" {
+				require.EqualError(t, err, tc.expectedErr)
+			} else {
+				assert.Nil(t, err)
+				assert.NotNil(t, p)
+				u := manager.httpURL
+				assert.Equal(t, tc.httpGet.Host, u.Hostname())
+				assert.Equal(t, strconv.Itoa(tc.httpGet.Port.IntValue()), u.Port())
+				if tc.httpGet.Scheme != "" {
+					assert.Equal(t, strings.ToLower(string(tc.httpGet.Scheme)), u.Scheme)
+				} else {
+					assert.Equal(t, "http", u.Scheme)
+				}
+				assert.Equal(t, tc.httpGet.Path, u.Path)
+				for _, h := range tc.httpGet.HTTPHeaders {
+					assert.Contains(t, manager.httpHeaders[h.Name], h.Value)
+				}
+			}
+		})
+	}
+}
+
+func TestProbeFromSpecExec(t *testing.T) {
+	cases := [][]string{
+		{"echo"},
+		{"echo", "arg1", "arg2"},
+	}
+	for i, command := range cases {
+		t.Run(fmt.Sprintf("[%d] %s", i, command), func(t *testing.T) {
+			probeSpec := &v1.Probe{
+				Handler: v1.Handler{
+					Exec: &v1.ExecAction{
+						Command: command,
+					},
+				},
+			}
+			manager := &mockProbeManager{}
+			p, err := proberFromSpec(manager, probeSpec)
+			assert.Nil(t, err)
+			assert.NotNil(t, p)
+			assert.Equal(t, command[0], manager.execName)
+			assert.Equal(t, command[1:], manager.execArgs)
+		})
+	}
+}

--- a/internal/engine/local/probe_test.go
+++ b/internal/engine/local/probe_test.go
@@ -32,6 +32,7 @@ func TestProbeFromSpecTCP(t *testing.T) {
 		{"localhost", intstr.FromString("http"), "invalid port number: http"},
 		{"localhost", intstr.FromInt(-1), "invalid port number: -1"},
 		{"localhost", intstr.FromInt(65536), "invalid port number: 65536"},
+		{"", intstr.FromInt(22), ""},
 	}
 	for i, tc := range cases {
 		t.Run(fmt.Sprintf("[%d] %s:%s", i, tc.host, tc.port.String()), func(t *testing.T) {
@@ -50,7 +51,11 @@ func TestProbeFromSpecTCP(t *testing.T) {
 			} else {
 				assert.Nil(t, err)
 				assert.NotNil(t, p)
-				assert.Equal(t, tc.host, manager.tcpHost)
+				if tc.host != "" {
+					assert.Equal(t, tc.host, manager.tcpHost)
+				} else {
+					assert.Equal(t, "localhost", manager.tcpHost)
+				}
 				assert.Equal(t, tc.port.IntValue(), manager.tcpPort)
 			}
 		})
@@ -65,7 +70,7 @@ func TestProbeFromSpecHTTP(t *testing.T) {
 	cases := []tc{
 		{
 			&v1.HTTPGetAction{
-				Host: "localhost",
+				Host: "",
 				Port: intstr.FromInt(80),
 			},
 			"",
@@ -113,7 +118,11 @@ func TestProbeFromSpecHTTP(t *testing.T) {
 				assert.Nil(t, err)
 				assert.NotNil(t, p)
 				u := manager.httpURL
-				assert.Equal(t, tc.httpGet.Host, u.Hostname())
+				if tc.httpGet.Host != "" {
+					assert.Equal(t, tc.httpGet.Host, u.Hostname())
+				} else {
+					assert.Equal(t, "localhost", u.Hostname())
+				}
 				assert.Equal(t, strconv.Itoa(tc.httpGet.Port.IntValue()), u.Port())
 				if tc.httpGet.Scheme != "" {
 					assert.Equal(t, strings.ToLower(string(tc.httpGet.Scheme)), u.Scheme)

--- a/internal/engine/local/probe_test.go
+++ b/internal/engine/local/probe_test.go
@@ -28,10 +28,11 @@ func TestProbeFromSpecTCP(t *testing.T) {
 	}
 	cases := []tc{
 		{"localhost", intstr.FromInt(8080), ""},
-		{"localhost", intstr.IntOrString{}, "invalid port number: 0"},
-		{"localhost", intstr.FromString("http"), "invalid port number: http"},
-		{"localhost", intstr.FromInt(-1), "invalid port number: -1"},
-		{"localhost", intstr.FromInt(65536), "invalid port number: 65536"},
+		{"localhost", intstr.IntOrString{}, "port number out of range: 0"},
+		{"localhost", intstr.FromString("http"), `invalid port number: "http"`},
+		{"localhost", intstr.FromInt(-1), "port number out of range: -1"},
+		{"localhost", intstr.FromInt(65536), "port number out of range: 65536"},
+		{"localhost", intstr.FromString("1234"), ""},
 		{"", intstr.FromInt(22), ""},
 	}
 	for i, tc := range cases {
@@ -56,6 +57,7 @@ func TestProbeFromSpecTCP(t *testing.T) {
 				} else {
 					assert.Equal(t, "localhost", manager.tcpHost)
 				}
+				// IntValue does implicit conversion for strings that are valid ints
 				assert.Equal(t, tc.port.IntValue(), manager.tcpPort)
 			}
 		})
@@ -80,7 +82,7 @@ func TestProbeFromSpecHTTP(t *testing.T) {
 				Host: "localhost",
 				Port: intstr.FromInt(-1),
 			},
-			"invalid port number: -1",
+			"port number out of range: -1",
 		},
 		{
 			&v1.HTTPGetAction{

--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -171,6 +171,8 @@ func upperReducerFn(ctx context.Context, state *store.EngineState, action store.
 		handleSetTiltfileArgsAction(state, action)
 	case local.LocalServeStatusAction:
 		handleLocalServeStatusAction(ctx, state, action)
+	case local.LocalServeReadinessProbeAction:
+		handleLocalServeReadinessProbeAction(ctx, state, action)
 	case store.LogAction:
 		handleLogAction(state, action)
 	case exit.Action:
@@ -773,6 +775,17 @@ func handleLocalServeStatusAction(ctx context.Context, state *store.EngineState,
 	lrs.State = action.State
 	lrs.PID = action.PID
 	lrs.SpanID = action.SpanID
+	ms.RuntimeState = lrs
+}
+
+func handleLocalServeReadinessProbeAction(ctx context.Context, state *store.EngineState, action local.LocalServeReadinessProbeAction) {
+	ms, ok := state.ManifestState(action.ManifestName)
+	if !ok {
+		logger.Get(ctx).Infof("got readiness probe information for unknown local resource %s", action.ManifestName)
+	}
+
+	lrs := ms.LocalRuntimeState()
+	lrs.SetReadinessProbeState(action.Ready)
 	ms.RuntimeState = lrs
 }
 

--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -463,8 +463,9 @@ func handleBuildCompleted(ctx context.Context, engineState *store.EngineState, c
 
 	if mt.Manifest.IsLocal() {
 		lrs := ms.LocalRuntimeState()
-		if err == nil {
-			lrs.HasSucceededAtLeastOnce = true
+		if err == nil && mt.Manifest.LocalTarget().ReadinessProbe == nil {
+			// only update the succeeded time if there's no readiness probe
+			lrs.LastReadyOrSucceededTime = time.Now()
 		}
 		ms.RuntimeState = lrs
 	}

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -3707,6 +3707,7 @@ type testFixture struct {
 	opter                      *tiltanalytics.FakeOpter
 	dp                         *dockerprune.DockerPruner
 	fe                         *local.FakeExecer
+	fpm                        *local.FakeProberManager
 	overrideMaxParallelUpdates int
 
 	onchangeCh chan bool
@@ -3765,7 +3766,8 @@ func newTestFixture(t *testing.T) *testFixture {
 	ewm := k8swatch.NewEventWatchManager(kCli, of, ns)
 	tcum := cloud.NewStatusManager(httptest.NewFakeClientEmptyJSON(), clock)
 	fe := local.NewFakeExecer()
-	lc := local.NewController(fe)
+	fpm := local.NewFakeProberManager()
+	lc := local.NewController(fe, fpm)
 	ts := hud.NewTerminalStream(hud.NewIncrementalPrinter(log), st)
 	tp := prompt.NewTerminalPrompt(ta, prompt.TTYOpen, prompt.BrowserOpen,
 		log, "localhost", model.WebURL{})
@@ -3799,6 +3801,7 @@ func newTestFixture(t *testing.T) *testFixture {
 		opter:          to,
 		dp:             dp,
 		fe:             fe,
+		fpm:            fpm,
 	}
 
 	ret.disableEnvAnalyticsOpt()

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -4089,6 +4089,7 @@ func (f *testFixture) nextCallComplete(msgAndArgs ...interface{}) buildAndDeploy
 // the completed build.
 // using `nextCallComplete` will ensure you block until the EngineState reflects the completed build.
 func (f *testFixture) nextCall(msgAndArgs ...interface{}) buildAndDeployCall {
+	f.t.Helper()
 	msg := "timed out waiting for BuildAndDeployCall"
 	if len(msgAndArgs) > 0 {
 		format := msgAndArgs[0].(string)

--- a/pkg/model/local_target.go
+++ b/pkg/model/local_target.go
@@ -3,6 +3,8 @@ package model
 import (
 	"fmt"
 
+	v1 "k8s.io/api/core/v1"
+
 	"github.com/tilt-dev/tilt/internal/sliceutils"
 )
 
@@ -23,6 +25,8 @@ type LocalTarget struct {
 	// For testing MVP
 	Tags   []string // eventually we might want tags to be more widespread -- stored on manifest maybe?
 	IsTest bool     // does this target represent a Test?
+
+	ReadinessProbe *v1.Probe
 }
 
 var _ TargetSpec = LocalTarget{}

--- a/vendor/github.com/jonboulle/clockwork/.editorconfig
+++ b/vendor/github.com/jonboulle/clockwork/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.go]
+indent_style = tab

--- a/vendor/github.com/jonboulle/clockwork/.gitignore
+++ b/vendor/github.com/jonboulle/clockwork/.gitignore
@@ -1,3 +1,5 @@
+/.idea/
+
 # Compiled Object files, Static and Dynamic libs (Shared Objects)
 *.o
 *.a

--- a/vendor/github.com/jonboulle/clockwork/.travis.yml
+++ b/vendor/github.com/jonboulle/clockwork/.travis.yml
@@ -1,5 +1,0 @@
-language: go
-go:
-  - 1.3
-
-sudo: false

--- a/vendor/github.com/jonboulle/clockwork/README.md
+++ b/vendor/github.com/jonboulle/clockwork/README.md
@@ -1,61 +1,80 @@
-clockwork
-=========
+# clockwork
 
-[![Build Status](https://travis-ci.org/jonboulle/clockwork.png?branch=master)](https://travis-ci.org/jonboulle/clockwork)
-[![godoc](https://godoc.org/github.com/jonboulle/clockwork?status.svg)](http://godoc.org/github.com/jonboulle/clockwork) 
+[![Mentioned in Awesome Go](https://awesome.re/mentioned-badge-flat.svg)](https://github.com/avelino/awesome-go#utilities)
 
-a simple fake clock for golang
+[![GitHub Workflow Status](https://img.shields.io/github/workflow/status/jonboulle/clockwork/CI?style=flat-square)](https://github.com/jonboulle/clockwork/actions?query=workflow%3ACI)
+[![Go Report Card](https://goreportcard.com/badge/github.com/jonboulle/clockwork?style=flat-square)](https://goreportcard.com/report/github.com/jonboulle/clockwork)
+![Go Version](https://img.shields.io/badge/go%20version-%3E=1.11-61CFDD.svg?style=flat-square)
+[![go.dev reference](https://img.shields.io/badge/go.dev-reference-007d9c?logo=go&logoColor=white&style=flat-square)](https://pkg.go.dev/mod/github.com/jonboulle/clockwork)
 
-# Usage
+**A simple fake clock for Go.**
+
+
+## Usage
 
 Replace uses of the `time` package with the `clockwork.Clock` interface instead.
 
 For example, instead of using `time.Sleep` directly:
 
-```
-func my_func() {
+```go
+func myFunc() {
 	time.Sleep(3 * time.Second)
-	do_something()
+	doSomething()
 }
 ```
 
-inject a clock and use its `Sleep` method instead:
+Inject a clock and use its `Sleep` method instead:
 
-```
-func my_func(clock clockwork.Clock) {
+```go
+func myFunc(clock clockwork.Clock) {
 	clock.Sleep(3 * time.Second)
-	do_something()
+	doSomething()
 }
 ```
 
-Now you can easily test `my_func` with a `FakeClock`:
+Now you can easily test `myFunc` with a `FakeClock`:
 
-```
+```go
 func TestMyFunc(t *testing.T) {
 	c := clockwork.NewFakeClock()
 
 	// Start our sleepy function
-	my_func(c)
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		myFunc(c)
+		wg.Done()
+	}()
 
-	// Ensure we wait until my_func is sleeping
+	// Ensure we wait until myFunc is sleeping
 	c.BlockUntil(1)
 
-	assert_state()
+	assertState()
 
 	// Advance the FakeClock forward in time
-	c.Advance(3)
+	c.Advance(3 * time.Second)
 
-	assert_state()
+	// Wait until the function completes
+	wg.Wait()
+
+	assertState()
 }
 ```
 
 and in production builds, simply inject the real clock instead:
-```
-my_func(clockwork.NewRealClock())
+
+```go
+myFunc(clockwork.NewRealClock())
 ```
 
 See [example_test.go](example_test.go) for a full example.
 
+
 # Credits
 
-clockwork is inspired by @wickman's [threaded fake clock](https://gist.github.com/wickman/3840816), and the [Golang playground](http://blog.golang.org/playground#Faking time)
+clockwork is inspired by @wickman's [threaded fake clock](https://gist.github.com/wickman/3840816), and the [Golang playground](https://blog.golang.org/playground#TOC_3.1.)
+
+
+## License
+
+Apache License, Version 2.0. Please see [License File](LICENSE) for more information.

--- a/vendor/github.com/jonboulle/clockwork/clockwork.go
+++ b/vendor/github.com/jonboulle/clockwork/clockwork.go
@@ -11,6 +11,8 @@ type Clock interface {
 	After(d time.Duration) <-chan time.Time
 	Sleep(d time.Duration)
 	Now() time.Time
+	Since(t time.Time) time.Duration
+	NewTicker(d time.Duration) Ticker
 }
 
 // FakeClock provides an interface for a clock which can be
@@ -60,6 +62,14 @@ func (rc *realClock) Now() time.Time {
 	return time.Now()
 }
 
+func (rc *realClock) Since(t time.Time) time.Duration {
+	return rc.Now().Sub(t)
+}
+
+func (rc *realClock) NewTicker(d time.Duration) Ticker {
+	return &realTicker{time.NewTicker(d)}
+}
+
 type fakeClock struct {
 	sleepers []*sleeper
 	blockers []*blocker
@@ -87,7 +97,7 @@ func (fc *fakeClock) After(d time.Duration) <-chan time.Time {
 	defer fc.l.Unlock()
 	now := fc.time
 	done := make(chan time.Time, 1)
-	if d.Nanoseconds() == 0 {
+	if d.Nanoseconds() <= 0 {
 		// special case - trigger immediately
 		done <- now
 	} else {
@@ -128,6 +138,22 @@ func (fc *fakeClock) Now() time.Time {
 	t := fc.time
 	fc.l.RUnlock()
 	return t
+}
+
+// Since returns the duration that has passed since the given time on the fakeClock
+func (fc *fakeClock) Since(t time.Time) time.Duration {
+	return fc.Now().Sub(t)
+}
+
+func (fc *fakeClock) NewTicker(d time.Duration) Ticker {
+	ft := &fakeTicker{
+		c:      make(chan time.Time, 1),
+		stop:   make(chan bool, 1),
+		clock:  fc,
+		period: d,
+	}
+	ft.runTickThread()
+	return ft
 }
 
 // Advance advances fakeClock to a new point in time, ensuring channels from any

--- a/vendor/github.com/jonboulle/clockwork/go.mod
+++ b/vendor/github.com/jonboulle/clockwork/go.mod
@@ -1,0 +1,3 @@
+module github.com/jonboulle/clockwork
+
+go 1.13

--- a/vendor/github.com/jonboulle/clockwork/ticker.go
+++ b/vendor/github.com/jonboulle/clockwork/ticker.go
@@ -1,0 +1,72 @@
+package clockwork
+
+import (
+	"time"
+)
+
+// Ticker provides an interface which can be used instead of directly
+// using the ticker within the time module. The real-time ticker t
+// provides ticks through t.C which becomes now t.Chan() to make
+// this channel requirement definable in this interface.
+type Ticker interface {
+	Chan() <-chan time.Time
+	Stop()
+}
+
+type realTicker struct{ *time.Ticker }
+
+func (rt *realTicker) Chan() <-chan time.Time {
+	return rt.C
+}
+
+type fakeTicker struct {
+	c      chan time.Time
+	stop   chan bool
+	clock  FakeClock
+	period time.Duration
+}
+
+func (ft *fakeTicker) Chan() <-chan time.Time {
+	return ft.c
+}
+
+func (ft *fakeTicker) Stop() {
+	ft.stop <- true
+}
+
+// runTickThread initializes a background goroutine to send the tick time to the ticker channel
+// after every period. Tick events are discarded if the underlying ticker channel does not have
+// enough capacity.
+func (ft *fakeTicker) runTickThread() {
+	nextTick := ft.clock.Now().Add(ft.period)
+	next := ft.clock.After(ft.period)
+	go func() {
+		for {
+			select {
+			case <-ft.stop:
+				return
+			case <-next:
+				// We send the time that the tick was supposed to occur at.
+				tick := nextTick
+				// Before sending the tick, we'll compute the next tick time and star the clock.After call.
+				now := ft.clock.Now()
+				// First, figure out how many periods there have been between "now" and the time we were
+				// supposed to have trigged, then advance over all of those.
+				skipTicks := (now.Sub(tick) + ft.period - 1) / ft.period
+				nextTick = nextTick.Add(skipTicks * ft.period)
+				// Now, keep advancing until we are past now. This should happen at most once.
+				for !nextTick.After(now) {
+					nextTick = nextTick.Add(ft.period)
+				}
+				// Figure out how long between now and the next scheduled tick, then wait that long.
+				remaining := nextTick.Sub(now)
+				next = ft.clock.After(remaining)
+				// Finally, we can actually send the tick.
+				select {
+				case ft.c <- tick:
+				default:
+				}
+			}
+		}
+	}()
+}

--- a/vendor/github.com/stretchr/testify/assert/assertion_compare.go
+++ b/vendor/github.com/stretchr/testify/assert/assertion_compare.go
@@ -13,12 +13,42 @@ const (
 	compareGreater
 )
 
+var (
+	intType   = reflect.TypeOf(int(1))
+	int8Type  = reflect.TypeOf(int8(1))
+	int16Type = reflect.TypeOf(int16(1))
+	int32Type = reflect.TypeOf(int32(1))
+	int64Type = reflect.TypeOf(int64(1))
+
+	uintType   = reflect.TypeOf(uint(1))
+	uint8Type  = reflect.TypeOf(uint8(1))
+	uint16Type = reflect.TypeOf(uint16(1))
+	uint32Type = reflect.TypeOf(uint32(1))
+	uint64Type = reflect.TypeOf(uint64(1))
+
+	float32Type = reflect.TypeOf(float32(1))
+	float64Type = reflect.TypeOf(float64(1))
+
+	stringType = reflect.TypeOf("")
+)
+
 func compare(obj1, obj2 interface{}, kind reflect.Kind) (CompareType, bool) {
+	obj1Value := reflect.ValueOf(obj1)
+	obj2Value := reflect.ValueOf(obj2)
+
+	// throughout this switch we try and avoid calling .Convert() if possible,
+	// as this has a pretty big performance impact
 	switch kind {
 	case reflect.Int:
 		{
-			intobj1 := obj1.(int)
-			intobj2 := obj2.(int)
+			intobj1, ok := obj1.(int)
+			if !ok {
+				intobj1 = obj1Value.Convert(intType).Interface().(int)
+			}
+			intobj2, ok := obj2.(int)
+			if !ok {
+				intobj2 = obj2Value.Convert(intType).Interface().(int)
+			}
 			if intobj1 > intobj2 {
 				return compareGreater, true
 			}
@@ -31,8 +61,14 @@ func compare(obj1, obj2 interface{}, kind reflect.Kind) (CompareType, bool) {
 		}
 	case reflect.Int8:
 		{
-			int8obj1 := obj1.(int8)
-			int8obj2 := obj2.(int8)
+			int8obj1, ok := obj1.(int8)
+			if !ok {
+				int8obj1 = obj1Value.Convert(int8Type).Interface().(int8)
+			}
+			int8obj2, ok := obj2.(int8)
+			if !ok {
+				int8obj2 = obj2Value.Convert(int8Type).Interface().(int8)
+			}
 			if int8obj1 > int8obj2 {
 				return compareGreater, true
 			}
@@ -45,8 +81,14 @@ func compare(obj1, obj2 interface{}, kind reflect.Kind) (CompareType, bool) {
 		}
 	case reflect.Int16:
 		{
-			int16obj1 := obj1.(int16)
-			int16obj2 := obj2.(int16)
+			int16obj1, ok := obj1.(int16)
+			if !ok {
+				int16obj1 = obj1Value.Convert(int16Type).Interface().(int16)
+			}
+			int16obj2, ok := obj2.(int16)
+			if !ok {
+				int16obj2 = obj2Value.Convert(int16Type).Interface().(int16)
+			}
 			if int16obj1 > int16obj2 {
 				return compareGreater, true
 			}
@@ -59,8 +101,14 @@ func compare(obj1, obj2 interface{}, kind reflect.Kind) (CompareType, bool) {
 		}
 	case reflect.Int32:
 		{
-			int32obj1 := obj1.(int32)
-			int32obj2 := obj2.(int32)
+			int32obj1, ok := obj1.(int32)
+			if !ok {
+				int32obj1 = obj1Value.Convert(int32Type).Interface().(int32)
+			}
+			int32obj2, ok := obj2.(int32)
+			if !ok {
+				int32obj2 = obj2Value.Convert(int32Type).Interface().(int32)
+			}
 			if int32obj1 > int32obj2 {
 				return compareGreater, true
 			}
@@ -73,8 +121,14 @@ func compare(obj1, obj2 interface{}, kind reflect.Kind) (CompareType, bool) {
 		}
 	case reflect.Int64:
 		{
-			int64obj1 := obj1.(int64)
-			int64obj2 := obj2.(int64)
+			int64obj1, ok := obj1.(int64)
+			if !ok {
+				int64obj1 = obj1Value.Convert(int64Type).Interface().(int64)
+			}
+			int64obj2, ok := obj2.(int64)
+			if !ok {
+				int64obj2 = obj2Value.Convert(int64Type).Interface().(int64)
+			}
 			if int64obj1 > int64obj2 {
 				return compareGreater, true
 			}
@@ -87,8 +141,14 @@ func compare(obj1, obj2 interface{}, kind reflect.Kind) (CompareType, bool) {
 		}
 	case reflect.Uint:
 		{
-			uintobj1 := obj1.(uint)
-			uintobj2 := obj2.(uint)
+			uintobj1, ok := obj1.(uint)
+			if !ok {
+				uintobj1 = obj1Value.Convert(uintType).Interface().(uint)
+			}
+			uintobj2, ok := obj2.(uint)
+			if !ok {
+				uintobj2 = obj2Value.Convert(uintType).Interface().(uint)
+			}
 			if uintobj1 > uintobj2 {
 				return compareGreater, true
 			}
@@ -101,8 +161,14 @@ func compare(obj1, obj2 interface{}, kind reflect.Kind) (CompareType, bool) {
 		}
 	case reflect.Uint8:
 		{
-			uint8obj1 := obj1.(uint8)
-			uint8obj2 := obj2.(uint8)
+			uint8obj1, ok := obj1.(uint8)
+			if !ok {
+				uint8obj1 = obj1Value.Convert(uint8Type).Interface().(uint8)
+			}
+			uint8obj2, ok := obj2.(uint8)
+			if !ok {
+				uint8obj2 = obj2Value.Convert(uint8Type).Interface().(uint8)
+			}
 			if uint8obj1 > uint8obj2 {
 				return compareGreater, true
 			}
@@ -115,8 +181,14 @@ func compare(obj1, obj2 interface{}, kind reflect.Kind) (CompareType, bool) {
 		}
 	case reflect.Uint16:
 		{
-			uint16obj1 := obj1.(uint16)
-			uint16obj2 := obj2.(uint16)
+			uint16obj1, ok := obj1.(uint16)
+			if !ok {
+				uint16obj1 = obj1Value.Convert(uint16Type).Interface().(uint16)
+			}
+			uint16obj2, ok := obj2.(uint16)
+			if !ok {
+				uint16obj2 = obj2Value.Convert(uint16Type).Interface().(uint16)
+			}
 			if uint16obj1 > uint16obj2 {
 				return compareGreater, true
 			}
@@ -129,8 +201,14 @@ func compare(obj1, obj2 interface{}, kind reflect.Kind) (CompareType, bool) {
 		}
 	case reflect.Uint32:
 		{
-			uint32obj1 := obj1.(uint32)
-			uint32obj2 := obj2.(uint32)
+			uint32obj1, ok := obj1.(uint32)
+			if !ok {
+				uint32obj1 = obj1Value.Convert(uint32Type).Interface().(uint32)
+			}
+			uint32obj2, ok := obj2.(uint32)
+			if !ok {
+				uint32obj2 = obj2Value.Convert(uint32Type).Interface().(uint32)
+			}
 			if uint32obj1 > uint32obj2 {
 				return compareGreater, true
 			}
@@ -143,8 +221,14 @@ func compare(obj1, obj2 interface{}, kind reflect.Kind) (CompareType, bool) {
 		}
 	case reflect.Uint64:
 		{
-			uint64obj1 := obj1.(uint64)
-			uint64obj2 := obj2.(uint64)
+			uint64obj1, ok := obj1.(uint64)
+			if !ok {
+				uint64obj1 = obj1Value.Convert(uint64Type).Interface().(uint64)
+			}
+			uint64obj2, ok := obj2.(uint64)
+			if !ok {
+				uint64obj2 = obj2Value.Convert(uint64Type).Interface().(uint64)
+			}
 			if uint64obj1 > uint64obj2 {
 				return compareGreater, true
 			}
@@ -157,8 +241,14 @@ func compare(obj1, obj2 interface{}, kind reflect.Kind) (CompareType, bool) {
 		}
 	case reflect.Float32:
 		{
-			float32obj1 := obj1.(float32)
-			float32obj2 := obj2.(float32)
+			float32obj1, ok := obj1.(float32)
+			if !ok {
+				float32obj1 = obj1Value.Convert(float32Type).Interface().(float32)
+			}
+			float32obj2, ok := obj2.(float32)
+			if !ok {
+				float32obj2 = obj2Value.Convert(float32Type).Interface().(float32)
+			}
 			if float32obj1 > float32obj2 {
 				return compareGreater, true
 			}
@@ -171,8 +261,14 @@ func compare(obj1, obj2 interface{}, kind reflect.Kind) (CompareType, bool) {
 		}
 	case reflect.Float64:
 		{
-			float64obj1 := obj1.(float64)
-			float64obj2 := obj2.(float64)
+			float64obj1, ok := obj1.(float64)
+			if !ok {
+				float64obj1 = obj1Value.Convert(float64Type).Interface().(float64)
+			}
+			float64obj2, ok := obj2.(float64)
+			if !ok {
+				float64obj2 = obj2Value.Convert(float64Type).Interface().(float64)
+			}
 			if float64obj1 > float64obj2 {
 				return compareGreater, true
 			}
@@ -185,8 +281,14 @@ func compare(obj1, obj2 interface{}, kind reflect.Kind) (CompareType, bool) {
 		}
 	case reflect.String:
 		{
-			stringobj1 := obj1.(string)
-			stringobj2 := obj2.(string)
+			stringobj1, ok := obj1.(string)
+			if !ok {
+				stringobj1 = obj1Value.Convert(stringType).Interface().(string)
+			}
+			stringobj2, ok := obj2.(string)
+			if !ok {
+				stringobj2 = obj2Value.Convert(stringType).Interface().(string)
+			}
 			if stringobj1 > stringobj2 {
 				return compareGreater, true
 			}
@@ -238,6 +340,24 @@ func Less(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{})
 //    assert.LessOrEqual(t, "b", "b")
 func LessOrEqual(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) bool {
 	return compareTwoValues(t, e1, e2, []CompareType{compareLess, compareEqual}, "\"%v\" is not less than or equal to \"%v\"", msgAndArgs)
+}
+
+// Positive asserts that the specified element is positive
+//
+//    assert.Positive(t, 1)
+//    assert.Positive(t, 1.23)
+func Positive(t TestingT, e interface{}, msgAndArgs ...interface{}) bool {
+	zero := reflect.Zero(reflect.TypeOf(e))
+	return compareTwoValues(t, e, zero.Interface(), []CompareType{compareGreater}, "\"%v\" is not positive", msgAndArgs)
+}
+
+// Negative asserts that the specified element is negative
+//
+//    assert.Negative(t, -1)
+//    assert.Negative(t, -1.23)
+func Negative(t TestingT, e interface{}, msgAndArgs ...interface{}) bool {
+	zero := reflect.Zero(reflect.TypeOf(e))
+	return compareTwoValues(t, e, zero.Interface(), []CompareType{compareLess}, "\"%v\" is not negative", msgAndArgs)
 }
 
 func compareTwoValues(t TestingT, e1 interface{}, e2 interface{}, allowedComparesResults []CompareType, failMessage string, msgAndArgs ...interface{}) bool {

--- a/vendor/github.com/stretchr/testify/assert/assertion_format.go
+++ b/vendor/github.com/stretchr/testify/assert/assertion_format.go
@@ -114,6 +114,24 @@ func Errorf(t TestingT, err error, msg string, args ...interface{}) bool {
 	return Error(t, err, append([]interface{}{msg}, args...)...)
 }
 
+// ErrorAsf asserts that at least one of the errors in err's chain matches target, and if so, sets target to that error value.
+// This is a wrapper for errors.As.
+func ErrorAsf(t TestingT, err error, target interface{}, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return ErrorAs(t, err, target, append([]interface{}{msg}, args...)...)
+}
+
+// ErrorIsf asserts that at least one of the errors in err's chain matches target.
+// This is a wrapper for errors.Is.
+func ErrorIsf(t TestingT, err error, target error, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return ErrorIs(t, err, target, append([]interface{}{msg}, args...)...)
+}
+
 // Eventuallyf asserts that given condition will be met in waitFor time,
 // periodically checking target function each tick.
 //
@@ -321,6 +339,54 @@ func InEpsilonSlicef(t TestingT, expected interface{}, actual interface{}, epsil
 	return InEpsilonSlice(t, expected, actual, epsilon, append([]interface{}{msg}, args...)...)
 }
 
+// IsDecreasingf asserts that the collection is decreasing
+//
+//    assert.IsDecreasingf(t, []int{2, 1, 0}, "error message %s", "formatted")
+//    assert.IsDecreasingf(t, []float{2, 1}, "error message %s", "formatted")
+//    assert.IsDecreasingf(t, []string{"b", "a"}, "error message %s", "formatted")
+func IsDecreasingf(t TestingT, object interface{}, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return IsDecreasing(t, object, append([]interface{}{msg}, args...)...)
+}
+
+// IsIncreasingf asserts that the collection is increasing
+//
+//    assert.IsIncreasingf(t, []int{1, 2, 3}, "error message %s", "formatted")
+//    assert.IsIncreasingf(t, []float{1, 2}, "error message %s", "formatted")
+//    assert.IsIncreasingf(t, []string{"a", "b"}, "error message %s", "formatted")
+func IsIncreasingf(t TestingT, object interface{}, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return IsIncreasing(t, object, append([]interface{}{msg}, args...)...)
+}
+
+// IsNonDecreasingf asserts that the collection is not decreasing
+//
+//    assert.IsNonDecreasingf(t, []int{1, 1, 2}, "error message %s", "formatted")
+//    assert.IsNonDecreasingf(t, []float{1, 2}, "error message %s", "formatted")
+//    assert.IsNonDecreasingf(t, []string{"a", "b"}, "error message %s", "formatted")
+func IsNonDecreasingf(t TestingT, object interface{}, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return IsNonDecreasing(t, object, append([]interface{}{msg}, args...)...)
+}
+
+// IsNonIncreasingf asserts that the collection is not increasing
+//
+//    assert.IsNonIncreasingf(t, []int{2, 1, 1}, "error message %s", "formatted")
+//    assert.IsNonIncreasingf(t, []float{2, 1}, "error message %s", "formatted")
+//    assert.IsNonIncreasingf(t, []string{"b", "a"}, "error message %s", "formatted")
+func IsNonIncreasingf(t TestingT, object interface{}, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return IsNonIncreasing(t, object, append([]interface{}{msg}, args...)...)
+}
+
 // IsTypef asserts that the specified objects are of the same type.
 func IsTypef(t TestingT, expectedType interface{}, object interface{}, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
@@ -373,6 +439,17 @@ func LessOrEqualf(t TestingT, e1 interface{}, e2 interface{}, msg string, args .
 		h.Helper()
 	}
 	return LessOrEqual(t, e1, e2, append([]interface{}{msg}, args...)...)
+}
+
+// Negativef asserts that the specified element is negative
+//
+//    assert.Negativef(t, -1, "error message %s", "formatted")
+//    assert.Negativef(t, -1.23, "error message %s", "formatted")
+func Negativef(t TestingT, e interface{}, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return Negative(t, e, append([]interface{}{msg}, args...)...)
 }
 
 // Neverf asserts that the given condition doesn't satisfy in waitFor time,
@@ -476,6 +553,15 @@ func NotEqualValuesf(t TestingT, expected interface{}, actual interface{}, msg s
 	return NotEqualValues(t, expected, actual, append([]interface{}{msg}, args...)...)
 }
 
+// NotErrorIsf asserts that at none of the errors in err's chain matches target.
+// This is a wrapper for errors.Is.
+func NotErrorIsf(t TestingT, err error, target error, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return NotErrorIs(t, err, target, append([]interface{}{msg}, args...)...)
+}
+
 // NotNilf asserts that the specified object is not nil.
 //
 //    assert.NotNilf(t, err, "error message %s", "formatted")
@@ -570,6 +656,17 @@ func PanicsWithValuef(t TestingT, expected interface{}, f PanicTestFunc, msg str
 		h.Helper()
 	}
 	return PanicsWithValue(t, expected, f, append([]interface{}{msg}, args...)...)
+}
+
+// Positivef asserts that the specified element is positive
+//
+//    assert.Positivef(t, 1, "error message %s", "formatted")
+//    assert.Positivef(t, 1.23, "error message %s", "formatted")
+func Positivef(t TestingT, e interface{}, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return Positive(t, e, append([]interface{}{msg}, args...)...)
 }
 
 // Regexpf asserts that a specified regexp matches a string.

--- a/vendor/github.com/stretchr/testify/assert/assertion_forward.go
+++ b/vendor/github.com/stretchr/testify/assert/assertion_forward.go
@@ -204,6 +204,42 @@ func (a *Assertions) Error(err error, msgAndArgs ...interface{}) bool {
 	return Error(a.t, err, msgAndArgs...)
 }
 
+// ErrorAs asserts that at least one of the errors in err's chain matches target, and if so, sets target to that error value.
+// This is a wrapper for errors.As.
+func (a *Assertions) ErrorAs(err error, target interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return ErrorAs(a.t, err, target, msgAndArgs...)
+}
+
+// ErrorAsf asserts that at least one of the errors in err's chain matches target, and if so, sets target to that error value.
+// This is a wrapper for errors.As.
+func (a *Assertions) ErrorAsf(err error, target interface{}, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return ErrorAsf(a.t, err, target, msg, args...)
+}
+
+// ErrorIs asserts that at least one of the errors in err's chain matches target.
+// This is a wrapper for errors.Is.
+func (a *Assertions) ErrorIs(err error, target error, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return ErrorIs(a.t, err, target, msgAndArgs...)
+}
+
+// ErrorIsf asserts that at least one of the errors in err's chain matches target.
+// This is a wrapper for errors.Is.
+func (a *Assertions) ErrorIsf(err error, target error, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return ErrorIsf(a.t, err, target, msg, args...)
+}
+
 // Errorf asserts that a function returned an error (i.e. not `nil`).
 //
 //   actualObj, err := SomeFunction()
@@ -631,6 +667,102 @@ func (a *Assertions) InEpsilonf(expected interface{}, actual interface{}, epsilo
 	return InEpsilonf(a.t, expected, actual, epsilon, msg, args...)
 }
 
+// IsDecreasing asserts that the collection is decreasing
+//
+//    a.IsDecreasing([]int{2, 1, 0})
+//    a.IsDecreasing([]float{2, 1})
+//    a.IsDecreasing([]string{"b", "a"})
+func (a *Assertions) IsDecreasing(object interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return IsDecreasing(a.t, object, msgAndArgs...)
+}
+
+// IsDecreasingf asserts that the collection is decreasing
+//
+//    a.IsDecreasingf([]int{2, 1, 0}, "error message %s", "formatted")
+//    a.IsDecreasingf([]float{2, 1}, "error message %s", "formatted")
+//    a.IsDecreasingf([]string{"b", "a"}, "error message %s", "formatted")
+func (a *Assertions) IsDecreasingf(object interface{}, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return IsDecreasingf(a.t, object, msg, args...)
+}
+
+// IsIncreasing asserts that the collection is increasing
+//
+//    a.IsIncreasing([]int{1, 2, 3})
+//    a.IsIncreasing([]float{1, 2})
+//    a.IsIncreasing([]string{"a", "b"})
+func (a *Assertions) IsIncreasing(object interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return IsIncreasing(a.t, object, msgAndArgs...)
+}
+
+// IsIncreasingf asserts that the collection is increasing
+//
+//    a.IsIncreasingf([]int{1, 2, 3}, "error message %s", "formatted")
+//    a.IsIncreasingf([]float{1, 2}, "error message %s", "formatted")
+//    a.IsIncreasingf([]string{"a", "b"}, "error message %s", "formatted")
+func (a *Assertions) IsIncreasingf(object interface{}, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return IsIncreasingf(a.t, object, msg, args...)
+}
+
+// IsNonDecreasing asserts that the collection is not decreasing
+//
+//    a.IsNonDecreasing([]int{1, 1, 2})
+//    a.IsNonDecreasing([]float{1, 2})
+//    a.IsNonDecreasing([]string{"a", "b"})
+func (a *Assertions) IsNonDecreasing(object interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return IsNonDecreasing(a.t, object, msgAndArgs...)
+}
+
+// IsNonDecreasingf asserts that the collection is not decreasing
+//
+//    a.IsNonDecreasingf([]int{1, 1, 2}, "error message %s", "formatted")
+//    a.IsNonDecreasingf([]float{1, 2}, "error message %s", "formatted")
+//    a.IsNonDecreasingf([]string{"a", "b"}, "error message %s", "formatted")
+func (a *Assertions) IsNonDecreasingf(object interface{}, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return IsNonDecreasingf(a.t, object, msg, args...)
+}
+
+// IsNonIncreasing asserts that the collection is not increasing
+//
+//    a.IsNonIncreasing([]int{2, 1, 1})
+//    a.IsNonIncreasing([]float{2, 1})
+//    a.IsNonIncreasing([]string{"b", "a"})
+func (a *Assertions) IsNonIncreasing(object interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return IsNonIncreasing(a.t, object, msgAndArgs...)
+}
+
+// IsNonIncreasingf asserts that the collection is not increasing
+//
+//    a.IsNonIncreasingf([]int{2, 1, 1}, "error message %s", "formatted")
+//    a.IsNonIncreasingf([]float{2, 1}, "error message %s", "formatted")
+//    a.IsNonIncreasingf([]string{"b", "a"}, "error message %s", "formatted")
+func (a *Assertions) IsNonIncreasingf(object interface{}, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return IsNonIncreasingf(a.t, object, msg, args...)
+}
+
 // IsType asserts that the specified objects are of the same type.
 func (a *Assertions) IsType(expectedType interface{}, object interface{}, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
@@ -737,6 +869,28 @@ func (a *Assertions) Lessf(e1 interface{}, e2 interface{}, msg string, args ...i
 		h.Helper()
 	}
 	return Lessf(a.t, e1, e2, msg, args...)
+}
+
+// Negative asserts that the specified element is negative
+//
+//    a.Negative(-1)
+//    a.Negative(-1.23)
+func (a *Assertions) Negative(e interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return Negative(a.t, e, msgAndArgs...)
+}
+
+// Negativef asserts that the specified element is negative
+//
+//    a.Negativef(-1, "error message %s", "formatted")
+//    a.Negativef(-1.23, "error message %s", "formatted")
+func (a *Assertions) Negativef(e interface{}, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return Negativef(a.t, e, msg, args...)
 }
 
 // Never asserts that the given condition doesn't satisfy in waitFor time,
@@ -941,6 +1095,24 @@ func (a *Assertions) NotEqualf(expected interface{}, actual interface{}, msg str
 	return NotEqualf(a.t, expected, actual, msg, args...)
 }
 
+// NotErrorIs asserts that at none of the errors in err's chain matches target.
+// This is a wrapper for errors.Is.
+func (a *Assertions) NotErrorIs(err error, target error, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return NotErrorIs(a.t, err, target, msgAndArgs...)
+}
+
+// NotErrorIsf asserts that at none of the errors in err's chain matches target.
+// This is a wrapper for errors.Is.
+func (a *Assertions) NotErrorIsf(err error, target error, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return NotErrorIsf(a.t, err, target, msg, args...)
+}
+
 // NotNil asserts that the specified object is not nil.
 //
 //    a.NotNil(err)
@@ -1131,6 +1303,28 @@ func (a *Assertions) Panicsf(f PanicTestFunc, msg string, args ...interface{}) b
 		h.Helper()
 	}
 	return Panicsf(a.t, f, msg, args...)
+}
+
+// Positive asserts that the specified element is positive
+//
+//    a.Positive(1)
+//    a.Positive(1.23)
+func (a *Assertions) Positive(e interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return Positive(a.t, e, msgAndArgs...)
+}
+
+// Positivef asserts that the specified element is positive
+//
+//    a.Positivef(1, "error message %s", "formatted")
+//    a.Positivef(1.23, "error message %s", "formatted")
+func (a *Assertions) Positivef(e interface{}, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return Positivef(a.t, e, msg, args...)
 }
 
 // Regexp asserts that a specified regexp matches a string.

--- a/vendor/github.com/stretchr/testify/assert/assertion_order.go
+++ b/vendor/github.com/stretchr/testify/assert/assertion_order.go
@@ -1,0 +1,81 @@
+package assert
+
+import (
+	"fmt"
+	"reflect"
+)
+
+// isOrdered checks that collection contains orderable elements.
+func isOrdered(t TestingT, object interface{}, allowedComparesResults []CompareType, failMessage string, msgAndArgs ...interface{}) bool {
+	objKind := reflect.TypeOf(object).Kind()
+	if objKind != reflect.Slice && objKind != reflect.Array {
+		return false
+	}
+
+	objValue := reflect.ValueOf(object)
+	objLen := objValue.Len()
+
+	if objLen <= 1 {
+		return true
+	}
+
+	value := objValue.Index(0)
+	valueInterface := value.Interface()
+	firstValueKind := value.Kind()
+
+	for i := 1; i < objLen; i++ {
+		prevValue := value
+		prevValueInterface := valueInterface
+
+		value = objValue.Index(i)
+		valueInterface = value.Interface()
+
+		compareResult, isComparable := compare(prevValueInterface, valueInterface, firstValueKind)
+
+		if !isComparable {
+			return Fail(t, fmt.Sprintf("Can not compare type \"%s\" and \"%s\"", reflect.TypeOf(value), reflect.TypeOf(prevValue)), msgAndArgs...)
+		}
+
+		if !containsValue(allowedComparesResults, compareResult) {
+			return Fail(t, fmt.Sprintf(failMessage, prevValue, value), msgAndArgs...)
+		}
+	}
+
+	return true
+}
+
+// IsIncreasing asserts that the collection is increasing
+//
+//    assert.IsIncreasing(t, []int{1, 2, 3})
+//    assert.IsIncreasing(t, []float{1, 2})
+//    assert.IsIncreasing(t, []string{"a", "b"})
+func IsIncreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) bool {
+	return isOrdered(t, object, []CompareType{compareLess}, "\"%v\" is not less than \"%v\"", msgAndArgs)
+}
+
+// IsNonIncreasing asserts that the collection is not increasing
+//
+//    assert.IsNonIncreasing(t, []int{2, 1, 1})
+//    assert.IsNonIncreasing(t, []float{2, 1})
+//    assert.IsNonIncreasing(t, []string{"b", "a"})
+func IsNonIncreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) bool {
+	return isOrdered(t, object, []CompareType{compareEqual, compareGreater}, "\"%v\" is not greater than or equal to \"%v\"", msgAndArgs)
+}
+
+// IsDecreasing asserts that the collection is decreasing
+//
+//    assert.IsDecreasing(t, []int{2, 1, 0})
+//    assert.IsDecreasing(t, []float{2, 1})
+//    assert.IsDecreasing(t, []string{"b", "a"})
+func IsDecreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) bool {
+	return isOrdered(t, object, []CompareType{compareGreater}, "\"%v\" is not greater than \"%v\"", msgAndArgs)
+}
+
+// IsNonDecreasing asserts that the collection is not decreasing
+//
+//    assert.IsNonDecreasing(t, []int{1, 1, 2})
+//    assert.IsNonDecreasing(t, []float{1, 2})
+//    assert.IsNonDecreasing(t, []string{"a", "b"})
+func IsNonDecreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) bool {
+	return isOrdered(t, object, []CompareType{compareLess, compareEqual}, "\"%v\" is not less than or equal to \"%v\"", msgAndArgs)
+}

--- a/vendor/github.com/stretchr/testify/assert/assertions.go
+++ b/vendor/github.com/stretchr/testify/assert/assertions.go
@@ -172,8 +172,8 @@ func isTest(name, prefix string) bool {
 	if len(name) == len(prefix) { // "Test" is ok
 		return true
 	}
-	rune, _ := utf8.DecodeRuneInString(name[len(prefix):])
-	return !unicode.IsLower(rune)
+	r, _ := utf8.DecodeRuneInString(name[len(prefix):])
+	return !unicode.IsLower(r)
 }
 
 func messageFromMsgAndArgs(msgAndArgs ...interface{}) string {
@@ -1622,6 +1622,7 @@ var spewConfig = spew.ConfigState{
 	DisableCapacities:       true,
 	SortKeys:                true,
 	DisableMethods:          true,
+	MaxDepth:                10,
 }
 
 type tHelper interface {
@@ -1692,4 +1693,82 @@ func Never(t TestingT, condition func() bool, waitFor time.Duration, tick time.D
 			tick = ticker.C
 		}
 	}
+}
+
+// ErrorIs asserts that at least one of the errors in err's chain matches target.
+// This is a wrapper for errors.Is.
+func ErrorIs(t TestingT, err, target error, msgAndArgs ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if errors.Is(err, target) {
+		return true
+	}
+
+	var expectedText string
+	if target != nil {
+		expectedText = target.Error()
+	}
+
+	chain := buildErrorChainString(err)
+
+	return Fail(t, fmt.Sprintf("Target error should be in err chain:\n"+
+		"expected: %q\n"+
+		"in chain: %s", expectedText, chain,
+	), msgAndArgs...)
+}
+
+// NotErrorIs asserts that at none of the errors in err's chain matches target.
+// This is a wrapper for errors.Is.
+func NotErrorIs(t TestingT, err, target error, msgAndArgs ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if !errors.Is(err, target) {
+		return true
+	}
+
+	var expectedText string
+	if target != nil {
+		expectedText = target.Error()
+	}
+
+	chain := buildErrorChainString(err)
+
+	return Fail(t, fmt.Sprintf("Target error should not be in err chain:\n"+
+		"found: %q\n"+
+		"in chain: %s", expectedText, chain,
+	), msgAndArgs...)
+}
+
+// ErrorAs asserts that at least one of the errors in err's chain matches target, and if so, sets target to that error value.
+// This is a wrapper for errors.As.
+func ErrorAs(t TestingT, err error, target interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if errors.As(err, target) {
+		return true
+	}
+
+	chain := buildErrorChainString(err)
+
+	return Fail(t, fmt.Sprintf("Should be in error chain:\n"+
+		"expected: %q\n"+
+		"in chain: %s", target, chain,
+	), msgAndArgs...)
+}
+
+func buildErrorChainString(err error) string {
+	if err == nil {
+		return ""
+	}
+
+	e := errors.Unwrap(err)
+	chain := fmt.Sprintf("%q", err.Error())
+	for e != nil {
+		chain += fmt.Sprintf("\n\t%q", e.Error())
+		e = errors.Unwrap(e)
+	}
+	return chain
 }

--- a/vendor/github.com/stretchr/testify/require/require.go
+++ b/vendor/github.com/stretchr/testify/require/require.go
@@ -256,6 +256,54 @@ func Error(t TestingT, err error, msgAndArgs ...interface{}) {
 	t.FailNow()
 }
 
+// ErrorAs asserts that at least one of the errors in err's chain matches target, and if so, sets target to that error value.
+// This is a wrapper for errors.As.
+func ErrorAs(t TestingT, err error, target interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.ErrorAs(t, err, target, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// ErrorAsf asserts that at least one of the errors in err's chain matches target, and if so, sets target to that error value.
+// This is a wrapper for errors.As.
+func ErrorAsf(t TestingT, err error, target interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.ErrorAsf(t, err, target, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// ErrorIs asserts that at least one of the errors in err's chain matches target.
+// This is a wrapper for errors.Is.
+func ErrorIs(t TestingT, err error, target error, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.ErrorIs(t, err, target, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// ErrorIsf asserts that at least one of the errors in err's chain matches target.
+// This is a wrapper for errors.Is.
+func ErrorIsf(t TestingT, err error, target error, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.ErrorIsf(t, err, target, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
 // Errorf asserts that a function returned an error (i.e. not `nil`).
 //
 //   actualObj, err := SomeFunction()
@@ -806,6 +854,126 @@ func InEpsilonf(t TestingT, expected interface{}, actual interface{}, epsilon fl
 	t.FailNow()
 }
 
+// IsDecreasing asserts that the collection is decreasing
+//
+//    assert.IsDecreasing(t, []int{2, 1, 0})
+//    assert.IsDecreasing(t, []float{2, 1})
+//    assert.IsDecreasing(t, []string{"b", "a"})
+func IsDecreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.IsDecreasing(t, object, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// IsDecreasingf asserts that the collection is decreasing
+//
+//    assert.IsDecreasingf(t, []int{2, 1, 0}, "error message %s", "formatted")
+//    assert.IsDecreasingf(t, []float{2, 1}, "error message %s", "formatted")
+//    assert.IsDecreasingf(t, []string{"b", "a"}, "error message %s", "formatted")
+func IsDecreasingf(t TestingT, object interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.IsDecreasingf(t, object, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// IsIncreasing asserts that the collection is increasing
+//
+//    assert.IsIncreasing(t, []int{1, 2, 3})
+//    assert.IsIncreasing(t, []float{1, 2})
+//    assert.IsIncreasing(t, []string{"a", "b"})
+func IsIncreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.IsIncreasing(t, object, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// IsIncreasingf asserts that the collection is increasing
+//
+//    assert.IsIncreasingf(t, []int{1, 2, 3}, "error message %s", "formatted")
+//    assert.IsIncreasingf(t, []float{1, 2}, "error message %s", "formatted")
+//    assert.IsIncreasingf(t, []string{"a", "b"}, "error message %s", "formatted")
+func IsIncreasingf(t TestingT, object interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.IsIncreasingf(t, object, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// IsNonDecreasing asserts that the collection is not decreasing
+//
+//    assert.IsNonDecreasing(t, []int{1, 1, 2})
+//    assert.IsNonDecreasing(t, []float{1, 2})
+//    assert.IsNonDecreasing(t, []string{"a", "b"})
+func IsNonDecreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.IsNonDecreasing(t, object, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// IsNonDecreasingf asserts that the collection is not decreasing
+//
+//    assert.IsNonDecreasingf(t, []int{1, 1, 2}, "error message %s", "formatted")
+//    assert.IsNonDecreasingf(t, []float{1, 2}, "error message %s", "formatted")
+//    assert.IsNonDecreasingf(t, []string{"a", "b"}, "error message %s", "formatted")
+func IsNonDecreasingf(t TestingT, object interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.IsNonDecreasingf(t, object, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// IsNonIncreasing asserts that the collection is not increasing
+//
+//    assert.IsNonIncreasing(t, []int{2, 1, 1})
+//    assert.IsNonIncreasing(t, []float{2, 1})
+//    assert.IsNonIncreasing(t, []string{"b", "a"})
+func IsNonIncreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.IsNonIncreasing(t, object, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// IsNonIncreasingf asserts that the collection is not increasing
+//
+//    assert.IsNonIncreasingf(t, []int{2, 1, 1}, "error message %s", "formatted")
+//    assert.IsNonIncreasingf(t, []float{2, 1}, "error message %s", "formatted")
+//    assert.IsNonIncreasingf(t, []string{"b", "a"}, "error message %s", "formatted")
+func IsNonIncreasingf(t TestingT, object interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.IsNonIncreasingf(t, object, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
 // IsType asserts that the specified objects are of the same type.
 func IsType(t TestingT, expectedType interface{}, object interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
@@ -939,6 +1107,34 @@ func Lessf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...inter
 		h.Helper()
 	}
 	if assert.Lessf(t, e1, e2, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Negative asserts that the specified element is negative
+//
+//    assert.Negative(t, -1)
+//    assert.Negative(t, -1.23)
+func Negative(t TestingT, e interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Negative(t, e, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Negativef asserts that the specified element is negative
+//
+//    assert.Negativef(t, -1, "error message %s", "formatted")
+//    assert.Negativef(t, -1.23, "error message %s", "formatted")
+func Negativef(t TestingT, e interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Negativef(t, e, msg, args...) {
 		return
 	}
 	t.FailNow()
@@ -1200,6 +1396,30 @@ func NotEqualf(t TestingT, expected interface{}, actual interface{}, msg string,
 	t.FailNow()
 }
 
+// NotErrorIs asserts that at none of the errors in err's chain matches target.
+// This is a wrapper for errors.Is.
+func NotErrorIs(t TestingT, err error, target error, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotErrorIs(t, err, target, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotErrorIsf asserts that at none of the errors in err's chain matches target.
+// This is a wrapper for errors.Is.
+func NotErrorIsf(t TestingT, err error, target error, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotErrorIsf(t, err, target, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
 // NotNil asserts that the specified object is not nil.
 //
 //    assert.NotNil(t, err)
@@ -1441,6 +1661,34 @@ func Panicsf(t TestingT, f assert.PanicTestFunc, msg string, args ...interface{}
 		h.Helper()
 	}
 	if assert.Panicsf(t, f, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Positive asserts that the specified element is positive
+//
+//    assert.Positive(t, 1)
+//    assert.Positive(t, 1.23)
+func Positive(t TestingT, e interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Positive(t, e, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Positivef asserts that the specified element is positive
+//
+//    assert.Positivef(t, 1, "error message %s", "formatted")
+//    assert.Positivef(t, 1.23, "error message %s", "formatted")
+func Positivef(t TestingT, e interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Positivef(t, e, msg, args...) {
 		return
 	}
 	t.FailNow()

--- a/vendor/github.com/stretchr/testify/require/require_forward.go
+++ b/vendor/github.com/stretchr/testify/require/require_forward.go
@@ -205,6 +205,42 @@ func (a *Assertions) Error(err error, msgAndArgs ...interface{}) {
 	Error(a.t, err, msgAndArgs...)
 }
 
+// ErrorAs asserts that at least one of the errors in err's chain matches target, and if so, sets target to that error value.
+// This is a wrapper for errors.As.
+func (a *Assertions) ErrorAs(err error, target interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	ErrorAs(a.t, err, target, msgAndArgs...)
+}
+
+// ErrorAsf asserts that at least one of the errors in err's chain matches target, and if so, sets target to that error value.
+// This is a wrapper for errors.As.
+func (a *Assertions) ErrorAsf(err error, target interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	ErrorAsf(a.t, err, target, msg, args...)
+}
+
+// ErrorIs asserts that at least one of the errors in err's chain matches target.
+// This is a wrapper for errors.Is.
+func (a *Assertions) ErrorIs(err error, target error, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	ErrorIs(a.t, err, target, msgAndArgs...)
+}
+
+// ErrorIsf asserts that at least one of the errors in err's chain matches target.
+// This is a wrapper for errors.Is.
+func (a *Assertions) ErrorIsf(err error, target error, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	ErrorIsf(a.t, err, target, msg, args...)
+}
+
 // Errorf asserts that a function returned an error (i.e. not `nil`).
 //
 //   actualObj, err := SomeFunction()
@@ -632,6 +668,102 @@ func (a *Assertions) InEpsilonf(expected interface{}, actual interface{}, epsilo
 	InEpsilonf(a.t, expected, actual, epsilon, msg, args...)
 }
 
+// IsDecreasing asserts that the collection is decreasing
+//
+//    a.IsDecreasing([]int{2, 1, 0})
+//    a.IsDecreasing([]float{2, 1})
+//    a.IsDecreasing([]string{"b", "a"})
+func (a *Assertions) IsDecreasing(object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	IsDecreasing(a.t, object, msgAndArgs...)
+}
+
+// IsDecreasingf asserts that the collection is decreasing
+//
+//    a.IsDecreasingf([]int{2, 1, 0}, "error message %s", "formatted")
+//    a.IsDecreasingf([]float{2, 1}, "error message %s", "formatted")
+//    a.IsDecreasingf([]string{"b", "a"}, "error message %s", "formatted")
+func (a *Assertions) IsDecreasingf(object interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	IsDecreasingf(a.t, object, msg, args...)
+}
+
+// IsIncreasing asserts that the collection is increasing
+//
+//    a.IsIncreasing([]int{1, 2, 3})
+//    a.IsIncreasing([]float{1, 2})
+//    a.IsIncreasing([]string{"a", "b"})
+func (a *Assertions) IsIncreasing(object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	IsIncreasing(a.t, object, msgAndArgs...)
+}
+
+// IsIncreasingf asserts that the collection is increasing
+//
+//    a.IsIncreasingf([]int{1, 2, 3}, "error message %s", "formatted")
+//    a.IsIncreasingf([]float{1, 2}, "error message %s", "formatted")
+//    a.IsIncreasingf([]string{"a", "b"}, "error message %s", "formatted")
+func (a *Assertions) IsIncreasingf(object interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	IsIncreasingf(a.t, object, msg, args...)
+}
+
+// IsNonDecreasing asserts that the collection is not decreasing
+//
+//    a.IsNonDecreasing([]int{1, 1, 2})
+//    a.IsNonDecreasing([]float{1, 2})
+//    a.IsNonDecreasing([]string{"a", "b"})
+func (a *Assertions) IsNonDecreasing(object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	IsNonDecreasing(a.t, object, msgAndArgs...)
+}
+
+// IsNonDecreasingf asserts that the collection is not decreasing
+//
+//    a.IsNonDecreasingf([]int{1, 1, 2}, "error message %s", "formatted")
+//    a.IsNonDecreasingf([]float{1, 2}, "error message %s", "formatted")
+//    a.IsNonDecreasingf([]string{"a", "b"}, "error message %s", "formatted")
+func (a *Assertions) IsNonDecreasingf(object interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	IsNonDecreasingf(a.t, object, msg, args...)
+}
+
+// IsNonIncreasing asserts that the collection is not increasing
+//
+//    a.IsNonIncreasing([]int{2, 1, 1})
+//    a.IsNonIncreasing([]float{2, 1})
+//    a.IsNonIncreasing([]string{"b", "a"})
+func (a *Assertions) IsNonIncreasing(object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	IsNonIncreasing(a.t, object, msgAndArgs...)
+}
+
+// IsNonIncreasingf asserts that the collection is not increasing
+//
+//    a.IsNonIncreasingf([]int{2, 1, 1}, "error message %s", "formatted")
+//    a.IsNonIncreasingf([]float{2, 1}, "error message %s", "formatted")
+//    a.IsNonIncreasingf([]string{"b", "a"}, "error message %s", "formatted")
+func (a *Assertions) IsNonIncreasingf(object interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	IsNonIncreasingf(a.t, object, msg, args...)
+}
+
 // IsType asserts that the specified objects are of the same type.
 func (a *Assertions) IsType(expectedType interface{}, object interface{}, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
@@ -738,6 +870,28 @@ func (a *Assertions) Lessf(e1 interface{}, e2 interface{}, msg string, args ...i
 		h.Helper()
 	}
 	Lessf(a.t, e1, e2, msg, args...)
+}
+
+// Negative asserts that the specified element is negative
+//
+//    a.Negative(-1)
+//    a.Negative(-1.23)
+func (a *Assertions) Negative(e interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Negative(a.t, e, msgAndArgs...)
+}
+
+// Negativef asserts that the specified element is negative
+//
+//    a.Negativef(-1, "error message %s", "formatted")
+//    a.Negativef(-1.23, "error message %s", "formatted")
+func (a *Assertions) Negativef(e interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Negativef(a.t, e, msg, args...)
 }
 
 // Never asserts that the given condition doesn't satisfy in waitFor time,
@@ -942,6 +1096,24 @@ func (a *Assertions) NotEqualf(expected interface{}, actual interface{}, msg str
 	NotEqualf(a.t, expected, actual, msg, args...)
 }
 
+// NotErrorIs asserts that at none of the errors in err's chain matches target.
+// This is a wrapper for errors.Is.
+func (a *Assertions) NotErrorIs(err error, target error, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotErrorIs(a.t, err, target, msgAndArgs...)
+}
+
+// NotErrorIsf asserts that at none of the errors in err's chain matches target.
+// This is a wrapper for errors.Is.
+func (a *Assertions) NotErrorIsf(err error, target error, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotErrorIsf(a.t, err, target, msg, args...)
+}
+
 // NotNil asserts that the specified object is not nil.
 //
 //    a.NotNil(err)
@@ -1132,6 +1304,28 @@ func (a *Assertions) Panicsf(f assert.PanicTestFunc, msg string, args ...interfa
 		h.Helper()
 	}
 	Panicsf(a.t, f, msg, args...)
+}
+
+// Positive asserts that the specified element is positive
+//
+//    a.Positive(1)
+//    a.Positive(1.23)
+func (a *Assertions) Positive(e interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Positive(a.t, e, msgAndArgs...)
+}
+
+// Positivef asserts that the specified element is positive
+//
+//    a.Positivef(1, "error message %s", "formatted")
+//    a.Positivef(1.23, "error message %s", "formatted")
+func (a *Assertions) Positivef(e interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Positivef(a.t, e, msg, args...)
 }
 
 // Regexp asserts that a specified regexp matches a string.

--- a/vendor/github.com/tilt-dev/probe/LICENSE
+++ b/vendor/github.com/tilt-dev/probe/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/tilt-dev/probe/pkg/probe/doc.go
+++ b/vendor/github.com/tilt-dev/probe/pkg/probe/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package probe contains utilities for health probing, as well as health status information.
+package probe

--- a/vendor/github.com/tilt-dev/probe/pkg/probe/worker.go
+++ b/vendor/github.com/tilt-dev/probe/pkg/probe/worker.go
@@ -1,0 +1,319 @@
+package probe
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+
+	"github.com/jonboulle/clockwork"
+	"k8s.io/klog/v2"
+
+	"github.com/tilt-dev/probe/pkg/prober"
+)
+
+const (
+	// DefaultProbePeriod is the default value for the interval between
+	// probe invocations.
+	DefaultProbePeriod = 10 * time.Second
+
+	// DefaultProbeTimeout is the default value for the timeout when
+	// executing a probe to cancel it and consider it failed.
+	DefaultProbeTimeout = 1 * time.Second
+
+	// DefaultInitialDelay is the default value for the initial delay
+	// before beginning to invoke the probe after the Worker is started.
+	DefaultInitialDelay = 0 * time.Second
+
+	// DefaultProbeSuccessThreshold is the default value for the
+	// minimum number of consecutive successes required after having
+	// failed before the status will transition to probe.Success.
+	DefaultProbeSuccessThreshold = 1
+
+	// DefaultProbeFailureThreshold is the default value for the
+	// minimum number of consecutive failures required after having
+	// succeeded before the status will transition to probe.Failure.
+	DefaultProbeFailureThreshold = 3
+)
+
+// realClock is a thin wrapper around Go stdlib methods; a global
+// instance is shared to avoid allocating for every Worker. It is
+// safe to use from multiple Goroutines.
+var realClock = clockwork.NewRealClock()
+
+// StatusChangedFunc is invoked on status transitions.
+//
+// It will NOT be called for subsequent probe invocations that do not
+// result in a status change.
+type StatusChangedFunc func(status prober.Result, output string)
+
+// WorkerOption can be passed when creating a Worker to configure the
+// instance.
+type WorkerOption func(w *Worker)
+
+type probeResult struct {
+	result prober.Result
+	output string
+	err    error
+}
+
+// NewWorker creates a Worker instance using the provided probe.Prober
+// and options (if any).
+func NewWorker(p prober.Prober, opts ...WorkerOption) *Worker {
+	w := &Worker{
+		prober:           p,
+		clock:            realClock,
+		period:           DefaultProbePeriod,
+		timeout:          DefaultProbeTimeout,
+		initialDelay:     DefaultInitialDelay,
+		successThreshold: DefaultProbeSuccessThreshold,
+		failureThreshold: DefaultProbeFailureThreshold,
+		status:           prober.Unknown,
+	}
+
+	for _, opt := range opts {
+		opt(w)
+	}
+
+	return w
+}
+
+// Worker handles executing probes and reporting results.
+//
+// It's loosely based (but simplified) on the k8s.io/kubernetes/pkg/kubelet/prober design.
+type Worker struct {
+	// probe is the actual logic that will be invoked to determine status.
+	prober prober.Prober
+	// clock is used to create timers and facilitate easier unit testing.
+	clock clockwork.Clock
+	// mu guards mutable state that can be accessed from multiple goroutines (see docs on
+	// individual fields for which mu must be held before access).
+	mu sync.Mutex
+	// stopFunc is invoked when a running Worker instance is stopped to cancel the context.
+	//
+	// mu must be held before accessing.
+	stopFunc context.CancelFunc
+	// initialDelay is the amount of time before the probe is first executed.
+	initialDelay time.Duration
+	// period is the interval on which the probe is executed.
+	period time.Duration
+	// timeout is the maximum duration for which a probe can execute before it's considered
+	// to have failed (and its result ignored).
+	timeout time.Duration
+	// successThreshold is the number of times a probe must succeed after previously having
+	// failed before it will transition to a successful state.
+	successThreshold int
+	// failureThreshold is the number of times a probe must fail after previously having
+	// been successful before it will transition to a failure state.
+	failureThreshold int
+	// resultsChan receives ALL probe execution results, including duplicates.
+	//
+	// Currently, this is only exposed internally for testing to force synchronization.
+	resultsChan chan probeResult
+	// status is only updated after the failure/success threshold is crossed.
+	//
+	// mu must be held before accessing.
+	status prober.Result
+	// statusFunc is an optional function to call whenever the status changes.
+	statusFunc StatusChangedFunc
+	// lastResult is the result of the previous probe execution and is used along with
+	// resultRun to determine when a threshold has been crossed.
+	lastResult prober.Result
+	// resultRun is the number of times the probe has returned the same result and is
+	// used along with lastResult to determine when a threshold has been crossed.
+	resultRun int
+}
+
+// Run periodically executes a probe until stopped.
+//
+// The Worker can be stopped by explicitly calling Stop() or implicitly
+// via context cancellation.
+//
+// Calling Run() on an instance that is already running will result in
+// a panic.
+func (w *Worker) Run(ctx context.Context) {
+	w.mu.Lock()
+	if w.stopFunc != nil {
+		panic("prober is already running")
+	}
+	ctx, cancel := context.WithCancel(ctx)
+	w.stopFunc = cancel
+
+	w.lastResult = prober.Unknown
+	w.resultRun = 0
+	// initial status is failure until a successful probe
+	w.status = prober.Failure
+
+	w.mu.Unlock()
+
+	w.clock.Sleep(w.initialDelay)
+
+	ticker := w.clock.NewTicker(w.period)
+	for {
+		w.doProbe(ctx)
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.Chan():
+		}
+	}
+}
+
+// Stop halts further probe invocations. It is safe to call Stop()
+// more than once.
+func (w *Worker) Stop() {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.stopFunc != nil {
+		w.stopFunc()
+		w.stopFunc = nil
+		w.status = prober.Unknown
+	}
+}
+
+// Status returns the current probe result.
+//
+// If not running, this will always return probe.Unknown.
+func (w *Worker) Status() prober.Result {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.status
+}
+
+func (w *Worker) doProbe(ctx context.Context) {
+	ctx, cancel := context.WithTimeout(ctx, w.timeout)
+	defer cancel()
+	result := make(chan probeResult, 1)
+	go func() {
+		r, out, err := w.prober.Probe(ctx)
+		result <- probeResult{result: r, output: out, err: err}
+	}()
+
+	for {
+		select {
+		case r := <-result:
+			w.handleResult(r)
+			return
+		case <-ctx.Done():
+			if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+				// only context deadline exceeded triggers a result handling
+				// (if context was explicitly canceled, there's no reason to
+				// record a result as the prober is being stopped)
+				w.handleResult(probeResult{result: prober.Failure, err: ctx.Err()})
+			}
+			return
+		}
+	}
+}
+
+// handleResult updates prober internal state based on the probe result.
+//
+// This is very similar to https://github.com/kubernetes/kubernetes/blob/v1.20.2/pkg/kubelet/prober/worker.go#L260-L273
+func (w *Worker) handleResult(probeResult probeResult) {
+	if w.resultsChan != nil {
+		defer func() {
+			w.resultsChan <- probeResult
+		}()
+	}
+
+	result := probeResult.result
+	if probeResult.err != nil {
+		if !errors.Is(probeResult.err, context.DeadlineExceeded) {
+			// the probe itself returned an error, so ignore this execution
+			klog.V(4).ErrorS(probeResult.err, "Probe returned an error; result ignored")
+			return
+		}
+		result = prober.Failure
+	}
+
+	if w.lastResult == result {
+		w.resultRun++
+	} else {
+		w.lastResult = result
+		w.resultRun = 1
+	}
+
+	success := isSuccessResult(result)
+	if (!success && w.resultRun < w.failureThreshold) ||
+		(success && w.resultRun < w.successThreshold) {
+		return
+	}
+
+	w.mu.Lock()
+	if w.stopFunc == nil || w.status == result {
+		w.mu.Unlock()
+		return
+	}
+	w.status = result
+	w.mu.Unlock()
+
+	if w.statusFunc != nil {
+		w.statusFunc(result, probeResult.output)
+	}
+}
+
+// isSuccessResult coerces a probe.Result value into a bool based on
+// whether it's considered a successful value or not.
+func isSuccessResult(result prober.Result) bool {
+	if result == prober.Success || result == prober.Warning {
+		return true
+	}
+	return false
+}
+
+// WorkerPeriod sets the period between probe invocations.
+func WorkerPeriod(period time.Duration) WorkerOption {
+	return func(w *Worker) {
+		w.period = period
+	}
+}
+
+// WorkerTimeout sets the duration before a running probe is canceled
+// and considered to have failed.
+func WorkerTimeout(timeout time.Duration) WorkerOption {
+	return func(w *Worker) {
+		w.timeout = timeout
+	}
+}
+
+// WorkerFailureThreshold sets the number of consecutive failures
+// required after a probe has succeeded before the status will
+// transition to probe.Failure.
+func WorkerFailureThreshold(v int) WorkerOption {
+	return func(w *Worker) {
+		w.failureThreshold = v
+	}
+}
+
+// WorkerSuccessThreshold sets the number of consecutive successes
+// required after a probe has failed before the status will
+// transition to probe.Success.
+func WorkerSuccessThreshold(v int) WorkerOption {
+	return func(w *Worker) {
+		w.successThreshold = v
+	}
+}
+
+// WorkerInitialDelay sets the amount of time that will be waited
+// when the prober starts before beginning to invoke the probe.
+//
+// The status will be probe.Failure during the initial delay
+// period.
+func WorkerInitialDelay(delay time.Duration) WorkerOption {
+	return func(w *Worker) {
+		w.initialDelay = delay
+	}
+}
+
+// WorkerOnStatusChange sets the function to invoke when the status
+// transitions.
+//
+// Subsequent probe invocations that do not result in a change to the
+// status (either because they return the same result or the failure/
+// success threshold has not been met) will not emit a status change
+// update.
+func WorkerOnStatusChange(f StatusChangedFunc) WorkerOption {
+	return func(w *Worker) {
+		w.statusFunc = f
+	}
+}

--- a/vendor/github.com/tilt-dev/probe/pkg/prober/exec.go
+++ b/vendor/github.com/tilt-dev/probe/pkg/prober/exec.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+Modified 2021 Windmill Engineering.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package prober
+
+import (
+	"context"
+
+	"k8s.io/klog/v2"
+	"k8s.io/utils/exec"
+)
+
+const (
+	// TODO(milas): consider adding back limited output
+	maxReadLength = 10 * 1 << 10 // 10KB
+)
+
+// osExecRunner is the default runner that's a shim around stdlib os/exec.
+//
+// A global instance is used to avoid creating an instance for every probe (it is Goroutine safe).
+var osExecRunner = exec.New()
+
+// NewExecProber creates an ExecProber.
+func NewExecProber() ExecProber {
+	return execProber{
+		runner: osExecRunner,
+	}
+}
+
+// ExecProber executes a command to check a service status.
+type ExecProber interface {
+	// Probe executes a command to check a service status.
+	//
+	// If the process terminates with any exit code besides 0, Failure will be returned.
+	// The merged result of stdout + stderr are returned as output.
+	Probe(ctx context.Context, name string, args ...string) (Result, string, error)
+}
+
+type execProber struct {
+	runner exec.Interface
+}
+
+// Probe executes a command to check service status.
+func (pr execProber) Probe(ctx context.Context, name string, args ...string) (Result, string, error) {
+	cmd := pr.runner.CommandContext(ctx, name, args...)
+	data, err := cmd.CombinedOutput()
+
+	klog.V(4).Infof("Exec probe response: %q", string(data))
+	if err != nil {
+		exit, ok := err.(exec.ExitError)
+		if ok {
+			if exit.ExitStatus() == 0 {
+				return Success, string(data), nil
+			}
+			return Failure, string(data), nil
+		}
+
+		return Unknown, "", err
+	}
+	return Success, string(data), nil
+}

--- a/vendor/github.com/tilt-dev/probe/pkg/prober/http.go
+++ b/vendor/github.com/tilt-dev/probe/pkg/prober/http.go
@@ -1,0 +1,160 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+Modified 2021 Windmill Engineering.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package prober
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+
+	"k8s.io/klog/v2"
+)
+
+const (
+	maxRespBodyLength = 10 * 1 << 10 // 10KB
+)
+
+// ErrLimitReached means that the read limit is reached.
+var ErrLimitReached = errors.New("the read limit is reached")
+
+func defaultTransport() *http.Transport {
+	// TODO(milas): add http2 healthcheck -> https://github.com/kubernetes/apimachinery/blob/master/pkg/util/net/http.go#L173-L189
+	return &http.Transport{
+		TLSClientConfig:   &tls.Config{InsecureSkipVerify: true},
+		DisableKeepAlives: true,
+		Proxy:             http.ProxyURL(nil),
+	}
+}
+
+// NewHTTPGetProber creates a HTTPGetProber that will perform an HTTP GET request to determine service status.
+func NewHTTPGetProber() HTTPGetProber {
+	return httpProber{defaultTransport()}
+}
+
+// HTTPGetProber executes HTTP GET requests to determine service status.
+type HTTPGetProber interface {
+	// Probe executes an HTTP GET request to determine service status.
+	//
+	// Any non-successful status code (< 200 or >= 400) or HTTP/network communication error will return Failure.
+	// A potentially truncated version of the HTTP response body is returned as output.
+	Probe(ctx context.Context, url *url.URL, headers http.Header) (Result, string, error)
+}
+
+type httpProber struct {
+	transport *http.Transport
+}
+
+// Probe executes an HTTP GET request to determine service status.
+func (pr httpProber) Probe(ctx context.Context, url *url.URL, headers http.Header) (Result, string, error) {
+	pr.transport.DisableCompression = true // removes Accept-Encoding header
+	client := &http.Client{
+		Transport:     pr.transport,
+		CheckRedirect: redirectChecker(),
+	}
+	return doHTTPProbe(ctx, url, headers, client)
+}
+
+// httpClient is an interface for making HTTP requests that returns a response and error.
+type httpClient interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+// doHTTPProbe checks if a GET request to the url succeeds.
+// If the HTTP response code is successful (i.e. 400 > code >= 200), it returns Success.
+// If the HTTP response code is unsuccessful or HTTP communication fails, it returns Failure.
+func doHTTPProbe(ctx context.Context, url *url.URL, headers http.Header, client httpClient) (Result, string, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", url.String(), nil)
+	if err != nil {
+		// Convert errors into failures to catch timeouts.
+		return Failure, err.Error(), nil
+	}
+	if _, ok := headers["User-Agent"]; !ok {
+		if headers == nil {
+			headers = http.Header{}
+		}
+		// TODO(milas): add version support to package
+		// explicitly set User-Agent so it's not set to default Go value
+		headers.Set("User-Agent", fmt.Sprintf("tilt-probe/%s.%s", "0", "1"))
+	}
+	if _, ok := headers["Accept"]; !ok {
+		// Accept header was not defined. accept all
+		headers.Set("Accept", "*/*")
+	} else if headers.Get("Accept") == "" {
+		// Accept header was overridden but is empty. removing
+		headers.Del("Accept")
+	}
+	req.Header = headers
+	req.Host = headers.Get("Host")
+	res, err := client.Do(req)
+	if err != nil {
+		// Convert errors into failures to catch timeouts.
+		return Failure, err.Error(), nil
+	}
+	defer res.Body.Close()
+	b, err := readAtMost(res.Body, maxRespBodyLength)
+	if err != nil {
+		if err == ErrLimitReached {
+			klog.V(4).Infof("Non fatal body truncation for %s, Response: %v", url.String(), *res)
+		} else {
+			return Failure, "", err
+		}
+	}
+	body := string(b)
+	if res.StatusCode >= http.StatusOK && res.StatusCode < http.StatusBadRequest {
+		if res.StatusCode >= http.StatusMultipleChoices { // Redirect
+			klog.V(4).Infof("Probe terminated redirects for %s, Response: %v", url.String(), *res)
+			return Warning, body, nil
+		}
+		klog.V(4).Infof("Probe succeeded for %s, Response: %v", url.String(), *res)
+		return Success, body, nil
+	}
+	klog.V(4).Infof("Probe failed for %s with request headers %v, response body: %v", url.String(), headers, body)
+	return Failure, fmt.Sprintf("HTTP probe failed with statuscode: %d", res.StatusCode), nil
+}
+
+func redirectChecker() func(*http.Request, []*http.Request) error {
+	return func(req *http.Request, via []*http.Request) error {
+		if req.URL.Hostname() != via[0].URL.Hostname() {
+			return http.ErrUseLastResponse
+		}
+		// Default behavior: stop after 10 redirects.
+		if len(via) >= 10 {
+			return errors.New("stopped after 10 redirects")
+		}
+		return nil
+	}
+}
+
+// readAtMost reads up to `limit` bytes from `r`, and reports an error
+// when `limit` bytes are read.
+func readAtMost(r io.Reader, limit int64) ([]byte, error) {
+	limitedReader := &io.LimitedReader{R: r, N: limit}
+	data, err := ioutil.ReadAll(limitedReader)
+	if err != nil {
+		return data, err
+	}
+	if limitedReader.N <= 0 {
+		return data, ErrLimitReached
+	}
+	return data, nil
+}

--- a/vendor/github.com/tilt-dev/probe/pkg/prober/manager.go
+++ b/vendor/github.com/tilt-dev/probe/pkg/prober/manager.go
@@ -1,0 +1,45 @@
+package prober
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+)
+
+// Manager creates standardized Prober instances from shared instances of underlying
+// implementations for common probe types.
+type Manager struct {
+	httpProber HTTPGetProber
+	execProber ExecProber
+	tcpProber  TCPSocketProber
+}
+
+// NewManager creates a Manager instance to create standard Prober types.
+func NewManager() *Manager {
+	return &Manager{
+		httpProber: NewHTTPGetProber(),
+		execProber: NewExecProber(),
+		tcpProber:  NewTCPSocketProber(),
+	}
+}
+
+// HTTPGet returns a ProberFunc that performs HTTP GET probes for a specific URL & header combination.
+func (m *Manager) HTTPGet(u *url.URL, headers http.Header) ProberFunc {
+	return func(ctx context.Context) (Result, string, error) {
+		return m.httpProber.Probe(ctx, u, headers)
+	}
+}
+
+// TCPSocket returns a ProberFunc that performs TCP socket probes for a specific host & port combination.
+func (m *Manager) TCPSocket(host string, port int) ProberFunc {
+	return func(ctx context.Context) (Result, string, error) {
+		return m.tcpProber.Probe(ctx, host, port)
+	}
+}
+
+// Exec returns a ProberFunc that performs exec probes for a specific command.
+func (m *Manager) Exec(name string, args ...string) ProberFunc {
+	return func(ctx context.Context) (Result, string, error) {
+		return m.execProber.Probe(ctx, name, args...)
+	}
+}

--- a/vendor/github.com/tilt-dev/probe/pkg/prober/prober.go
+++ b/vendor/github.com/tilt-dev/probe/pkg/prober/prober.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+Modified 2021 Windmill Engineering.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package prober
+
+import "context"
+
+// Result is a string used to indicate service status.
+type Result string
+
+const (
+	// Success indicates that the service is healthy.
+	Success Result = "success"
+	// Warning indicates that the service is healthy but additional diagnostic information might be attached.
+	Warning Result = "warning"
+	// Failure indicates that the service is not healthy.
+	Failure Result = "failure"
+	// Unknown indicates that the prober was unable to determine the service status due to an internal issue.
+	//
+	// An Unknown result should also include an error in the Prober return values.
+	Unknown Result = "unknown"
+)
+
+// Prober performs a check to determine a service status.
+type Prober interface {
+	// Probe executes a single status check.
+	//
+	// result is the current service status
+	// output is optional info from the probe (such as a process stdout or HTTP response)
+	// err indicates an issue with the probe itself and that the result should be ignored
+	Probe(ctx context.Context) (result Result, output string, err error)
+}
+
+// ProberFunc is a functional version of Prober.
+type ProberFunc func(ctx context.Context) (Result, string, error)
+
+// Probe executes a single status check.
+//
+// result is the current service status
+// output is optional info from the probe (such as a process stdout or HTTP response)
+// err indicates an issue with the probe itself and that the result should be ignored
+func (f ProberFunc) Probe(ctx context.Context) (Result, string, error) {
+	return f(ctx)
+}

--- a/vendor/github.com/tilt-dev/probe/pkg/prober/tcp.go
+++ b/vendor/github.com/tilt-dev/probe/pkg/prober/tcp.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+Modified 2021 Windmill Engineering.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package prober
+
+import (
+	"context"
+	"net"
+	"strconv"
+
+	"k8s.io/klog/v2"
+)
+
+// NewTCPSocketProber creates a TCPSocketProber that checks connectivity to a given address
+// to determine service status.
+func NewTCPSocketProber() TCPSocketProber {
+	return tcpProber{}
+}
+
+// TCPSocketProber establishes a TCP socket to determine service status.
+type TCPSocketProber interface {
+	// Probe establishes a TCP socket to determine service status.
+	//
+	// Any error establishing the TCP connection will return Failure.
+	// In the event of inability to establish a TCP connection, the output will include error information.
+	// Successful TCP connections will result in no output returned.
+	Probe(ctx context.Context, host string, port int) (Result, string, error)
+}
+
+type tcpProber struct{}
+
+// Probe establishes a TCP socket to determine service status.
+func (pr tcpProber) Probe(ctx context.Context, host string, port int) (Result, string, error) {
+	return doTCPProbe(ctx, net.JoinHostPort(host, strconv.Itoa(port)))
+}
+
+// doTCPProbe checks that a TCP socket to the address can be opened.
+// If the socket can be opened, it returns Success
+// If the socket fails to open, it returns Failure.
+func doTCPProbe(ctx context.Context, addr string) (Result, string, error) {
+	var d net.Dialer
+	conn, err := d.DialContext(ctx, "tcp", addr)
+	if err != nil {
+		// Convert errors to failures to handle timeouts.
+		return Failure, err.Error(), nil
+	}
+	err = conn.Close()
+	if err != nil {
+		klog.Errorf("Unexpected error closing TCP probe socket: %v (%#v)", err, err)
+	}
+	return Success, "", nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -311,7 +311,7 @@ github.com/imdario/mergo
 github.com/inconshreveable/mousetrap
 # github.com/jinzhu/gorm v1.9.12
 ## explicit
-# github.com/jonboulle/clockwork v0.1.0
+# github.com/jonboulle/clockwork v0.2.2
 ## explicit
 github.com/jonboulle/clockwork
 # github.com/josharian/intern v1.0.0
@@ -457,7 +457,7 @@ github.com/spf13/cobra/doc
 # github.com/spf13/pflag v1.0.5
 ## explicit
 github.com/spf13/pflag
-# github.com/stretchr/testify v1.6.1
+# github.com/stretchr/testify v1.7.0
 ## explicit
 github.com/stretchr/testify/assert
 github.com/stretchr/testify/require
@@ -494,6 +494,10 @@ github.com/tilt-dev/go-get/internal/web
 # github.com/tilt-dev/localregistry-go v0.0.0-20200615231835-07e386f4ebd7
 ## explicit
 github.com/tilt-dev/localregistry-go
+# github.com/tilt-dev/probe v0.1.0
+## explicit
+github.com/tilt-dev/probe/pkg/probe
+github.com/tilt-dev/probe/pkg/prober
 # github.com/tilt-dev/wmclient v0.0.0-20201109174454-1839d0355fbc
 ## explicit
 github.com/tilt-dev/wmclient/pkg/analytics
@@ -1111,7 +1115,7 @@ k8s.io/kubectl/pkg/util/openapi/validation
 k8s.io/kubectl/pkg/util/templates
 k8s.io/kubectl/pkg/util/term
 k8s.io/kubectl/pkg/validation
-# k8s.io/utils v0.0.0-20201110183641-67b214c5f920
+# k8s.io/utils v0.0.0-20210111153108-fddb29f9d009
 k8s.io/utils/buffer
 k8s.io/utils/exec
 k8s.io/utils/integer
@@ -1174,7 +1178,7 @@ sigs.k8s.io/yaml
 vbom.ml/util/sortorder
 # github.com/Azure/go-autorest => github.com/Azure/go-autorest v14.2.0+incompatible
 # github.com/evanphx/json-patch => github.com/tilt-dev/json-patch/v4 v4.8.1
+# github.com/go-openapi/spec => github.com/go-openapi/spec v0.19.3
 # go.opencensus.io => github.com/tilt-dev/opencensus-go v0.22.5-0.20200904175236-275b1754f353
 # golang.org/x/crypto => golang.org/x/crypto v0.0.0-20191206172530-e9b2fee46413
 # golang.org/x/sys => golang.org/x/sys v0.0.0-20200826173525-f9321e4c35a6
-# github.com/go-openapi/spec => github.com/go-openapi/spec v0.19.3


### PR DESCRIPTION
Readiness checks for local resources - see #3109 and [tilt-dev/tilt.specs : readiness_probe.md](https://github.com/tilt-dev/tilt.specs/blob/0667128fb7c5b33de16b305f4acd71525f3aab04/readiness_probe.md) for context.

This is currently still a WIP, but putting up a first pass to get feedback on integration points in `local.Controller`.

### TODO
- [x] Vendor in [tilt-dev/probe](https://github.com/tilt-dev/probe) (needs to be made public + initial release tagged)
- [x] `local.Controller` tests for readiness probes
- [x] Prevent deps from starting until resource is ready (see [comment](https://github.com/tilt-dev/tilt/pull/4102#pullrequestreview-574552508))

A few things to think about:
- If the probe spec is invalid, a warning will get logged and then it'll continue as though there was no readiness probe defined -> this seems sane to me, and there's honestly not a TON more that can be done here
- I added the probe worker to `currentProcess` which seems ok to me, but not sure if this should be kept more "pure" to be JUST OS process tracking and add another top-level map for probes?
- If a failing probe returns some output (e.g. saying that it timed out or maybe part of an HTTP response or exec stdout) it'll get logged as debug to the local resource log -> should we try to do anything fancier here (e.g. prepend `[probe]` to each line)?

(I threw everyone on as a reviewer to solicit feedback, but no pressure! 😸)