### PR TITLE
tiltfile: make probe types play nicer with None

### DIFF
--- a/integration/local_resource/Tiltfile
+++ b/integration/local_resource/Tiltfile
@@ -7,5 +7,7 @@ p = probe(initial_delay_secs=0,
 
 local_resource('foo', serve_cmd='./hello.sh foo', readiness_probe=p)
 
+# readiness probe explicitly set to None
 local_resource('bar', serve_cmd='./hello.sh bar',
+               readiness_probe=None,
                resource_deps=['foo'])

--- a/internal/tiltfile/probe/probe_test.go
+++ b/internal/tiltfile/probe/probe_test.go
@@ -19,7 +19,8 @@ p = probe(initial_delay_secs=123,
           period_secs=789,
           success_threshold=987,
           failure_threshold=654,
-          exec=exec_action([]))
+          exec=exec_action([]),
+          http_get=None)
 
 print(p.initial_delay_secs)
 print(p.timeout_secs)
@@ -40,7 +41,7 @@ print("tcp_socket:", p.tcp_socket)
 789
 987
 654
-exec: "exec_action"(command = [])
+exec: "ExecAction"(command = [])
 http_get: None
 tcp_socket: None
 `)
@@ -62,7 +63,9 @@ func TestProbeActions_Multiple(t *testing.T) {
 	f := starkit.NewFixture(t, NewExtension())
 	defer f.TearDown()
 
-	f.File("Tiltfile", `p = probe(exec=exec_action([]), http_get=http_get_action(8000))`)
+	f.File("Tiltfile", `
+p = probe(exec=exec_action([]), http_get=http_get_action(8000), tcp_socket=None)
+`)
 
 	_, err := f.ExecFile("Tiltfile")
 	require.EqualError(t, err, `exactly one of exec, http_get, or tcp_socket must be specified`)


### PR DESCRIPTION
There's often a lot of boilerplate involved for optional object arguments
that can be `None` or an actual value; it's necessary to use a
`starlark.Value`, check to see if it's `nil` (kwarg not specified)
or `starlark.None` (kwarg specified) or present and then make sure
the expected type constraint is met.

~~This is exacerbated by `starlarkstruct.Struct`, which does not play
nice with Go nil by design, and when you've got a struct with embedded
structs that can be `None`, this results in a bunch of extra nil/None/type
checking on top of the above.~~

~~Adding an `Optional` type helps abstract some of this and provides
type-checking and a couple convenience methods depending on whether
you're interoping with Go code (`ValueOrNil()`) or Starlark types
(`ValueOrNone()`). There's still some type-casting, unfortunately,
but it makes things safer and cuts down on boilerplate code
substantially.~~

This adds `Unpack()` implementations that check for `starlark.None` first
and then attempt to cast to the correct type.

Closes #4160.