### PR TITLE
web: fix card layouts on firefox

### DIFF
--- a/web/src/OverviewItemView.tsx
+++ b/web/src/OverviewItemView.tsx
@@ -167,7 +167,7 @@ export let OverviewItemBox = styled.div`
 
 let OverviewItemRuntimeBox = styled.div`
   display: flex;
-  align-items: top;
+  align-items: stretch;
   transition: border-color ${AnimDuration.default} linear;
 `
 
@@ -185,7 +185,7 @@ let InnerRuntimeBox = styled.div`
 
 let OverviewItemBuildBox = styled.div`
   display: flex;
-  align-items: center;
+  align-items: stretch;
   flex-shrink: 1;
   border-top: 1px solid ${Color.grayLighter};
 `

--- a/web/src/SidebarIcon.tsx
+++ b/web/src/SidebarIcon.tsx
@@ -48,7 +48,6 @@ let SidebarIconRoot = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
-  height: 100%;
   width: ${Width.statusIcon}px;
   margin-right: ${Width.statusIconMarginRight}px;
   transition: background-color ${AnimDuration.default} linear,

--- a/web/src/SidebarItemView.tsx
+++ b/web/src/SidebarItemView.tsx
@@ -88,7 +88,7 @@ let SidebarItemAllBox = styled(SidebarItemBox)`
 
 let SidebarItemRuntimeBox = styled.div`
   display: flex;
-  align-items: center;
+  align-items: stretch;
   height: ${SizeUnit(1)};
   border-bottom: 1px solid ${Color.grayLighter};
   box-sizing: border-box;
@@ -102,7 +102,7 @@ let SidebarItemRuntimeBox = styled.div`
 
 let SidebarItemBuildBox = styled.div`
   display: flex;
-  align-items: center;
+  align-items: stretch;
   flex-shrink: 1;
   height: ${SizeUnit(0.875)};
 `
@@ -175,6 +175,8 @@ let SidebarItemName = (props: { name: string }) => {
 
 let SidebarItemTimeAgo = styled.span`
   opacity: ${ColorAlpha.almostOpaque};
