### PR TITLE
store: even if a local_resource has no build command, it can still be pending

### DIFF
--- a/internal/store/manifest_target.go
+++ b/internal/store/manifest_target.go
@@ -30,11 +30,18 @@ func (t ManifestTarget) Status() model.TargetStatus {
 
 func (mt *ManifestTarget) UpdateStatus() model.UpdateStatus {
 	m := mt.Manifest
+	us := mt.State.UpdateStatus(m.TriggerMode)
+
+	if us == model.UpdateStatusPending {
+		// A resource with no update command can still be in pending mode.
+		return us
+	}
+
 	if m.IsLocal() && m.LocalTarget().UpdateCmd.Empty() {
 		return model.UpdateStatusNotApplicable
 	}
 
-	return mt.State.UpdateStatus(m.TriggerMode)
+	return us
 }
 
 var _ model.Target = &ManifestTarget{}

--- a/internal/store/manifest_target_test.go
+++ b/internal/store/manifest_target_test.go
@@ -4,7 +4,9 @@ import (
 	"encoding/base64"
 	"fmt"
 	"testing"
+	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/tilt-dev/tilt/pkg/model"
@@ -30,4 +32,17 @@ func TestManifestTarget_FacetsSecretsScrubbed(t *testing.T) {
 	}
 
 	require.Equal(t, expected, actual)
+}
+
+func TestLocalTargetUpdateStatus(t *testing.T) {
+	m := model.Manifest{Name: "serve-cmd"}.WithDeployTarget(
+		model.NewLocalTarget("serve-cmd", model.Cmd{}, model.ToHostCmd("busybox httpd"), nil))
+	mt := NewManifestTarget(m)
+	assert.Equal(t, model.UpdateStatusPending, mt.UpdateStatus())
+
+	mt.State.AddCompletedBuild(model.BuildRecord{StartTime: time.Now(), FinishTime: time.Now()})
+	assert.Equal(t, model.UpdateStatusNotApplicable, mt.UpdateStatus())
+
+	mt.State.TriggerReason = model.BuildReasonFlagTriggerWeb
+	assert.Equal(t, model.UpdateStatusPending, mt.UpdateStatus())
 }


### PR DESCRIPTION
Hello @landism, @milas,

Please review the following commits I made in branch nicks/pending:

19f305eee54c6d16c8ff254ab818a42c00d1f25a (2021-02-04 13:23:42 -0500)
store: even if a local_resource has no build command, it can still be pending

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics