### PR TITLE
integration: use a random port for each tilt up invocation

### DIFF
--- a/integration/crash_test.go
+++ b/integration/crash_test.go
@@ -4,22 +4,27 @@ package integration
 
 import (
 	"bytes"
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-// Make sure that Tilt crashes if there are two tilts running
+// Make sure that Tilt crashes if there are two tilts running on the same port.
 func TestCrash(t *testing.T) {
 	f := newK8sFixture(t, "oneup")
 	defer f.TearDown()
 
 	f.TiltWatch()
+	require.NotZero(t, f.activeTiltUp.port)
 	time.Sleep(500 * time.Millisecond)
 
 	out := bytes.NewBuffer(nil)
-	res, err := f.tilt.Up([]string{"--watch=false"}, out)
+	// explicitly pass a port argument or the integration tests will pick a random unused one, thus defeating
+	// the point of the test
+	res, err := f.tilt.Up([]string{"--watch=false", fmt.Sprintf("--port=%d", f.activeTiltUp.port)}, out)
 	assert.NoError(t, err)
 	<-res.Done()
 	assert.Contains(t, out.String(), "Tilt cannot start")

--- a/integration/tilt_args_test.go
+++ b/integration/tilt_args_test.go
@@ -17,13 +17,15 @@ func TestTiltArgs(t *testing.T) {
 	f.tiltArgs = []string{"foo"}
 
 	f.TiltWatch()
+	require.NotZero(t, f.activeTiltUp.port)
 
 	err := f.logs.WaitUntilContains("foo run", 5*time.Second)
 	require.NoError(t, err)
 
 	f.logs.Reset()
 
-	err = f.tilt.Args([]string{"bar"}, f.LogWriter())
+	// need to explicitly pass the port number to connect to the instance launched by this test
+	err = f.tilt.Args([]string{"bar", fmt.Sprintf("--port=%d", f.activeTiltUp.port)}, f.LogWriter())
 	if err != nil {
 		// Currently, Tilt starts printing logs before the webserver has bound to a port.
 		// If this happens, just sleep for a second and try again.


### PR DESCRIPTION
This just makes things easier if you've got Tilt running in the
background on your machine already so that you can still run an
integration test.