### PR TITLE
web: Add divider lines between sections in Overview

### DIFF
--- a/web/src/OverviewGrid.tsx
+++ b/web/src/OverviewGrid.tsx
@@ -19,10 +19,10 @@ let OverviewGridRoot = styled.ul`
   box-sizing: border-box;
   &:nth-child(even) {
     border-bottom: 1px dotted ${Color.grayLight};
-  }
+  };
   &:last-child {
     border-bottom-width: 0;
-  }
+  };
 `
 
 export default function OverviewGrid(props: OverviewGridProps) {

--- a/web/src/OverviewGrid.tsx
+++ b/web/src/OverviewGrid.tsx
@@ -17,12 +17,12 @@ let OverviewGridRoot = styled.ul`
   padding-left: ${SizeUnit(0.25)};
   position: relative;
   box-sizing: border-box;
-  &:nth-child(2) {
+  &:nth-child(2n) {
     border-bottom: 1px dotted ${Color.grayLight};
   }
-  &:nth-child(4) {
-    border-bottom: 1px dotted ${Color.grayLight};
-  }
+  &:last-child {
+    border-bottom-width: 0;
+  }  
 `
 
 export default function OverviewGrid(props: OverviewGridProps) {

--- a/web/src/OverviewGrid.tsx
+++ b/web/src/OverviewGrid.tsx
@@ -16,7 +16,7 @@ let OverviewGridRoot = styled.ul`
   padding-left: ${SizeUnit(0.25)};
   position: relative;
   box-sizing: border-box;
-  border-bottom: 1px dotted ${Color.grayLight};  
+  border-bottom: 1px dotted ${Color.grayLight};
   &:last-child {
     border-bottom-width: 0;
   }

--- a/web/src/OverviewGrid.tsx
+++ b/web/src/OverviewGrid.tsx
@@ -22,7 +22,7 @@ let OverviewGridRoot = styled.ul`
   }
   &:last-child {
     border-bottom-width: 0;
-  }  
+  }
 `
 
 export default function OverviewGrid(props: OverviewGridProps) {

--- a/web/src/OverviewGrid.tsx
+++ b/web/src/OverviewGrid.tsx
@@ -17,7 +17,7 @@ let OverviewGridRoot = styled.ul`
   padding-left: ${SizeUnit(0.25)};
   position: relative;
   box-sizing: border-box;
-  &:nth-child(2n) {
+  &:nth-child(even) {
     border-bottom: 1px dotted ${Color.grayLight};
   }
   &:last-child {

--- a/web/src/OverviewGrid.tsx
+++ b/web/src/OverviewGrid.tsx
@@ -2,6 +2,7 @@ import React from "react"
 import styled from "styled-components"
 import OverviewItemView, { OverviewItem } from "./OverviewItemView"
 import { SizeUnit } from "./style-helpers"
+import { Color } from "./style-helpers"
 
 type OverviewGridProps = {
   items: OverviewItem[]
@@ -16,6 +17,12 @@ let OverviewGridRoot = styled.ul`
   padding-left: ${SizeUnit(0.25)};
   position: relative;
   box-sizing: border-box;
+  &:nth-child(2) {
+    border-bottom: 1px dotted ${Color.grayLight};
+  }
+  &:nth-child(4) {
+    border-bottom: 1px dotted ${Color.grayLight};
+  }
 `
 
 export default function OverviewGrid(props: OverviewGridProps) {

--- a/web/src/OverviewGrid.tsx
+++ b/web/src/OverviewGrid.tsx
@@ -20,7 +20,7 @@ let OverviewGridRoot = styled.ul`
     border-bottom: 1px dotted ${Color.grayLight};
   }
   &:last-child {
-    border-bottom-width: 0px;
+    border-bottom-width: 0;
   }
 `
 

--- a/web/src/OverviewGrid.tsx
+++ b/web/src/OverviewGrid.tsx
@@ -16,9 +16,7 @@ let OverviewGridRoot = styled.ul`
   padding-left: ${SizeUnit(0.25)};
   position: relative;
   box-sizing: border-box;
-  &:nth-child(even) {
-    border-bottom: 1px dotted ${Color.grayLight};
-  }
+  border-bottom: 1px dotted ${Color.grayLight};  
   &:last-child {
     border-bottom-width: 0;
   }

--- a/web/src/OverviewGrid.tsx
+++ b/web/src/OverviewGrid.tsx
@@ -1,8 +1,7 @@
 import React from "react"
 import styled from "styled-components"
 import OverviewItemView, { OverviewItem } from "./OverviewItemView"
-import { SizeUnit } from "./style-helpers"
-import { Color } from "./style-helpers"
+import { Color, SizeUnit } from "./style-helpers"
 
 type OverviewGridProps = {
   items: OverviewItem[]
@@ -19,10 +18,10 @@ let OverviewGridRoot = styled.ul`
   box-sizing: border-box;
   &:nth-child(even) {
     border-bottom: 1px dotted ${Color.grayLight};
-  };
+  }
   &:last-child {
-    border-bottom-width: 0;
-  };
+    border-bottom-width: 0px;
+  }
 `
 
 export default function OverviewGrid(props: OverviewGridProps) {


### PR DESCRIPTION
https://app.clubhouse.io/windmill/story/11181/section-divider-line

# Without tests

<img width="1669" alt="Screen Shot 2021-02-08 at 7 12 47 PM" src="https://user-images.githubusercontent.com/10860550/107297572-a34bbb80-6a41-11eb-8233-f96fec8ff513.png">


# With tests

<img width="1659" alt="Screen Shot 2021-02-08 at 7 12 12 PM" src="https://user-images.githubusercontent.com/10860550/107297525-8dd69180-6a41-11eb-97ab-f98423d6c78b.png">
