### PR TITLE
web: Add endpoint keyboard shortcuts.

### DIFF
--- a/web/src/OverviewActionBar.tsx
+++ b/web/src/OverviewActionBar.tsx
@@ -5,6 +5,7 @@ import { ReactComponent as CheckmarkSvg } from "./assets/svg/checkmark.svg"
 import { ReactComponent as CopySvg } from "./assets/svg/copy.svg"
 import { ReactComponent as LinkSvg } from "./assets/svg/link.svg"
 import { displayURL } from "./links"
+import OverviewActionBarKeyboardShortcuts from "./OverviewActionBarKeyboardShortcuts"
 import { AnimDuration, Color, Font, FontSize, SizeUnit } from "./style-helpers"
 
 type OverviewActionBarProps = {
@@ -126,6 +127,15 @@ let EndpointIcon = styled(LinkSvg)`
   margin-right: ${SizeUnit(0.25)};
 `
 
+// TODO(nick): Put this in a global React Context object with
+// other page-level stuffs
+function openEndpointUrl(url: string) {
+  // We deliberately don't use rel=noopener. These are trusted tabs, and we want
+  // to have a persistent link to them (so that clicking on the same link opens
+  // the same tab).
+  window.open(url, url)
+}
+
 export default function OverviewActionBar(props: OverviewActionBarProps) {
   let { resource } = props
   let manifestName = resource?.name || ""
@@ -162,6 +172,10 @@ export default function OverviewActionBar(props: OverviewActionBarProps) {
         <EndpointSet />
       )}
       {copyButton}
+      <OverviewActionBarKeyboardShortcuts
+        endpoints={endpoints}
+        openEndpointUrl={openEndpointUrl}
+      />
     </ActionBarRoot>
   )
 }

--- a/web/src/OverviewActionBarKeyboardShortcuts.test.tsx
+++ b/web/src/OverviewActionBarKeyboardShortcuts.test.tsx
@@ -1,0 +1,51 @@
+import { fireEvent } from "@testing-library/dom"
+import { mount } from "enzyme"
+import React from "react"
+import OverviewActionBarKeyboardShortcuts from "./OverviewActionBarKeyboardShortcuts"
+
+function numKeyCode(num: number): number {
+  return num + 48
+}
+
+type Link = Proto.webviewLink
+
+let component: any
+let endpointUrl = ""
+const shortcuts = (endpoints: Link[]) => {
+  endpointUrl = ""
+  component = mount(
+    <OverviewActionBarKeyboardShortcuts
+      endpoints={endpoints}
+      openEndpointUrl={(url) => (endpointUrl = url)}
+    />
+  )
+}
+
+afterEach(() => {
+  if (component) {
+    component.unmount()
+    component = null
+  }
+})
+
+it("zero endpoint urls", () => {
+  shortcuts([])
+  fireEvent.keyDown(document.body, { keyCode: numKeyCode(1), shiftKey: true })
+  expect(endpointUrl).toEqual("")
+})
+it("two endpoint urls trigger first", () => {
+  shortcuts([
+    { url: "https://tilt.dev:4000" },
+    { url: "https://tilt.dev:4001" },
+  ])
+  fireEvent.keyDown(document.body, { keyCode: numKeyCode(1), shiftKey: true })
+  expect(endpointUrl).toEqual("https://tilt.dev:4000")
+})
+it("two endpoint urls trigger second", () => {
+  shortcuts([
+    { url: "https://tilt.dev:4000" },
+    { url: "https://tilt.dev:4001" },
+  ])
+  fireEvent.keyDown(document.body, { keyCode: numKeyCode(2), shiftKey: true })
+  expect(endpointUrl).toEqual("https://tilt.dev:4001")
+})

--- a/web/src/OverviewActionBarKeyboardShortcuts.tsx
+++ b/web/src/OverviewActionBarKeyboardShortcuts.tsx
@@ -1,0 +1,55 @@
+import React, { Component } from "react"
+import { incr } from "./analytics"
+
+type Link = Proto.webviewLink
+
+type Props = {
+  endpoints?: Link[]
+  openEndpointUrl: (url: string) => void
+}
+
+const keyCodeOne = 49
+const keyCodeNine = 57
+
+/**
+ * Sets up keyboard shortcuts that depend on the state of the current resource.
+ */
+class OverviewActionBarKeyboardShortcuts extends Component<Props> {
+  constructor(props: Props) {
+    super(props)
+    this.onKeydown = this.onKeydown.bind(this)
+  }
+
+  componentDidMount() {
+    document.body.addEventListener("keydown", this.onKeydown)
+  }
+
+  componentWillUnmount() {
+    document.body.removeEventListener("keydown", this.onKeydown)
+  }
+
+  onKeydown(e: KeyboardEvent) {
+    if (e.metaKey || e.altKey || e.ctrlKey || e.isComposing) {
+      return
+    }
+
+    if (e.keyCode >= keyCodeOne && e.keyCode <= keyCodeNine && e.shiftKey) {
+      let endpointIndex = e.keyCode - keyCodeOne
+      let endpoint = this.props.endpoints && this.props.endpoints[endpointIndex]
+      if (!endpoint || !endpoint.url) {
+        return
+      }
+
+      incr("ui.web.endpoint", { action: "shortcut" })
+      this.props.openEndpointUrl(endpoint.url)
+      e.preventDefault()
+      return
+    }
+  }
+
+  render() {
+    return <span style={{ display: "none" }}></span>
+  }
+}
+
+export default OverviewActionBarKeyboardShortcuts


### PR DESCRIPTION
Hello @hyu,

Please review the following commits I made in branch nicks/ch10892:

83e0392bdda1c0db8b1643b490f8d9f0a502217a (2021-01-22 13:16:49 -0500)
web: Add endpoint keyboard shortcuts.
This is a straight-up copy-and-paste from
https://github.com/tilt-dev/tilt/blob/master/web/src/ResourceInfoKeyboardShortcuts.tsx

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics