### PR TITLE
web: add (more) links to errors that scrolls to the error in-context

### DIFF
--- a/web/src/LogPaneLine.scss
+++ b/web/src/LogPaneLine.scss
@@ -4,6 +4,7 @@
 
 .LogPaneLine {
   display: flex;
+  position: relative;
 
   &.is-highlighted {
     background-color: rgba($color-blue, $translucent);
@@ -20,6 +21,35 @@
   }
   &.is-buildEvent-fallback {
     background-color: $color-gray-darker;
+  }
+
+  &.is-startOfAlert {
+    margin-top: $spacing-unit * 1.5;
+  }
+  &.is-endOfAlert {
+    padding-bottom: $spacing-unit * 0.5;
+    margin-bottom: $spacing-unit * 0.5;
+    border-bottom: 1px solid $color-gray-darker;
+  }
+}
+
+.LogPaneLine-alertNav {
+  position: absolute;
+  display: block;
+  color: $color-gray-lightest;
+  position: absolute;
+  top: $spacing-unit * -1;
+  left: $spacing-unit * 0.5;
+  cursor: pointer;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  transition: color 300ms ease, border-color 300ms ease;
+  padding: 4px $spacing-unit * 0.25;
+  
+  &:hover {
+    color: $color-blue;
+    border-color: $color-blue;
   }
 }
 

--- a/web/src/OverviewLogPane.stories.tsx
+++ b/web/src/OverviewLogPane.stories.tsx
@@ -206,13 +206,13 @@ ForeverLog.argTypes = {
 export const BuildLogAndRunLog = (args: any) => {
   let logStore = new LogStore()
   let segments = []
-  for (let i = 0; i < 10; i++) {
+  for (let i = 0; i < 20; i++) {
     let level = ""
     let lineType = "build"
-    if (i === 5) {
+    if (i === 15) {
       level = LogLevel.WARN
       lineType = "build warning"
-    } else if (i === 9) {
+    } else if (i === 19) {
       level = LogLevel.ERROR
       lineType = "build error"
     }
@@ -223,13 +223,13 @@ export const BuildLogAndRunLog = (args: any) => {
       level,
     })
   }
-  for (let i = 0; i < 10; i++) {
+  for (let i = 0; i < 20; i++) {
     let level = ""
     let lineType = "pod"
-    if (i === 5) {
+    if (i === 15) {
       level = LogLevel.WARN
       lineType = "pod warning"
-    } else if (i === 9) {
+    } else if (i === 19) {
       level = LogLevel.ERROR
       lineType = "pod error"
     }

--- a/web/src/OverviewLogPane.test.tsx
+++ b/web/src/OverviewLogPane.test.tsx
@@ -1,6 +1,10 @@
 import { mount } from "enzyme"
 import { FilterLevel, FilterSource } from "./logfilters"
-import { OverviewLogComponent, renderWindow } from "./OverviewLogPane"
+import {
+  OverviewLogComponent,
+  PROLOGUE_LENGTH,
+  renderWindow,
+} from "./OverviewLogPane"
 import {
   BuildLogAndRunLog,
   ManyLines,
@@ -37,13 +41,13 @@ it("escapes html and linkifies", () => {
 it("filters by source", () => {
   let root = logPaneMount(<BuildLogAndRunLog />)
   let el = root.getDOMNode()
-  expect(el.querySelectorAll(".LogPaneLine")).toHaveLength(20)
+  expect(el.querySelectorAll(".LogPaneLine")).toHaveLength(40)
 
   let root2 = logPaneMount(
     <BuildLogAndRunLog level="" source={FilterSource.runtime} />
   )
   let el2 = root2.getDOMNode()
-  expect(el2.querySelectorAll(".LogPaneLine")).toHaveLength(10)
+  expect(el2.querySelectorAll(".LogPaneLine")).toHaveLength(20)
   expect(el2.innerHTML).toEqual(expect.stringContaining("Vigoda pod line"))
   expect(el2.innerHTML).toEqual(
     expect.not.stringContaining("Vigoda build line")
@@ -53,26 +57,33 @@ it("filters by source", () => {
     <BuildLogAndRunLog level="" source={FilterSource.build} />
   )
   let el3 = root3.getDOMNode()
-  expect(el3.querySelectorAll(".LogPaneLine")).toHaveLength(10)
+  expect(el3.querySelectorAll(".LogPaneLine")).toHaveLength(20)
   expect(el3.innerHTML).toEqual(expect.not.stringContaining("Vigoda pod line"))
   expect(el3.innerHTML).toEqual(expect.stringContaining("Vigoda build line"))
 })
 
 it("filters by level", () => {
-  let root = logPaneMount(<BuildLogAndRunLog />)
+  let root = logPaneMount(<BuildLogAndRunLog source="" level="" />)
   let el = root.getDOMNode()
-  expect(el.querySelectorAll(".LogPaneLine")).toHaveLength(20)
+  expect(el.querySelectorAll(".LogPaneLine")).toHaveLength(40)
 
   let root2 = logPaneMount(
     <BuildLogAndRunLog level={FilterLevel.warn} source="" />
   )
   let el2 = root2.getDOMNode()
-  expect(el2.querySelectorAll(".LogPaneLine")).toHaveLength(2)
-  expect(el2.innerHTML).toEqual(
+  expect(el2.querySelectorAll(".LogPaneLine")).toHaveLength(
+    2 * (1 + PROLOGUE_LENGTH)
+  )
+
+  let alertEnds = el2.querySelectorAll(".is-endOfAlert")
+  let alertEnd = alertEnds[alertEnds.length - 1]
+  expect(alertEnd.innerHTML).toEqual(
     expect.stringContaining("Vigoda pod warning line")
   )
-  expect(el2.innerHTML).toEqual(expect.not.stringContaining("Vigoda pod line"))
-  expect(el2.innerHTML).toEqual(
+  expect(alertEnd.innerHTML).toEqual(
+    expect.not.stringContaining("Vigoda pod line")
+  )
+  expect(alertEnd.innerHTML).toEqual(
     expect.not.stringContaining("Vigoda pod error line")
   )
 
@@ -80,12 +91,19 @@ it("filters by level", () => {
     <BuildLogAndRunLog level={FilterLevel.error} source="" />
   )
   let el3 = root3.getDOMNode()
-  expect(el3.querySelectorAll(".LogPaneLine")).toHaveLength(2)
-  expect(el3.innerHTML).toEqual(
+  expect(el3.querySelectorAll(".LogPaneLine")).toHaveLength(
+    2 * (1 + PROLOGUE_LENGTH)
+  )
+
+  alertEnds = el3.querySelectorAll(".is-endOfAlert")
+  alertEnd = alertEnds[alertEnds.length - 1]
+  expect(alertEnd.innerHTML).toEqual(
     expect.not.stringContaining("Vigoda pod warning line")
   )
-  expect(el3.innerHTML).toEqual(expect.not.stringContaining("Vigoda pod line"))
-  expect(el3.innerHTML).toEqual(
+  expect(alertEnd.innerHTML).toEqual(
+    expect.not.stringContaining("Vigoda pod line")
+  )
+  expect(alertEnd.innerHTML).toEqual(
     expect.stringContaining("Vigoda pod error line")
   )
 })


### PR DESCRIPTION
Hello @hyu,

Please review the following commits I made in branch nicks/errorcontext:

eab5bf25dbed1ecff30dc1765eb3df638e416110 (2021-01-27 22:41:12 -0500)
web: add (more) links to errors that scrolls to the error in-context

7302ea2845620004029acb58b303fa6aa621d4ed (2021-01-27 14:44:18 -0500)
web: add counts to error and warning pickers

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics