### PR TITLE
web: clear logs functionality

### DIFF
--- a/internal/engine/configs/tiltfile_log_writer.go
+++ b/internal/engine/configs/tiltfile_log_writer.go
@@ -24,5 +24,5 @@ func (w *tiltfileLogWriter) Write(level logger.Level, fields logger.Fields, p []
 }
 
 func SpanIDForLoadCount(loadCount int) logstore.SpanID {
-	return logstore.SpanID(fmt.Sprintf("tilfile:%d", loadCount))
+	return logstore.SpanID(fmt.Sprintf("tiltfile:%d", loadCount))
 }

--- a/web/src/AlertPane.test.tsx
+++ b/web/src/AlertPane.test.tsx
@@ -6,6 +6,7 @@ import AlertPane from "./AlertPane"
 import LogStore from "./LogStore"
 import PathBuilder from "./PathBuilder"
 import { oneResourceUnrecognizedError } from "./testdata"
+import { appendLinesForManifestAndSpan } from "./testlogs"
 import { TriggerMode } from "./types"
 
 type Resource = Proto.webviewResource
@@ -205,11 +206,16 @@ it("renders warnings", () => {
       finishTime: ts,
       isCrashRebuild: true,
       warnings: ["Hi I'm a warning"],
+      spanId: "build:1",
     },
   ]
   if (!resource.k8sResourceInfo) throw new Error("missing k8s info")
   resource.k8sResourceInfo.podCreationTime = ts
   resource.k8sResourceInfo.podStatus = "ok"
+
+  appendLinesForManifestAndSpan(logStore, resource.name!, "build:1", [
+    "build 1",
+  ])
 
   let resources = [resource]
 

--- a/web/src/ClearLogs.test.tsx
+++ b/web/src/ClearLogs.test.tsx
@@ -1,0 +1,104 @@
+import { mount } from "enzyme"
+import React from "react"
+import { Alert } from "./alerts"
+import ClearLogs from "./ClearLogs"
+import { FilterLevel, FilterSource } from "./logfilters"
+import { logLinesToString } from "./logs"
+import LogStore, { LogStoreProvider } from "./LogStore"
+import { oneResource } from "./testdata"
+import { appendLinesForManifestAndSpan } from "./testlogs"
+
+describe("ClearLogs", () => {
+  const createAlert = (
+    resourceName: string,
+    source: FilterSource,
+    level: FilterLevel
+  ): Alert => {
+    return {
+      alertType: "",
+      header: "",
+      msg: "",
+      timestamp: "",
+      resourceName,
+      source,
+      level,
+    }
+  }
+
+  const createPopulatedLogStore = (): LogStore => {
+    const logStore = new LogStore()
+    appendLinesForManifestAndSpan(logStore, "", "", [
+      "global 1\n",
+      "global 2\n",
+    ])
+    appendLinesForManifestAndSpan(logStore, "vigoda", "build:m1:1", [
+      "m1:1 build line 1\n",
+    ])
+    appendLinesForManifestAndSpan(logStore, "vigoda", "pod:m1-abc123", [
+      "m1:1 runtime line 1\n",
+    ])
+    appendLinesForManifestAndSpan(logStore, "manifest2", "build:m2", [
+      "m2 build line 1\n",
+    ])
+    appendLinesForManifestAndSpan(logStore, "vigoda", "build:m1:2", [
+      "m1:2 build line 1\n",
+      "m1:2 build line 2\n",
+    ])
+    appendLinesForManifestAndSpan(logStore, "manifest2", "pod:m2-def456", [
+      "m2 runtime line 1\n",
+    ])
+    return logStore
+  }
+
+  it("clears all resources", () => {
+    const logStore = createPopulatedLogStore()
+    const root = mount(
+      <LogStoreProvider value={logStore}>
+        <ClearLogs />
+      </LogStoreProvider>
+    )
+    root.find(ClearLogs).simulate("click")
+    expect(logStore.spans).toEqual({})
+    expect(logStore.allLog()).toHaveLength(0)
+  })
+
+  it("clears all resources except ones with current alerts", () => {
+    const logStore = createPopulatedLogStore()
+    const alerts: Alert[] = [
+      createAlert("vigoda", FilterSource.build, FilterLevel.warn),
+      createAlert("manifest2", FilterSource.runtime, FilterLevel.error),
+    ]
+    const root = mount(
+      <LogStoreProvider value={logStore}>
+        <ClearLogs alerts={alerts} />
+      </LogStoreProvider>
+    )
+    root.find(ClearLogs).simulate("click")
+    expect(Object.keys(logStore.spans).sort()).toEqual([
+      "build:m1:2",
+      "pod:m2-def456",
+    ])
+    expect(logLinesToString(logStore.allLog(), false)).toEqual(
+      "m1:2 build line 1\nm1:2 build line 2\nm2 runtime line 1"
+    )
+  })
+
+  it("clears a specific resource", () => {
+    const logStore = createPopulatedLogStore()
+    const resource = oneResource()
+    const root = mount(
+      <LogStoreProvider value={logStore}>
+        <ClearLogs resource={resource} />
+      </LogStoreProvider>
+    )
+    root.find(ClearLogs).simulate("click")
+    expect(Object.keys(logStore.spans).sort()).toEqual([
+      "_",
+      "build:m2",
+      "pod:m2-def456",
+    ])
+    expect(logLinesToString(logStore.allLog(), false)).toEqual(
+      "global 1\nglobal 2\nm2 build line 1\nm2 runtime line 1"
+    )
+  })
+})

--- a/web/src/ClearLogs.test.tsx
+++ b/web/src/ClearLogs.test.tsx
@@ -1,30 +1,12 @@
 import { mount } from "enzyme"
 import React from "react"
-import { Alert } from "./alerts"
 import ClearLogs from "./ClearLogs"
-import { FilterLevel, FilterSource } from "./logfilters"
 import { logLinesToString } from "./logs"
 import LogStore, { LogStoreProvider } from "./LogStore"
 import { oneResource } from "./testdata"
 import { appendLinesForManifestAndSpan } from "./testlogs"
 
 describe("ClearLogs", () => {
-  const createAlert = (
-    resourceName: string,
-    source: FilterSource,
-    level: FilterLevel
-  ): Alert => {
-    return {
-      alertType: "",
-      header: "",
-      msg: "",
-      timestamp: "",
-      resourceName,
-      source,
-      level,
-    }
-  }
-
   const createPopulatedLogStore = (): LogStore => {
     const logStore = new LogStore()
     appendLinesForManifestAndSpan(logStore, "", "", [
@@ -60,27 +42,6 @@ describe("ClearLogs", () => {
     root.find(ClearLogs).simulate("click")
     expect(logStore.spans).toEqual({})
     expect(logStore.allLog()).toHaveLength(0)
-  })
-
-  it("clears all resources except ones with current alerts", () => {
-    const logStore = createPopulatedLogStore()
-    const alerts: Alert[] = [
-      createAlert("vigoda", FilterSource.build, FilterLevel.warn),
-      createAlert("manifest2", FilterSource.runtime, FilterLevel.error),
-    ]
-    const root = mount(
-      <LogStoreProvider value={logStore}>
-        <ClearLogs alerts={alerts} />
-      </LogStoreProvider>
-    )
-    root.find(ClearLogs).simulate("click")
-    expect(Object.keys(logStore.spans).sort()).toEqual([
-      "build:m1:2",
-      "pod:m2-def456",
-    ])
-    expect(logLinesToString(logStore.allLog(), false)).toEqual(
-      "m1:2 build line 1\nm1:2 build line 2\nm2 runtime line 1"
-    )
   })
 
   it("clears a specific resource", () => {

--- a/web/src/ClearLogs.tsx
+++ b/web/src/ClearLogs.tsx
@@ -1,8 +1,5 @@
 import React from "react"
 import styled from "styled-components"
-import { Alert } from "./alerts"
-import { FilterSource } from "./logfilters"
-import { isBuildSpanId, isTiltfileSpanId } from "./logs"
 import { useLogStore } from "./LogStore"
 import { Color, FontSize } from "./style-helpers"
 
@@ -18,48 +15,19 @@ const ClearLogsButton = styled.a`
 
 export interface ClearLogsProps {
   resource?: Proto.webviewResource
-  alerts?: Alert[]
 }
 
-const ClearLogs: React.FC<ClearLogsProps> = ({ resource, alerts }) => {
+const ClearLogs: React.FC<ClearLogsProps> = ({ resource }) => {
   const logStore = useLogStore()
   const label = resource?.name ? "Clear Logs" : "Clear All Logs"
 
   const clearLogs = () => {
     let spans: { [key: string]: Proto.webviewLogSpan }
-    let relevantAlerts: Alert[]
     if (resource) {
       const manifestName = resource.name ?? ""
       spans = logStore.spansForManifest(manifestName)
-      relevantAlerts = (alerts || []).filter(
-        (alert) => alert.resourceName == manifestName
-      )
     } else {
       spans = logStore.allSpans()
-      relevantAlerts = alerts || []
-    }
-
-    // don't delete the latest span that corresponds to an alert
-    for (const alert of relevantAlerts) {
-      let spanIdsForResource = logStore.getOrderedSpansIdsForManifest(
-        alert.resourceName
-      )
-      if (alert.source == FilterSource.build) {
-        spanIdsForResource = spanIdsForResource.filter(
-          (spanId) => isBuildSpanId(spanId) || isTiltfileSpanId(spanId)
-        )
-      } else if (alert.source == FilterSource.runtime) {
-        spanIdsForResource = spanIdsForResource.filter(
-          (spanId) => !isBuildSpanId(spanId) && !isTiltfileSpanId(spanId)
-        )
-      } else {
-        // unsupported source, so don't attempt to prevent truncation
-        continue
-      }
-      if (spanIdsForResource.length !== 0) {
-        const latestSpanId = spanIdsForResource[spanIdsForResource.length - 1]
-        delete spans[latestSpanId]
-      }
     }
 
     logStore.removeSpans(Object.keys(spans))

--- a/web/src/ClearLogs.tsx
+++ b/web/src/ClearLogs.tsx
@@ -1,12 +1,22 @@
 import React from "react"
 import styled from "styled-components"
 import { useLogStore } from "./LogStore"
-import { Color, FontSize } from "./style-helpers"
+import {
+  AnimDuration,
+  Color,
+  FontSize,
+  mixinResetButtonStyle,
+} from "./style-helpers"
 
-const ClearLogsButton = styled.a`
+const ClearLogsButton = styled.button`
+  ${mixinResetButtonStyle}
   margin-left: auto;
-  cursor: pointer;
   font-size: ${FontSize.small};
+  color: ${Color.white};
+
+  & {
+    transition: color ${AnimDuration.default} ease;
+  }
 
   &:hover {
     color: ${Color.blue};

--- a/web/src/ClearLogs.tsx
+++ b/web/src/ClearLogs.tsx
@@ -13,10 +13,7 @@ const ClearLogsButton = styled.button`
   margin-left: auto;
   font-size: ${FontSize.small};
   color: ${Color.white};
-
-  & {
-    transition: color ${AnimDuration.default} ease;
-  }
+  transition: color ${AnimDuration.default} ease;
 
   &:hover {
     color: ${Color.blue};

--- a/web/src/ClearLogs.tsx
+++ b/web/src/ClearLogs.tsx
@@ -1,0 +1,71 @@
+import React from "react"
+import styled from "styled-components"
+import { Alert } from "./alerts"
+import { FilterSource } from "./logfilters"
+import { isBuildSpanId, isTiltfileSpanId } from "./logs"
+import { useLogStore } from "./LogStore"
+import { Color, FontSize } from "./style-helpers"
+
+const ClearLogsButton = styled.a`
+  margin-left: auto;
+  cursor: pointer;
+  font-size: ${FontSize.small};
+
+  &:hover {
+    color: ${Color.blue};
+  }
+`
+
+export interface ClearLogsProps {
+  resource?: Proto.webviewResource
+  alerts?: Alert[]
+}
+
+const ClearLogs: React.FC<ClearLogsProps> = ({ resource, alerts }) => {
+  const logStore = useLogStore()
+  const label = resource?.name ? "Clear Logs" : "Clear All Logs"
+
+  const clearLogs = () => {
+    let spans: { [key: string]: Proto.webviewLogSpan }
+    let relevantAlerts: Alert[]
+    if (resource) {
+      const manifestName = resource.name ?? ""
+      spans = logStore.spansForManifest(manifestName)
+      relevantAlerts = (alerts || []).filter(
+        (alert) => alert.resourceName == manifestName
+      )
+    } else {
+      spans = logStore.allSpans()
+      relevantAlerts = alerts || []
+    }
+
+    // don't delete the latest span that corresponds to an alert
+    for (const alert of relevantAlerts) {
+      let spanIdsForResource = logStore.getOrderedSpansIdsForManifest(
+        alert.resourceName
+      )
+      if (alert.source == FilterSource.build) {
+        spanIdsForResource = spanIdsForResource.filter(
+          (spanId) => isBuildSpanId(spanId) || isTiltfileSpanId(spanId)
+        )
+      } else if (alert.source == FilterSource.runtime) {
+        spanIdsForResource = spanIdsForResource.filter(
+          (spanId) => !isBuildSpanId(spanId) && !isTiltfileSpanId(spanId)
+        )
+      } else {
+        // unsupported source, so don't attempt to prevent truncation
+        continue
+      }
+      if (spanIdsForResource.length !== 0) {
+        const latestSpanId = spanIdsForResource[spanIdsForResource.length - 1]
+        delete spans[latestSpanId]
+      }
+    }
+
+    logStore.removeSpans(Object.keys(spans))
+  }
+
+  return <ClearLogsButton onClick={() => clearLogs()}>{label}</ClearLogsButton>
+}
+
+export default ClearLogs

--- a/web/src/LogStore.ts
+++ b/web/src/LogStore.ts
@@ -117,6 +117,11 @@ class LogStore {
     this.updateCallbacks = this.updateCallbacks.filter((item) => item !== c)
   }
 
+  hasLinesForSpan(spanId: string): boolean {
+    const span = this.spans[spanId]
+    return span && span.firstLineIndex !== -1
+  }
+
   warnings(spanId: string): LogWarning[] {
     return this.warningIndex[spanId] ?? []
   }
@@ -380,11 +385,6 @@ class LogStore {
       }
     }
     return result
-  }
-
-  getOrderedSpansIdsForManifest(mn: string): string[] {
-    const spans = this.spansForManifest(mn)
-    return this.sortedSpanIds(Object.keys(spans))
   }
 
   getOrderedBuildSpanIds(spanId: string): string[] {

--- a/web/src/OverviewActionBar.tsx
+++ b/web/src/OverviewActionBar.tsx
@@ -15,6 +15,7 @@ import ClearLogs from "./ClearLogs"
 import { displayURL } from "./links"
 import { FilterLevel, FilterSet, FilterSource } from "./logfilters"
 import OverviewActionBarKeyboardShortcuts from "./OverviewActionBarKeyboardShortcuts"
+import { usePathBuilder } from "./PathBuilder"
 import { AnimDuration, Color, Font, FontSize, SizeUnit } from "./style-helpers"
 
 type OverviewActionBarProps = {
@@ -417,6 +418,7 @@ export default function OverviewActionBar(props: OverviewActionBarProps) {
   let manifestName = resource?.name || ""
   let endpoints = resource?.endpointLinks || []
   let podId = resource?.podID || ""
+  const isSnapshot = usePathBuilder().isSnapshot()
 
   let endpointEls: any = []
   endpoints.forEach((ep, i) => {
@@ -476,7 +478,7 @@ export default function OverviewActionBar(props: OverviewActionBarProps) {
           filterSet={props.filterSet}
           alerts={alerts}
         />
-        <ClearLogs resource={resource} alerts={alerts} />
+        {isSnapshot || <ClearLogs resource={resource} alerts={alerts} />}
       </ActionBarBottomRow>
     </ActionBarRoot>
   )

--- a/web/src/OverviewActionBar.tsx
+++ b/web/src/OverviewActionBar.tsx
@@ -11,6 +11,7 @@ import { incr } from "./analytics"
 import { ReactComponent as CheckmarkSvg } from "./assets/svg/checkmark.svg"
 import { ReactComponent as CopySvg } from "./assets/svg/copy.svg"
 import { ReactComponent as LinkSvg } from "./assets/svg/link.svg"
+import ClearLogs from "./ClearLogs"
 import { displayURL } from "./links"
 import { FilterLevel, FilterSet, FilterSource } from "./logfilters"
 import OverviewActionBarKeyboardShortcuts from "./OverviewActionBarKeyboardShortcuts"
@@ -475,6 +476,7 @@ export default function OverviewActionBar(props: OverviewActionBarProps) {
           filterSet={props.filterSet}
           alerts={alerts}
         />
+        <ClearLogs resource={resource} alerts={alerts} />
       </ActionBarBottomRow>
     </ActionBarRoot>
   )

--- a/web/src/OverviewActionBar.tsx
+++ b/web/src/OverviewActionBar.tsx
@@ -478,7 +478,7 @@ export default function OverviewActionBar(props: OverviewActionBarProps) {
           filterSet={props.filterSet}
           alerts={alerts}
         />
-        {isSnapshot || <ClearLogs resource={resource} alerts={alerts} />}
+        {isSnapshot || <ClearLogs resource={resource} />}
       </ActionBarBottomRow>
     </ActionBarRoot>
   )

--- a/web/src/OverviewLogPane.test.tsx
+++ b/web/src/OverviewLogPane.test.tsx
@@ -198,10 +198,7 @@ it("renders new logs first", () => {
     lines.push(`incremental line ${i}\n`)
   }
   appendLines(component.props.logStore, "fe", ...lines)
-  component.onLogUpdate({
-    action: LogUpdateAction.append,
-    spans: { fe: { manifestName: "fe" } },
-  })
+  component.onLogUpdate({ action: LogUpdateAction.append })
   expect(component.forwardBuffer.length).toEqual(newLineCount)
   expect(component.backwardBuffer.length).toEqual(initLineCount)
 

--- a/web/src/OverviewLogPane.test.tsx
+++ b/web/src/OverviewLogPane.test.tsx
@@ -1,5 +1,6 @@
 import { mount } from "enzyme"
 import { FilterLevel, FilterSource } from "./logfilters"
+import { LogUpdateAction } from "./LogStore"
 import {
   OverviewLogComponent,
   PROLOGUE_LENGTH,
@@ -197,7 +198,10 @@ it("renders new logs first", () => {
     lines.push(`incremental line ${i}\n`)
   }
   appendLines(component.props.logStore, "fe", ...lines)
-  component.onLogUpdate()
+  component.onLogUpdate({
+    action: LogUpdateAction.append,
+    spans: { fe: { manifestName: "fe" } },
+  })
   expect(component.forwardBuffer.length).toEqual(newLineCount)
   expect(component.backwardBuffer.length).toEqual(initLineCount)
 

--- a/web/src/OverviewLogPane.tsx
+++ b/web/src/OverviewLogPane.tsx
@@ -221,28 +221,11 @@ export class OverviewLogComponent extends Component<OverviewLogComponentProps> {
       return
     }
 
-    let isAffectedByUpdate = false
-    if (this.props.manifestName === "") {
-      isAffectedByUpdate = true
-    } else {
-      for (const span of Object.values(e.spans)) {
-        if (span.manifestName == this.props.manifestName) {
-          isAffectedByUpdate = true
-          break
-        }
-      }
-    }
-
-    if (!isAffectedByUpdate) {
-      return
-    }
-
-    if (e.action == LogUpdateAction.append) {
-      this.readLogsFromLogStore()
-    } else if (e.action == LogUpdateAction.truncate) {
+    if (e.action === LogUpdateAction.truncate) {
       this.resetRender()
-      this.readLogsFromLogStore()
     }
+
+    this.readLogsFromLogStore()
   }
 
   componentDidUpdate(prevProps: OverviewLogComponentProps) {

--- a/web/src/OverviewResourcePane.test.tsx
+++ b/web/src/OverviewResourcePane.test.tsx
@@ -1,7 +1,14 @@
 import { mount } from "enzyme"
 import { MemoryRouter } from "react-router-dom"
+import { FilterLevel } from "./logfilters"
+import LogStore, { LogStoreProvider } from "./LogStore"
+import { ButtonLeftPill, FilterRadioButton } from "./OverviewActionBar"
+import OverviewResourcePane from "./OverviewResourcePane"
 import { NotFound } from "./OverviewResourcePane.stories"
 import OverviewResourceSidebar from "./OverviewResourceSidebar"
+import { OverviewNavProvider } from "./TabNav"
+import { oneResourceView } from "./testdata"
+import { appendLinesForManifestAndSpan } from "./testlogs"
 
 it("renders correctly when no resource found", () => {
   let root = mount(
@@ -13,4 +20,79 @@ it("renders correctly when no resource found", () => {
   )
 
   expect(root.find(OverviewResourceSidebar)).toHaveLength(1)
+})
+
+describe("alert filtering", () => {
+  const doTest = (
+    expectedErrs: number,
+    expectedWarns: number,
+    prepare: (logStore: LogStore, r: Proto.webviewResource) => any
+  ) => {
+    const logStore = new LogStore()
+    const view = oneResourceView()
+
+    const r = view.resources[0]
+
+    prepare(logStore, r)
+
+    let root = mount(
+      <MemoryRouter initialEntries={["/"]}>
+        <LogStoreProvider value={logStore}>
+          <OverviewNavProvider validateTab={() => true}>
+            <OverviewResourcePane view={view} />
+          </OverviewNavProvider>
+        </LogStoreProvider>
+      </MemoryRouter>
+    )
+    let errorFilter = root
+      .find(FilterRadioButton)
+      .filter({ level: FilterLevel.error })
+      .find(ButtonLeftPill)
+    let warnFilter = root
+      .find(FilterRadioButton)
+      .filter({ level: FilterLevel.warn })
+      .find(ButtonLeftPill)
+
+    expect(errorFilter.text()).toEqual(`Errors (${expectedErrs})`)
+    expect(warnFilter.text()).toEqual(`Warnings (${expectedWarns})`)
+  }
+
+  it("creates no alerts if no build failures", () => {
+    doTest(0, 0, (logStore, r) => {
+      const latestBuild = r.buildHistory![0]
+      latestBuild.spanId = "build:1"
+      latestBuild.error = undefined
+      latestBuild.warnings = []
+
+      appendLinesForManifestAndSpan(logStore, r.name!, "build:1", [
+        "the build failed!",
+      ])
+    })
+  })
+
+  it("creates alerts for build failures with existing spans", () => {
+    doTest(1, 2, (logStore, r) => {
+      const latestBuild = r.buildHistory![0]
+      latestBuild.spanId = "build:1"
+      latestBuild.error = "the build failed!"
+      latestBuild.warnings = ["warning 1!", "warning 2!"]
+
+      appendLinesForManifestAndSpan(logStore, r.name!, "build:1", [
+        "the build failed!",
+      ])
+    })
+  })
+
+  it("ignores alerts for removed spans", () => {
+    doTest(0, 0, (logStore, r) => {
+      const latestBuild = r.buildHistory![0]
+      latestBuild.spanId = "build:1"
+      latestBuild.error = "the build failed!"
+      latestBuild.warnings = ["warning!"]
+
+      appendLinesForManifestAndSpan(logStore, r.name!, "build:2", [
+        "the build failed!",
+      ])
+    })
+  })
 })

--- a/web/src/OverviewResourcePane.tsx
+++ b/web/src/OverviewResourcePane.tsx
@@ -1,6 +1,7 @@
-import React, { useEffect } from "react"
+import React, { useEffect, useState } from "react"
 import styled from "styled-components"
 import { Alert, combinedAlerts } from "./alerts"
+import { LogUpdateAction, LogUpdateEvent, useLogStore } from "./LogStore"
 import OverviewResourceBar from "./OverviewResourceBar"
 import OverviewResourceDetails from "./OverviewResourceDetails"
 import OverviewResourceSidebar from "./OverviewResourceSidebar"
@@ -32,6 +33,7 @@ let Main = styled.div`
 
 export default function OverviewResourcePane(props: OverviewResourcePaneProps) {
   let nav = useTabNav()
+  const logStore = useLogStore()
   let resources = props.view?.resources || []
   let name = nav.invalidTab || nav.selectedTab || ""
   let r: Proto.webviewResource | undefined
@@ -46,12 +48,37 @@ export default function OverviewResourcePane(props: OverviewResourcePaneProps) {
     selectedTab = r.name
   }
 
-  let alerts: Alert[] = []
-  if (r) {
-    alerts = combinedAlerts(r, null)
-  } else if (all) {
-    resources.forEach((r) => alerts.push(...combinedAlerts(r, null)))
+  const buildAlerts = () => {
+    let alerts: Alert[] = []
+    if (r) {
+      alerts = combinedAlerts(r, logStore)
+    } else if (all) {
+      resources.forEach((r) => alerts.push(...combinedAlerts(r, logStore)))
+    }
+    return alerts
   }
+  const [alerts, setAlerts] = useState<Alert[]>([])
+  // update alerts whenever the selected resource changes
+  useEffect(() => setAlerts(buildAlerts), [r])
+
+  // add a listener to rebuild alerts whenever a truncation event occurs
+  useEffect(() => {
+    const rebuildAlertsOnLogClear = (e: LogUpdateEvent) => {
+      if (e.action !== LogUpdateAction.truncate) {
+        return
+      }
+
+      if (
+        all ||
+        Object.values(e.spans).some((span) => span.manifestName == r?.name)
+      ) {
+        setAlerts(buildAlerts)
+      }
+    }
+
+    logStore.addUpdateListener(rebuildAlertsOnLogClear)
+    return () => logStore.removeUpdateListener(rebuildAlertsOnLogClear)
+  }, [])
 
   // Hide the HTML element scrollbars, since this pane does all scrolling internally.
   // TODO(nick): Remove this when the old UI is deleted.

--- a/web/src/alerts.test.ts
+++ b/web/src/alerts.test.ts
@@ -9,6 +9,7 @@ import {
 } from "./alerts"
 import { FilterLevel, FilterSource } from "./logfilters"
 import LogStore from "./LogStore"
+import { appendLinesForManifestAndSpan } from "./testlogs"
 import { TriggerMode } from "./types"
 
 type Resource = Proto.webviewResource
@@ -130,11 +131,16 @@ describe("combinedAlerts", () => {
       {
         warnings: ["Hi i'm a warning"],
         finishTime: "10:00am",
+        spanId: "build:2",
       },
       {
         warnings: ["This warning shouldn't show up", "Or this one"],
+        spanId: "build:1",
       },
     ]
+
+    appendLinesForManifestAndSpan(logStore, r.name!, "build:1", ["build 1"])
+    appendLinesForManifestAndSpan(logStore, r.name!, "build:2", ["build 2"])
 
     let actual = combinedAlerts(r, logStore)
     let expectedAlerts: Alert[] = [
@@ -268,38 +274,17 @@ it("DC Resource: should show a warning alert using the first build history", () 
     {
       warnings: ["Hi i'm a warning"],
       finishTime: "10:00am",
+      spanId: "build:2",
     },
     {
       warnings: ["This warning shouldn't show up", "Or this one"],
+      spanId: "build:1",
     },
   ]
-  let actual = combinedAlerts(r, logStore)
-  let expectedAlerts: Alert[] = [
-    {
-      alertType: WarningErrorType,
-      msg: "Hi i'm a warning",
-      timestamp: "10:00am",
-      header: "vigoda",
-      resourceName: "vigoda",
-      level: FilterLevel.warn,
-      source: FilterSource.build,
-    },
-  ]
-  expect(actual).toEqual(expectedAlerts)
-})
 
-//DC Resource Tests
-it("DC resource: should show a warning alert using the first build history", () => {
-  let r: Resource = dcResource()
-  r.buildHistory = [
-    {
-      warnings: ["Hi i'm a warning"],
-      finishTime: "10:00am",
-    },
-    {
-      warnings: ["This warning shouldn't show up", "Or this one"],
-    },
-  ]
+  appendLinesForManifestAndSpan(logStore, r.name!, "build:1", ["build 1"])
+  appendLinesForManifestAndSpan(logStore, r.name!, "build:2", ["build 2"])
+
   let actual = combinedAlerts(r, logStore)
   let expectedAlerts: Alert[] = [
     {

--- a/web/src/logs.ts
+++ b/web/src/logs.ts
@@ -50,7 +50,3 @@ export function sourcePrefix(n: string) {
 export function isBuildSpanId(spanId: string): boolean {
   return spanId.indexOf("build:") !== -1
 }
-
-export function isTiltfileSpanId(spanId: string): boolean {
-  return spanId.indexOf("tiltfile:") !== -1
-}

--- a/web/src/logs.ts
+++ b/web/src/logs.ts
@@ -50,3 +50,7 @@ export function sourcePrefix(n: string) {
 export function isBuildSpanId(spanId: string): boolean {
   return spanId.indexOf("build:") !== -1
 }
+
+export function isTiltfileSpanId(spanId: string): boolean {
+  return spanId.indexOf("tiltfile:") !== -1
+}

--- a/web/src/testlogs.tsx
+++ b/web/src/testlogs.tsx
@@ -14,13 +14,25 @@ export function appendLines(
   name: string,
   ...lineOrList: Line[] | Line[][]
 ) {
+  appendLinesForManifestAndSpan(logStore, name, name, ...lineOrList)
+}
+
+// Adds lines to a log store.
+// We accept lines expressed as var args or as an array.
+// (Expressing them as var args can hit call stack maximums if you're not careful).
+export function appendLinesForManifestAndSpan(
+  logStore: LogStore,
+  manifestName: string,
+  spanId: string,
+  ...lineOrList: Line[] | Line[][]
+) {
   let lines = lineOrList.flat()
   let fromCheckpoint = logStore.checkpoint
   let toCheckpoint = fromCheckpoint + lines.length
 
   let spans = {} as any
-  let spanId = name || "_"
-  spans[spanId] = { manifestName: name }
+  spanId = spanId || "_"
+  spans[spanId] = { manifestName: manifestName }
 
   let segments = []
   for (let line of lines) {


### PR DESCRIPTION
New button in the resource bar to clear logs. On the all view,
this will clear logs for all resources. On an individual resource,
it will just clear that resource's logs.

If a resource currently has error/warnings, the latest build or
runtime span respectively will be retained. This is to avoid having
a bunch of alerts that just show empty text on click.

### TODO
- [x] Hide button in snapshots

![2021-02-05 13 43 32](https://user-images.githubusercontent.com/841263/107081934-6f626300-67c1-11eb-8d4b-88ff6ea01bca.gif)

Closes #1885.