### PR TITLE
web: enable autoscroll in snapshots

### DIFF
--- a/web/src/OverviewLogPane.tsx
+++ b/web/src/OverviewLogPane.tsx
@@ -235,8 +235,7 @@ export class OverviewLogComponent extends Component<OverviewLogComponentProps> {
       if (typeof this.props.scrollToStoredLineIndex === "number") {
         this.needsScrollToLine = true
       }
-      this.autoscroll =
-        !this.props.pathBuilder.isSnapshot() && !this.needsScrollToLine
+      this.autoscroll = !this.needsScrollToLine
       this.scrollTop = -1
 
       this.readLogsFromLogStore()
@@ -255,8 +254,7 @@ export class OverviewLogComponent extends Component<OverviewLogComponentProps> {
     if (typeof this.props.scrollToStoredLineIndex == "number") {
       this.needsScrollToLine = true
     }
-    this.autoscroll =
-      !this.props.pathBuilder.isSnapshot() && !this.needsScrollToLine
+    this.autoscroll = !this.needsScrollToLine
 
     rootEl.addEventListener("scroll", this.onScroll, {
       passive: true,
@@ -317,6 +315,8 @@ export class OverviewLogComponent extends Component<OverviewLogComponentProps> {
   }
 
   private maybeEngageAutoscroll() {
+    // We don't expect new log lines in snapshots. So when we scroll down, we don't need
+    // to worry about re-engaging autoscroll.
     if (this.props.pathBuilder.isSnapshot()) {
       return
     }


### PR DESCRIPTION
Hello @hyu, @maiamcc,

Please review the following commits I made in branch nicks/autoscroll:

83e26bbf5bae9c35321a89ed9173e0ae49ff7466 (2021-02-04 13:05:49 -0500)
web: enable autoscroll in snapshots
we lazily render log lines, so autoscroll needs to kick in to scroll to the
bottom of the first render. We still leave in the logic around
re-engaging autoscroll on scrolldown.

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics