### PR TITLE
server: fix local snapshot testing mode

### DIFF
--- a/internal/hud/server/server.go
+++ b/internal/hud/server/server.go
@@ -13,6 +13,7 @@ import (
 	"time"
 	"unsafe"
 
+	"github.com/golang/protobuf/jsonpb"
 	"github.com/gorilla/mux"
 	_ "github.com/gorilla/websocket"
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
@@ -169,7 +170,8 @@ func (s *HeadsUpServer) SnapshotJSON(w http.ResponseWriter, req *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	err = json.NewEncoder(w).Encode(&proto_webview.Snapshot{
+	var m jsonpb.Marshaler
+	err = m.Marshal(w, &proto_webview.Snapshot{
 		View: view,
 	})
 	if err != nil {


### PR DESCRIPTION
Serialize with the JSON protobuf marshaler rather than stdlib so
that we get `camelCase` rather than `snake_case`.

(This is using the "deprecated" `jsonpb` rather than `protojson`
as we haven't moved to `google.golang.org/protobuf` yet.)