### PR TITLE
tiltfile: make host truly optional for http/tcp probes

### DIFF
--- a/internal/tiltfile/probe/probe.go
+++ b/internal/tiltfile/probe/probe.go
@@ -148,8 +148,8 @@ func (e Extension) httpGetAction(thread *starlark.Thread, fn *starlark.Builtin, 
 	var port int
 	// TODO(milas): support headers
 	err := starkit.UnpackArgs(thread, fn.Name(), args, kwargs,
-		"host", &host,
 		"port", &port,
+		"host?", &host,
 		"scheme?", &scheme,
 		"path?", &path,
 	)
@@ -194,7 +194,10 @@ func (t TCPSocketAction) ValueOrNone() starlark.Value {
 func (e Extension) tcpSocketAction(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	var host starlark.String
 	var port int
-	err := starkit.UnpackArgs(thread, fn.Name(), args, kwargs, "host", &host, "port", &port)
+	err := starkit.UnpackArgs(thread, fn.Name(), args, kwargs,
+		"port", &port,
+		"host?", &host,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/tiltfile/probe/probe_test.go
+++ b/internal/tiltfile/probe/probe_test.go
@@ -89,12 +89,37 @@ https
 	require.Contains(t, f.PrintOutput(), expectedOutput)
 }
 
+func TestProbeHTTPGetNoHost(t *testing.T) {
+	f := starkit.NewFixture(t, NewExtension())
+	defer f.TearDown()
+
+	f.File("Tiltfile", `
+p = probe(http_get=http_get_action(8888, scheme='https', path='/status'))
+
+print(p.http_get.host)
+print(p.http_get.port)
+print(p.http_get.scheme)
+print(p.http_get.path)
+`)
+
+	_, err := f.ExecFile("Tiltfile")
+	require.NoError(t, err)
+
+	expectedOutput := strings.TrimSpace(`
+8888
+https
+/status
+`)
+
+	require.Contains(t, f.PrintOutput(), expectedOutput)
+}
+
 func TestProbeTCP(t *testing.T) {
 	f := starkit.NewFixture(t, NewExtension())
 	defer f.TearDown()
 
 	f.File("Tiltfile", `
-p = probe(tcp_socket=tcp_socket_action("localhost", 1234))
+p = probe(tcp_socket=tcp_socket_action(1234, "localhost"))
 
 print(p.tcp_socket.host)
 print(p.tcp_socket.port)


### PR DESCRIPTION
Oversight when adding a default of `localhost` - the `host` arg needed to be made optional, which means `port` is the only positional (required) argument.