+  display: flex;
+  align-items: center;
 `
 
 export function triggerUpdate(name: string, action: string) {

--- a/web/src/__snapshots__/Sidebar.test.tsx.snap
+++ b/web/src/__snapshots__/Sidebar.test.tsx.snap
@@ -26,7 +26,7 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
             tabIndex={-1}
           >
             <div
-              className="sc-bdfBwQ jvkcBC isNone"
+              className="sc-bdfBwQ gsbKhm isNone"
             >
               <svg>
                 checkmark-small.svg
@@ -61,11 +61,11 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
             tabIndex={-1}
           >
             <div
-              className="sc-fubCfw cCiuJW"
+              className="sc-fubCfw fJcNga"
             >
               <div
                 aria-describedby={null}
-                className="sc-bdfBwQ jvkcBC isHealthy"
+                className="sc-bdfBwQ gsbKhm isHealthy"
                 onBlur={[Function]}
                 onFocus={[Function]}
                 onMouseLeave={[Function]}
@@ -89,7 +89,7 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
                 </span>
               </div>
               <span
-                className="sc-dQppl rWCkn"
+                className="sc-dQppl ca-dvvb"
               >
                 <time
                   dateTime="2017-12-21T15:36:03.000Z"
@@ -115,11 +115,11 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
               </button>
             </div>
             <div
-              className="sc-pFZIQ bHvBzm"
+              className="sc-pFZIQ iIlHOe"
             >
               <div
                 aria-describedby={null}
-                className="sc-bdfBwQ jvkcBC isHealthy"
+                className="sc-bdfBwQ gsbKhm isHealthy"
                 onBlur={[Function]}
                 onFocus={[Function]}
                 onMouseLeave={[Function]}
@@ -162,11 +162,11 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
             tabIndex={-1}
           >
             <div
-              className="sc-fubCfw cCiuJW"
+              className="sc-fubCfw fJcNga"
             >
               <div
                 aria-describedby={null}
-                className="sc-bdfBwQ jvkcBC isHealthy"
+                className="sc-bdfBwQ gsbKhm isHealthy"
                 onBlur={[Function]}
                 onFocus={[Function]}
                 onMouseLeave={[Function]}
@@ -190,7 +190,7 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
                 </span>
               </div>
               <span
-                className="sc-dQppl rWCkn"
+                className="sc-dQppl ca-dvvb"
               >
                 <time
                   dateTime="2017-12-21T15:35:58.000Z"
@@ -216,11 +216,11 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
               </button>
             </div>
             <div
-              className="sc-pFZIQ bHvBzm"
+              className="sc-pFZIQ iIlHOe"
             >
               <div
                 aria-describedby={null}
-                className="sc-bdfBwQ jvkcBC isHealthy"
+                className="sc-bdfBwQ gsbKhm isHealthy"
                 onBlur={[Function]}
                 onFocus={[Function]}
                 onMouseLeave={[Function]}
@@ -263,11 +263,11 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
             tabIndex={-1}
           >
             <div
-              className="sc-fubCfw cCiuJW"
+              className="sc-fubCfw fJcNga"
             >
               <div
                 aria-describedby={null}
-                className="sc-bdfBwQ jvkcBC isHealthy"
+                className="sc-bdfBwQ gsbKhm isHealthy"
                 onBlur={[Function]}
                 onFocus={[Function]}
                 onMouseLeave={[Function]}
@@ -291,7 +291,7 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
                 </span>
               </div>
               <span
-                className="sc-dQppl rWCkn"
+                className="sc-dQppl ca-dvvb"
               >
                 <time
                   dateTime="2017-12-21T15:35:48.000Z"
@@ -317,11 +317,11 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
               </button>
             </div>
             <div
-              className="sc-pFZIQ bHvBzm"
+              className="sc-pFZIQ iIlHOe"
             >
               <div
                 aria-describedby={null}
-                className="sc-bdfBwQ jvkcBC isHealthy"
+                className="sc-bdfBwQ gsbKhm isHealthy"
                 onBlur={[Function]}
                 onFocus={[Function]}
                 onMouseLeave={[Function]}
@@ -364,11 +364,11 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
             tabIndex={-1}
           >
             <div
-              className="sc-fubCfw cCiuJW"
+              className="sc-fubCfw fJcNga"
             >
               <div
                 aria-describedby={null}
-                className="sc-bdfBwQ jvkcBC isHealthy"
+                className="sc-bdfBwQ gsbKhm isHealthy"
                 onBlur={[Function]}
                 onFocus={[Function]}
                 onMouseLeave={[Function]}
@@ -392,7 +392,7 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
                 </span>
               </div>
               <span
-                className="sc-dQppl rWCkn"
+                className="sc-dQppl ca-dvvb"
               >
                 <time
                   dateTime="2017-12-21T15:35:38.000Z"
@@ -418,11 +418,11 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
               </button>
             </div>
             <div
-              className="sc-pFZIQ bHvBzm"
+              className="sc-pFZIQ iIlHOe"
             >
               <div
                 aria-describedby={null}
-                className="sc-bdfBwQ jvkcBC isHealthy"
+                className="sc-bdfBwQ gsbKhm isHealthy"
                 onBlur={[Function]}
                 onFocus={[Function]}
                 onMouseLeave={[Function]}
@@ -465,11 +465,11 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
             tabIndex={-1}
           >
             <div
-              className="sc-fubCfw cCiuJW"
+              className="sc-fubCfw fJcNga"
             >
               <div
                 aria-describedby={null}
-                className="sc-bdfBwQ jvkcBC isHealthy"
+                className="sc-bdfBwQ gsbKhm isHealthy"
                 onBlur={[Function]}
                 onFocus={[Function]}
                 onMouseLeave={[Function]}
@@ -493,7 +493,7 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
                 </span>
               </div>
               <span
-                className="sc-dQppl rWCkn"
+                className="sc-dQppl ca-dvvb"
               >
                 <time
                   dateTime="2017-12-21T15:35:28.000Z"
@@ -519,11 +519,11 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
               </button>
             </div>
             <div
-              className="sc-pFZIQ bHvBzm"
+              className="sc-pFZIQ iIlHOe"
             >
               <div
                 aria-describedby={null}
-                className="sc-bdfBwQ jvkcBC isHealthy"
+                className="sc-bdfBwQ gsbKhm isHealthy"
                 onBlur={[Function]}
                 onFocus={[Function]}
                 onMouseLeave={[Function]}
@@ -566,11 +566,11 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
             tabIndex={-1}
           >
             <div
-              className="sc-fubCfw cCiuJW"
+              className="sc-fubCfw fJcNga"
             >
               <div
                 aria-describedby={null}
-                className="sc-bdfBwQ jvkcBC isHealthy"
+                className="sc-bdfBwQ gsbKhm isHealthy"
                 onBlur={[Function]}
                 onFocus={[Function]}
                 onMouseLeave={[Function]}
@@ -594,7 +594,7 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
                 </span>
               </div>
               <span
-                className="sc-dQppl rWCkn"
+                className="sc-dQppl ca-dvvb"
               >
                 <time
                   dateTime="2017-12-21T15:35:18.000Z"
@@ -620,11 +620,11 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
               </button>
             </div>
             <div
-              className="sc-pFZIQ bHvBzm"
+              className="sc-pFZIQ iIlHOe"
             >
               <div
                 aria-describedby={null}
-                className="sc-bdfBwQ jvkcBC isHealthy"
+                className="sc-bdfBwQ gsbKhm isHealthy"
                 onBlur={[Function]}
                 onFocus={[Function]}
                 onMouseLeave={[Function]}
@@ -667,11 +667,11 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
             tabIndex={-1}
           >
             <div
-              className="sc-fubCfw cCiuJW"
+              className="sc-fubCfw fJcNga"
             >
               <div
                 aria-describedby={null}
-                className="sc-bdfBwQ jvkcBC isHealthy"
+                className="sc-bdfBwQ gsbKhm isHealthy"
                 onBlur={[Function]}
                 onFocus={[Function]}
                 onMouseLeave={[Function]}
@@ -695,7 +695,7 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
                 </span>
               </div>
               <span
-                className="sc-dQppl rWCkn"
+                className="sc-dQppl ca-dvvb"
               >
                 <time
                   dateTime="2017-12-21T15:35:13.000Z"
@@ -721,11 +721,11 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
               </button>
             </div>
             <div
-              className="sc-pFZIQ bHvBzm"
+              className="sc-pFZIQ iIlHOe"
             >
               <div
                 aria-describedby={null}
-                className="sc-bdfBwQ jvkcBC isHealthy"
+                className="sc-bdfBwQ gsbKhm isHealthy"
                 onBlur={[Function]}
                 onFocus={[Function]}
                 onMouseLeave={[Function]}
@@ -790,7 +790,7 @@ exports[`sidebar renders empty resource list without crashing 1`] = `
             tabIndex={-1}
           >
             <div
