### PR TITLE
web: Use smallest font for log lines

### DIFF
--- a/web/src/LogPaneLine.scss
+++ b/web/src/LogPaneLine.scss
@@ -5,6 +5,7 @@
 .LogPaneLine {
   display: flex;
   position: relative;
+  font-size: $font-size-smallest;  
 
   &.is-highlighted {
     background-color: rgba($color-blue, $translucent);


### PR DESCRIPTION
<img width="1407" alt="Screen Shot 2021-02-03 at 2 58 08 PM" src="https://user-images.githubusercontent.com/10860550/106941318-acaaf000-66f0-11eb-8691-8b4e5fe9c63b.png">

https://app.clubhouse.io/windmill/epic/11101/make-log-font-size-smaller