### PR TITLE
web: persist sidebar options in localStorage

### DIFF
--- a/web/src/LocalStorage.tsx
+++ b/web/src/LocalStorage.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from "react"
+import React, { Dispatch, SetStateAction, useContext } from "react"
 import { useStorageState } from "react-storage-hooks"
 
 export type TiltfileKey = string
@@ -6,6 +6,31 @@ export const tiltfileKeyContext = React.createContext<TiltfileKey>("unset")
 
 export function makeKey(tiltfileKey: string, key: string): string {
   return "tilt-" + JSON.stringify({ tiltfileKey: tiltfileKey, key: key })
+}
+
+export type accessor<S> = {
+  get: () => S | null
+  set: (s: S) => void
+}
+
+export function accessorsForTesting<S>(name: string) {
+  const key = makeKey("test", name)
+  function get(): S | null {
+    const v = localStorage.getItem(key)
+    if (!v) {
+      return null
+    }
+    return JSON.parse(v) as S
+  }
+
+  function set(s: S): void {
+    localStorage.setItem(key, JSON.stringify(s))
+  }
+
+  return {
+    get: get,
+    set: set,
+  }
 }
 
 // Like `useState`, but backed by localStorage and namespaced by the tiltfileKey
@@ -21,7 +46,7 @@ export function usePersistentState<S>(name: string, defaultValue: S) {
 export function PersistentStateProvider<S>(props: {
   name: string
   defaultValue: S
-  children: (state: S, setState: (newState: S) => void) => JSX.Element
+  children: (state: S, setState: Dispatch<SetStateAction<S>>) => JSX.Element
 }) {
   const [state, setState] = usePersistentState(props.name, props.defaultValue)
   return props.children(state, setState)

--- a/web/src/LocalStorage.tsx
+++ b/web/src/LocalStorage.tsx
@@ -17,3 +17,12 @@ export function usePersistentState<S>(name: string, defaultValue: S) {
     defaultValue
   )
 }
+
+export function PersistentStateProvider<S>(props: {
+  name: string
+  defaultValue: S
+  children: (state: S, setState: (newState: S) => void) => JSX.Element
+}) {
+  const [state, setState] = usePersistentState(props.name, props.defaultValue)
+  return props.children(state, setState)
+}

--- a/web/src/OverviewPane.test.tsx
+++ b/web/src/OverviewPane.test.tsx
@@ -1,7 +1,7 @@
 import { mount, ReactWrapper } from "enzyme"
 import React from "react"
 import { MemoryRouter } from "react-router"
-import { makeKey, tiltfileKeyContext } from "./LocalStorage"
+import { accessorsForTesting, tiltfileKeyContext } from "./LocalStorage"
 import OverviewItemView from "./OverviewItemView"
 import OverviewPane, {
   AllResources,
@@ -27,6 +27,10 @@ function assertContainerWithResources(
   }
 }
 
+const pinnedResourcesAccessor = accessorsForTesting<string[]>(
+  "pinned-resources"
+)
+
 it("renders all resources if no pinned and no tests", () => {
   const root = mount(
     <MemoryRouter initialEntries={["/"]}>{TwoResources()}</MemoryRouter>
@@ -38,10 +42,7 @@ it("renders all resources if no pinned and no tests", () => {
 })
 
 it("renders pinned resources", () => {
-  localStorage.setItem(
-    makeKey("test", "pinned-resources"),
-    JSON.stringify(["snack"])
-  )
+  pinnedResourcesAccessor.set(["snack"])
 
   const root = mount(
     <MemoryRouter initialEntries={["/"]}>

--- a/web/src/OverviewSidebarOptions.test.tsx
+++ b/web/src/OverviewSidebarOptions.test.tsx
@@ -43,117 +43,125 @@ function assertSidebarItemsAndOptions(
 
 const allNames = ["(Tiltfile)", "vigoda", "snack", "beep", "boop"]
 
-it("shows tests and resources by default", () => {
-  const root = mount(TwoResourcesTwoTests())
-  assertSidebarItemsAndOptions(root, allNames, true, true)
-})
+describe("overview sidebar options", () => {
+  afterEach(() => {
+    localStorage.clear()
+  })
 
-it("hides resources when resources unchecked", () => {
-  const root = mount(TwoResourcesTwoTests())
-  assertSidebarItemsAndOptions(root, allNames, true, true)
+  it("shows tests and resources by default", () => {
+    const root = mount(TwoResourcesTwoTests())
+    assertSidebarItemsAndOptions(root, allNames, true, true)
+  })
 
-  root
-    .find("input#resources")
-    .simulate("change", { target: { checked: false } })
-  assertSidebarItemsAndOptions(
-    root,
-    ["(Tiltfile)", "beep", "boop"],
-    false,
-    true
-  )
-})
+  it("hides resources when resources unchecked", () => {
+    const root = mount(TwoResourcesTwoTests())
+    assertSidebarItemsAndOptions(root, allNames, true, true)
 
-it("hides tests when tests unchecked", () => {
-  const root = mount(TwoResourcesTwoTests())
-  assertSidebarItemsAndOptions(root, allNames, true, true)
+    root
+      .find("input#resources")
+      .simulate("change", { target: { checked: false } })
+    assertSidebarItemsAndOptions(
+      root,
+      ["(Tiltfile)", "beep", "boop"],
+      false,
+      true
+    )
+  })
 
-  root.find("input#tests").simulate("change", { target: { checked: false } })
-  assertSidebarItemsAndOptions(
-    root,
-    ["(Tiltfile)", "vigoda", "snack"],
-    true,
-    false
-  )
-})
+  it("hides tests when tests unchecked", () => {
+    const root = mount(TwoResourcesTwoTests())
+    assertSidebarItemsAndOptions(root, allNames, true, true)
 
-it("hides resources and tests when both unchecked", () => {
-  const root = mount(TwoResourcesTwoTests())
-  assertSidebarItemsAndOptions(root, allNames, true, true)
+    root.find("input#tests").simulate("change", { target: { checked: false } })
+    assertSidebarItemsAndOptions(
+      root,
+      ["(Tiltfile)", "vigoda", "snack"],
+      true,
+      false
+    )
+  })
 
-  root
-    .find("input#resources")
-    .simulate("change", { target: { checked: false } })
-  root.find("input#tests").simulate("change", { target: { checked: false } })
-  assertSidebarItemsAndOptions(root, ["(Tiltfile)"], false, false)
-})
+  it("hides resources and tests when both unchecked", () => {
+    const root = mount(TwoResourcesTwoTests())
+    assertSidebarItemsAndOptions(root, allNames, true, true)
 
-it("doesn't show SidebarOptionSetter if no tests present", () => {
-  let items = [tiltfileResource(), oneResource()].map((r) => new SidebarItem(r))
-  const root = mount(
-    <MemoryRouter>
-      <tiltfileKeyContext.Provider value="test">
-        <SidebarPinContextProvider>
-          <SidebarResources
-            items={items}
-            selected={""}
-            resourceView={ResourceView.Log}
-            pathBuilder={pathBuilder}
-          />
-        </SidebarPinContextProvider>
-      </tiltfileKeyContext.Provider>
-    </MemoryRouter>
-  )
-  let sidebar = root.find(SidebarResources)
-  expect(sidebar).toHaveLength(1)
+    root
+      .find("input#resources")
+      .simulate("change", { target: { checked: false } })
+    root.find("input#tests").simulate("change", { target: { checked: false } })
+    assertSidebarItemsAndOptions(root, ["(Tiltfile)"], false, false)
+  })
 
-  let optSetter = sidebar.find(OverviewSidebarOptions)
-  expect(optSetter).toHaveLength(0)
-})
+  it("doesn't show SidebarOptionSetter if no tests present", () => {
+    let items = [tiltfileResource(), oneResource()].map(
+      (r) => new SidebarItem(r)
+    )
+    const root = mount(
+      <MemoryRouter>
+        <tiltfileKeyContext.Provider value="test">
+          <SidebarPinContextProvider>
+            <SidebarResources
+              items={items}
+              selected={""}
+              resourceView={ResourceView.Log}
+              pathBuilder={pathBuilder}
+            />
+          </SidebarPinContextProvider>
+        </tiltfileKeyContext.Provider>
+      </MemoryRouter>
+    )
+    let sidebar = root.find(SidebarResources)
+    expect(sidebar).toHaveLength(1)
 
-it("still displays pinned tests when tests hidden", () => {
-  localStorage.setItem(
-    makeKey("test", "pinned-resources"),
-    JSON.stringify(["beep"])
-  )
-  const root = mount(
-    <MemoryRouter>
-      <tiltfileKeyContext.Provider value="test">
-        <SidebarPinContextProvider>
-          {TwoResourcesTwoTests()}
-        </SidebarPinContextProvider>
-      </tiltfileKeyContext.Provider>
-    </MemoryRouter>
-  )
+    let optSetter = sidebar.find(OverviewSidebarOptions)
+    expect(optSetter).toHaveLength(0)
+  })
 
-  assertSidebarItemsAndOptions(
-    root,
-    ["(Tiltfile)", "vigoda", "snack", "beep", "boop"],
-    true,
-    true
-  )
+  it("still displays pinned tests when tests hidden", () => {
+    localStorage.setItem(
+      makeKey("test", "pinned-resources"),
+      JSON.stringify(["beep"])
+    )
+    const root = mount(
+      <MemoryRouter>
+        <tiltfileKeyContext.Provider value="test">
+          <SidebarPinContextProvider>
+            {TwoResourcesTwoTests()}
+          </SidebarPinContextProvider>
+        </tiltfileKeyContext.Provider>
+      </MemoryRouter>
+    )
 
-  let pinned = root
-    .find(SidebarListSection)
-    .find({ name: "Pinned" })
-    .find(SidebarItemView)
-  expect(pinned).toHaveLength(1)
-  expect(pinned.at(0).props().item.name).toEqual("beep")
+    assertSidebarItemsAndOptions(
+      root,
+      ["(Tiltfile)", "vigoda", "snack", "beep", "boop"],
+      true,
+      true
+    )
 
-  root.find("input#tests").simulate("change", { target: { checked: false } })
-  assertSidebarItemsAndOptions(
-    root,
-    ["(Tiltfile)", "vigoda", "snack"],
-    true,
-    false
-  )
+    let pinned = root
+      .find(SidebarListSection)
+      .find({ name: "Pinned" })
+      .find(SidebarItemView)
+    expect(pinned).toHaveLength(1)
+    expect(pinned.at(0).props().item.name).toEqual("beep")
 
-  // "beep" should still be pinned, even though we're no longer showing tests in the main resource list
-  pinned = root
-    .find(SidebarListSection)
-    .find({ name: "Pinned" })
-    .find(SidebarItemView)
-  expect(pinned).toHaveLength(1)
-  expect(pinned.at(0).props().item.name).toEqual("beep")
+    root.find("input#tests").simulate("change", { target: { checked: false } })
+    assertSidebarItemsAndOptions(
+      root,
+      ["(Tiltfile)", "vigoda", "snack"],
+      true,
+      false
+    )
+
+    // "beep" should still be pinned, even though we're no longer showing tests in the main resource list
+    pinned = root
+      .find(SidebarListSection)
+      .find({ name: "Pinned" })
+      .find(SidebarItemView)
+    expect(pinned).toHaveLength(1)
+    expect(pinned.at(0).props().item.name).toEqual("beep")
+  })
 })
 
 // TODO:

--- a/web/src/OverviewSidebarOptions.tsx
+++ b/web/src/OverviewSidebarOptions.tsx
@@ -13,7 +13,7 @@ import {
   mixinResetListStyle,
   SizeUnit,
 } from "./style-helpers"
-import {SidebarOptions} from "./types"
+import { SidebarOptions } from "./types"
 
 const OverviewSidebarOptionsRoot = styled.div`
   display: flex;
@@ -58,15 +58,21 @@ type OverviewSidebarOptionsProps = {
 }
 
 function toggleAlertsOnTop(props: OverviewSidebarOptionsProps) {
-  props.setOptions({...props.options, alertsOnTop: !props.options.alertsOnTop})
+  props.setOptions({
+    ...props.options,
+    alertsOnTop: !props.options.alertsOnTop,
+  })
 }
 
 function toggleShowTests(props: OverviewSidebarOptionsProps) {
-  props.setOptions({...props.options, showTests: !props.options.showTests})
+  props.setOptions({ ...props.options, showTests: !props.options.showTests })
 }
 
 function toggleShowResources(props: OverviewSidebarOptionsProps) {
-  props.setOptions({...props.options, showResources: !props.options.showResources})
+  props.setOptions({
+    ...props.options,
+    showResources: !props.options.showResources,
+  })
 }
 
 export function OverviewSidebarOptions(

--- a/web/src/OverviewSidebarOptions.tsx
+++ b/web/src/OverviewSidebarOptions.tsx
@@ -3,7 +3,7 @@ import FormControlLabel from "@material-ui/core/FormControlLabel"
 import { makeStyles } from "@material-ui/core/styles"
 import CheckBoxIcon from "@material-ui/icons/CheckBox"
 import CheckBoxOutlineBlankIcon from "@material-ui/icons/CheckBoxOutlineBlank"
-import React from "react"
+import React, { Dispatch, SetStateAction } from "react"
 import styled from "styled-components"
 import {
   Color,
@@ -38,7 +38,7 @@ const useStyles = makeStyles({
   },
 })
 
-const AlertsOnTopToggle = styled.button`
+export const AlertsOnTopToggle = styled.button`
   ${mixinResetButtonStyle}
   color: ${Color.grayLightest};
   background-color: ${Color.gray};
@@ -54,24 +54,30 @@ const AlertsOnTopToggle = styled.button`
 
 type OverviewSidebarOptionsProps = {
   options: SidebarOptions
-  setOptions: (newOptions: SidebarOptions) => void
+  setOptions: Dispatch<SetStateAction<SidebarOptions>>
 }
 
-function toggleAlertsOnTop(props: OverviewSidebarOptionsProps) {
-  props.setOptions({
-    ...props.options,
-    alertsOnTop: !props.options.alertsOnTop,
+function setAlertsOnTop(
+  props: OverviewSidebarOptionsProps,
+  alertsOnTop: boolean
+) {
+  props.setOptions((prevOptions) => {
+    return { ...prevOptions, alertsOnTop: alertsOnTop }
   })
 }
 
-function toggleShowTests(props: OverviewSidebarOptionsProps) {
-  props.setOptions({ ...props.options, showTests: !props.options.showTests })
+function setShowTests(props: OverviewSidebarOptionsProps, showTests: boolean) {
+  props.setOptions((prevOptions) => {
+    return { ...prevOptions, showTests: showTests }
+  })
 }
 
-function toggleShowResources(props: OverviewSidebarOptionsProps) {
-  props.setOptions({
-    ...props.options,
-    showResources: !props.options.showResources,
+function setShowResources(
+  props: OverviewSidebarOptionsProps,
+  showResources: boolean
+) {
+  props.setOptions((prevOptions) => {
+    return { ...prevOptions, showResources: showResources }
   })
 }
 
@@ -93,7 +99,7 @@ export function OverviewSidebarOptions(
               icon={<CheckBoxOutlineBlankIcon fontSize="small" />}
               checkedIcon={<CheckBoxIcon fontSize="small" />}
               checked={props.options.showResources}
-              onChange={(e) => toggleShowResources(props)}
+              onChange={(e) => setShowResources(props, e.target.checked)}
               name="resources"
               id="resources"
             />
@@ -108,7 +114,7 @@ export function OverviewSidebarOptions(
               icon={<CheckBoxOutlineBlankIcon fontSize="small" />}
               checkedIcon={<CheckBoxIcon fontSize="small" />}
               checked={props.options.showTests}
-              onChange={(e) => toggleShowTests(props)}
+              onChange={(e) => setShowTests(props, e.target.checked)}
               name="tests"
               id="tests"
             />
@@ -119,7 +125,7 @@ export function OverviewSidebarOptions(
 
       <AlertsOnTopToggle
         className={props.options.alertsOnTop ? "is-enabled" : ""}
-        onClick={(e) => toggleAlertsOnTop(props)}
+        onClick={(e) => setAlertsOnTop(props, !props.options.alertsOnTop)}
       >
         Alerts on Top
       </AlertsOnTopToggle>

--- a/web/src/OverviewSidebarOptions.tsx
+++ b/web/src/OverviewSidebarOptions.tsx
@@ -13,7 +13,7 @@ import {
   mixinResetListStyle,
   SizeUnit,
 } from "./style-helpers"
-import { SidebarOptions } from "./types"
+import {SidebarOptions} from "./types"
 
 const OverviewSidebarOptionsRoot = styled.div`
   display: flex;
@@ -53,10 +53,20 @@ const AlertsOnTopToggle = styled.button`
 `
 
 type OverviewSidebarOptionsProps = {
-  curState: SidebarOptions
-  toggleShowResources: () => void
-  toggleShowTests: () => void
-  toggleAlertsOnTop: () => void
+  options: SidebarOptions
+  setOptions: (newOptions: SidebarOptions) => void
+}
+
+function toggleAlertsOnTop(props: OverviewSidebarOptionsProps) {
+  props.setOptions({...props.options, alertsOnTop: !props.options.alertsOnTop})
+}
+
+function toggleShowTests(props: OverviewSidebarOptionsProps) {
+  props.setOptions({...props.options, showTests: !props.options.showTests})
+}
+
+function toggleShowResources(props: OverviewSidebarOptionsProps) {
+  props.setOptions({...props.options, showResources: !props.options.showResources})
 }
 
 export function OverviewSidebarOptions(
@@ -76,8 +86,8 @@ export function OverviewSidebarOptions(
               color={"default"}
               icon={<CheckBoxOutlineBlankIcon fontSize="small" />}
               checkedIcon={<CheckBoxIcon fontSize="small" />}
-              checked={props.curState.showResources}
-              onChange={(e) => props.toggleShowResources()}
+              checked={props.options.showResources}
+              onChange={(e) => toggleShowResources(props)}
               name="resources"
               id="resources"
             />
@@ -91,8 +101,8 @@ export function OverviewSidebarOptions(
               color={"default"}
               icon={<CheckBoxOutlineBlankIcon fontSize="small" />}
               checkedIcon={<CheckBoxIcon fontSize="small" />}
-              checked={props.curState.showTests}
-              onChange={(e) => props.toggleShowTests()}
+              checked={props.options.showTests}
+              onChange={(e) => toggleShowTests(props)}
               name="tests"
               id="tests"
             />
@@ -102,8 +112,8 @@ export function OverviewSidebarOptions(
       </FilterOptionList>
 
       <AlertsOnTopToggle
-        className={props.curState.alertsOnTop ? "is-enabled" : ""}
-        onClick={(e) => props.toggleAlertsOnTop()}
+        className={props.options.alertsOnTop ? "is-enabled" : ""}
+        onClick={(e) => toggleAlertsOnTop(props)}
       >
         Alerts on Top
       </AlertsOnTopToggle>

--- a/web/src/SidebarItemView.tsx
+++ b/web/src/SidebarItemView.tsx
@@ -28,7 +28,7 @@ import {
   TriggerMode,
 } from "./types"
 
-const SidebarItemRoot = styled.li`
+export const SidebarItemRoot = styled.li`
   & + & {
     margin-top: ${SizeUnit(0.35)};
   }

--- a/web/src/SidebarResources.tsx
+++ b/web/src/SidebarResources.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import React, { Dispatch, SetStateAction } from "react"
 import styled from "styled-components"
 import { PersistentStateProvider } from "./LocalStorage"
 import { OverviewSidebarOptions } from "./OverviewSidebarOptions"
@@ -108,7 +108,7 @@ export class SidebarResources extends React.Component<SidebarProps> {
 
   renderWithOptions(
     options: SidebarOptions,
-    setOptions: (so: SidebarOptions) => void
+    setOptions: Dispatch<SetStateAction<SidebarOptions>>
   ) {
     let pb = this.props.pathBuilder
     let totalAlerts = this.props.items // Open Q: do we include alert totals for hidden elems?

--- a/web/src/SidebarResources.tsx
+++ b/web/src/SidebarResources.tsx
@@ -1,5 +1,6 @@
 import React from "react"
 import styled from "styled-components"
+import { PersistentStateProvider } from "./LocalStorage"
 import { OverviewSidebarOptions } from "./OverviewSidebarOptions"
 import PathBuilder from "./PathBuilder"
 import SidebarItem from "./SidebarItem"
@@ -56,8 +57,6 @@ type SidebarProps = {
   pathBuilder: PathBuilder
 }
 
-type SidebarState = SidebarOptions
-
 let defaultOptions: SidebarOptions = {
   showResources: true,
   showTests: true,
@@ -95,17 +94,10 @@ function sortByHasAlerts(itemA: SidebarItem, itemB: SidebarItem): number {
   return Number(hasAlerts(itemB)) - Number(hasAlerts(itemA))
 }
 
-export class SidebarResources extends React.Component<
-  SidebarProps,
-  SidebarState
-> {
+export class SidebarResources extends React.Component<SidebarProps> {
   constructor(props: SidebarProps) {
     super(props)
     this.triggerSelected = this.triggerSelected.bind(this)
-    this.toggleShowResources = this.toggleShowResources.bind(this)
-    this.toggleShowTests = this.toggleShowTests.bind(this)
-    this.toggleAlertsOnTop = this.toggleAlertsOnTop.bind(this)
-    this.state = defaultOptions
   }
 
   triggerSelected(action: string) {
@@ -114,31 +106,10 @@ export class SidebarResources extends React.Component<
     }
   }
 
-  toggleShowResources() {
-    this.setState((prevState: SidebarOptions) => {
-      return {
-        showResources: !prevState.showResources,
-      }
-    })
-  }
-
-  toggleShowTests() {
-    this.setState((prevState: SidebarOptions) => {
-      return {
-        showTests: !prevState.showTests,
-      }
-    })
-  }
-
-  toggleAlertsOnTop() {
-    this.setState((prevState: SidebarOptions) => {
-      return {
-        alertsOnTop: !prevState.alertsOnTop,
-      }
-    })
-  }
-
-  render() {
+  renderWithOptions(
+    options: SidebarOptions,
+    setOptions: (so: SidebarOptions) => void
+  ) {
     let pb = this.props.pathBuilder
     let totalAlerts = this.props.items // Open Q: do we include alert totals for hidden elems?
       .map((i) => i.buildAlertCount + i.runtimeAlertCount)
@@ -150,12 +121,12 @@ export class SidebarResources extends React.Component<
     //       and what effect does this have on keyboard shortcuts? :(
     let filteredItems = this.props.items.filter(
       (item) =>
-        (!item.isTest && this.state.showResources) ||
-        (item.isTest && this.state.showTests) ||
+        (!item.isTest && options.showResources) ||
+        (item.isTest && options.showTests) ||
         item.isTiltfile
     )
 
-    if (this.state.alertsOnTop) {
+    if (options.alertsOnTop) {
       filteredItems.sort(sortByHasAlerts)
     }
 
@@ -186,12 +157,7 @@ export class SidebarResources extends React.Component<
           </SidebarListSection>
           <PinnedItems {...this.props} />
           {testsPresent && (
-            <OverviewSidebarOptions
-              curState={this.state}
-              toggleShowResources={this.toggleShowResources}
-              toggleShowTests={this.toggleShowTests}
-              toggleAlertsOnTop={this.toggleAlertsOnTop}
-            /> // TODO: if this vanishes because no tests present, reset it to show everything
+            <OverviewSidebarOptions options={options} setOptions={setOptions}/> // TODO: if this vanishes because no tests present, reset it to show everything
           )}
           <SidebarListSection name="resources">{listItems}</SidebarListSection>
         </SidebarList>
@@ -202,6 +168,17 @@ export class SidebarResources extends React.Component<
           resourceView={this.props.resourceView}
         />
       </SidebarResourcesRoot>
+    )
+  }
+
+  render() {
+    return (
+      <PersistentStateProvider
+        defaultValue={defaultOptions}
+        name={"sidebar_options"}
+      >
+        {(value: SidebarOptions, set) => this.renderWithOptions(value, set)}
+      </PersistentStateProvider>
     )
   }
 }

--- a/web/src/SidebarResources.tsx
+++ b/web/src/SidebarResources.tsx
@@ -157,7 +157,7 @@ export class SidebarResources extends React.Component<SidebarProps> {
           </SidebarListSection>
           <PinnedItems {...this.props} />
           {testsPresent && (
-            <OverviewSidebarOptions options={options} setOptions={setOptions}/> // TODO: if this vanishes because no tests present, reset it to show everything
+            <OverviewSidebarOptions options={options} setOptions={setOptions} /> // TODO: if this vanishes because no tests present, reset it to show everything
           )}
           <SidebarListSection name="resources">{listItems}</SidebarListSection>
         </SidebarList>


### PR DESCRIPTION
fwiw all the indenting in the tests is just for:
```
afterEach(() => {
    localStorage.clear()
  })
```