### PR TITLE
web: centralize all tabs dataflow into OverviewTabNavProvider

### DIFF
--- a/web/src/HUD.tsx
+++ b/web/src/HUD.tsx
@@ -349,10 +349,12 @@ export default class HUD extends Component<HudProps, HudState> {
       : ResourceView.Log
 
     if (matchOverview) {
+      let validateTab = (name: string) =>
+        resources.some((res) => res.name === name)
       return (
         <LocalStorageContextProvider tiltfileKey={view.tiltfileKey}>
           <SidebarPinContextProvider>
-            <OverviewNavProvider>
+            <OverviewNavProvider validateTab={validateTab}>
               <div className={hudClasses.join(" ")}>
                 <AnalyticsNudge needsNudge={needsNudge} />
                 <SocketBar state={this.state.socketState} />

--- a/web/src/OverviewResourcePane.stories.tsx
+++ b/web/src/OverviewResourcePane.stories.tsx
@@ -23,16 +23,29 @@ export default {
   ],
 }
 
+function OverviewResourcePaneHarness(props: {
+  name: string
+  view: Proto.webviewView
+}) {
+  let { name, view } = props
+  let entry = name ? `/r/${props.name}/overview` : `/overview`
+  let resources = view?.resources || []
+  let validateTab = (name: string) => resources.some((res) => res.name == name)
+  return (
+    <MemoryRouter initialEntries={[entry]}>
+      <OverviewNavProvider validateTab={validateTab}>
+        <OverviewResourcePane view={view} />
+      </OverviewNavProvider>
+    </MemoryRouter>
+  )
+}
+
 export const TwoResources = () => (
-  <OverviewNavProvider candidateTabForTesting={"vigoda"}>
-    <OverviewResourcePane view={twoResourceView()} />
-  </OverviewNavProvider>
+  <OverviewResourcePaneHarness name={"vigoda"} view={twoResourceView()} />
 )
 
 export const TenResources = () => (
-  <OverviewNavProvider candidateTabForTesting={"vigoda_1"}>
-    <OverviewResourcePane view={tenResourceView()} />
-  </OverviewNavProvider>
+  <OverviewResourcePaneHarness name="vigoda_1" view={tenResourceView()} />
 )
 
 export const FullResourceBar = () => {
@@ -44,11 +57,7 @@ export const FullResourceBar = () => {
     { url: "http://localhost:4003" },
   ]
   res.podID = "my-pod-deadbeef"
-  return (
-    <OverviewNavProvider candidateTabForTesting={"vigoda_1"}>
-      <OverviewResourcePane view={view} />
-    </OverviewNavProvider>
-  )
+  return <OverviewResourcePaneHarness name="vigoda_1" view={view} />
 }
 
 export const TenResourcesWithLogStore = () => {
@@ -70,9 +79,7 @@ export const TenResourcesWithLogStore = () => {
 
   return (
     <LogStoreProvider value={logStore}>
-      <OverviewNavProvider candidateTabForTesting={"vigoda_1"}>
-        <OverviewResourcePane view={tenResourceView()} />
-      </OverviewNavProvider>
+      <OverviewResourcePaneHarness name="vigoda_1" view={tenResourceView()} />
     </LogStoreProvider>
   )
 }
@@ -101,9 +108,7 @@ export const TenResourcesWithLongLogLines = () => {
 
   return (
     <LogStoreProvider value={logStore}>
-      <OverviewNavProvider candidateTabForTesting={"vigoda_1"}>
-        <OverviewResourcePane view={tenResourceView()} />
-      </OverviewNavProvider>
+      <OverviewResourcePaneHarness name={"vigoda_1"} view={tenResourceView()} />
     </LogStoreProvider>
   )
 }
@@ -135,21 +140,15 @@ export const TenResourcesWithBuildLogAndPodLog = () => {
 
   return (
     <LogStoreProvider value={logStore}>
-      <OverviewNavProvider candidateTabForTesting={"vigoda_1"}>
-        <OverviewResourcePane view={tenResourceView()} />
-      </OverviewNavProvider>
+      <OverviewResourcePaneHarness name="vigoda_1" view={tenResourceView()} />
     </LogStoreProvider>
   )
 }
 
 export const OneHundredResources = () => (
-  <OverviewNavProvider candidateTabForTesting={"vigoda_1"}>
-    <OverviewResourcePane view={nResourceView(100)} />
-  </OverviewNavProvider>
+  <OverviewResourcePaneHarness name="vigoda_1" view={nResourceView(100)} />
 )
 
 export const NotFound = () => (
-  <OverviewNavProvider candidateTabForTesting={"does-not-exist"}>
-    <OverviewResourcePane view={twoResourceView()} />
-  </OverviewNavProvider>
+  <OverviewResourcePaneHarness name="does-not-exist" view={twoResourceView()} />
 )

--- a/web/src/OverviewResourcePane.tsx
+++ b/web/src/OverviewResourcePane.tsx
@@ -32,7 +32,7 @@ let Main = styled.div`
 export default function OverviewResourcePane(props: OverviewResourcePaneProps) {
   let nav = useTabNav()
   let resources = props.view?.resources || []
-  let name = nav.candidateTab || nav.selectedTab || ""
+  let name = nav.invalidTab || nav.selectedTab || ""
   let r: Proto.webviewResource | undefined
   let all = name === "" || name === ResourceName.all
   if (!all) {

--- a/web/src/OverviewTabBar.stories.tsx
+++ b/web/src/OverviewTabBar.stories.tsx
@@ -26,7 +26,7 @@ export const InferOneTab = () => <OverviewTabBar selectedTab={"vigoda"} />
 export const TwoTabs = () => {
   let tabs = ["vigoda", "snack"]
   return (
-    <OverviewNavProvider tabsForTesting={tabs}>
+    <OverviewNavProvider tabsForTesting={tabs} validateTab={() => true}>
       <OverviewTabBar selectedTab={""} />
     </OverviewNavProvider>
   )
@@ -46,7 +46,7 @@ export const TenTabs = () => {
     "vigoda_10",
   ]
   return (
-    <OverviewNavProvider tabsForTesting={tabs}>
+    <OverviewNavProvider tabsForTesting={tabs} validateTab={() => true}>
       <OverviewTabBar selectedTab={"vigoda_2"} />
     </OverviewNavProvider>
   )
@@ -56,7 +56,7 @@ export const LongTabName = () => {
   let tabs = ["extremely-long-tab-name-yes-this-is-very-long"]
 
   return (
-    <OverviewNavProvider tabsForTesting={tabs}>
+    <OverviewNavProvider tabsForTesting={tabs} validateTab={() => true}>
       <OverviewTabBar selectedTab={""} />
     </OverviewNavProvider>
   )

--- a/web/src/OverviewTabBar.test.tsx
+++ b/web/src/OverviewTabBar.test.tsx
@@ -8,7 +8,10 @@ it("propagate selected tab", () => {
   let capturedNav: any = null
   const root = mount(
     <MemoryRouter initialEntries={["/r/vigoda/overview"]}>
-      <OverviewNavProvider tabsForTesting={["vigoda", "snack"]}>
+      <OverviewNavProvider
+        tabsForTesting={["vigoda", "snack"]}
+        validateTab={() => true}
+      >
         <OverviewTabBar selectedTab="vigoda" />
         <TabNavContextConsumer>
           {(nav) => void (capturedNav = nav)}

--- a/web/src/OverviewTabBar.tsx
+++ b/web/src/OverviewTabBar.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react"
+import React from "react"
 import { Link } from "react-router-dom"
 import styled from "styled-components"
 import { ReactComponent as CloseSvg } from "./assets/svg/close.svg"
@@ -115,19 +115,6 @@ export default function OverviewTabBar(props: OverviewTabBarProps) {
   let nav = useTabNav()
   let tabs = nav.tabs
   let selectedTab = props.selectedTab
-  let candidateTab = nav.candidateTab
-
-  // There are two bits of state to determine the selected tab:
-  //
-  // 1) If the user navigates to a url, we need to pull the candidate tab name from the URL.
-  // 2) Then we need to look at the Tilt state to see if that resource exists.
-  //
-  // If the resource exists, then we select that tab. We need propagate it back
-  // up to the context provider. This creates weird data flow, but is probably
-  // ok for this simple case.
-  useEffect(() => {
-    nav.ensureSelectedTab(selectedTab)
-  }, [selectedTab, nav.candidateTab])
 
   let onClose = (e: any, name: string) => {
     e.stopPropagation()
@@ -152,7 +139,7 @@ export default function OverviewTabBar(props: OverviewTabBarProps) {
     )
   })
 
-  let isSelectedHome = !selectedTab || selectedTab === ResourceName.all
+  let isSelectedHome = !selectedTab
   let homeTabClasses = isSelectedHome ? "isSelected" : ""
 
   tabEls.unshift(

--- a/web/src/SidebarKeyboardShortcuts.test.tsx
+++ b/web/src/SidebarKeyboardShortcuts.test.tsx
@@ -15,11 +15,10 @@ const shortcuts = (items: SidebarItem[], selected: string) => {
   let tabNav = {
     tabs: [],
     selectedTab: "",
-    candidateTab: "",
+    invalidTab: "",
     openResource: (name: string, options?: { newTab: boolean }) => {
       opened = name
     },
-    ensureSelectedTab: () => {},
     closeTab: (name: string) => {},
   }
   opened = null

--- a/web/src/TabNav.test.tsx
+++ b/web/src/TabNav.test.tsx
@@ -1,25 +1,55 @@
-import { mount, ReactWrapper } from "enzyme"
+import { mount } from "enzyme"
 import { createMemoryHistory, MemoryHistory } from "history"
 import React from "react"
 import { act } from "react-dom/test-utils"
 import { Router } from "react-router"
-import { OverviewNavProvider, TabNav, TabNavContextConsumer } from "./TabNav"
+import { OverviewNavProvider, TabNavContextConsumer } from "./TabNav"
 import { ResourceName } from "./types"
 
-type Fixture = { nav: TabNav; root: ReactWrapper; history: MemoryHistory }
+// A fixture to help test the context provider
+class Fixture {
+  initialTabs: string[]
+  nav: any = null
+  root: any = null
+  history: MemoryHistory = createMemoryHistory()
 
-function newFixture(tabs: string[]): Fixture {
-  let result: any = { nav: null, root: null, history: createMemoryHistory() }
-  result.root = mount(
-    <Router history={result.history}>
-      <OverviewNavProvider tabsForTesting={tabs}>
-        <TabNavContextConsumer>
-          {(capturedNav) => void (result.nav = capturedNav)}
-        </TabNavContextConsumer>
-      </OverviewNavProvider>
-    </Router>
-  )
-  return result
+  constructor(initialTabs: string[]) {
+    this.initialTabs = initialTabs
+  }
+
+  mount() {
+    let tabs = this.nav?.tabs || this.initialTabs
+    this.root = mount(
+      <Router history={this.history}>
+        <OverviewNavProvider tabsForTesting={tabs} validateTab={() => true}>
+          <TabNavContextConsumer>
+            {(capturedNav) => void (this.nav = capturedNav)}
+          </TabNavContextConsumer>
+        </OverviewNavProvider>
+      </Router>
+    )
+  }
+
+  openResource(name: string, options?: any) {
+    act(() => this.nav.openResource(name, options))
+
+    // Enzyme doesn't properly re-render context providers with hooks,
+    // so we manually re-render.
+    this.mount()
+  }
+  closeTab(name: string) {
+    act(() => this.nav.closeTab(name))
+
+    // Enzyme doesn't properly re-render context providers with hooks,
+    // so we manually re-render.
+    this.mount()
+  }
+}
+
+function newFixture(initialTabs: string[]): Fixture {
+  let f = new Fixture(initialTabs)
+  f.mount()
+  return f
 }
 
 it("navigates to existing tab on click resource", () => {
@@ -27,7 +57,7 @@ it("navigates to existing tab on click resource", () => {
   expect(f.nav.tabs).toEqual(["res1", "res2"])
   expect(f.nav.selectedTab).toEqual("")
 
-  act(() => f.nav.openResource("res1"))
+  f.openResource("res1")
 
   expect(f.nav.tabs).toEqual(["res1", "res2"])
   expect(f.nav.selectedTab).toEqual("res1")
@@ -39,7 +69,7 @@ it("navigates to new tab on click resource", () => {
   expect(f.nav.tabs).toEqual(["res1", "res2"])
   expect(f.nav.selectedTab).toEqual("")
 
-  act(() => f.nav.openResource("res3"))
+  f.openResource("res3")
 
   expect(f.nav.tabs).toEqual(["res1", "res2", "res3"])
   expect(f.nav.selectedTab).toEqual("res3")
@@ -50,12 +80,12 @@ it("changes selected tab on click existing resource", () => {
   expect(f.nav.tabs).toEqual(["res1", "res2", "res3"])
   expect(f.nav.selectedTab).toEqual("")
 
-  act(() => f.nav.openResource("res1"))
+  f.openResource("res1")
 
   expect(f.nav.tabs).toEqual(["res1", "res2", "res3"])
   expect(f.nav.selectedTab).toEqual("res1")
 
-  act(() => f.nav.openResource("res3"))
+  f.openResource("res3")
   expect(f.nav.tabs).toEqual(["res1", "res2", "res3"])
   expect(f.nav.selectedTab).toEqual("res3")
 })
@@ -65,12 +95,12 @@ it("changes selected tab on click new resource", () => {
   expect(f.nav.tabs).toEqual(["res1", "res2", "res3"])
   expect(f.nav.selectedTab).toEqual("")
 
-  act(() => f.nav.openResource("res2"))
+  f.openResource("res2")
 
   expect(f.nav.tabs).toEqual(["res1", "res2", "res3"])
   expect(f.nav.selectedTab).toEqual("res2")
 
-  act(() => f.nav.openResource("res4"))
+  f.openResource("res4")
   expect(f.nav.tabs).toEqual(["res1", "res4", "res3"])
   expect(f.nav.selectedTab).toEqual("res4")
 })
@@ -80,12 +110,12 @@ it("open new tab to the right on double-click existing resource", () => {
   expect(f.nav.tabs).toEqual(["res1", "res2", "res3"])
   expect(f.nav.selectedTab).toEqual("")
 
-  act(() => f.nav.openResource("res1"))
+  f.openResource("res1")
 
   expect(f.nav.tabs).toEqual(["res1", "res2", "res3"])
   expect(f.nav.selectedTab).toEqual("res1")
 
-  act(() => f.nav.openResource("res3", { newTab: true }))
+  f.openResource("res3", { newTab: true })
   expect(f.nav.tabs).toEqual(["res1", "res2", "res3"])
   expect(f.nav.selectedTab).toEqual("res3")
 })
@@ -95,12 +125,12 @@ it("open new tab to the right on double-click new resource", () => {
   expect(f.nav.tabs).toEqual(["res1", "res2", "res3"])
   expect(f.nav.selectedTab).toEqual("")
 
-  act(() => f.nav.openResource("res1"))
+  f.openResource("res1")
 
   expect(f.nav.tabs).toEqual(["res1", "res2", "res3"])
   expect(f.nav.selectedTab).toEqual("res1")
 
-  act(() => f.nav.openResource("res4", { newTab: true }))
+  f.openResource("res4", { newTab: true })
   expect(f.nav.tabs).toEqual(["res1", "res4", "res2", "res3"])
   expect(f.nav.selectedTab).toEqual("res4")
 })
@@ -110,12 +140,12 @@ it("navigates to the tab on the right when closing", () => {
   expect(f.nav.tabs).toEqual(["res1", "res2", "res3"])
   expect(f.nav.selectedTab).toEqual("")
 
-  act(() => f.nav.openResource("res2"))
+  f.openResource("res2")
 
   expect(f.nav.tabs).toEqual(["res1", "res2", "res3"])
   expect(f.nav.selectedTab).toEqual("res2")
 
-  act(() => f.nav.closeTab("res2"))
+  f.closeTab("res2")
   expect(f.nav.tabs).toEqual(["res1", "res3"])
   expect(f.nav.selectedTab).toEqual("res3")
   expect(f.history.location.pathname).toEqual("/r/res3/overview")
@@ -126,12 +156,12 @@ it("navigates to home on closing last tab when closing", () => {
   expect(f.nav.tabs).toEqual(["res1"])
   expect(f.nav.selectedTab).toEqual("")
 
-  act(() => f.nav.openResource("res1"))
+  f.openResource("res1")
 
   expect(f.nav.tabs).toEqual(["res1"])
   expect(f.nav.selectedTab).toEqual("res1")
 
-  act(() => f.nav.closeTab("res1"))
+  f.closeTab("res1")
   expect(f.nav.tabs).toEqual([ResourceName.all])
   expect(f.nav.selectedTab).toEqual("")
   expect(f.history.location.pathname).toEqual("/overview")


### PR DESCRIPTION
Hello @hyu, @landism,

Please review the following commits I made in branch nicks/ch10999:

950758da3b62996bec2cdd816985a6146a7b3863 (2021-01-26 15:47:02 -0500)
web: centralize all tabs dataflow into OverviewTabNavProvider
This is what I should have done in the first place. It makes everything
much simpler and ensures we're not affected as much by React scheduler
conditions.

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics