### PR TITLE
web: move pin button inside SidebarItemVeiw and OverviewItemView cards

### DIFF
--- a/web/src/OverviewItemView.tsx
+++ b/web/src/OverviewItemView.tsx
@@ -14,6 +14,7 @@ import { ReactComponent as MaximizeSvg } from "./assets/svg/maximize.svg"
 import { displayURL } from "./links"
 import { usePathBuilder } from "./PathBuilder"
 import SidebarIcon from "./SidebarIcon"
+import SidebarPinButton from "./SidebarPinButton"
 import SidebarTriggerButton from "./SidebarTriggerButton"
 import { buildStatus, runtimeStatus } from "./status"
 import {
@@ -302,8 +303,14 @@ function buildTooltipText(status: ResourceStatus): string {
   }
 }
 
-function BuildBox(props: { item: OverviewItem }) {
-  let item = props.item
+type BuildBoxProps = {
+  item: OverviewItem
+  isDetailsBox: boolean
+}
+
+function BuildBox(props: BuildBoxProps) {
+  let { item, isDetailsBox } = props
+
   return (
     <OverviewItemBuildBox>
       <SidebarIcon
@@ -314,6 +321,8 @@ function BuildBox(props: { item: OverviewItem }) {
       <OverviewItemText style={{ margin: "8px 0px" }}>
         {buildStatusText(item)}
       </OverviewItemText>
+
+      <SidebarPinButton resourceName={item.name} persistShow={isDetailsBox} />
     </OverviewItemBuildBox>
   )
 }
@@ -478,7 +487,7 @@ export function OverviewItemDetails(props: OverviewItemDetailsProps) {
 
           <DetailText>Show details</DetailText>
         </ShowDetailsBox>
-        <BuildBox item={props.item} />
+        <BuildBox item={props.item} isDetailsBox={true} />
       </OverviewItemDetailsBox>
     </OverviewItemDetailsRoot>
   )
@@ -526,7 +535,11 @@ export default function OverviewItemView(props: OverviewItemViewProps) {
   let isBuildingClass = building ? "isBuilding" : ""
   let onTrigger = triggerUpdate.bind(null, item.name)
   return (
-    <OverviewItemRoot key={item.name} onClick={handleClick}>
+    <OverviewItemRoot
+      key={item.name}
+      onClick={handleClick}
+      className="u-showPinOnHover"
+    >
       <OverviewItemBox className={`${isBuildingClass}`} data-name={item.name}>
         <OverviewItemRuntimeBox>
           <SidebarIcon
@@ -556,7 +569,7 @@ export default function OverviewItemView(props: OverviewItemViewProps) {
             </InnerRuntimeBox>
           </RuntimeBoxStack>
         </OverviewItemRuntimeBox>
-        <BuildBox item={item} />
+        <BuildBox item={item} isDetailsBox={false} />
       </OverviewItemBox>
 
       <Popover

--- a/web/src/OverviewPane.stories.tsx
+++ b/web/src/OverviewPane.stories.tsx
@@ -12,7 +12,9 @@ export default {
     (Story: any) => (
       <MemoryRouter initialEntries={["/"]}>
         <div style={{ margin: "-1rem", height: "80vh" }}>
-          <Story />
+          <SidebarPinMemoryProvider>
+            <Story />
+          </SidebarPinMemoryProvider>
         </div>
       </MemoryRouter>
     ),

--- a/web/src/SidebarItemView.stories.tsx
+++ b/web/src/SidebarItemView.stories.tsx
@@ -91,7 +91,6 @@ function itemView(...options: optionFn[]) {
   let props = {
     item: item,
     selected: false,
-    renderPin: true,
     resourceView: ResourceView.Log,
     pathBuilder: pathBuilder,
   }

--- a/web/src/SidebarItemView.tsx
+++ b/web/src/SidebarItemView.tsx
@@ -5,7 +5,6 @@ import { incr } from "./analytics"
 import PathBuilder from "./PathBuilder"
 import SidebarIcon from "./SidebarIcon"
 import SidebarItem from "./SidebarItem"
-import { SidebarPinButtonSpacer } from "./SidebarPin"
 import SidebarPinButton from "./SidebarPinButton"
 import SidebarTriggerButton from "./SidebarTriggerButton"
 import {
@@ -16,7 +15,6 @@ import {
   Font,
   FontSize,
   SizeUnit,
-  Width,
 } from "./style-helpers"
 import { useTabNav } from "./TabNav"
 import { formatBuildDuration, isZeroTime } from "./time"
@@ -51,7 +49,7 @@ export let SidebarItemBox = styled.div`
   text-decoration: none;
   font-size: ${FontSize.small};
   font-family: ${Font.monospace};
-  margin-right: ${SizeUnit(0.5)};
+  margin: 0 ${SizeUnit(0.5)};
   cursor: pointer;
 
   &:hover {
@@ -109,7 +107,6 @@ let SidebarItemBuildBox = styled.div`
 `
 
 let SidebarItemAllRoot = styled(SidebarItemRoot)`
-  margin-left: ${Width.sidebarPinButton}px;
   text-transform: uppercase;
 `
 
@@ -198,7 +195,6 @@ export function triggerUpdate(name: string, action: string) {
 export type SidebarItemViewProps = {
   item: SidebarItem
   selected: boolean
-  renderPin: boolean
   resourceView: ResourceView
   pathBuilder: PathBuilder
 }
@@ -271,18 +267,12 @@ export default function SidebarItemView(props: SidebarItemViewProps) {
   let isSelectedClass = isSelected ? "isSelected" : ""
   let isBuildingClass = building ? "isBuilding" : ""
   let onTrigger = triggerUpdate.bind(null, item.name)
-  let renderPin = props.renderPin
 
   return (
     <SidebarItemRoot
       key={item.name}
       className={`u-showPinOnHover ${isSelectedClass} ${isBuildingClass}`}
     >
-      {renderPin ? (
-        <SidebarPinButton resourceName={item.name} />
-      ) : (
-        <SidebarPinButtonSpacer />
-      )}
       <SidebarItemBox
         className={`${isSelectedClass} ${isBuildingClass}`}
         tabIndex={-1}
@@ -320,6 +310,7 @@ export default function SidebarItemView(props: SidebarItemViewProps) {
             alertCount={item.buildAlertCount}
           />
           <SidebarItemText>{buildStatusText(item)}</SidebarItemText>
+          <SidebarPinButton resourceName={item.name} />
         </SidebarItemBuildBox>
       </SidebarItemBox>
     </SidebarItemRoot>

--- a/web/src/SidebarPin.tsx
+++ b/web/src/SidebarPin.tsx
@@ -4,10 +4,8 @@ import React, {
   useEffect,
   useState,
 } from "react"
-import styled from "styled-components"
 import { incr } from "./analytics"
 import { useLocalStorageContext } from "./LocalStorage"
-import { Width } from "./style-helpers"
 
 type SidebarPinContext = {
   pinnedResources: string[]
@@ -108,7 +106,3 @@ export function SidebarPinContextProvider(
     </sidebarPinContext.Provider>
   )
 }
-
-export const SidebarPinButtonSpacer = styled.div`
-  width: ${Width.sidebarPinButton}px;
-`

--- a/web/src/SidebarPinButton.tsx
+++ b/web/src/SidebarPinButton.tsx
@@ -2,7 +2,7 @@ import React from "react"
 import styled from "styled-components"
 import { ReactComponent as PinResourceFilledSvg } from "./assets/svg/pin.svg"
 import { useSidebarPin } from "./SidebarPin"
-import { AnimDuration, Color, Width } from "./style-helpers"
+import { AnimDuration, Color } from "./style-helpers"
 
 let PinButton = styled.button`
   display: flex;
@@ -10,66 +10,79 @@ let PinButton = styled.button`
   padding: 0;
   background-color: transparent;
   border: 0 none;
-  width: ${Width.sidebarPinButton}px;
   align-items: center;
   justify-content: center;
+  margin-right: 5px;
 `
 
 let PinnedPinIcon = styled(PinResourceFilledSvg)`
   transition: transform ${AnimDuration.short} ease;
-  fill: ${Color.blue};
+  fill: ${Color.grayLight};
 
-  ${PinButton}:active & {
-    fill: ${Color.blueDark};
-    transform: scale(1.2);
+  ${PinButton}:hover & {
+    fill: ${Color.blue};
   }
 `
 
 let UnpinnedPinIcon = styled(PinResourceFilledSvg)`
   transition: fill ${AnimDuration.default} linear,
-    transform ${AnimDuration.short} ease, opacity ${AnimDuration.short} linear;
+    opacity ${AnimDuration.short} linear;
   opacity: 0;
 
-  .u-showPinOnHover:hover & {
+  .u-showPinOnHover:hover &,
+  ${PinButton}:focus &,
+  ${PinButton}.u-persistShow & {
     fill: ${Color.grayLight};
     opacity: 1;
   }
 
   ${PinButton}:hover & {
-    fill: ${Color.blueDark};
-    opacity: 1;
-  }
-
-  ${PinButton}:active & {
     fill: ${Color.blue};
-    transform: scale(1.2);
     opacity: 1;
   }
 `
 
-export default function SidebarPinButton(props: {
+type SidebarPinButtonProps = {
   resourceName: string
-}): JSX.Element {
+  persistShow?: boolean
+}
+
+export default function SidebarPinButton(
+  props: SidebarPinButtonProps
+): JSX.Element {
   let ctx = useSidebarPin()
+  let { resourceName, persistShow } = props
   let isPinned =
-    ctx.pinnedResources && ctx.pinnedResources.includes(props.resourceName)
+    ctx.pinnedResources && ctx.pinnedResources.includes(resourceName)
 
   let icon: JSX.Element
-  let onClick: (resourceName: string) => void
   let title: string
 
   if (isPinned) {
     icon = <PinnedPinIcon />
-    onClick = ctx.unpinResource
     title = "Remove Pin"
   } else {
     icon = <UnpinnedPinIcon />
-    onClick = ctx.pinResource
     title = "Pin to Top"
   }
 
+  function onClick(e: any) {
+    e.preventDefault()
+    e.stopPropagation()
+    if (isPinned) {
+      ctx.unpinResource(resourceName)
+    } else {
+      ctx.pinResource(resourceName)
+    }
+  }
+
+  let className = ""
+  if (persistShow) {
+    className = "u-persistShow"
+  }
+
   return (
-    <PinButton title={title} onClick={() => onClick(props.resourceName)}>
+    <PinButton title={title} onClick={onClick} className={className}>
       {icon}
     </PinButton>
   )

--- a/web/src/SidebarResources.test.tsx
+++ b/web/src/SidebarResources.test.tsx
@@ -29,9 +29,9 @@ function clickPin(
   root: ReactWrapper<any, React.Component["state"], React.Component>,
   name: string
 ) {
-  let pinButton = root.find(SidebarPinButton).find({ resourceName: name })
-  expect(pinButton).toHaveLength(1)
-  pinButton.simulate("click")
+  let pinButtons = root.find(SidebarPinButton).find({ resourceName: name })
+  expect(pinButtons.length).toBeGreaterThan(0)
+  pinButtons.at(0).simulate("click")
 }
 
 describe("SidebarResources", () => {

--- a/web/src/SidebarResources.tsx
+++ b/web/src/SidebarResources.tsx
@@ -8,7 +8,7 @@ import SidebarItemView, {
 } from "./SidebarItemView"
 import SidebarKeyboardShortcuts from "./SidebarKeyboardShortcuts"
 import { useSidebarPin } from "./SidebarPin"
-import { Color, FontSize, SizeUnit, Width } from "./style-helpers"
+import { Color, FontSize, SizeUnit } from "./style-helpers"
 import { ResourceView } from "./types"
 
 let SidebarResourcesRoot = styled.nav`
@@ -24,7 +24,7 @@ let SidebarList = styled.div``
 
 let SidebarListSectionName = styled.div`
   margin-top: ${SizeUnit(0.5)};
-  margin-left: ${Width.sidebarPinButton}px;
+  margin-left: ${SizeUnit(0.5)};
   text-transform: uppercase;
   color: ${Color.grayLight};
   font-size: ${FontSize.small};
@@ -65,7 +65,6 @@ function PinnedItems(props: SidebarProps) {
           key={"sidebarItemPinned-" + i.name}
           item={i}
           selected={props.selected === i.name}
-          renderPin={false}
           pathBuilder={props.pathBuilder}
           resourceView={props.resourceView}
         />
@@ -104,7 +103,6 @@ export class SidebarResources extends PureComponent<SidebarProps> {
         key={"sidebarItem-" + item.name}
         item={item}
         selected={this.props.selected == item.name}
-        renderPin={true}
         pathBuilder={this.props.pathBuilder}
         resourceView={this.props.resourceView}
       />

--- a/web/src/__snapshots__/Sidebar.test.tsx.snap
+++ b/web/src/__snapshots__/Sidebar.test.tsx.snap
@@ -2,25 +2,25 @@
 
 exports[`sidebar abbreviates durations under a minute 1`] = `
 <nav
-  className="sc-kstrdz cVJnKg Sidebar-resources "
+  className="sc-bqyKva cUnZrS Sidebar-resources "
 >
   <div
-    className="sc-hBEYos"
+    className="sc-kstrdz"
   >
     <div>
       <div
-        className="sc-fodVxV hjvysh"
+        className="sc-hBEYos bxmZqH"
       >
         
       </div>
       <ul
-        className="sc-fFubgz lggJRB"
+        className="sc-fodVxV ewSMuO"
       >
         <li
-          className="sc-gKsewC sc-kEjbxe eWwnQD bmYsyG"
+          className="sc-jSgupP sc-jrAGrp jnEojC jhbijv"
         >
           <div
-            className="sc-iBPRYJ sc-fubCfw epmLcA hDyxGh isSelected"
+            className="sc-gKsewC sc-iBPRYJ jSnJQd kEXXSo isSelected"
             onClick={[Function]}
             role="button"
             tabIndex={-1}
@@ -33,7 +33,7 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
               </svg>
             </div>
             <div
-              className="sc-iqHYGH sc-crrsfI dWLKtY fACPxI"
+              className="sc-kEjbxe sc-iqHYGH nCYed gNenIV"
             >
               All
             </div>
@@ -43,36 +43,25 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
     </div>
     <div>
       <div
-        className="sc-fodVxV hjvysh"
+        className="sc-hBEYos bxmZqH"
       >
         resources
       </div>
       <ul
-        className="sc-fFubgz lggJRB"
+        className="sc-fodVxV ewSMuO"
       >
         <li
-          className="sc-gKsewC eWwnQD u-showPinOnHover  isBuilding"
+          className="sc-jSgupP jnEojC u-showPinOnHover  isBuilding"
         >
-          <button
-            className="sc-dlfnbm begUcN"
-            onClick={[Function]}
-            title="Pin to Top"
-          >
-            <svg
-              className="sc-eCssSg eisvUy"
-            >
-              pin.svg
-            </svg>
-          </button>
           <div
-            className="sc-iBPRYJ epmLcA  isBuilding"
+            className="sc-gKsewC jSnJQd  isBuilding"
             data-name="resource4"
             onClick={[Function]}
             role="button"
             tabIndex={-1}
           >
             <div
-              className="sc-pFZIQ jNegfI"
+              className="sc-fubCfw giLNdL"
             >
               <div
                 aria-describedby={null}
@@ -90,17 +79,17 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
                 </span>
               </div>
               <div
-                className="sc-iqHYGH sc-crrsfI dWLKtY fACPxI"
+                className="sc-kEjbxe sc-iqHYGH nCYed gNenIV"
                 title="resource4"
               >
                 <span
-                  className="sc-dQppl dMras"
+                  className="sc-crrsfI jcYrCe"
                 >
                   resource4
                 </span>
               </div>
               <span
-                className="sc-bqyKva kPKqMc"
+                className="sc-dQppl rWCkn"
               >
                 <time
                   dateTime="2017-12-21T15:36:03.000Z"
@@ -110,7 +99,7 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
                 </time>
               </span>
               <button
-                className="sc-jSgupP gdBoFx SidebarTriggerButton 
+                className="sc-eCssSg fIfNJU SidebarTriggerButton 
           "
                 disabled={true}
                 onClick={[Function]}
@@ -118,7 +107,7 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
               />
             </div>
             <div
-              className="sc-jrAGrp hzspIa"
+              className="sc-pFZIQ bHvBzm"
             >
               <div
                 aria-describedby={null}
@@ -136,36 +125,36 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
                 </span>
               </div>
               <div
-                className="sc-iqHYGH dWLKtY"
+                className="sc-kEjbxe nCYed"
               >
                 Completed in 12s, with issues
               </div>
+              <button
+                className="sc-gsTCUz sZTnv"
+                onClick={[Function]}
+                title="Pin to Top"
+              >
+                <svg
+                  className="sc-hKgILt cXIGbx"
+                >
+                  pin.svg
+                </svg>
+              </button>
             </div>
           </div>
         </li>
         <li
-          className="sc-gKsewC eWwnQD u-showPinOnHover  isBuilding"
+          className="sc-jSgupP jnEojC u-showPinOnHover  isBuilding"
         >
-          <button
-            className="sc-dlfnbm begUcN"
-            onClick={[Function]}
-            title="Pin to Top"
-          >
-            <svg
-              className="sc-eCssSg eisvUy"
-            >
-              pin.svg
-            </svg>
-          </button>
           <div
-            className="sc-iBPRYJ epmLcA  isBuilding"
+            className="sc-gKsewC jSnJQd  isBuilding"
             data-name="resource9"
             onClick={[Function]}
             role="button"
             tabIndex={-1}
           >
             <div
-              className="sc-pFZIQ jNegfI"
+              className="sc-fubCfw giLNdL"
             >
               <div
                 aria-describedby={null}
@@ -183,17 +172,17 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
                 </span>
               </div>
               <div
-                className="sc-iqHYGH sc-crrsfI dWLKtY fACPxI"
+                className="sc-kEjbxe sc-iqHYGH nCYed gNenIV"
                 title="resource9"
               >
                 <span
-                  className="sc-dQppl dMras"
+                  className="sc-crrsfI jcYrCe"
                 >
                   resource9
                 </span>
               </div>
               <span
-                className="sc-bqyKva kPKqMc"
+                className="sc-dQppl rWCkn"
               >
                 <time
                   dateTime="2017-12-21T15:35:58.000Z"
@@ -203,7 +192,7 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
                 </time>
               </span>
               <button
-                className="sc-jSgupP gdBoFx SidebarTriggerButton 
+                className="sc-eCssSg fIfNJU SidebarTriggerButton 
           "
                 disabled={true}
                 onClick={[Function]}
@@ -211,7 +200,7 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
               />
             </div>
             <div
-              className="sc-jrAGrp hzspIa"
+              className="sc-pFZIQ bHvBzm"
             >
               <div
                 aria-describedby={null}
@@ -229,36 +218,36 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
                 </span>
               </div>
               <div
-                className="sc-iqHYGH dWLKtY"
+                className="sc-kEjbxe nCYed"
               >
                 Completed in 12s, with issues
               </div>
+              <button
+                className="sc-gsTCUz sZTnv"
+                onClick={[Function]}
+                title="Pin to Top"
+              >
+                <svg
+                  className="sc-hKgILt cXIGbx"
+                >
+                  pin.svg
+                </svg>
+              </button>
             </div>
           </div>
         </li>
         <li
-          className="sc-gKsewC eWwnQD u-showPinOnHover  isBuilding"
+          className="sc-jSgupP jnEojC u-showPinOnHover  isBuilding"
         >
-          <button
-            className="sc-dlfnbm begUcN"
-            onClick={[Function]}
-            title="Pin to Top"
-          >
-            <svg
-              className="sc-eCssSg eisvUy"
-            >
-              pin.svg
-            </svg>
-          </button>
           <div
-            className="sc-iBPRYJ epmLcA  isBuilding"
+            className="sc-gKsewC jSnJQd  isBuilding"
             data-name="resource19"
             onClick={[Function]}
             role="button"
             tabIndex={-1}
           >
             <div
-              className="sc-pFZIQ jNegfI"
+              className="sc-fubCfw giLNdL"
             >
               <div
                 aria-describedby={null}
@@ -276,17 +265,17 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
                 </span>
               </div>
               <div
-                className="sc-iqHYGH sc-crrsfI dWLKtY fACPxI"
+                className="sc-kEjbxe sc-iqHYGH nCYed gNenIV"
                 title="resource19"
               >
                 <span
-                  className="sc-dQppl dMras"
+                  className="sc-crrsfI jcYrCe"
                 >
                   resource19
                 </span>
               </div>
               <span
-                className="sc-bqyKva kPKqMc"
+                className="sc-dQppl rWCkn"
               >
                 <time
                   dateTime="2017-12-21T15:35:48.000Z"
@@ -296,7 +285,7 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
                 </time>
               </span>
               <button
-                className="sc-jSgupP gdBoFx SidebarTriggerButton 
+                className="sc-eCssSg fIfNJU SidebarTriggerButton 
           "
                 disabled={true}
                 onClick={[Function]}
@@ -304,7 +293,7 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
               />
             </div>
             <div
-              className="sc-jrAGrp hzspIa"
+              className="sc-pFZIQ bHvBzm"
             >
               <div
                 aria-describedby={null}
@@ -322,36 +311,36 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
                 </span>
               </div>
               <div
-                className="sc-iqHYGH dWLKtY"
+                className="sc-kEjbxe nCYed"
               >
                 Completed in 12s, with issues
               </div>
+              <button
+                className="sc-gsTCUz sZTnv"
+                onClick={[Function]}
+                title="Pin to Top"
+              >
+                <svg
+                  className="sc-hKgILt cXIGbx"
+                >
+                  pin.svg
+                </svg>
+              </button>
             </div>
           </div>
         </li>
         <li
-          className="sc-gKsewC eWwnQD u-showPinOnHover  isBuilding"
+          className="sc-jSgupP jnEojC u-showPinOnHover  isBuilding"
         >
-          <button
-            className="sc-dlfnbm begUcN"
-            onClick={[Function]}
-            title="Pin to Top"
-          >
-            <svg
-              className="sc-eCssSg eisvUy"
-            >
-              pin.svg
-            </svg>
-          </button>
           <div
-            className="sc-iBPRYJ epmLcA  isBuilding"
+            className="sc-gKsewC jSnJQd  isBuilding"
             data-name="resource29"
             onClick={[Function]}
             role="button"
             tabIndex={-1}
           >
             <div
-              className="sc-pFZIQ jNegfI"
+              className="sc-fubCfw giLNdL"
             >
               <div
                 aria-describedby={null}
@@ -369,17 +358,17 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
                 </span>
               </div>
               <div
-                className="sc-iqHYGH sc-crrsfI dWLKtY fACPxI"
+                className="sc-kEjbxe sc-iqHYGH nCYed gNenIV"
                 title="resource29"
               >
                 <span
-                  className="sc-dQppl dMras"
+                  className="sc-crrsfI jcYrCe"
                 >
                   resource29
                 </span>
               </div>
               <span
-                className="sc-bqyKva kPKqMc"
+                className="sc-dQppl rWCkn"
               >
                 <time
                   dateTime="2017-12-21T15:35:38.000Z"
@@ -389,7 +378,7 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
                 </time>
               </span>
               <button
-                className="sc-jSgupP gdBoFx SidebarTriggerButton 
+                className="sc-eCssSg fIfNJU SidebarTriggerButton 
           "
                 disabled={true}
                 onClick={[Function]}
@@ -397,7 +386,7 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
               />
             </div>
             <div
-              className="sc-jrAGrp hzspIa"
+              className="sc-pFZIQ bHvBzm"
             >
               <div
                 aria-describedby={null}
@@ -415,36 +404,36 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
                 </span>
               </div>
               <div
-                className="sc-iqHYGH dWLKtY"
+                className="sc-kEjbxe nCYed"
               >
                 Completed in 12s, with issues
               </div>
+              <button
+                className="sc-gsTCUz sZTnv"
+                onClick={[Function]}
+                title="Pin to Top"
+              >
+                <svg
+                  className="sc-hKgILt cXIGbx"
+                >
+                  pin.svg
+                </svg>
+              </button>
             </div>
           </div>
         </li>
         <li
-          className="sc-gKsewC eWwnQD u-showPinOnHover  isBuilding"
+          className="sc-jSgupP jnEojC u-showPinOnHover  isBuilding"
         >
-          <button
-            className="sc-dlfnbm begUcN"
-            onClick={[Function]}
-            title="Pin to Top"
-          >
-            <svg
-              className="sc-eCssSg eisvUy"
-            >
-              pin.svg
-            </svg>
-          </button>
           <div
-            className="sc-iBPRYJ epmLcA  isBuilding"
+            className="sc-gKsewC jSnJQd  isBuilding"
             data-name="resource39"
             onClick={[Function]}
             role="button"
             tabIndex={-1}
           >
             <div
-              className="sc-pFZIQ jNegfI"
+              className="sc-fubCfw giLNdL"
             >
               <div
                 aria-describedby={null}
@@ -462,17 +451,17 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
                 </span>
               </div>
               <div
-                className="sc-iqHYGH sc-crrsfI dWLKtY fACPxI"
+                className="sc-kEjbxe sc-iqHYGH nCYed gNenIV"
                 title="resource39"
               >
                 <span
-                  className="sc-dQppl dMras"
+                  className="sc-crrsfI jcYrCe"
                 >
                   resource39
                 </span>
               </div>
               <span
-                className="sc-bqyKva kPKqMc"
+                className="sc-dQppl rWCkn"
               >
                 <time
                   dateTime="2017-12-21T15:35:28.000Z"
@@ -482,7 +471,7 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
                 </time>
               </span>
               <button
-                className="sc-jSgupP gdBoFx SidebarTriggerButton 
+                className="sc-eCssSg fIfNJU SidebarTriggerButton 
           "
                 disabled={true}
                 onClick={[Function]}
@@ -490,7 +479,7 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
               />
             </div>
             <div
-              className="sc-jrAGrp hzspIa"
+              className="sc-pFZIQ bHvBzm"
             >
               <div
                 aria-describedby={null}
@@ -508,36 +497,36 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
                 </span>
               </div>
               <div
-                className="sc-iqHYGH dWLKtY"
+                className="sc-kEjbxe nCYed"
               >
                 Completed in 12s, with issues
               </div>
+              <button
+                className="sc-gsTCUz sZTnv"
+                onClick={[Function]}
+                title="Pin to Top"
+              >
+                <svg
+                  className="sc-hKgILt cXIGbx"
+                >
+                  pin.svg
+                </svg>
+              </button>
             </div>
           </div>
         </li>
         <li
-          className="sc-gKsewC eWwnQD u-showPinOnHover  isBuilding"
+          className="sc-jSgupP jnEojC u-showPinOnHover  isBuilding"
         >
-          <button
-            className="sc-dlfnbm begUcN"
-            onClick={[Function]}
-            title="Pin to Top"
-          >
-            <svg
-              className="sc-eCssSg eisvUy"
-            >
-              pin.svg
-            </svg>
-          </button>
           <div
-            className="sc-iBPRYJ epmLcA  isBuilding"
+            className="sc-gKsewC jSnJQd  isBuilding"
             data-name="resource49"
             onClick={[Function]}
             role="button"
             tabIndex={-1}
           >
             <div
-              className="sc-pFZIQ jNegfI"
+              className="sc-fubCfw giLNdL"
             >
               <div
                 aria-describedby={null}
@@ -555,17 +544,17 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
                 </span>
               </div>
               <div
-                className="sc-iqHYGH sc-crrsfI dWLKtY fACPxI"
+                className="sc-kEjbxe sc-iqHYGH nCYed gNenIV"
                 title="resource49"
               >
                 <span
-                  className="sc-dQppl dMras"
+                  className="sc-crrsfI jcYrCe"
                 >
                   resource49
                 </span>
               </div>
               <span
-                className="sc-bqyKva kPKqMc"
+                className="sc-dQppl rWCkn"
               >
                 <time
                   dateTime="2017-12-21T15:35:18.000Z"
@@ -575,7 +564,7 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
                 </time>
               </span>
               <button
-                className="sc-jSgupP gdBoFx SidebarTriggerButton 
+                className="sc-eCssSg fIfNJU SidebarTriggerButton 
           "
                 disabled={true}
                 onClick={[Function]}
@@ -583,7 +572,7 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
               />
             </div>
             <div
-              className="sc-jrAGrp hzspIa"
+              className="sc-pFZIQ bHvBzm"
             >
               <div
                 aria-describedby={null}
@@ -601,36 +590,36 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
                 </span>
               </div>
               <div
-                className="sc-iqHYGH dWLKtY"
+                className="sc-kEjbxe nCYed"
               >
                 Completed in 12s, with issues
               </div>
+              <button
+                className="sc-gsTCUz sZTnv"
+                onClick={[Function]}
+                title="Pin to Top"
+              >
+                <svg
+                  className="sc-hKgILt cXIGbx"
+                >
+                  pin.svg
+                </svg>
+              </button>
             </div>
           </div>
         </li>
         <li
-          className="sc-gKsewC eWwnQD u-showPinOnHover  isBuilding"
+          className="sc-jSgupP jnEojC u-showPinOnHover  isBuilding"
         >
-          <button
-            className="sc-dlfnbm begUcN"
-            onClick={[Function]}
-            title="Pin to Top"
-          >
-            <svg
-              className="sc-eCssSg eisvUy"
-            >
-              pin.svg
-            </svg>
-          </button>
           <div
-            className="sc-iBPRYJ epmLcA  isBuilding"
+            className="sc-gKsewC jSnJQd  isBuilding"
             data-name="resource54"
             onClick={[Function]}
             role="button"
             tabIndex={-1}
           >
             <div
-              className="sc-pFZIQ jNegfI"
+              className="sc-fubCfw giLNdL"
             >
               <div
                 aria-describedby={null}
@@ -648,17 +637,17 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
                 </span>
               </div>
               <div
-                className="sc-iqHYGH sc-crrsfI dWLKtY fACPxI"
+                className="sc-kEjbxe sc-iqHYGH nCYed gNenIV"
                 title="resource54"
               >
                 <span
-                  className="sc-dQppl dMras"
+                  className="sc-crrsfI jcYrCe"
                 >
                   resource54
                 </span>
               </div>
               <span
-                className="sc-bqyKva kPKqMc"
+                className="sc-dQppl rWCkn"
               >
                 <time
                   dateTime="2017-12-21T15:35:13.000Z"
@@ -668,7 +657,7 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
                 </time>
               </span>
               <button
-                className="sc-jSgupP gdBoFx SidebarTriggerButton 
+                className="sc-eCssSg fIfNJU SidebarTriggerButton 
           "
                 disabled={true}
                 onClick={[Function]}
@@ -676,7 +665,7 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
               />
             </div>
             <div
-              className="sc-jrAGrp hzspIa"
+              className="sc-pFZIQ bHvBzm"
             >
               <div
                 aria-describedby={null}
@@ -694,10 +683,21 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
                 </span>
               </div>
               <div
-                className="sc-iqHYGH dWLKtY"
+                className="sc-kEjbxe nCYed"
               >
                 Completed in 12s, with issues
               </div>
+              <button
+                className="sc-gsTCUz sZTnv"
+                onClick={[Function]}
+                title="Pin to Top"
+              >
+                <svg
+                  className="sc-hKgILt cXIGbx"
+                >
+                  pin.svg
+                </svg>
+              </button>
             </div>
           </div>
         </li>
@@ -710,25 +710,25 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
 
 exports[`sidebar renders empty resource list without crashing 1`] = `
 <nav
-  className="sc-kstrdz cVJnKg Sidebar-resources "
+  className="sc-bqyKva cUnZrS Sidebar-resources "
 >
   <div
-    className="sc-hBEYos"
+    className="sc-kstrdz"
   >
     <div>
       <div
-        className="sc-fodVxV hjvysh"
+        className="sc-hBEYos bxmZqH"
       >
         
       </div>
       <ul
-        className="sc-fFubgz lggJRB"
+        className="sc-fodVxV ewSMuO"
       >
         <li
-          className="sc-gKsewC sc-kEjbxe eWwnQD bmYsyG"
+          className="sc-jSgupP sc-jrAGrp jnEojC jhbijv"
         >
           <div
-            className="sc-iBPRYJ sc-fubCfw epmLcA hDyxGh isSelected"
+            className="sc-gKsewC sc-iBPRYJ jSnJQd kEXXSo isSelected"
             onClick={[Function]}
             role="button"
             tabIndex={-1}
@@ -741,7 +741,7 @@ exports[`sidebar renders empty resource list without crashing 1`] = `
               </svg>
             </div>
             <div
-              className="sc-iqHYGH sc-crrsfI dWLKtY fACPxI"
+              className="sc-kEjbxe sc-iqHYGH nCYed gNenIV"
             >
               All
             </div>
@@ -751,12 +751,12 @@ exports[`sidebar renders empty resource list without crashing 1`] = `
     </div>
     <div>
       <div
-        className="sc-fodVxV hjvysh"
+        className="sc-hBEYos bxmZqH"
       >
         resources
       </div>
       <ul
-        className="sc-fFubgz lggJRB"
+        className="sc-fodVxV ewSMuO"
       />
     </div>
   </div>
@@ -766,25 +766,25 @@ exports[`sidebar renders empty resource list without crashing 1`] = `
 
 exports[`sidebar renders list of resources 1`] = `
 <nav
-  className="sc-kstrdz cVJnKg Sidebar-resources "
+  className="sc-bqyKva cUnZrS Sidebar-resources "
 >
   <div
-    className="sc-hBEYos"
+    className="sc-kstrdz"
   >
     <div>
       <div
-        className="sc-fodVxV hjvysh"
+        className="sc-hBEYos bxmZqH"
       >
         
       </div>
       <ul
-        className="sc-fFubgz lggJRB"
+        className="sc-fodVxV ewSMuO"
       >
         <li
-          className="sc-gKsewC sc-kEjbxe eWwnQD bmYsyG"
+          className="sc-jSgupP sc-jrAGrp jnEojC jhbijv"
         >
           <div
-            className="sc-iBPRYJ sc-fubCfw epmLcA hDyxGh isSelected"
+            className="sc-gKsewC sc-iBPRYJ jSnJQd kEXXSo isSelected"
             onClick={[Function]}
             role="button"
             tabIndex={-1}
@@ -797,7 +797,7 @@ exports[`sidebar renders list of resources 1`] = `
               </svg>
             </div>
             <div
-              className="sc-iqHYGH sc-crrsfI dWLKtY fACPxI"
+              className="sc-kEjbxe sc-iqHYGH nCYed gNenIV"
             >
               All
             </div>
@@ -807,36 +807,25 @@ exports[`sidebar renders list of resources 1`] = `
     </div>
     <div>
       <div
-        className="sc-fodVxV hjvysh"
+        className="sc-hBEYos bxmZqH"
       >
         resources
       </div>
       <ul
-        className="sc-fFubgz lggJRB"
+        className="sc-fodVxV ewSMuO"
       >
         <li
-          className="sc-gKsewC eWwnQD u-showPinOnHover  isBuilding"
+          className="sc-jSgupP jnEojC u-showPinOnHover  isBuilding"
         >
-          <button
-            className="sc-dlfnbm begUcN"
-            onClick={[Function]}
-            title="Pin to Top"
-          >
-            <svg
-              className="sc-eCssSg eisvUy"
-            >
-              pin.svg
-            </svg>
-          </button>
           <div
-            className="sc-iBPRYJ epmLcA  isBuilding"
+            className="sc-gKsewC jSnJQd  isBuilding"
             data-name="vigoda"
             onClick={[Function]}
             role="button"
             tabIndex={-1}
           >
             <div
-              className="sc-pFZIQ jNegfI"
+              className="sc-fubCfw giLNdL"
             >
               <div
                 aria-describedby={null}
@@ -854,17 +843,17 @@ exports[`sidebar renders list of resources 1`] = `
                 </span>
               </div>
               <div
-                className="sc-iqHYGH sc-crrsfI dWLKtY fACPxI"
+                className="sc-kEjbxe sc-iqHYGH nCYed gNenIV"
                 title="vigoda"
               >
                 <span
-                  className="sc-dQppl dMras"
+                  className="sc-crrsfI jcYrCe"
                 >
                   vigoda
                 </span>
               </div>
               <span
-                className="sc-bqyKva kPKqMc"
+                className="sc-dQppl rWCkn"
               >
                 <time
                   dateTime="2017-12-21T15:36:07.000Z"
@@ -874,7 +863,7 @@ exports[`sidebar renders list of resources 1`] = `
                 </time>
               </span>
               <button
-                className="sc-jSgupP gdBoFx SidebarTriggerButton 
+                className="sc-eCssSg fIfNJU SidebarTriggerButton 
           "
                 disabled={true}
                 onClick={[Function]}
@@ -882,7 +871,7 @@ exports[`sidebar renders list of resources 1`] = `
               />
             </div>
             <div
-              className="sc-jrAGrp hzspIa"
+              className="sc-pFZIQ bHvBzm"
             >
               <div
                 aria-describedby={null}
@@ -902,36 +891,36 @@ exports[`sidebar renders list of resources 1`] = `
                 </svg>
               </div>
               <div
-                className="sc-iqHYGH dWLKtY"
+                className="sc-kEjbxe nCYed"
               >
                 Update error
               </div>
+              <button
+                className="sc-gsTCUz sZTnv"
+                onClick={[Function]}
+                title="Pin to Top"
+              >
+                <svg
+                  className="sc-hKgILt cXIGbx"
+                >
+                  pin.svg
+                </svg>
+              </button>
             </div>
           </div>
         </li>
         <li
-          className="sc-gKsewC eWwnQD u-showPinOnHover  isBuilding"
+          className="sc-jSgupP jnEojC u-showPinOnHover  isBuilding"
         >
-          <button
-            className="sc-dlfnbm begUcN"
-            onClick={[Function]}
-            title="Pin to Top"
-          >
-            <svg
-              className="sc-eCssSg eisvUy"
-            >
-              pin.svg
-            </svg>
-          </button>
           <div
-            className="sc-iBPRYJ epmLcA  isBuilding"
+            className="sc-gKsewC jSnJQd  isBuilding"
             data-name="snack"
             onClick={[Function]}
             role="button"
             tabIndex={-1}
           >
             <div
-              className="sc-pFZIQ jNegfI"
+              className="sc-fubCfw giLNdL"
             >
               <div
                 aria-describedby={null}
@@ -949,17 +938,17 @@ exports[`sidebar renders list of resources 1`] = `
                 </span>
               </div>
               <div
-                className="sc-iqHYGH sc-crrsfI dWLKtY fACPxI"
+                className="sc-kEjbxe sc-iqHYGH nCYed gNenIV"
                 title="snack"
               >
                 <span
-                  className="sc-dQppl dMras"
+                  className="sc-crrsfI jcYrCe"
                 >
                   snack
                 </span>
               </div>
               <span
-                className="sc-bqyKva kPKqMc"
+                className="sc-dQppl rWCkn"
               >
                 <time
                   dateTime="2017-12-21T15:35:57.000Z"
@@ -969,7 +958,7 @@ exports[`sidebar renders list of resources 1`] = `
                 </time>
               </span>
               <button
-                className="sc-jSgupP gdBoFx SidebarTriggerButton 
+                className="sc-eCssSg fIfNJU SidebarTriggerButton 
           "
                 disabled={true}
                 onClick={[Function]}
@@ -977,7 +966,7 @@ exports[`sidebar renders list of resources 1`] = `
               />
             </div>
             <div
-              className="sc-jrAGrp hzspIa"
+              className="sc-pFZIQ bHvBzm"
             >
               <div
                 aria-describedby={null}
@@ -997,10 +986,21 @@ exports[`sidebar renders list of resources 1`] = `
                 </svg>
               </div>
               <div
-                className="sc-iqHYGH dWLKtY"
+                className="sc-kEjbxe nCYed"
               >
                 Update error
               </div>
+              <button
+                className="sc-gsTCUz sZTnv"
+                onClick={[Function]}
+                title="Pin to Top"
+              >
+                <svg
+                  className="sc-hKgILt cXIGbx"
+                >
+                  pin.svg
+                </svg>
+              </button>
             </div>
           </div>
         </li>
@@ -1013,25 +1013,25 @@ exports[`sidebar renders list of resources 1`] = `
 
 exports[`sidebar renders resources that haven't been built yet 1`] = `
 <nav
-  className="sc-kstrdz cVJnKg Sidebar-resources "
+  className="sc-bqyKva cUnZrS Sidebar-resources "
 >
   <div
-    className="sc-hBEYos"
+    className="sc-kstrdz"
   >
     <div>
       <div
-        className="sc-fodVxV hjvysh"
+        className="sc-hBEYos bxmZqH"
       >
         
       </div>
       <ul
-        className="sc-fFubgz lggJRB"
+        className="sc-fodVxV ewSMuO"
       >
         <li
-          className="sc-gKsewC sc-kEjbxe eWwnQD bmYsyG"
+          className="sc-jSgupP sc-jrAGrp jnEojC jhbijv"
         >
           <div
-            className="sc-iBPRYJ sc-fubCfw epmLcA hDyxGh isSelected"
+            className="sc-gKsewC sc-iBPRYJ jSnJQd kEXXSo isSelected"
             onClick={[Function]}
             role="button"
             tabIndex={-1}
@@ -1044,7 +1044,7 @@ exports[`sidebar renders resources that haven't been built yet 1`] = `
               </svg>
             </div>
             <div
-              className="sc-iqHYGH sc-crrsfI dWLKtY fACPxI"
+              className="sc-kEjbxe sc-iqHYGH nCYed gNenIV"
             >
               All
             </div>
@@ -1054,36 +1054,25 @@ exports[`sidebar renders resources that haven't been built yet 1`] = `
     </div>
     <div>
       <div
-        className="sc-fodVxV hjvysh"
+        className="sc-hBEYos bxmZqH"
       >
         resources
       </div>
       <ul
-        className="sc-fFubgz lggJRB"
+        className="sc-fodVxV ewSMuO"
       >
         <li
-          className="sc-gKsewC eWwnQD u-showPinOnHover  isBuilding"
+          className="sc-jSgupP jnEojC u-showPinOnHover  isBuilding"
         >
-          <button
-            className="sc-dlfnbm begUcN"
-            onClick={[Function]}
-            title="Pin to Top"
-          >
-            <svg
-              className="sc-eCssSg eisvUy"
-            >
-              pin.svg
-            </svg>
-          </button>
           <div
-            className="sc-iBPRYJ epmLcA  isBuilding"
+            className="sc-gKsewC jSnJQd  isBuilding"
             data-name="vigoda"
             onClick={[Function]}
             role="button"
             tabIndex={-1}
           >
             <div
-              className="sc-pFZIQ jNegfI"
+              className="sc-fubCfw giLNdL"
             >
               <div
                 aria-describedby={null}
@@ -1101,22 +1090,22 @@ exports[`sidebar renders resources that haven't been built yet 1`] = `
                 </span>
               </div>
               <div
-                className="sc-iqHYGH sc-crrsfI dWLKtY fACPxI"
+                className="sc-kEjbxe sc-iqHYGH nCYed gNenIV"
                 title="vigoda"
               >
                 <span
-                  className="sc-dQppl dMras"
+                  className="sc-crrsfI jcYrCe"
                 >
                   vigoda
                 </span>
               </div>
               <span
-                className="sc-bqyKva kPKqMc"
+                className="sc-dQppl rWCkn"
               >
                 —
               </span>
               <button
-                className="sc-jSgupP gdBoFx SidebarTriggerButton 
+                className="sc-eCssSg fIfNJU SidebarTriggerButton 
           "
                 disabled={true}
                 onClick={[Function]}
@@ -1124,7 +1113,7 @@ exports[`sidebar renders resources that haven't been built yet 1`] = `
               />
             </div>
             <div
-              className="sc-jrAGrp hzspIa"
+              className="sc-pFZIQ bHvBzm"
             >
               <div
                 aria-describedby={null}
@@ -1142,36 +1131,36 @@ exports[`sidebar renders resources that haven't been built yet 1`] = `
                 </span>
               </div>
               <div
-                className="sc-iqHYGH dWLKtY"
+                className="sc-kEjbxe nCYed"
               >
                 Updating…
               </div>
+              <button
+                className="sc-gsTCUz sZTnv"
+                onClick={[Function]}
+                title="Pin to Top"
+              >
+                <svg
+                  className="sc-hKgILt cXIGbx"
+                >
+                  pin.svg
+                </svg>
+              </button>
             </div>
           </div>
         </li>
         <li
-          className="sc-gKsewC eWwnQD u-showPinOnHover  isBuilding"
+          className="sc-jSgupP jnEojC u-showPinOnHover  isBuilding"
         >
-          <button
-            className="sc-dlfnbm begUcN"
-            onClick={[Function]}
-            title="Pin to Top"
-          >
-            <svg
-              className="sc-eCssSg eisvUy"
-            >
-              pin.svg
-            </svg>
-          </button>
           <div
-            className="sc-iBPRYJ epmLcA  isBuilding"
+            className="sc-gKsewC jSnJQd  isBuilding"
             data-name="snack"
             onClick={[Function]}
             role="button"
             tabIndex={-1}
           >
             <div
-              className="sc-pFZIQ jNegfI"
+              className="sc-fubCfw giLNdL"
             >
               <div
                 aria-describedby={null}
@@ -1189,22 +1178,22 @@ exports[`sidebar renders resources that haven't been built yet 1`] = `
                 </span>
               </div>
               <div
-                className="sc-iqHYGH sc-crrsfI dWLKtY fACPxI"
+                className="sc-kEjbxe sc-iqHYGH nCYed gNenIV"
                 title="snack"
               >
                 <span
-                  className="sc-dQppl dMras"
+                  className="sc-crrsfI jcYrCe"
                 >
                   snack
                 </span>
               </div>
               <span
-                className="sc-bqyKva kPKqMc"
+                className="sc-dQppl rWCkn"
               >
                 —
               </span>
               <button
-                className="sc-jSgupP gdBoFx SidebarTriggerButton 
+                className="sc-eCssSg fIfNJU SidebarTriggerButton 
           "
                 disabled={true}
                 onClick={[Function]}
@@ -1212,7 +1201,7 @@ exports[`sidebar renders resources that haven't been built yet 1`] = `
               />
             </div>
             <div
-              className="sc-jrAGrp hzspIa"
+              className="sc-pFZIQ bHvBzm"
             >
               <div
                 aria-describedby={null}
@@ -1230,10 +1219,21 @@ exports[`sidebar renders resources that haven't been built yet 1`] = `
                 </span>
               </div>
               <div
-                className="sc-iqHYGH dWLKtY"
+                className="sc-kEjbxe nCYed"
               >
                 Updating…
               </div>
+              <button
+                className="sc-gsTCUz sZTnv"
+                onClick={[Function]}
+                title="Pin to Top"
+              >
+                <svg
+                  className="sc-hKgILt cXIGbx"
+                >
+                  pin.svg
+                </svg>
+              </button>
             </div>
           </div>
         </li>

--- a/web/src/style-helpers.ts
+++ b/web/src/style-helpers.ts
@@ -74,7 +74,6 @@ export enum Width {
   badge = unit * 0.6,
   secondaryNavItem = unit * 5,
   sidebarTriggerButton = unit,
-  sidebarPinButton = unit * 0.75,
   sidebar = unit * 10.5, // Sync with constants.scss > $sidebar-width
   sidebarCollapsed = unit,
   statusbar = unit * 1.5, // sync with constants.scss > $statusbar-height


### PR DESCRIPTION
Hello @hyu,

Please review the following commits I made in branch nicks/ch10512:

517ab132fb94371f03501fdbe224812db4edfa1c (2021-01-21 17:42:08 -0500)
web: move pin button inside SidebarItemVeiw and OverviewItemView cards

2171601e02cddb6c87a6dbfdf9ac568fbff66767 (2021-01-21 14:40:07 -0500)
web: split SidebarPinButton into a standalone component

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics