### PR TITLE
web: Change OverviewResourceBar font size from smallester to smallest

### DIFF
--- a/web/src/OverviewResourceBar.tsx
+++ b/web/src/OverviewResourceBar.tsx
@@ -52,7 +52,7 @@ let ResourceBarEndRoot = styled.div`
 let ResourceBarStatusRoot = styled.div`
   display: flex;
   font-family: ${Font.sansSerif};
-  font-size: ${FontSize.smallester};
+  font-size: ${FontSize.smallest};
   align-items: center;
   color: ${Color.grayLightest};
 

--- a/web/src/OverviewResourceBar.tsx
+++ b/web/src/OverviewResourceBar.tsx
@@ -300,7 +300,7 @@ export let MenuButton = styled.button`
 let MenuButtonLabel = styled.div`
   position: absolute;
   bottom: 0;
-  font-size: ${FontSize.smallester};
+  font-size: ${FontSize.smallest};
   color: ${Color.blueDark};
   width: 200%;
   transition: opacity ${AnimDuration.default} ease;


### PR DESCRIPTION
https://app.clubhouse.io/windmill/story/11154/edit-font-size

**Before**
<img width="675" alt="before" src="https://user-images.githubusercontent.com/10860550/107248901-c6a24680-6a00-11eb-840d-9cf904ddace3.png">

**After**
<img width="691" alt="after" src="https://user-images.githubusercontent.com/10860550/107248900-c609b000-6a00-11eb-94b5-db688ede264f.png">

**Before**
<img width="319" alt="Screen Shot 2021-02-08 at 11 31 26 AM" src="https://user-images.githubusercontent.com/10860550/107249406-56e08b80-6a01-11eb-979f-51c87009a131.png">

**After**
<img width="328" alt="Screen Shot 2021-02-08 at 11 31 43 AM" src="https://user-images.githubusercontent.com/10860550/107249407-56e08b80-6a01-11eb-8953-ea30a1d98705.png">


Surbhi says that the font size should be at least 12px. With this change, it will be 13px.
