### PR TITLE
ui: test and resource sidebar toggles use onlick instead of onchange

### DIFF
--- a/web/src/OverviewSidebarOptions.test.tsx
+++ b/web/src/OverviewSidebarOptions.test.tsx
@@ -49,6 +49,13 @@ export function assertSidebarItemsAndOptions(
   )
 }
 
+function clickResourcesToggle(root: ReactWrapper) {
+  root.find("input#resources").simulate("click")
+}
+function clickTestsToggle(root: ReactWrapper) {
+  root.find("input#tests").simulate("click")
+}
+
 const allNames = ["(Tiltfile)", "vigoda", "snack", "beep", "boop"]
 
 describe("overview sidebar options", () => {
@@ -65,9 +72,7 @@ describe("overview sidebar options", () => {
     const root = mount(TwoResourcesTwoTests())
     assertSidebarItemsAndOptions(root, allNames, true, true, false)
 
-    root
-      .find("input#resources")
-      .simulate("change", { target: { checked: false } })
+    clickResourcesToggle(root)
     assertSidebarItemsAndOptions(
       root,
       ["(Tiltfile)", "beep", "boop"],
@@ -81,7 +86,7 @@ describe("overview sidebar options", () => {
     const root = mount(TwoResourcesTwoTests())
     assertSidebarItemsAndOptions(root, allNames, true, true, false)
 
-    root.find("input#tests").simulate("change", { target: { checked: false } })
+    clickTestsToggle(root)
     assertSidebarItemsAndOptions(
       root,
       ["(Tiltfile)", "vigoda", "snack"],
@@ -95,10 +100,8 @@ describe("overview sidebar options", () => {
     const root = mount(TwoResourcesTwoTests())
     assertSidebarItemsAndOptions(root, allNames, true, true, false)
 
-    root
-      .find("input#resources")
-      .simulate("change", { target: { checked: false } })
-    root.find("input#tests").simulate("change", { target: { checked: false } })
+    clickResourcesToggle(root)
+    clickTestsToggle(root)
     assertSidebarItemsAndOptions(root, ["(Tiltfile)"], false, false, false)
   })
 
@@ -154,7 +157,7 @@ describe("overview sidebar options", () => {
     expect(pinned).toHaveLength(1)
     expect(pinned.at(0).props().item.name).toEqual("beep")
 
-    root.find("input#tests").simulate("change", { target: { checked: false } })
+    clickTestsToggle(root)
     assertSidebarItemsAndOptions(
       root,
       ["(Tiltfile)", "vigoda", "snack"],
@@ -172,7 +175,3 @@ describe("overview sidebar options", () => {
     expect(pinned.at(0).props().item.name).toEqual("beep")
   })
 })
-
-// TODO:
-//   - if test present; hide/show tests/resources; and then test removed (e.g. commented
-//     out of tiltfile) then we hide the check boxes AND ALSO reset filters to show everything

--- a/web/src/OverviewSidebarOptions.tsx
+++ b/web/src/OverviewSidebarOptions.tsx
@@ -99,7 +99,9 @@ export function OverviewSidebarOptions(
               icon={<CheckBoxOutlineBlankIcon fontSize="small" />}
               checkedIcon={<CheckBoxIcon fontSize="small" />}
               checked={props.options.showResources}
-              onChange={(e) => setShowResources(props, e.target.checked)}
+              onClick={(e) =>
+                setShowResources(props, !props.options.showResources)
+              }
               name="resources"
               id="resources"
             />
@@ -114,7 +116,7 @@ export function OverviewSidebarOptions(
               icon={<CheckBoxOutlineBlankIcon fontSize="small" />}
               checkedIcon={<CheckBoxIcon fontSize="small" />}
               checked={props.options.showTests}
-              onChange={(e) => setShowTests(props, e.target.checked)}
+              onClick={(e) => setShowTests(props, !props.options.showTests)}
               name="tests"
               id="tests"
             />

--- a/web/src/SidebarResources.test.tsx
+++ b/web/src/SidebarResources.test.tsx
@@ -222,17 +222,19 @@ describe("SidebarResources", () => {
         </MemoryRouter>
       )
 
-      root.find("input#resources").simulate("change", {
-        target: { checked: expectedOptions.showResources },
-      })
-      root
-        .find("input#tests")
-        .simulate("change", { target: { checked: expectedOptions.showTests } })
-      if (
-        root.find(AlertsOnTopToggle).hasClass("is-enabled") !=
-        expectedOptions.alertsOnTop
-      ) {
-        root.find(AlertsOnTopToggle).simulate("click")
+      let resToggle = root.find("input#resources")
+      if (resToggle.props().checked != expectedOptions.showResources) {
+        resToggle.simulate("click")
+      }
+
+      let testToggle = root.find("input#tests")
+      if (testToggle.props().checked != expectedOptions.showTests) {
+        testToggle.simulate("click")
+      }
+
+      let aotToggle = root.find(AlertsOnTopToggle)
+      if (aotToggle.hasClass("is-enabled") != expectedOptions.alertsOnTop) {
+        aotToggle.simulate("click")
       }
 
       const observedOptions = sidebarOptionsAccessor.get()


### PR DESCRIPTION
streamline handling of the alertsOnTop toggle with show/hide resource/test checkboxes

also add some test helpers