### PR TITLE
engine: Adds dc_resource link support

### DIFF
--- a/internal/store/engine_state.go
+++ b/internal/store/engine_state.go
@@ -734,6 +734,8 @@ func ManifestTargetEndpoints(mt *ManifestTarget) (endpoints []model.Link) {
 			endpoints = append(endpoints, model.MustNewLink(fmt.Sprintf("http://localhost:%d/", p), ""))
 		}
 	}
+
+	endpoints = append(endpoints, mt.Manifest.DockerComposeTarget().Links...)
 	return endpoints
 }
 

--- a/internal/store/engine_state_test.go
+++ b/internal/store/engine_state_test.go
@@ -34,6 +34,7 @@ type endpointsCase struct {
 
 	k8sResLinks   []model.Link
 	localResLinks []model.Link
+	dcResLinks    []model.Link
 }
 
 func (c endpointsCase) validate() {
@@ -324,6 +325,10 @@ func TestManifestTargetEndpoints(t *testing.T) {
 				model.MustNewLink("http://localhost:7000/", ""),
 			},
 			dcPublishedPorts: []int{8000, 7000},
+			dcResLinks: []model.Link{
+				model.MustNewLink("www.apple.edu", "apple"),
+				model.MustNewLink("www.zombo.com", "zombo"),
+			},
 		},
 		{
 			name: "load balancers",
@@ -372,6 +377,8 @@ func TestManifestTargetEndpoints(t *testing.T) {
 				m = m.WithDeployTarget(model.LocalTarget{Links: c.localResLinks})
 			} else if len(c.dcPublishedPorts) > 0 {
 				m = m.WithDeployTarget(model.DockerComposeTarget{}.WithPublishedPorts(c.dcPublishedPorts))
+			} else if len(c.dcResLinks) > 0 {
+				m = m.WithDeployTarget(model.DockerComposeTarget{Links: c.dcResLinks})
 			}
 
 			mt := newManifestTargetWithLoadBalancerURLs(m, c.lbURLs)


### PR DESCRIPTION
Follow up to https://github.com/tilt-dev/tilt/pull/4164

This should wrap up link support for `dc_resource`s.