### PR TITLE
web: Revamp how the OverviewItemView details are rendered, to improve the animation and interaction

### DIFF
--- a/web/src/OverviewItemView.stories.tsx
+++ b/web/src/OverviewItemView.stories.tsx
@@ -123,7 +123,7 @@ export const MinimumDetails = () => {
   let item = new OverviewItem(oneResourceNoAlerts())
   item.endpoints = []
   item.podId = ""
-  return <OverviewItemDetails item={item} />
+  return <OverviewItemDetails item={item} width={330} height={0} />
 }
 
 export const CompleteDetails = () => {
@@ -133,7 +133,7 @@ export const CompleteDetails = () => {
     { url: "http://localhost:4002" },
   ]
   item.podId = "my-pod-deadbeef"
-  return <OverviewItemDetails item={item} />
+  return <OverviewItemDetails item={item} width={330} height={0} />
 }
 
 export const LongDetails = () => {
@@ -143,5 +143,5 @@ export const LongDetails = () => {
     { url: "http://my-pod-grafana-long-service-name-deadbeef:4002" },
   ]
   item.podId = "my-pod-grafana-long-service-name-deadbeef"
-  return <OverviewItemDetails item={item} />
+  return <OverviewItemDetails item={item} width={330} height={0} />
 }

--- a/web/src/OverviewItemView.tsx
+++ b/web/src/OverviewItemView.tsx
@@ -1,7 +1,7 @@
 import Collapse from "@material-ui/core/Collapse"
 import Popover from "@material-ui/core/Popover"
 import { makeStyles } from "@material-ui/core/styles"
-import React, { useState } from "react"
+import React, { useEffect, useRef, useState } from "react"
 import { Link } from "react-router-dom"
 import TimeAgo from "react-timeago"
 import styled, { css, keyframes } from "styled-components"
@@ -303,6 +303,51 @@ function buildTooltipText(status: ResourceStatus): string {
   }
 }
 
+type RuntimeBoxProps = {
+  item: OverviewItem
+}
+
+function RuntimeBox(props: RuntimeBoxProps) {
+  let { item } = props
+
+  let formatter = timeAgoFormatter
+  let hasBuilt = item.lastBuild !== null
+  let building = !isZeroTime(item.currentBuildStartTime)
+  let timeAgo = <TimeAgo date={item.lastDeployTime} formatter={formatter} />
+  let hasSuccessfullyDeployed = !isZeroTime(item.lastDeployTime)
+  let onTrigger = triggerUpdate.bind(null, item.name)
+  return (
+    <OverviewItemRuntimeBox>
+      <SidebarIcon
+        tooltipText={runtimeTooltipText(item.runtimeStatus)}
+        status={item.runtimeStatus}
+        alertCount={item.runtimeAlertCount}
+      />
+      <RuntimeBoxStack style={{ margin: "8px 0px" }}>
+        <InnerRuntimeBox>
+          <OverviewItemText>{item.resourceTypeLabel}</OverviewItemText>
+          <OverviewItemTimeAgo>
+            {hasSuccessfullyDeployed ? timeAgo : "—"}
+          </OverviewItemTimeAgo>
+          <SidebarTriggerButton
+            isTiltfile={item.isTiltfile}
+            isSelected={false}
+            hasPendingChanges={item.hasPendingChanges}
+            hasBuilt={hasBuilt}
+            isBuilding={building}
+            triggerMode={item.triggerMode}
+            isQueued={item.queued}
+            onTrigger={onTrigger}
+          />
+        </InnerRuntimeBox>
+        <InnerRuntimeBox>
+          <OverviewItemName name={item.name} />
+        </InnerRuntimeBox>
+      </RuntimeBoxStack>
+    </OverviewItemRuntimeBox>
+  )
+}
+
 type BuildBoxProps = {
   item: OverviewItem
   isDetailsBox: boolean
@@ -329,13 +374,15 @@ function BuildBox(props: BuildBoxProps) {
 
 type OverviewItemDetailsProps = {
   item: OverviewItem
-  width?: number
+  width: number
+  height: number
 }
 
 let OverviewItemDetailsRoot = styled.div`
   display: flex;
   min-width: 330px;
   box-sizing: border-box;
+  transition: height 200ms ease;
 
   &.isBuilding::after {
     content: "";
@@ -364,12 +411,11 @@ let OverviewItemDetailsBox = styled.div`
   overflow: hidden;
   width: 100%;
   border: 1px solid ${Color.grayLighter};
-  border-top: 0;
   position: relative;
   font-size: ${FontSize.small};
   font-family: ${Font.monospace};
   box-shadow: 0px 4px 4px 0px rgba(0, 0, 0, 0.51);
-  border-radius: 0 0 8px 8px;
+  border-radius: 8px;
 `
 
 let OverviewItemDetailsLinkBox = styled.div`
@@ -435,8 +481,10 @@ async function copyTextToClipboard(text: string, cb: () => void) {
   cb()
 }
 
+// OverviewItemDetails is a clone of the OverviewItemView, positioned
+// with a popover over the original OverviewItemDetails
 export function OverviewItemDetails(props: OverviewItemDetailsProps) {
-  let item = props.item
+  let { item, width, height } = props
   let link = `/r/${item.name}/overview`
   let endpoints = item.endpoints.map((ep) => {
     return (
@@ -484,15 +532,27 @@ export function OverviewItemDetails(props: OverviewItemDetailsProps) {
   }
 
   let pathBuilder = usePathBuilder()
-  let width = props.width || 330
   let isBuildingClass =
     item.buildStatus === ResourceStatus.Building ? "isBuilding" : ""
+  let ref = useRef(null as any)
+
+  // Simulate an 'expansion' animation by modifying the height post-render.
+  useEffect(() => {
+    if (ref.current && height) {
+      ref.current.style.height = ref.current.firstChild.scrollHeight + "px"
+    }
+  }, [height])
+
+  let widthStyle = width ? width + "px" : "auto"
+  let heightStyle = height ? height + "px" : "auto"
   return (
     <OverviewItemDetailsRoot
-      style={{ width: width + "px" }}
+      ref={ref}
+      style={{ width: widthStyle, height: heightStyle }}
       className={isBuildingClass}
     >
       <OverviewItemDetailsBox>
+        <RuntimeBox item={item} />
         <OverviewItemDetailsLinkBox>
           {endpoints}
           {copy}
@@ -523,32 +583,32 @@ export default function OverviewItemView(props: OverviewItemViewProps) {
   let [anchorSpec, setAnchorSpec] = useState({
     element: null as Element | null,
     width: 330,
+    height: 0,
   })
   let handleClick = (event: any) => {
     let currentTarget = event.currentTarget
-    let buildBox = currentTarget.querySelector(`${OverviewItemBuildBox}`)
+    let rect = currentTarget.getBoundingClientRect()
     setAnchorSpec({
-      element: buildBox,
-      width: currentTarget.getBoundingClientRect().width,
+      element: currentTarget,
+      width: rect.width,
+      height: rect.height,
     })
   }
   let handleClose = (e: any) => {
     e.stopPropagation()
-    setAnchorSpec({ element: null, width: anchorSpec.width })
+    setAnchorSpec({
+      element: null,
+      width: anchorSpec.width,
+      height: anchorSpec.height,
+    })
   }
 
   let open = Boolean(anchorSpec.element)
   let popoverId = open ? "item-open-popover" : undefined
 
   let item = props.item
-  let formatter = timeAgoFormatter
-  let hasSuccessfullyDeployed = !isZeroTime(item.lastDeployTime)
-  let hasBuilt = item.lastBuild !== null
-  let building = !isZeroTime(item.currentBuildStartTime)
-  let timeAgo = <TimeAgo date={item.lastDeployTime} formatter={formatter} />
-
+  let building = item.buildStatus === ResourceStatus.Building
   let isBuildingClass = building ? "isBuilding" : ""
-  let onTrigger = triggerUpdate.bind(null, item.name)
   return (
     <OverviewItemRoot
       key={item.name}
@@ -556,34 +616,7 @@ export default function OverviewItemView(props: OverviewItemViewProps) {
       className="u-showPinOnHover"
     >
       <OverviewItemBox className={`${isBuildingClass}`} data-name={item.name}>
-        <OverviewItemRuntimeBox>
-          <SidebarIcon
-            tooltipText={runtimeTooltipText(item.runtimeStatus)}
-            status={item.runtimeStatus}
-            alertCount={item.runtimeAlertCount}
-          />
-          <RuntimeBoxStack style={{ margin: "8px 0px" }}>
-            <InnerRuntimeBox>
-              <OverviewItemText>{item.resourceTypeLabel}</OverviewItemText>
-              <OverviewItemTimeAgo>
-                {hasSuccessfullyDeployed ? timeAgo : "—"}
-              </OverviewItemTimeAgo>
-              <SidebarTriggerButton
-                isTiltfile={item.isTiltfile}
-                isSelected={false}
-                hasPendingChanges={item.hasPendingChanges}
-                hasBuilt={hasBuilt}
-                isBuilding={building}
-                triggerMode={item.triggerMode}
-                isQueued={item.queued}
-                onTrigger={onTrigger}
-              />
-            </InnerRuntimeBox>
-            <InnerRuntimeBox>
-              <OverviewItemName name={item.name} />
-            </InnerRuntimeBox>
-          </RuntimeBoxStack>
-        </OverviewItemRuntimeBox>
+        <RuntimeBox item={item} />
         <BuildBox item={item} isDetailsBox={false} />
       </OverviewItemBox>
 
@@ -604,7 +637,11 @@ export default function OverviewItemView(props: OverviewItemViewProps) {
           horizontal: "center",
         }}
       >
-        <OverviewItemDetails item={item} width={anchorSpec.width} />
+        <OverviewItemDetails
+          item={item}
+          width={anchorSpec.width}
+          height={anchorSpec.height}
+        />
       </Popover>
     </OverviewItemRoot>
   )


### PR DESCRIPTION
Hello @hyu,

Please review the following commits I made in branch nicks/ch10958:

57847ef15fbdb74bad4d1e6f27f326209cfc3eb7 (2021-01-26 16:48:44 -0500)
web: Revamp how the OverviewItemView details are rendered, to improve the animation and interaction

d0d5321dc0e042394ca6b370aa940074c57ef068 (2021-01-26 16:05:56 -0500)
engine: handle readiness probes for local resources (#4102)
Local controller creates a probe worker when starting a serve command
if a probe spec is defined.

The worker will emit readiness probe status update actions that will
result in updates to the local runtime state, which internally tracks
the current passing state of the readiness probe. (Local resources
without a readiness probe will consider themselves to always have a
passing probe, but this is never exposed.)

Some adjustments to the way that "ready OR succeeded" is
tracked/computed align this closer to the K8s runtime state and try
to reduce the amount of logic going on inside of the state object.
This ensures that dependent resources won't start until the probe
is passing (if defined).
3664df6f7ff3ba8606cdf222f1508d3a10156965 (2021-01-26 12:41:41 -0500)
web: make the 'View Details' button bold

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics