### PR TITLE
web: log tiltfile errors with the right error level

### DIFF
--- a/internal/engine/configs/configs_controller.go
+++ b/internal/engine/configs/configs_controller.go
@@ -159,7 +159,7 @@ func (cc *ConfigsController) loadTiltfile(ctx context.Context, st store.RStore, 
 	}
 
 	if tlr.Error != nil {
-		logger.Get(ctx).Infof("%s", tlr.Error.Error())
+		logger.Get(ctx).Errorf("%s", tlr.Error.Error())
 	}
 
 	st.Dispatch(ConfigsReloadedAction{

--- a/internal/engine/configs/configs_controller_test.go
+++ b/internal/engine/configs/configs_controller_test.go
@@ -1,9 +1,9 @@
 package configs
 
 import (
+	"bytes"
 	"context"
 	"fmt"
-	"reflect"
 	"runtime"
 	"testing"
 	"time"
@@ -18,6 +18,7 @@ import (
 	"github.com/tilt-dev/tilt/internal/testutils/manifestbuilder"
 	"github.com/tilt-dev/tilt/internal/testutils/tempdir"
 	"github.com/tilt-dev/tilt/internal/tiltfile"
+	"github.com/tilt-dev/tilt/pkg/logger"
 	"github.com/tilt-dev/tilt/pkg/model"
 )
 
@@ -32,14 +33,15 @@ func TestConfigsController(t *testing.T) {
 	f.addManifest("fe")
 
 	bar := manifestbuilder.New(f, "bar").WithK8sYAML(testyaml.SanchoYAML).Build()
-	_, a := f.run(bar)
+	f.setManifestResult(bar)
+	f.cc.OnChange(f.ctx, f.st)
 
-	expected := ConfigsReloadedAction{
+	expected := &ConfigsReloadedAction{
 		Manifests:  []model.Manifest{bar},
 		FinishTime: f.fc.Times[1],
 	}
 
-	assert.Equal(t, expected, a)
+	assert.Equal(t, expected, f.st.end)
 	assert.Equal(t, model.OrchestratorK8s, f.docker.Orchestrator)
 }
 
@@ -55,10 +57,11 @@ func TestConfigsControllerDockerNotConnected(t *testing.T) {
 		WithK8sYAML(testyaml.SanchoYAML).
 		WithImageTarget(NewSanchoDockerBuildImageTarget(f)).
 		Build()
-	_, a := f.run(bar)
+	f.setManifestResult(bar)
+	f.cc.OnChange(f.ctx, f.st)
 
-	if assert.Error(t, a.Err) {
-		assert.Equal(t, "Failed to connect to Docker: connection-error", a.Err.Error())
+	if assert.Error(t, f.st.end.Err) {
+		assert.Equal(t, "Failed to connect to Docker: connection-error", f.st.end.Err.Error())
 	}
 }
 
@@ -73,9 +76,10 @@ func TestConfigsControllerDockerNotConnectedButNotRequired(t *testing.T) {
 	bar := manifestbuilder.New(f, "bar").
 		WithK8sYAML(testyaml.SanchoYAML).
 		Build()
-	_, a := f.run(bar)
+	f.setManifestResult(bar)
+	f.cc.OnChange(f.ctx, f.st)
 
-	assert.NoError(t, a.Err)
+	assert.NoError(t, f.st.end.Err)
 }
 
 func TestBuildReasonTrigger(t *testing.T) {
@@ -89,10 +93,58 @@ func TestBuildReasonTrigger(t *testing.T) {
 	state.AppendToTriggerQueue(model.TiltfileManifestName, model.BuildReasonFlagTriggerWeb)
 	f.st.UnlockMutableState()
 
-	reloadStarted, _ := f.run(bar)
+	f.setManifestResult(bar)
+	f.cc.OnChange(f.ctx, f.st)
 
-	assert.True(t, reloadStarted.Reason.Has(model.BuildReasonFlagTriggerWeb),
+	assert.True(t, f.st.start.Reason.Has(model.BuildReasonFlagTriggerWeb),
 		"expected build reason has flag: TriggerWeb")
+}
+
+func TestErrorLog(t *testing.T) {
+	f := newCCFixture(t)
+	defer f.TearDown()
+
+	f.tfl.Result = tiltfile.TiltfileLoadResult{Error: fmt.Errorf("The goggles do nothing!")}
+	f.cc.OnChange(f.ctx, f.st)
+
+	assert.Contains(f.T(), f.st.out.String(), "ERROR LEVEL: The goggles do nothing!")
+}
+
+type testStore struct {
+	*store.TestingStore
+	out   *bytes.Buffer
+	start *ConfigsReloadStartedAction
+	end   *ConfigsReloadedAction
+}
+
+func NewTestingStore() *testStore {
+	return &testStore{
+		TestingStore: store.NewTestingStore(),
+		out:          bytes.NewBuffer(nil),
+	}
+}
+
+func (s *testStore) Dispatch(action store.Action) {
+	s.TestingStore.Dispatch(action)
+
+	logAction, ok := action.(store.LogAction)
+	if ok {
+		level := ""
+		if logAction.Level() == logger.ErrorLvl {
+			level = "ERROR LEVEL:"
+		}
+		_, _ = fmt.Fprintf(s.out, "%s %s", level, logAction.Message())
+	}
+
+	start, ok := action.(ConfigsReloadStartedAction)
+	if ok {
+		s.start = &start
+	}
+
+	end, ok := action.(ConfigsReloadedAction)
+	if ok {
+		s.end = &end
+	}
 }
 
 type ccFixture struct {
@@ -100,7 +152,7 @@ type ccFixture struct {
 	ctx    context.Context
 	cancel func()
 	cc     *ConfigsController
-	st     *store.TestingStore
+	st     *testStore
 	tfl    *tiltfile.FakeTiltfileLoader
 	fc     *testutils.FakeClock
 	docker *docker.FakeClient
@@ -108,7 +160,7 @@ type ccFixture struct {
 
 func newCCFixture(t *testing.T) *ccFixture {
 	f := tempdir.NewTempDirFixture(t)
-	st := store.NewTestingStore()
+	st := NewTestingStore()
 	tfl := tiltfile.NewFakeTiltfileLoader()
 	d := docker.NewFakeClient()
 	cc := NewConfigsController(tfl, d)
@@ -121,6 +173,11 @@ func newCCFixture(t *testing.T) *ccFixture {
 	// sometimes the original directory was invalid (e.g., it was another test's temp dir, which was deleted,
 	// but not changed out of), and if it was already invalid, then let's not worry about it.
 	f.Chdir()
+
+	state := st.LockMutableStateForTesting()
+	state.TiltfilePath = f.JoinPath("Tiltfile")
+	state.PendingConfigFileChanges["Tiltfile"] = time.Now()
+	st.UnlockMutableState()
 
 	return &ccFixture{
 		TempDirFixture: f,
@@ -145,32 +202,13 @@ func (f *ccFixture) addManifest(name model.ManifestName) {
 	m := manifestbuilder.New(f, name).WithK8sYAML(testyaml.SanchoYAML).Build()
 	mt := store.NewManifestTarget(m)
 	state.UpsertManifestTarget(mt)
-	state.PendingConfigFileChanges["Tiltfile"] = time.Now()
-	state.TiltfilePath = f.JoinPath("Tiltfile")
 	f.st.UnlockMutableState()
 }
 
-func (f *ccFixture) run(m model.Manifest) (start ConfigsReloadStartedAction, end ConfigsReloadedAction) {
+func (f *ccFixture) setManifestResult(m model.Manifest) {
 	f.tfl.Result = tiltfile.TiltfileLoadResult{
 		Manifests: []model.Manifest{m},
 	}
-
-	f.cc.OnChange(f.ctx, f.st)
-
-	var ok bool
-	a := store.WaitForAction(f.T(), reflect.TypeOf(ConfigsReloadStartedAction{}), f.st.Actions)
-	start, ok = a.(ConfigsReloadStartedAction)
-	if !ok {
-		f.T().Fatalf("didn't get an action of type %T", ConfigsReloadStartedAction{})
-	}
-
-	a = store.WaitForAction(f.T(), reflect.TypeOf(ConfigsReloadedAction{}), f.st.Actions)
-	end, ok = a.(ConfigsReloadedAction)
-	if !ok {
-		f.T().Fatalf("didn't get an action of type %T", ConfigsReloadedAction{})
-	}
-
-	return start, end
 }
 
 const SanchoDockerfile = `

--- a/internal/tiltfile/tiltfile.go
+++ b/internal/tiltfile/tiltfile.go
@@ -222,7 +222,9 @@ func (tfl tiltfileLoader) Load(ctx context.Context, filename string, userConfigS
 	tlr.UpdateSettings = us
 
 	duration := time.Since(start)
-	s.logger.Infof("Successfully loaded Tiltfile (%s)", duration)
+	if tlr.Error == nil {
+		s.logger.Infof("Successfully loaded Tiltfile (%s)", duration)
+	}
 	tfl.reportTiltfileLoaded(s.builtinCallCounts, s.builtinArgCounts, duration)
 	reportTiltfileExecMetrics(ctx, duration, err != nil)
 


### PR DESCRIPTION
Hello @landism,

Please review the following commits I made in branch nicks/ch11044:

b3587be01ec274bddaffef5ef96e87f45a70045f (2021-01-28 15:24:34 -0500)
web: log tiltfile errors with the right error level
also, simplify configs controller tests while i'm here

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics