### PR TITLE
web: simplify localstorage + use library

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -34,6 +34,7 @@
     "react-router-dom": "^5.1.0",
     "react-scripts": "^4.0.1",
     "react-select": "^2.4.2",
+    "react-storage-hooks": "^4.0.1",
     "react-timeago": "^4.4.0",
     "styled-components": "^5.1.1",
     "typescript": "^4.1.3"

--- a/web/src/HUD.tsx
+++ b/web/src/HUD.tsx
@@ -18,7 +18,7 @@ import HUDLayout from "./HUDLayout"
 import HudState from "./HudState"
 import { InterfaceVersion, useInterfaceVersion } from "./InterfaceVersion"
 import K8sViewPane from "./K8sViewPane"
-import { LocalStorageContextProvider } from "./LocalStorage"
+import { tiltfileKeyContext } from "./LocalStorage"
 import LogPane from "./LogPane"
 import { logLinesFromString } from "./logs"
 import LogStore, { LogStoreProvider } from "./LogStore"
@@ -353,7 +353,7 @@ export default class HUD extends Component<HudProps, HudState> {
       let validateTab = (name: string) =>
         resources.some((res) => res.name === name)
       return (
-        <LocalStorageContextProvider tiltfileKey={view.tiltfileKey}>
+        <tiltfileKeyContext.Provider value={view.tiltfileKey}>
           <SidebarPinContextProvider>
             <OverviewNavProvider validateTab={validateTab}>
               <div className={hudClasses.join(" ")}>
@@ -367,12 +367,12 @@ export default class HUD extends Component<HudProps, HudState> {
               </div>
             </OverviewNavProvider>
           </SidebarPinContextProvider>
-        </LocalStorageContextProvider>
+        </tiltfileKeyContext.Provider>
       )
     }
 
     return (
-      <LocalStorageContextProvider tiltfileKey={view.tiltfileKey}>
+      <tiltfileKeyContext.Provider value={view.tiltfileKey}>
         <SidebarPinContextProvider>
           <LegacyNavProvider resourceView={resourceView}>
             <div className={hudClasses.join(" ")}>
@@ -395,7 +395,7 @@ export default class HUD extends Component<HudProps, HudState> {
             </div>
           </LegacyNavProvider>
         </SidebarPinContextProvider>
-      </LocalStorageContextProvider>
+      </tiltfileKeyContext.Provider>
     )
   }
 

--- a/web/src/LocalStorage.tsx
+++ b/web/src/LocalStorage.tsx
@@ -1,54 +1,19 @@
 import React, { useContext } from "react"
+import { useStorageState } from "react-storage-hooks"
 
-export type LocalStorageContext = {
-  set: (key: string, value: any) => void
-  get: <T extends {}>(key: string) => T | null
-}
-
-export const localStorageContext = React.createContext<LocalStorageContext>({
-  set: (key: string, value: any): void => {},
-  get: <T extends {}>(key: string): T | null => null,
-})
-
-export function useLocalStorageContext(): LocalStorageContext {
-  return useContext(localStorageContext)
-}
+export type TiltfileKey = string
+export const tiltfileKeyContext = React.createContext<TiltfileKey>("unset")
 
 export function makeKey(tiltfileKey: string, key: string): string {
   return "tilt-" + JSON.stringify({ tiltfileKey: tiltfileKey, key: key })
 }
 
-// Provides access localStorage, but namespaced by `tiltfileKey`
-// Also handles serialization and typing.
-export function LocalStorageContextProvider(
-  props: React.PropsWithChildren<{ tiltfileKey: string }>
-) {
-  let tiltfileKey = props.tiltfileKey
-
-  let set = (key: string, value: any): void => {
-    localStorage.setItem(makeKey(tiltfileKey, key), JSON.stringify(value))
-  }
-
-  let get = <T extends {}>(key: string): T | null => {
-    let lsk = makeKey(tiltfileKey, key)
-    let json = localStorage.getItem(lsk)
-    if (!json) {
-      return null
-    }
-
-    try {
-      return JSON.parse(json)
-    } catch (e) {
-      console.log(
-        `error parsing local storage w/ key ${lsk}, val ${json}: ${e}`
-      )
-      return null
-    }
-  }
-
-  return (
-    <localStorageContext.Provider value={{ set: set, get: get }}>
-      {props.children}
-    </localStorageContext.Provider>
+// Like `useState`, but backed by localStorage and namespaced by the tiltfileKey
+export function usePersistentState<S>(name: string, defaultValue: S) {
+  const tiltfileKey = useContext(tiltfileKeyContext)
+  return useStorageState<S>(
+    localStorage,
+    makeKey(tiltfileKey, name),
+    defaultValue
   )
 }

--- a/web/src/OverviewPane.test.tsx
+++ b/web/src/OverviewPane.test.tsx
@@ -1,7 +1,7 @@
 import { mount, ReactWrapper } from "enzyme"
 import React from "react"
 import { MemoryRouter } from "react-router"
-import { LocalStorageContextProvider, makeKey } from "./LocalStorage"
+import { makeKey, tiltfileKeyContext } from "./LocalStorage"
 import OverviewItemView from "./OverviewItemView"
 import OverviewPane, {
   AllResources,
@@ -45,9 +45,9 @@ it("renders pinned resources", () => {
 
   const root = mount(
     <MemoryRouter initialEntries={["/"]}>
-      <LocalStorageContextProvider tiltfileKey={"test"}>
+      <tiltfileKeyContext.Provider value="test">
         <SidebarPinContextProvider>{TwoResources()}</SidebarPinContextProvider>
-      </LocalStorageContextProvider>
+      </tiltfileKeyContext.Provider>
     </MemoryRouter>
   )
 

--- a/web/src/OverviewSidebarOptions.test.tsx
+++ b/web/src/OverviewSidebarOptions.test.tsx
@@ -1,7 +1,7 @@
 import { mount, ReactWrapper } from "enzyme"
 import React from "react"
 import { MemoryRouter } from "react-router"
-import { LocalStorageContextProvider, makeKey } from "./LocalStorage"
+import { makeKey, tiltfileKeyContext } from "./LocalStorage"
 import { TwoResourcesTwoTests } from "./OverviewResourceSidebar.stories"
 import { OverviewSidebarOptions } from "./OverviewSidebarOptions"
 import PathBuilder from "./PathBuilder"
@@ -91,7 +91,7 @@ it("doesn't show SidebarOptionSetter if no tests present", () => {
   let items = [tiltfileResource(), oneResource()].map((r) => new SidebarItem(r))
   const root = mount(
     <MemoryRouter>
-      <LocalStorageContextProvider tiltfileKey={"test"}>
+      <tiltfileKeyContext.Provider value="test">
         <SidebarPinContextProvider>
           <SidebarResources
             items={items}
@@ -100,7 +100,7 @@ it("doesn't show SidebarOptionSetter if no tests present", () => {
             pathBuilder={pathBuilder}
           />
         </SidebarPinContextProvider>
-      </LocalStorageContextProvider>
+      </tiltfileKeyContext.Provider>
     </MemoryRouter>
   )
   let sidebar = root.find(SidebarResources)
@@ -117,11 +117,11 @@ it("still displays pinned tests when tests hidden", () => {
   )
   const root = mount(
     <MemoryRouter>
-      <LocalStorageContextProvider tiltfileKey={"test"}>
+      <tiltfileKeyContext.Provider value="test">
         <SidebarPinContextProvider>
           {TwoResourcesTwoTests()}
         </SidebarPinContextProvider>
-      </LocalStorageContextProvider>
+      </tiltfileKeyContext.Provider>
     </MemoryRouter>
   )
 

--- a/web/src/SidebarPin.tsx
+++ b/web/src/SidebarPin.tsx
@@ -5,7 +5,7 @@ import React, {
   useState,
 } from "react"
 import { incr } from "./analytics"
-import { useLocalStorageContext } from "./LocalStorage"
+import { usePersistentState } from "./LocalStorage"
 
 type SidebarPinContext = {
   pinnedResources: string[]
@@ -54,13 +54,9 @@ export function SidebarPinMemoryProvider(
 export function SidebarPinContextProvider(
   props: PropsWithChildren<{ initialValueForTesting?: string[] }>
 ) {
-  let lsc = useLocalStorageContext()
-
-  const [pinnedResources, setPinnedResources] = useState<Array<string>>(
-    () =>
-      props.initialValueForTesting ??
-      lsc.get<Array<string>>("pinned-resources") ??
-      []
+  let [pinnedResources, setPinnedResources] = usePersistentState<string[]>(
+    "pinned-resources",
+    props.initialValueForTesting ?? []
   )
 
   useEffect(() => {
@@ -71,10 +67,6 @@ export function SidebarPinContextProvider(
     // empty deps because we only want to report the loaded pin count once per app load
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
-
-  useEffect(() => {
-    lsc.set("pinned-resources", pinnedResources)
-  }, [pinnedResources, lsc])
 
   function pinResource(name: string) {
     setPinnedResources((prevState) => {

--- a/web/src/SidebarResources.test.tsx
+++ b/web/src/SidebarResources.test.tsx
@@ -3,7 +3,7 @@ import fetchMock from "jest-fetch-mock"
 import React from "react"
 import { MemoryRouter } from "react-router"
 import { expectIncr } from "./analytics_test_helpers"
-import { LocalStorageContextProvider, makeKey } from "./LocalStorage"
+import { makeKey, tiltfileKeyContext } from "./LocalStorage"
 import PathBuilder from "./PathBuilder"
 import SidebarItem from "./SidebarItem"
 import { SidebarItemBox } from "./SidebarItemView"
@@ -49,7 +49,7 @@ describe("SidebarResources", () => {
     let items = twoResourceView().resources.map((r) => new SidebarItem(r))
     const root = mount(
       <MemoryRouter>
-        <LocalStorageContextProvider tiltfileKey={"test"}>
+        <tiltfileKeyContext.Provider value="test">
           <SidebarPinContextProvider>
             <SidebarResources
               items={items}
@@ -58,7 +58,7 @@ describe("SidebarResources", () => {
               pathBuilder={pathBuilder}
             />
           </SidebarPinContextProvider>
-        </LocalStorageContextProvider>
+        </tiltfileKeyContext.Provider>
       </MemoryRouter>
     )
 
@@ -85,7 +85,7 @@ describe("SidebarResources", () => {
     let items = twoResourceView().resources.map((r) => new SidebarItem(r))
     const root = mount(
       <MemoryRouter>
-        <LocalStorageContextProvider tiltfileKey={"test"}>
+        <tiltfileKeyContext.Provider value="test">
           <SidebarPinContextProvider>
             <SidebarResources
               items={items}
@@ -94,7 +94,7 @@ describe("SidebarResources", () => {
               pathBuilder={pathBuilder}
             />
           </SidebarPinContextProvider>
-        </LocalStorageContextProvider>
+        </tiltfileKeyContext.Provider>
       </MemoryRouter>
     )
 
@@ -110,7 +110,7 @@ describe("SidebarResources", () => {
 
     const root = mount(
       <MemoryRouter>
-        <LocalStorageContextProvider tiltfileKey={"test"}>
+        <tiltfileKeyContext.Provider value="test">
           <SidebarPinContextProvider>
             <SidebarResources
               items={items}
@@ -119,7 +119,7 @@ describe("SidebarResources", () => {
               pathBuilder={pathBuilder}
             />
           </SidebarPinContextProvider>
-        </LocalStorageContextProvider>
+        </tiltfileKeyContext.Provider>
       </MemoryRouter>
     )
 

--- a/web/src/TabNav.test.tsx
+++ b/web/src/TabNav.test.tsx
@@ -52,117 +52,123 @@ function newFixture(initialTabs: string[]): Fixture {
   return f
 }
 
-it("navigates to existing tab on click resource", () => {
-  let f = newFixture(["res1", "res2"])
-  expect(f.nav.tabs).toEqual(["res1", "res2"])
-  expect(f.nav.selectedTab).toEqual("")
+describe("tabnav", () => {
+  afterEach(() => {
+    localStorage.clear()
+  })
 
-  f.openResource("res1")
+  it("navigates to existing tab on click resource", () => {
+    let f = newFixture(["res1", "res2"])
+    expect(f.nav.tabs).toEqual(["res1", "res2"])
+    expect(f.nav.selectedTab).toEqual("")
 
-  expect(f.nav.tabs).toEqual(["res1", "res2"])
-  expect(f.nav.selectedTab).toEqual("res1")
-  expect(f.history.location.pathname).toEqual("/r/res1/overview")
-})
+    f.openResource("res1")
 
-it("navigates to new tab on click resource", () => {
-  let f = newFixture(["res1", "res2"])
-  expect(f.nav.tabs).toEqual(["res1", "res2"])
-  expect(f.nav.selectedTab).toEqual("")
+    expect(f.nav.tabs).toEqual(["res1", "res2"])
+    expect(f.nav.selectedTab).toEqual("res1")
+    expect(f.history.location.pathname).toEqual("/r/res1/overview")
+  })
 
-  f.openResource("res3")
+  it("navigates to new tab on click resource", () => {
+    let f = newFixture(["res1", "res2"])
+    expect(f.nav.tabs).toEqual(["res1", "res2"])
+    expect(f.nav.selectedTab).toEqual("")
 
-  expect(f.nav.tabs).toEqual(["res1", "res2", "res3"])
-  expect(f.nav.selectedTab).toEqual("res3")
-})
+    f.openResource("res3")
 
-it("changes selected tab on click existing resource", () => {
-  let f = newFixture(["res1", "res2", "res3"])
-  expect(f.nav.tabs).toEqual(["res1", "res2", "res3"])
-  expect(f.nav.selectedTab).toEqual("")
+    expect(f.nav.tabs).toEqual(["res1", "res2", "res3"])
+    expect(f.nav.selectedTab).toEqual("res3")
+  })
 
-  f.openResource("res1")
+  it("changes selected tab on click existing resource", () => {
+    let f = newFixture(["res1", "res2", "res3"])
+    expect(f.nav.tabs).toEqual(["res1", "res2", "res3"])
+    expect(f.nav.selectedTab).toEqual("")
 
-  expect(f.nav.tabs).toEqual(["res1", "res2", "res3"])
-  expect(f.nav.selectedTab).toEqual("res1")
+    f.openResource("res1")
 
-  f.openResource("res3")
-  expect(f.nav.tabs).toEqual(["res1", "res2", "res3"])
-  expect(f.nav.selectedTab).toEqual("res3")
-})
+    expect(f.nav.tabs).toEqual(["res1", "res2", "res3"])
+    expect(f.nav.selectedTab).toEqual("res1")
 
-it("changes selected tab on click new resource", () => {
-  let f = newFixture(["res1", "res2", "res3"])
-  expect(f.nav.tabs).toEqual(["res1", "res2", "res3"])
-  expect(f.nav.selectedTab).toEqual("")
+    f.openResource("res3")
+    expect(f.nav.tabs).toEqual(["res1", "res2", "res3"])
+    expect(f.nav.selectedTab).toEqual("res3")
+  })
 
-  f.openResource("res2")
+  it("changes selected tab on click new resource", () => {
+    let f = newFixture(["res1", "res2", "res3"])
+    expect(f.nav.tabs).toEqual(["res1", "res2", "res3"])
+    expect(f.nav.selectedTab).toEqual("")
 
-  expect(f.nav.tabs).toEqual(["res1", "res2", "res3"])
-  expect(f.nav.selectedTab).toEqual("res2")
+    f.openResource("res2")
 
-  f.openResource("res4")
-  expect(f.nav.tabs).toEqual(["res1", "res4", "res3"])
-  expect(f.nav.selectedTab).toEqual("res4")
-})
+    expect(f.nav.tabs).toEqual(["res1", "res2", "res3"])
+    expect(f.nav.selectedTab).toEqual("res2")
 
-it("open new tab to the right on double-click existing resource", () => {
-  let f = newFixture(["res1", "res2", "res3"])
-  expect(f.nav.tabs).toEqual(["res1", "res2", "res3"])
-  expect(f.nav.selectedTab).toEqual("")
+    f.openResource("res4")
+    expect(f.nav.tabs).toEqual(["res1", "res4", "res3"])
+    expect(f.nav.selectedTab).toEqual("res4")
+  })
 
-  f.openResource("res1")
+  it("open new tab to the right on double-click existing resource", () => {
+    let f = newFixture(["res1", "res2", "res3"])
+    expect(f.nav.tabs).toEqual(["res1", "res2", "res3"])
+    expect(f.nav.selectedTab).toEqual("")
 
-  expect(f.nav.tabs).toEqual(["res1", "res2", "res3"])
-  expect(f.nav.selectedTab).toEqual("res1")
+    f.openResource("res1")
 
-  f.openResource("res3", { newTab: true })
-  expect(f.nav.tabs).toEqual(["res1", "res2", "res3"])
-  expect(f.nav.selectedTab).toEqual("res3")
-})
+    expect(f.nav.tabs).toEqual(["res1", "res2", "res3"])
+    expect(f.nav.selectedTab).toEqual("res1")
 
-it("open new tab to the right on double-click new resource", () => {
-  let f = newFixture(["res1", "res2", "res3"])
-  expect(f.nav.tabs).toEqual(["res1", "res2", "res3"])
-  expect(f.nav.selectedTab).toEqual("")
+    f.openResource("res3", { newTab: true })
+    expect(f.nav.tabs).toEqual(["res1", "res2", "res3"])
+    expect(f.nav.selectedTab).toEqual("res3")
+  })
 
-  f.openResource("res1")
+  it("open new tab to the right on double-click new resource", () => {
+    let f = newFixture(["res1", "res2", "res3"])
+    expect(f.nav.tabs).toEqual(["res1", "res2", "res3"])
+    expect(f.nav.selectedTab).toEqual("")
 
-  expect(f.nav.tabs).toEqual(["res1", "res2", "res3"])
-  expect(f.nav.selectedTab).toEqual("res1")
+    f.openResource("res1")
 
-  f.openResource("res4", { newTab: true })
-  expect(f.nav.tabs).toEqual(["res1", "res4", "res2", "res3"])
-  expect(f.nav.selectedTab).toEqual("res4")
-})
+    expect(f.nav.tabs).toEqual(["res1", "res2", "res3"])
+    expect(f.nav.selectedTab).toEqual("res1")
 
-it("navigates to the tab on the right when closing", () => {
-  let f = newFixture(["res1", "res2", "res3"])
-  expect(f.nav.tabs).toEqual(["res1", "res2", "res3"])
-  expect(f.nav.selectedTab).toEqual("")
+    f.openResource("res4", { newTab: true })
+    expect(f.nav.tabs).toEqual(["res1", "res4", "res2", "res3"])
+    expect(f.nav.selectedTab).toEqual("res4")
+  })
 
-  f.openResource("res2")
+  it("navigates to the tab on the right when closing", () => {
+    let f = newFixture(["res1", "res2", "res3"])
+    expect(f.nav.tabs).toEqual(["res1", "res2", "res3"])
+    expect(f.nav.selectedTab).toEqual("")
 
-  expect(f.nav.tabs).toEqual(["res1", "res2", "res3"])
-  expect(f.nav.selectedTab).toEqual("res2")
+    f.openResource("res2")
 
-  f.closeTab("res2")
-  expect(f.nav.tabs).toEqual(["res1", "res3"])
-  expect(f.nav.selectedTab).toEqual("res3")
-  expect(f.history.location.pathname).toEqual("/r/res3/overview")
-})
+    expect(f.nav.tabs).toEqual(["res1", "res2", "res3"])
+    expect(f.nav.selectedTab).toEqual("res2")
 
-it("navigates to home on closing last tab when closing", () => {
-  let f = newFixture(["res1"])
-  expect(f.nav.tabs).toEqual(["res1"])
-  expect(f.nav.selectedTab).toEqual("")
+    f.closeTab("res2")
+    expect(f.nav.tabs).toEqual(["res1", "res3"])
+    expect(f.nav.selectedTab).toEqual("res3")
+    expect(f.history.location.pathname).toEqual("/r/res3/overview")
+  })
 
-  f.openResource("res1")
+  it("navigates to home on closing last tab when closing", () => {
+    let f = newFixture(["res1"])
+    expect(f.nav.tabs).toEqual(["res1"])
+    expect(f.nav.selectedTab).toEqual("")
 
-  expect(f.nav.tabs).toEqual(["res1"])
-  expect(f.nav.selectedTab).toEqual("res1")
+    f.openResource("res1")
 
-  f.closeTab("res1")
-  expect(f.nav.tabs).toEqual([ResourceName.all])
-  expect(f.nav.selectedTab).toEqual("")
-  expect(f.history.location.pathname).toEqual("/overview")
+    expect(f.nav.tabs).toEqual(["res1"])
+    expect(f.nav.selectedTab).toEqual("res1")
+
+    f.closeTab("res1")
+    expect(f.nav.tabs).toEqual([ResourceName.all])
+    expect(f.nav.selectedTab).toEqual("")
+    expect(f.history.location.pathname).toEqual("/overview")
+  })
 })

--- a/web/src/TabNav.tsx
+++ b/web/src/TabNav.tsx
@@ -1,6 +1,6 @@
-import React, { useContext, useEffect, useState } from "react"
+import React, { useContext, useEffect } from "react"
 import { matchPath, useHistory } from "react-router-dom"
-import { useLocalStorageContext } from "./LocalStorage"
+import { usePersistentState } from "./LocalStorage"
 import { usePathBuilder } from "./PathBuilder"
 import { ResourceName, ResourceView } from "./types"
 
@@ -117,7 +117,10 @@ export function OverviewNavProvider(
   }>
 ) {
   let { children, validateTab, tabsForTesting } = props
-  let lsc = useLocalStorageContext()
+  const [tabs, setTabs] = usePersistentState<string[]>(
+    "tabs",
+    addAllTabIfEmpty(tabsForTesting || [])
+  )
   let history = useHistory()
   let pb = usePathBuilder()
   let selectedTab = ""
@@ -133,22 +136,11 @@ export function OverviewNavProvider(
     invalidTab = candidateTab
   }
 
-  // The list of tabs open. A tab name should never appear twice in the list.
-  const [tabs, setTabs] = useState<string[]>(() => {
-    return addAllTabIfEmpty(
-      tabsForTesting ?? lsc.get<Array<string>>("tabs") ?? []
-    )
-  })
-
   useEffect(() => {
     if (selectedTab && !tabs.includes(selectedTab)) {
       setTabs(tabs.concat([selectedTab]))
     }
   }, [tabs, selectedTab])
-
-  useEffect(() => {
-    lsc.set("tabs", tabs)
-  }, [tabs, lsc])
 
   // Deletes the resource in the tab list.
   // If we're deleting the current tab, navigate to the next reasonable tab.

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -12679,6 +12679,11 @@ react-sizeme@^2.6.7:
     shallowequal "^1.1.0"
     throttle-debounce "^2.1.0"
 
+react-storage-hooks@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/react-storage-hooks/-/react-storage-hooks-4.0.1.tgz#e30ed5cda48c77c431ecc02ec3824bd615f5b7fb"
+  integrity sha512-fetDkT5RDHGruc2NrdD1iqqoLuXgbx6AUpQSQLLkrCiJf8i97EtwJNXNTy3+GRfsATLG8TZgNc9lGRZOaU5yQA==
+
 react-syntax-highlighter@^13.5.0:
   version "13.5.3"
   resolved "https://registry.yarnpkg.com/react-syntax-highlighter/-/react-syntax-highlighter-13.5.3.tgz#9712850f883a3e19eb858cf93fad7bb357eea9c6"


### PR DESCRIPTION
The existing local storage code works ok for things that want to store stuff in a context and pass it down through a call stack, but is really onerous if you basically just want a `useState` backed by local storage and keyed by the tiltfile key.

This PR:
1. Separates those concerns, so now a component can just `usePersistentState` to get state backed by localstorage and keyed by the tiltfile without having to define a context and context producer and so on.
2. outsources the actual localstorage stuff to a library