### PR TITLE
integration: add coverage for local readiness probes

### DIFF
--- a/integration/fixture_test.go
+++ b/integration/fixture_test.go
@@ -45,9 +45,63 @@ type fixture struct {
 	tiltArgs      []string
 }
 
-func newFixture(t *testing.T, dir string) *fixture {
-	dir = filepath.Join(packageDir, dir)
-	err := os.Chdir(dir)
+func copyDir(src string, dest string) error {
+	absSrc, err := filepath.Abs(src)
+	if err != nil {
+		return fmt.Errorf("could not get absolute path for src dir: %v", err)
+	}
+	absDest, err := filepath.Abs(dest)
+	if err != nil {
+		return fmt.Errorf("could not get absolute path for dest dir: %v", err)
+	}
+	return filepath.Walk(absSrc, func(srcPath string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if srcPath == absSrc {
+			return nil
+		}
+		if !strings.HasPrefix(srcPath, absSrc) {
+			return fmt.Errorf("invalid src path: %s", srcPath)
+		}
+		destPath := strings.Replace(srcPath, absSrc, absDest, 1)
+		if info.IsDir() {
+			return os.Mkdir(destPath, info.Mode())
+		} else {
+			srcData, err := ioutil.ReadFile(srcPath)
+			if err != nil {
+				return fmt.Errorf("failed to read src file %q: %v", srcPath, err)
+			}
+			if err := ioutil.WriteFile(destPath, srcData, info.Mode()); err != nil {
+				return fmt.Errorf("failed to write dest file %q: %v", destPath, err)
+			}
+		}
+		return nil
+	})
+}
+
+func newFixture(t *testing.T, resourceDir string) *fixture {
+	t.Helper()
+
+	// copy the test resources to a temporary directory that's automatically cleaned up
+	// to avoid tests interacting with local repo source
+	// NOTE(milas): this can be simplified somewhat to use t.TempDir() once on Go 1.15+
+	resourceDir = filepath.Join(packageDir, resourceDir)
+	testDir, err := ioutil.TempDir("", filepath.Base(resourceDir))
+	if err != nil {
+		t.Fatalf("could not create temp dir: %v", err)
+	}
+	t.Logf("Using temporary directory for test: %q", testDir)
+	t.Cleanup(func() {
+		if err := os.RemoveAll(testDir); err != nil {
+			t.Logf("failed to clean up tempdir %q: %v", testDir, err)
+		}
+	})
+	if err := copyDir(resourceDir, testDir); err != nil {
+		t.Fatalf("failed to copy test resources to temp directory: %v", err)
+	}
+
+	err = os.Chdir(testDir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -60,7 +114,7 @@ func newFixture(t *testing.T, dir string) *fixture {
 		t:             t,
 		ctx:           ctx,
 		cancel:        cancel,
-		dir:           dir,
+		dir:           testDir,
 		logs:          bufsync.NewThreadSafeBuffer(),
 		originalFiles: make(map[string]string),
 		tilt:          client,
@@ -80,11 +134,14 @@ func (f *fixture) testDirPath(s string) string {
 }
 
 func (f *fixture) installTilt() {
+	f.t.Helper()
 	cmd := exec.CommandContext(f.ctx, "go", "install", "-mod", "vendor", "github.com/tilt-dev/tilt/cmd/tilt")
+	cmd.Dir = packageDir
 	f.runOrFail(cmd, "Building tilt")
 }
 
 func (f *fixture) runOrFail(cmd *exec.Cmd, msg string) {
+	f.t.Helper()
 	// Use Output() instead of Run() because that captures Stderr in the ExitError.
 	_, err := cmd.Output()
 	if err == nil {
@@ -241,7 +298,7 @@ func (f *fixture) StartTearDown() {
 func (f *fixture) KillProcs() {
 	if f.activeTiltUp != nil {
 		err := f.activeTiltUp.Kill()
-		if err != nil {
+		if err != nil && err.Error() != "os: process already finished" {
 			fmt.Printf("error killing tilt: %v\n", err)
 		}
 	}

--- a/integration/local_resource/Tiltfile
+++ b/integration/local_resource/Tiltfile
@@ -1,2 +1,11 @@
-local_resource('foo', serve_cmd='./hello.sh foo')
-local_resource('bar', serve_cmd='./hello.sh bar')
+p = probe(initial_delay_secs=0,
+          timeout_secs=1,
+          period_secs=1,
+          success_threshold=1,
+          failure_threshold=1,
+          exec=exec_action(command=['./probe.sh']))
+
+local_resource('foo', serve_cmd='./hello.sh foo', readiness_probe=p)
+
+local_resource('bar', serve_cmd='./hello.sh bar',
+               resource_deps=['foo'])

--- a/integration/local_resource/probe.sh
+++ b/integration/local_resource/probe.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+if [[ ! -f ./probe-success ]]; then
+  # failure -> stderr
+  echo "fake probe failure message" 1>&2
+  exit 1
+fi
+
+# success -> stdout
+echo "fake probe success message"
+exit 0

--- a/integration/local_resource_test.go
+++ b/integration/local_resource_test.go
@@ -1,34 +1,47 @@
-//+build integration
+// +build integration
 
 package integration
 
 import (
 	"io/ioutil"
 	"os"
+	"strings"
 	"syscall"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 const cleanupTxt = "cleanup.txt"
 
-func TestLocalResourceCleanup(t *testing.T) {
+func TestLocalResource(t *testing.T) {
 	f := newFixture(t, "local_resource")
 	defer f.TearDown()
 
-	defer func() {
-		_ = os.Remove(f.testDirPath(cleanupTxt))
-	}()
-
 	f.TiltWatch()
 
+	const barServeLogMessage = "Running serve cmd: ./hello.sh bar"
+	const readinessProbeSuccessMessage = `"[readiness probe] fake probe success message"`
+
 	require.NoError(t, f.logs.WaitUntilContains("hello! foo #1", 5*time.Second))
+
+	// write a sentinel file for the probe to find and change its result
+	require.NoError(t, ioutil.WriteFile(f.testDirPath("probe-success"), nil, 0777))
+	require.NoError(t, f.logs.WaitUntilContains("[readiness probe] fake probe success message", 5*time.Second))
+
+	// wait for second resource to start and then ensure that the order in the logs is as expected
+	require.NoError(t, f.logs.WaitUntilContains(barServeLogMessage, 5*time.Second))
+	curLogs := f.logs.String()
+	assert.Greater(t, strings.Index(curLogs, barServeLogMessage), strings.Index(curLogs, readinessProbeSuccessMessage),
+		"dependent resource started BEFORE other resource ready")
 	require.NoError(t, f.logs.WaitUntilContains("hello! bar #1", 5*time.Second))
 
-	// send a SIGTERM and make sure Tilt propagates it to its local_resource processes
+	require.NoError(t, os.Remove(f.testDirPath("probe-success")))
+	require.NoError(t, f.logs.WaitUntilContains(`[readiness probe] fake probe failure message`, 5*time.Second))
 
+	// send a SIGTERM and make sure Tilt propagates it to its local_resource processes
 	require.NoError(t, f.activeTiltUp.process.Signal(syscall.SIGTERM))
 
 	select {

--- a/integration/local_resource_test.go
+++ b/integration/local_resource_test.go
@@ -28,13 +28,13 @@ func TestLocalResource(t *testing.T) {
 	f.TiltWatch()
 
 	const barServeLogMessage = "Running serve cmd: ./hello.sh bar"
-	const readinessProbeSuccessMessage = `"[readiness probe] fake probe success message"`
+	const readinessProbeSuccessMessage = `[readiness probe] fake probe success message`
 
 	require.NoError(t, f.logs.WaitUntilContains("hello! foo #1", 5*time.Second))
 
 	// write a sentinel file for the probe to find and change its result
 	require.NoError(t, ioutil.WriteFile(f.testDirPath("probe-success"), nil, 0777))
-	require.NoError(t, f.logs.WaitUntilContains("[readiness probe] fake probe success message", 5*time.Second))
+	require.NoError(t, f.logs.WaitUntilContains(readinessProbeSuccessMessage, 5*time.Second))
 
 	// wait for second resource to start and then ensure that the order in the logs is as expected
 	require.NoError(t, f.logs.WaitUntilContains(barServeLogMessage, 5*time.Second))

--- a/integration/local_resource_test.go
+++ b/integration/local_resource_test.go
@@ -20,6 +20,11 @@ func TestLocalResource(t *testing.T) {
 	f := newFixture(t, "local_resource")
 	defer f.TearDown()
 
+	t.Cleanup(func() {
+		_ = os.Remove(f.testDirPath(cleanupTxt))
+		_ = os.Remove(f.testDirPath("probe-success"))
+	})
+
 	f.TiltWatch()
 
 	const barServeLogMessage = "Running serve cmd: ./hello.sh bar"


### PR DESCRIPTION
~There's some general integration tests improvements here (cc @nicks @maiamcc) to copy the test resource directory (i.e. the dir with `Tiltfile` for the test) to a temporary directory that gets cleaned up at the end of the test. The local resource test was already creating files and manually cleaning up - the readiness probe additions added more to that; I figured rather than continuing to manually clean up (and potentially risk messing with local working repo), this made sense.~
**EDIT:** Just kidding - some of the integration tests are structured in such a way that this isn't quite as straightforward (i.e. it'll need to touch a bunch of the fixtures) so reverted it and added explicit cleanup for new files in this test. 

Main focus is expanding the `local_resource` integration test to include a readiness probe. (See #4112 for `Tiltfile` syntax for readiness probes and #4102 for engine support.)

There's also a small improvement to the readiness probe log output so that it's prepended with `[readiness probe]` to disambiguate from resource app logs. (They're logged at `VerboseLvl` and only when the state _changes_, not on *every* probe run, so they shouldn't be too spammy, but they could be extremely confusing to a user with no context. Longer-term, we might want to consider a better separation here.)