-              className="sc-bdfBwQ jvkcBC isNone"
+              className="sc-bdfBwQ gsbKhm isNone"
             >
               <svg>
                 checkmark-small.svg
@@ -846,7 +846,7 @@ exports[`sidebar renders list of resources 1`] = `
             tabIndex={-1}
           >
             <div
-              className="sc-bdfBwQ jvkcBC isNone"
+              className="sc-bdfBwQ gsbKhm isNone"
             >
               <svg>
                 checkmark-small.svg
@@ -881,11 +881,11 @@ exports[`sidebar renders list of resources 1`] = `
             tabIndex={-1}
           >
             <div
-              className="sc-fubCfw cCiuJW"
+              className="sc-fubCfw fJcNga"
             >
               <div
                 aria-describedby={null}
-                className="sc-bdfBwQ jvkcBC isHealthy"
+                className="sc-bdfBwQ gsbKhm isHealthy"
                 onBlur={[Function]}
                 onFocus={[Function]}
                 onMouseLeave={[Function]}
@@ -909,7 +909,7 @@ exports[`sidebar renders list of resources 1`] = `
                 </span>
               </div>
               <span
-                className="sc-dQppl rWCkn"
+                className="sc-dQppl ca-dvvb"
               >
                 <time
                   dateTime="2017-12-21T15:36:07.000Z"
@@ -935,11 +935,11 @@ exports[`sidebar renders list of resources 1`] = `
               </button>
             </div>
             <div
-              className="sc-pFZIQ bHvBzm"
+              className="sc-pFZIQ iIlHOe"
             >
               <div
                 aria-describedby={null}
-                className="sc-bdfBwQ jvkcBC isUnhealthy"
+                className="sc-bdfBwQ gsbKhm isUnhealthy"
                 onBlur={[Function]}
                 onFocus={[Function]}
                 onMouseLeave={[Function]}
@@ -984,11 +984,11 @@ exports[`sidebar renders list of resources 1`] = `
             tabIndex={-1}
           >
             <div
-              className="sc-fubCfw cCiuJW"
+              className="sc-fubCfw fJcNga"
             >
               <div
                 aria-describedby={null}
-                className="sc-bdfBwQ jvkcBC isHealthy"
+                className="sc-bdfBwQ gsbKhm isHealthy"
                 onBlur={[Function]}
                 onFocus={[Function]}
                 onMouseLeave={[Function]}
@@ -1012,7 +1012,7 @@ exports[`sidebar renders list of resources 1`] = `
                 </span>
               </div>
               <span
-                className="sc-dQppl rWCkn"
+                className="sc-dQppl ca-dvvb"
               >
                 <time
                   dateTime="2017-12-21T15:35:57.000Z"
@@ -1038,11 +1038,11 @@ exports[`sidebar renders list of resources 1`] = `
               </button>
             </div>
             <div
-              className="sc-pFZIQ bHvBzm"
+              className="sc-pFZIQ iIlHOe"
             >
               <div
                 aria-describedby={null}
-                className="sc-bdfBwQ jvkcBC isUnhealthy"
+                className="sc-bdfBwQ gsbKhm isUnhealthy"
                 onBlur={[Function]}
                 onFocus={[Function]}
                 onMouseLeave={[Function]}
@@ -1109,7 +1109,7 @@ exports[`sidebar renders resources that haven't been built yet 1`] = `
             tabIndex={-1}
           >
             <div
-              className="sc-bdfBwQ jvkcBC isNone"
+              className="sc-bdfBwQ gsbKhm isNone"
             >
               <svg>
                 checkmark-small.svg
@@ -1144,11 +1144,11 @@ exports[`sidebar renders resources that haven't been built yet 1`] = `
             tabIndex={-1}
           >
             <div
-              className="sc-fubCfw cCiuJW"
+              className="sc-fubCfw fJcNga"
             >
               <div
                 aria-describedby={null}
-                className="sc-bdfBwQ jvkcBC isHealthy"
+                className="sc-bdfBwQ gsbKhm isHealthy"
                 onBlur={[Function]}
                 onFocus={[Function]}
                 onMouseLeave={[Function]}
@@ -1172,7 +1172,7 @@ exports[`sidebar renders resources that haven't been built yet 1`] = `
                 </span>
               </div>
               <span
-                className="sc-dQppl rWCkn"
+                className="sc-dQppl ca-dvvb"
               >
                 —
               </span>
@@ -1193,11 +1193,11 @@ exports[`sidebar renders resources that haven't been built yet 1`] = `
               </button>
             </div>
             <div
-              className="sc-pFZIQ bHvBzm"
+              className="sc-pFZIQ iIlHOe"
             >
               <div
                 aria-describedby={null}
-                className="sc-bdfBwQ jvkcBC isBuilding"
+                className="sc-bdfBwQ gsbKhm isBuilding"
                 onBlur={[Function]}
                 onFocus={[Function]}
                 onMouseLeave={[Function]}
@@ -1240,11 +1240,11 @@ exports[`sidebar renders resources that haven't been built yet 1`] = `
             tabIndex={-1}
           >
             <div
-              className="sc-fubCfw cCiuJW"
+              className="sc-fubCfw fJcNga"
             >
               <div
                 aria-describedby={null}
-                className="sc-bdfBwQ jvkcBC isHealthy"
+                className="sc-bdfBwQ gsbKhm isHealthy"
                 onBlur={[Function]}
                 onFocus={[Function]}
                 onMouseLeave={[Function]}
@@ -1268,7 +1268,7 @@ exports[`sidebar renders resources that haven't been built yet 1`] = `
                 </span>
               </div>
               <span
-                className="sc-dQppl rWCkn"
+                className="sc-dQppl ca-dvvb"
               >
                 —
               </span>
@@ -1289,11 +1289,11 @@ exports[`sidebar renders resources that haven't been built yet 1`] = `
               </button>
             </div>
             <div
-              className="sc-pFZIQ bHvBzm"
+              className="sc-pFZIQ iIlHOe"
             >
               <div
                 aria-describedby={null}
-                className="sc-bdfBwQ jvkcBC isBuilding"
+                className="sc-bdfBwQ gsbKhm isBuilding"
                 onBlur={[Function]}
                 onFocus={[Function]}
                 onMouseLeave={[Function]}


### PR DESCRIPTION
Hello @hyu,

Please review the following commits I made in branch nicks/ch10982:

f5d18e56b8f4dcc37b08b231e20807ba011a34e8 (2021-01-25 20:03:00 -0500)
web: fix card layouts on firefox
I suspect there's some deeper bug here where setting height: 100%
on a flex child isn't working correctly in Firefox...but I think
setting height: 100% on a flex child isn't a great practice anyway.

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics