### PR TITLE
web: ensure snapshots are under 4MB upload limit

### DIFF
--- a/web/src/HUD.tsx
+++ b/web/src/HUD.tsx
@@ -56,6 +56,10 @@ type HudProps = {
   interfaceVersion: InterfaceVersion
 }
 
+// Snapshot logs are capped to 2MB (max upload size is 4MB; this ensures between the rest of state and JSON overhead
+// that the snapshot should still fit)
+const maxSnapshotLogSize = 2 * 1000 * 1000;
+
 // The Main HUD view, as specified in
 // https://docs.google.com/document/d/1VNIGfpC4fMfkscboW0bjYYFJl07um_1tsFrbN-Fu3FI/edit#heading=h.l8mmnclsuxl1
 export default class HUD extends Component<HudProps, HudState> {
@@ -191,7 +195,7 @@ export default class HUD extends Component<HudProps, HudState> {
   snapshotFromState(state: HudState): Proto.webviewSnapshot {
     let view = _.cloneDeep(state.view ?? null)
     if (view && state.logStore) {
-      view.logList = state.logStore.toLogList()
+      view.logList = state.logStore.toLogList(maxSnapshotLogSize)
     }
     return {
       view: view,

--- a/web/src/HUD.tsx
+++ b/web/src/HUD.tsx
@@ -56,9 +56,9 @@ type HudProps = {
   interfaceVersion: InterfaceVersion
 }
 
-// Snapshot logs are capped to 2MB (max upload size is 4MB; this ensures between the rest of state and JSON overhead
+// Snapshot logs are capped to 1MB (max upload size is 4MB; this ensures between the rest of state and JSON overhead
 // that the snapshot should still fit)
-const maxSnapshotLogSize = 2 * 1000 * 1000;
+const maxSnapshotLogSize = 1000 * 1000
 
 // The Main HUD view, as specified in
 // https://docs.google.com/document/d/1VNIGfpC4fMfkscboW0bjYYFJl07um_1tsFrbN-Fu3FI/edit#heading=h.l8mmnclsuxl1

--- a/web/src/LogStore.test.ts
+++ b/web/src/LogStore.test.ts
@@ -434,9 +434,7 @@ describe("LogStore", () => {
       spans: {
         "build:1": { manifestName: "fe" },
       },
-      segments: [
-        newManifestSegment("build:1", "build 1\n"),
-      ],
+      segments: [newManifestSegment("build:1", "build 1\n")],
       fromCheckpoint: 0,
       toCheckpoint: 1,
     })
@@ -457,9 +455,7 @@ describe("LogStore", () => {
       spans: {
         "": {},
       },
-      segments: [
-        newGlobalSegment("global line 1\n"),
-      ],
+      segments: [newGlobalSegment("global line 1\n")],
       fromCheckpoint: 3,
       toCheckpoint: 4,
     })

--- a/web/src/LogStore.ts
+++ b/web/src/LogStore.ts
@@ -133,7 +133,7 @@ class LogStore {
         time: segment.time,
         text: segment.text,
         level: segment.level,
-        fields: segment.fields
+        fields: segment.fields,
       })
     }
 


### PR DESCRIPTION
Truncate logs included in the snapshot upload to avoid being rejected
by the server for > 4MB size.

The logs are truncated to 2MB as there is a substantial amount of
overhead from JSON as well as the rest of the actual UI state that
needs to fit in there as well.

Closes #3687.