### PR TITLE
web: fix vertical overflow for build event fallback lines

### DIFF
--- a/web/src/LogPaneLine.scss
+++ b/web/src/LogPaneLine.scss
@@ -4,7 +4,6 @@
 
 .LogPaneLine {
   display: flex;
-  position: relative;
   font-size: $font-size-smallest;  
 
   &.is-highlighted {


### PR DESCRIPTION
Honestly not sure why this only impacts build event fallback.
I can't see any regression by removing this across other log
line types including long wrapping ones etc.

These messages are only visible with `--debug` anyway, so not
a big deal. There was always a slight truncation but it's much
more severe with the reduced font size.

### Before
<img width="487" alt="Screen Shot 2021-02-05 at 3 49 47 PM" src="https://user-images.githubusercontent.com/841263/107088320-cc164b80-67ca-11eb-85d3-14b4b999ffcf.png">

### After
<img width="461" alt="Screen Shot 2021-02-05 at 3 56 52 PM" src="https://user-images.githubusercontent.com/841263/107088336-d0daff80-67ca-11eb-8f48-5ef5e5b2d38b.png">
