### PR TITLE
web: infer log filters from the url

### DIFF
--- a/web/src/OverviewLogPane.stories.tsx
+++ b/web/src/OverviewLogPane.stories.tsx
@@ -1,8 +1,10 @@
 import React, { Component, useEffect, useState } from "react"
 import { MemoryRouter } from "react-router"
+import { FilterLevel, FilterSource } from "./logfilters"
 import LogStore, { LogStoreProvider } from "./LogStore"
 import OverviewLogPane from "./OverviewLogPane"
 import { appendLines } from "./testlogs"
+import { LogLevel } from "./types"
 
 export default {
   title: "OverviewLogPane",
@@ -24,12 +26,14 @@ export default {
   ],
 }
 
+let defaultFilter = { source: FilterSource.all, level: FilterLevel.all }
+
 export const ThreeLines = () => {
   let logStore = new LogStore()
   appendLines(logStore, "fe", "line 1\n", "line2\n", "line3\n")
   return (
     <LogStoreProvider value={logStore}>
-      <OverviewLogPane manifestName="fe" />
+      <OverviewLogPane manifestName="fe" filterSet={defaultFilter} />
     </LogStoreProvider>
   )
 }
@@ -39,7 +43,7 @@ export const ThreeLinesAllLog = () => {
   appendLines(logStore, "", "line 1\n", "line2\n", "line3\n")
   return (
     <LogStoreProvider value={logStore}>
-      <OverviewLogPane manifestName="" />
+      <OverviewLogPane manifestName="" filterSet={defaultFilter} />
     </LogStoreProvider>
   )
 }
@@ -53,7 +57,7 @@ export const ManyLines = (args: any) => {
   appendLines(logStore, "fe", lines)
   return (
     <LogStoreProvider value={logStore}>
-      <OverviewLogPane manifestName="fe" />
+      <OverviewLogPane manifestName="fe" filterSet={defaultFilter} />
     </LogStoreProvider>
   )
 }
@@ -82,7 +86,7 @@ export const StyledLines = () => {
   appendLines(logStore, "fe", ...lines)
   return (
     <LogStoreProvider value={logStore}>
-      <OverviewLogPane manifestName="fe" />
+      <OverviewLogPane manifestName="fe" filterSet={defaultFilter} />
     </LogStoreProvider>
   )
 }
@@ -98,7 +102,7 @@ export const BuildEventLines = () => {
   appendLines(logStore, "fe", ...lines)
   return (
     <LogStoreProvider value={logStore}>
-      <OverviewLogPane manifestName="fe" />
+      <OverviewLogPane manifestName="fe" filterSet={defaultFilter} />
     </LogStoreProvider>
   )
 }
@@ -127,7 +131,7 @@ export const ProgressLines = (args: any) => {
 
   return (
     <LogStoreProvider value={logStore}>
-      <OverviewLogPane manifestName="fe" />
+      <OverviewLogPane manifestName="fe" filterSet={defaultFilter} />
     </LogStoreProvider>
   )
 }
@@ -181,7 +185,7 @@ class ForeverLogComponent extends Component<ForeverLogProps> {
   render() {
     return (
       <LogStoreProvider value={this.logStore}>
-        <OverviewLogPane manifestName="fe" />
+        <OverviewLogPane manifestName="fe" filterSet={defaultFilter} />
       </LogStoreProvider>
     )
   }
@@ -203,17 +207,37 @@ export const BuildLogAndRunLog = (args: any) => {
   let logStore = new LogStore()
   let segments = []
   for (let i = 0; i < 10; i++) {
+    let level = ""
+    let lineType = "build"
+    if (i === 5) {
+      level = LogLevel.WARN
+      lineType = "build warning"
+    } else if (i === 9) {
+      level = LogLevel.ERROR
+      lineType = "build error"
+    }
     segments.push({
       spanId: "build:1",
-      text: `Vigoda build line ${i}\n`,
+      text: `Vigoda ${lineType} line ${i}\n`,
       time: new Date().toString(),
+      level,
     })
   }
   for (let i = 0; i < 10; i++) {
+    let level = ""
+    let lineType = "pod"
+    if (i === 5) {
+      level = LogLevel.WARN
+      lineType = "pod warning"
+    } else if (i === 9) {
+      level = LogLevel.ERROR
+      lineType = "pod error"
+    }
     segments.push({
       spanId: "pod:1",
-      text: `Vigoda pod line ${i}\n`,
+      text: `Vigoda ${lineType} line ${i}\n`,
       time: new Date().toString(),
+      level,
     })
   }
   logStore.append({
@@ -228,19 +252,28 @@ export const BuildLogAndRunLog = (args: any) => {
     <LogStoreProvider value={logStore}>
       <OverviewLogPane
         manifestName={"vigoda_1"}
-        hideBuildLog={args.hideBuildLog}
-        hideRunLog={args.hideRunLog}
+        filterSet={{ source: args.source, level: args.level }}
       />
     </LogStoreProvider>
   )
 }
 
 BuildLogAndRunLog.args = {
-  hideBuildLog: false,
-  hideRunLog: false,
+  source: "",
+  level: "",
 }
 
 BuildLogAndRunLog.argTypes = {
-  hideBuildLog: { control: { type: "boolean" } },
-  hideRunLog: { control: { type: "boolean" } },
+  source: {
+    control: {
+      type: "select",
+      options: [FilterSource.all, FilterSource.build, FilterSource.runtime],
+    },
+  },
+  level: {
+    control: {
+      type: "select",
+      options: [FilterLevel.all, FilterLevel.warn, FilterLevel.error],
+    },
+  },
 }

--- a/web/src/OverviewLogPane.test.tsx
+++ b/web/src/OverviewLogPane.test.tsx
@@ -1,4 +1,5 @@
 import { mount } from "enzyme"
+import { FilterLevel, FilterSource } from "./logfilters"
 import { OverviewLogComponent, renderWindow } from "./OverviewLogPane"
 import {
   BuildLogAndRunLog,
@@ -33,12 +34,14 @@ it("escapes html and linkifies", () => {
   expect(el.querySelectorAll(".LogPaneLine button")).toHaveLength(0)
 })
 
-it("hides build logs", () => {
+it("filters by source", () => {
   let root = logPaneMount(<BuildLogAndRunLog />)
   let el = root.getDOMNode()
   expect(el.querySelectorAll(".LogPaneLine")).toHaveLength(20)
 
-  let root2 = logPaneMount(<BuildLogAndRunLog hideBuildLog={true} />)
+  let root2 = logPaneMount(
+    <BuildLogAndRunLog level="" source={FilterSource.runtime} />
+  )
   let el2 = root2.getDOMNode()
   expect(el2.querySelectorAll(".LogPaneLine")).toHaveLength(10)
   expect(el2.innerHTML).toEqual(expect.stringContaining("Vigoda pod line"))
@@ -46,11 +49,45 @@ it("hides build logs", () => {
     expect.not.stringContaining("Vigoda build line")
   )
 
-  let root3 = logPaneMount(<BuildLogAndRunLog hideRunLog={true} />)
+  let root3 = logPaneMount(
+    <BuildLogAndRunLog level="" source={FilterSource.build} />
+  )
   let el3 = root3.getDOMNode()
   expect(el3.querySelectorAll(".LogPaneLine")).toHaveLength(10)
   expect(el3.innerHTML).toEqual(expect.not.stringContaining("Vigoda pod line"))
   expect(el3.innerHTML).toEqual(expect.stringContaining("Vigoda build line"))
+})
+
+it("filters by level", () => {
+  let root = logPaneMount(<BuildLogAndRunLog />)
+  let el = root.getDOMNode()
+  expect(el.querySelectorAll(".LogPaneLine")).toHaveLength(20)
+
+  let root2 = logPaneMount(
+    <BuildLogAndRunLog level={FilterLevel.warn} source="" />
+  )
+  let el2 = root2.getDOMNode()
+  expect(el2.querySelectorAll(".LogPaneLine")).toHaveLength(2)
+  expect(el2.innerHTML).toEqual(
+    expect.stringContaining("Vigoda pod warning line")
+  )
+  expect(el2.innerHTML).toEqual(expect.not.stringContaining("Vigoda pod line"))
+  expect(el2.innerHTML).toEqual(
+    expect.not.stringContaining("Vigoda pod error line")
+  )
+
+  let root3 = logPaneMount(
+    <BuildLogAndRunLog level={FilterLevel.error} source="" />
+  )
+  let el3 = root3.getDOMNode()
+  expect(el3.querySelectorAll(".LogPaneLine")).toHaveLength(2)
+  expect(el3.innerHTML).toEqual(
+    expect.not.stringContaining("Vigoda pod warning line")
+  )
+  expect(el3.innerHTML).toEqual(expect.not.stringContaining("Vigoda pod line"))
+  expect(el3.innerHTML).toEqual(
+    expect.stringContaining("Vigoda pod error line")
+  )
 })
 
 it("engages autoscrolls on scroll down", () => {

--- a/web/src/OverviewLogPane.tsx
+++ b/web/src/OverviewLogPane.tsx
@@ -1,21 +1,26 @@
 import Anser from "anser"
 import React, { Component } from "react"
 import styled, { keyframes } from "styled-components"
+import {
+  FilterLevel,
+  FilterSet,
+  filterSetsEqual,
+  FilterSource,
+} from "./logfilters"
 import "./LogPane.scss"
 import "./LogPaneLine.scss"
 import LogStore, { useLogStore } from "./LogStore"
 import PathBuilder, { usePathBuilder } from "./PathBuilder"
 import { RafContext, useRaf } from "./raf"
 import { Color, SizeUnit } from "./style-helpers"
-import { LogLine } from "./types"
+import { LogLevel, LogLine } from "./types"
 
 type OverviewLogComponentProps = {
   manifestName: string
   pathBuilder: PathBuilder
   logStore: LogStore
   raf: RafContext
-  hideBuildLog?: boolean
-  hideRunLog?: boolean
+  filterSet: FilterSet
 }
 
 let LogPaneRoot = styled.section`
@@ -210,8 +215,7 @@ export class OverviewLogComponent extends Component<OverviewLogComponentProps> {
 
     if (
       prevProps.manifestName !== this.props.manifestName ||
-      prevProps.hideBuildLog !== this.props.hideBuildLog ||
-      prevProps.hideRunLog !== this.props.hideRunLog
+      !filterSetsEqual(prevProps.filterSet, this.props.filterSet)
     ) {
       this.resetRender()
       this.autoscroll = true
@@ -364,11 +368,24 @@ export class OverviewLogComponent extends Component<OverviewLogComponentProps> {
       ? logStore.manifestLogPatchSet(mn, startCheckpoint)
       : logStore.allLogPatchSet(startCheckpoint)
 
+    let { source, level } = this.props.filterSet
     let lines = patch.lines.filter((line) => {
-      if (this.props.hideBuildLog && line.spanId.indexOf("build:") === 0) {
+      if (
+        source === FilterSource.runtime &&
+        line.spanId.indexOf("build:") === 0
+      ) {
         return false
       }
-      if (this.props.hideRunLog && line.spanId.indexOf("build:") !== 0) {
+      if (
+        source === FilterSource.build &&
+        line.spanId.indexOf("build:") !== 0
+      ) {
+        return false
+      }
+      if (level === FilterLevel.warn && line.level !== LogLevel.WARN) {
+        return false
+      }
+      if (level === FilterLevel.error && line.level !== LogLevel.ERROR) {
         return false
       }
       return true
@@ -523,8 +540,7 @@ export class OverviewLogComponent extends Component<OverviewLogComponentProps> {
 
 type OverviewLogPaneProps = {
   manifestName: string
-  hideBuildLog?: boolean
-  hideRunLog?: boolean
+  filterSet: FilterSet
 }
 
 export default function OverviewLogPane(props: OverviewLogPaneProps) {
@@ -537,8 +553,7 @@ export default function OverviewLogPane(props: OverviewLogPaneProps) {
       pathBuilder={pathBuilder}
       logStore={logStore}
       raf={raf}
-      hideBuildLog={props.hideBuildLog}
-      hideRunLog={props.hideRunLog}
+      filterSet={props.filterSet}
     />
   )
 }

--- a/web/src/OverviewResourceDetails.tsx
+++ b/web/src/OverviewResourceDetails.tsx
@@ -1,5 +1,7 @@
 import React from "react"
+import { useHistory } from "react-router-dom"
 import styled from "styled-components"
+import { filterSetFromLocation } from "./logfilters"
 import OverviewActionBar from "./OverviewActionBar"
 import OverviewLogPane from "./OverviewLogPane"
 import { Color } from "./style-helpers"
@@ -33,13 +35,16 @@ export default function OverviewResourceDetails(
   let manifestName = resource?.name || ""
   let all = name === "" || name === ResourceName.all
   let notFound = !all && !manifestName
+  let history = useHistory()
+  let filterSet = filterSetFromLocation(history.location)
+
   return (
     <OverviewResourceDetailsRoot>
       <OverviewActionBar resource={resource} />
       {notFound ? (
         <NotFound>No resource '{name}'</NotFound>
       ) : (
-        <OverviewLogPane manifestName={manifestName} />
+        <OverviewLogPane manifestName={manifestName} filterSet={filterSet} />
       )}
     </OverviewResourceDetailsRoot>
   )

--- a/web/src/logfilters.ts
+++ b/web/src/logfilters.ts
@@ -1,0 +1,63 @@
+// Types and parsing logic for log filters.
+
+import { Location } from "history"
+
+export enum FilterLevel {
+  all = "",
+
+  // Only show warnings.
+  warn = "warn",
+
+  // Only show errors.
+  error = "error",
+}
+
+export enum FilterSource {
+  all = "",
+
+  // Only show build logs.
+  build = "build",
+
+  // Only show runtime logs.
+  runtime = "runtime",
+}
+
+export type FilterSet = {
+  level: FilterLevel
+  source: FilterSource
+}
+
+// The source of truth for log filters is the URL.
+// For example,
+// /r/(all)/overview?level=error&source=build
+// will only show errors from the build, not from the pod.
+export function filterSetFromLocation(l: Location): FilterSet {
+  let params = new URLSearchParams(l.search)
+  let filters = {
+    level: FilterLevel.all,
+    source: FilterSource.all,
+  }
+  switch (params.get("level")) {
+    case FilterLevel.warn:
+      filters.level = FilterLevel.warn
+      break
+    case FilterLevel.error:
+      filters.level = FilterLevel.error
+      break
+  }
+
+  switch (params.get("source")) {
+    case FilterSource.build:
+      filters.source = FilterSource.build
+      break
+    case FilterSource.runtime:
+      filters.source = FilterSource.runtime
+      break
+  }
+
+  return filters
+}
+
+export function filterSetsEqual(a: FilterSet, b: FilterSet): boolean {
+  return a.source === b.source && a.level === b.level
+}

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -88,6 +88,12 @@ export type Snapshot = {
   snapshotHighlight?: SnapshotHighlight | null
 }
 
+export enum LogLevel {
+  INFO = "INFO",
+  WARN = "WARN",
+  ERROR = "ERROR",
+}
+
 // A plaintext representation of a line of the log,
 // with metadata to render it in isolation.
 //


### PR DESCRIPTION
Hello @hyu,

Please review the following commits I made in branch nicks/filters:

99c25d98c45d019d29f0361f272e888f4281eb05 (2021-01-22 15:47:34 -0500)
web: infer log filters from the url

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics