### PR TITLE
tiltfile: Adds links to dc_resources

### DIFF
--- a/pkg/model/docker_compose_target.go
+++ b/pkg/model/docker_compose_target.go
@@ -28,6 +28,8 @@ type DockerComposeTarget struct {
 	dependencyIDs []TargetID
 
 	publishedPorts []int
+
+	Links []Link
 }
 
 // TODO(nick): This is a temporary hack until we figure out how we want
@@ -58,6 +60,11 @@ func (t DockerComposeTarget) LocalPaths() []string {
 
 func (t DockerComposeTarget) PublishedPorts() []int {
 	return append([]int{}, t.publishedPorts...)
+}
+
+func (t DockerComposeTarget) WithLinks(links []Link) DockerComposeTarget {
+	t.Links = links
+	return t
 }
 
 func (t DockerComposeTarget) WithPublishedPorts(ports []int) DockerComposeTarget {


### PR DESCRIPTION
Adds `links()` support to `dc_resource` for parity with k8s and local. I tried following the original local pr to add links, but I'm sure I've missed a thing or two.