### PR TITLE
web: show 'alerts on top' toggle even when there are no tests

### DIFF
--- a/web/src/OverviewSidebarOptions.test.tsx
+++ b/web/src/OverviewSidebarOptions.test.tsx
@@ -103,7 +103,7 @@ describe("overview sidebar options", () => {
     assertSidebarItemsAndOptions(root, ["(Tiltfile)"], false, false, false)
   })
 
-  it("doesn't show SidebarOptionSetter if no tests present", () => {
+  it("doesn't show filter options if no tests present", () => {
     let items = [tiltfileResource(), oneResource()].map(
       (r) => new SidebarItem(r)
     )
@@ -125,7 +125,7 @@ describe("overview sidebar options", () => {
     expect(sidebar).toHaveLength(1)
 
     let filters = sidebar.find(FilterOptionList)
-    expect(filters.get(0).props.visible).toEqual(false)
+    expect(filters).toHaveLength(0)
   })
 
   it("still displays pinned tests when tests hidden", () => {

--- a/web/src/OverviewSidebarOptions.test.tsx
+++ b/web/src/OverviewSidebarOptions.test.tsx
@@ -5,6 +5,7 @@ import { accessorsForTesting, tiltfileKeyContext } from "./LocalStorage"
 import { TwoResourcesTwoTests } from "./OverviewResourceSidebar.stories"
 import {
   AlertsOnTopToggle,
+  FilterOptionList,
   OverviewSidebarOptions,
 } from "./OverviewSidebarOptions"
 import PathBuilder from "./PathBuilder"
@@ -123,8 +124,8 @@ describe("overview sidebar options", () => {
     let sidebar = root.find(SidebarResources)
     expect(sidebar).toHaveLength(1)
 
-    let optSetter = sidebar.find(OverviewSidebarOptions)
-    expect(optSetter).toHaveLength(0)
+    let filters = sidebar.find(FilterOptionList)
+    expect(filters.get(0).props.visible).toEqual(false)
   })
 
   it("still displays pinned tests when tests hidden", () => {

--- a/web/src/OverviewSidebarOptions.tsx
+++ b/web/src/OverviewSidebarOptions.tsx
@@ -24,13 +24,16 @@ const OverviewSidebarOptionsRoot = styled.div`
   padding-left: ${SizeUnit(0.5)};
   padding-right: ${SizeUnit(0.5)};
   color: ${Color.offWhite};
+
+  &.is-filtersHidden {
+    justify-content: flex-end;
+  }
 `
 
-export const FilterOptionList = styled.ul<{ visible: boolean }>`
+export const FilterOptionList = styled.ul`
   ${mixinResetListStyle}
   display: flex;
   user-select: none; // Prevent unsightly highlighting on the label
-  visibility: ${(props) => (props.visible ? "default" : "hidden")};
 `
 
 const useStyles = makeStyles({
@@ -83,48 +86,53 @@ function setShowResources(
   })
 }
 
+function filterOptions(props: OverviewSidebarOptionsProps) {
+  const classes = useStyles()
+  return (
+    <FilterOptionList>
+      <FormControlLabel
+        control={
+          <Checkbox
+            className={classes.root}
+            color={"default"}
+            icon={<CheckBoxOutlineBlankIcon fontSize="small" />}
+            checkedIcon={<CheckBoxIcon fontSize="small" />}
+            checked={props.options.showResources}
+            onChange={(e) => setShowResources(props, e.target.checked)}
+            name="resources"
+            id="resources"
+          />
+        }
+        label="Resources"
+      />
+      <FormControlLabel
+        control={
+          <Checkbox
+            className={classes.root}
+            color={"default"}
+            icon={<CheckBoxOutlineBlankIcon fontSize="small" />}
+            checkedIcon={<CheckBoxIcon fontSize="small" />}
+            checked={props.options.showTests}
+            onChange={(e) => setShowTests(props, e.target.checked)}
+            name="tests"
+            id="tests"
+          />
+        }
+        label="Tests"
+      />
+    </FilterOptionList>
+  )
+}
+
 export function OverviewSidebarOptions(
   props: OverviewSidebarOptionsProps
 ): JSX.Element {
-  const classes = useStyles()
-
   return (
     <OverviewSidebarOptionsRoot
       style={{ marginTop: SizeUnit(0.75), marginBottom: SizeUnit(-0.5) }}
+      className={!props.showFilters ? "is-filtersHidden" : ""}
     >
-      <FilterOptionList visible={props.showFilters}>
-        <FormControlLabel
-          control={
-            <Checkbox
-              className={classes.root}
-              color={"default"}
-              icon={<CheckBoxOutlineBlankIcon fontSize="small" />}
-              checkedIcon={<CheckBoxIcon fontSize="small" />}
-              checked={props.options.showResources}
-              onChange={(e) => setShowResources(props, e.target.checked)}
-              name="resources"
-              id="resources"
-            />
-          }
-          label="Resources"
-        />
-        <FormControlLabel
-          control={
-            <Checkbox
-              className={classes.root}
-              color={"default"}
-              icon={<CheckBoxOutlineBlankIcon fontSize="small" />}
-              checkedIcon={<CheckBoxIcon fontSize="small" />}
-              checked={props.options.showTests}
-              onChange={(e) => setShowTests(props, e.target.checked)}
-              name="tests"
-              id="tests"
-            />
-          }
-          label="Tests"
-        />
-      </FilterOptionList>
-
+      {props.showFilters ? filterOptions(props) : null}
       <AlertsOnTopToggle
         className={props.options.alertsOnTop ? "is-enabled" : ""}
         onClick={(e) => setAlertsOnTop(props, !props.options.alertsOnTop)}

--- a/web/src/OverviewSidebarOptions.tsx
+++ b/web/src/OverviewSidebarOptions.tsx
@@ -26,10 +26,11 @@ const OverviewSidebarOptionsRoot = styled.div`
   color: ${Color.offWhite};
 `
 
-const FilterOptionList = styled.ul`
+export const FilterOptionList = styled.ul<{ visible: boolean }>`
   ${mixinResetListStyle}
   display: flex;
   user-select: none; // Prevent unsightly highlighting on the label
+  visibility: ${(props) => (props.visible ? "default" : "hidden")};
 `
 
 const useStyles = makeStyles({
@@ -53,6 +54,7 @@ export const AlertsOnTopToggle = styled.button`
 `
 
 type OverviewSidebarOptionsProps = {
+  showFilters: boolean
   options: SidebarOptions
   setOptions: Dispatch<SetStateAction<SidebarOptions>>
 }
@@ -90,7 +92,7 @@ export function OverviewSidebarOptions(
     <OverviewSidebarOptionsRoot
       style={{ marginTop: SizeUnit(0.75), marginBottom: SizeUnit(-0.5) }}
     >
-      <FilterOptionList>
+      <FilterOptionList visible={props.showFilters}>
         <FormControlLabel
           control={
             <Checkbox

--- a/web/src/SidebarResources.tsx
+++ b/web/src/SidebarResources.tsx
@@ -156,9 +156,14 @@ export class SidebarResources extends React.Component<SidebarProps> {
             />
           </SidebarListSection>
           <PinnedItems {...this.props} />
-          {testsPresent && (
-            <OverviewSidebarOptions options={options} setOptions={setOptions} /> // TODO: if this vanishes because no tests present, reset it to show everything
-          )}
+          {
+            // TODO: if this vanishes because no tests present, reset it to show everything}
+          }
+          <OverviewSidebarOptions
+            showFilters={testsPresent}
+            options={options}
+            setOptions={setOptions}
+          />
           <SidebarListSection name="resources">{listItems}</SidebarListSection>
         </SidebarList>
         <SidebarKeyboardShortcuts

--- a/web/src/SidebarResources.tsx
+++ b/web/src/SidebarResources.tsx
@@ -156,9 +156,6 @@ export class SidebarResources extends React.Component<SidebarProps> {
             />
           </SidebarListSection>
           <PinnedItems {...this.props} />
-          {
-            // TODO: if this vanishes because no tests present, reset it to show everything}
-          }
           <OverviewSidebarOptions
             showFilters={testsPresent}
             options={options}

--- a/web/src/__snapshots__/Sidebar.test.tsx.snap
+++ b/web/src/__snapshots__/Sidebar.test.tsx.snap
@@ -42,7 +42,7 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
       </ul>
     </div>
     <div
-      className="sc-bdfBwQ jYVSUn"
+      className="sc-bdfBwQ bcRcZF is-filtersHidden"
       style={
         Object {
           "marginBottom": "-16px",
@@ -50,114 +50,6 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
         }
       }
     >
-      <ul
-        className="sc-gsTCUz jipOPh"
-      >
-        <label
-          className="MuiFormControlLabel-root"
-        >
-          <span
-            aria-disabled={false}
-            className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-2 MuiCheckbox-root makeStyles-root-1 PrivateSwitchBase-checked-3 Mui-checked"
-            onBlur={[Function]}
-            onDragLeave={[Function]}
-            onFocus={[Function]}
-            onKeyDown={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseLeave={[Function]}
-            onMouseUp={[Function]}
-            onTouchEnd={[Function]}
-            onTouchMove={[Function]}
-            onTouchStart={[Function]}
-            tabIndex={null}
-          >
-            <span
-              className="MuiIconButton-label"
-            >
-              <input
-                checked={true}
-                className="PrivateSwitchBase-input-5"
-                data-indeterminate={false}
-                id="resources"
-                name="resources"
-                onChange={[Function]}
-                type="checkbox"
-              />
-              <svg
-                aria-hidden={true}
-                className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
-                focusable="false"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  d="M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2V5c0-1.1-.89-2-2-2zm-9 14l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
-                />
-              </svg>
-            </span>
-            <span
-              className="MuiTouchRipple-root"
-            />
-          </span>
-          <span
-            className="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
-          >
-            Resources
-          </span>
-        </label>
-        <label
-          className="MuiFormControlLabel-root"
-        >
-          <span
-            aria-disabled={false}
-            className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-2 MuiCheckbox-root makeStyles-root-1 PrivateSwitchBase-checked-3 Mui-checked"
-            onBlur={[Function]}
-            onDragLeave={[Function]}
-            onFocus={[Function]}
-            onKeyDown={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseLeave={[Function]}
-            onMouseUp={[Function]}
-            onTouchEnd={[Function]}
-            onTouchMove={[Function]}
-            onTouchStart={[Function]}
-            tabIndex={null}
-          >
-            <span
-              className="MuiIconButton-label"
-            >
-              <input
-                checked={true}
-                className="PrivateSwitchBase-input-5"
-                data-indeterminate={false}
-                id="tests"
-                name="tests"
-                onChange={[Function]}
-                type="checkbox"
-              />
-              <svg
-                aria-hidden={true}
-                className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
-                focusable="false"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  d="M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2V5c0-1.1-.89-2-2-2zm-9 14l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
-                />
-              </svg>
-            </span>
-            <span
-              className="MuiTouchRipple-root"
-            />
-          </span>
-          <span
-            className="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
-          >
-            Tests
-          </span>
-        </label>
-      </ul>
       <button
         className="sc-dlfnbm hYhRhc"
         onClick={[Function]}
@@ -986,7 +878,7 @@ exports[`sidebar renders empty resource list without crashing 1`] = `
       </ul>
     </div>
     <div
-      className="sc-bdfBwQ jYVSUn"
+      className="sc-bdfBwQ bcRcZF is-filtersHidden"
       style={
         Object {
           "marginBottom": "-16px",
@@ -994,108 +886,6 @@ exports[`sidebar renders empty resource list without crashing 1`] = `
         }
       }
     >
-      <ul
-        className="sc-gsTCUz jipOPh"
-      >
-        <label
-          className="MuiFormControlLabel-root"
-        >
-          <span
-            aria-disabled={false}
-            className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-2 MuiCheckbox-root makeStyles-root-1 PrivateSwitchBase-checked-3 Mui-checked"
-            onBlur={[Function]}
-            onDragLeave={[Function]}
-            onFocus={[Function]}
-            onKeyDown={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseLeave={[Function]}
-            onMouseUp={[Function]}
-            onTouchEnd={[Function]}
-            onTouchMove={[Function]}
-            onTouchStart={[Function]}
-            tabIndex={null}
-          >
-            <span
-              className="MuiIconButton-label"
-            >
-              <input
-                checked={true}
-                className="PrivateSwitchBase-input-5"
-                data-indeterminate={false}
-                id="resources"
-                name="resources"
-                onChange={[Function]}
-                type="checkbox"
-              />
-              <svg
-                aria-hidden={true}
-                className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
-                focusable="false"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  d="M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2V5c0-1.1-.89-2-2-2zm-9 14l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
-                />
-              </svg>
-            </span>
-          </span>
-          <span
-            className="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
-          >
-            Resources
-          </span>
-        </label>
-        <label
-          className="MuiFormControlLabel-root"
-        >
-          <span
-            aria-disabled={false}
-            className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-2 MuiCheckbox-root makeStyles-root-1 PrivateSwitchBase-checked-3 Mui-checked"
-            onBlur={[Function]}
-            onDragLeave={[Function]}
-            onFocus={[Function]}
-            onKeyDown={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseLeave={[Function]}
-            onMouseUp={[Function]}
-            onTouchEnd={[Function]}
-            onTouchMove={[Function]}
-            onTouchStart={[Function]}
-            tabIndex={null}
-          >
-            <span
-              className="MuiIconButton-label"
-            >
-              <input
-                checked={true}
-                className="PrivateSwitchBase-input-5"
-                data-indeterminate={false}
-                id="tests"
-                name="tests"
-                onChange={[Function]}
-                type="checkbox"
-              />
-              <svg
-                aria-hidden={true}
-                className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
-                focusable="false"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  d="M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2V5c0-1.1-.89-2-2-2zm-9 14l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
-                />
-              </svg>
-            </span>
-          </span>
-          <span
-            className="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
-          >
-            Tests
-          </span>
-        </label>
-      </ul>
       <button
         className="sc-dlfnbm hYhRhc"
         onClick={[Function]}
@@ -1160,7 +950,7 @@ exports[`sidebar renders list of resources 1`] = `
       </ul>
     </div>
     <div
-      className="sc-bdfBwQ jYVSUn"
+      className="sc-bdfBwQ bcRcZF is-filtersHidden"
       style={
         Object {
           "marginBottom": "-16px",
@@ -1168,114 +958,6 @@ exports[`sidebar renders list of resources 1`] = `
         }
       }
     >
-      <ul
-        className="sc-gsTCUz jipOPh"
-      >
-        <label
-          className="MuiFormControlLabel-root"
-        >
-          <span
-            aria-disabled={false}
-            className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-2 MuiCheckbox-root makeStyles-root-1 PrivateSwitchBase-checked-3 Mui-checked"
-            onBlur={[Function]}
-            onDragLeave={[Function]}
-            onFocus={[Function]}
-            onKeyDown={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseLeave={[Function]}
-            onMouseUp={[Function]}
-            onTouchEnd={[Function]}
-            onTouchMove={[Function]}
-            onTouchStart={[Function]}
-            tabIndex={null}
-          >
-            <span
-              className="MuiIconButton-label"
-            >
-              <input
-                checked={true}
-                className="PrivateSwitchBase-input-5"
-                data-indeterminate={false}
-                id="resources"
-                name="resources"
-                onChange={[Function]}
-                type="checkbox"
-              />
-              <svg
-                aria-hidden={true}
-                className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
-                focusable="false"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  d="M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2V5c0-1.1-.89-2-2-2zm-9 14l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
-                />
-              </svg>
-            </span>
-            <span
-              className="MuiTouchRipple-root"
-            />
-          </span>
-          <span
-            className="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
-          >
-            Resources
-          </span>
-        </label>
-        <label
-          className="MuiFormControlLabel-root"
-        >
-          <span
-            aria-disabled={false}
-            className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-2 MuiCheckbox-root makeStyles-root-1 PrivateSwitchBase-checked-3 Mui-checked"
-            onBlur={[Function]}
-            onDragLeave={[Function]}
-            onFocus={[Function]}
-            onKeyDown={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseLeave={[Function]}
-            onMouseUp={[Function]}
-            onTouchEnd={[Function]}
-            onTouchMove={[Function]}
-            onTouchStart={[Function]}
-            tabIndex={null}
-          >
-            <span
-              className="MuiIconButton-label"
-            >
-              <input
-                checked={true}
-                className="PrivateSwitchBase-input-5"
-                data-indeterminate={false}
-                id="tests"
-                name="tests"
-                onChange={[Function]}
-                type="checkbox"
-              />
-              <svg
-                aria-hidden={true}
-                className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
-                focusable="false"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  d="M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2V5c0-1.1-.89-2-2-2zm-9 14l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
-                />
-              </svg>
-            </span>
-            <span
-              className="MuiTouchRipple-root"
-            />
-          </span>
-          <span
-            className="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
-          >
-            Tests
-          </span>
-        </label>
-      </ul>
       <button
         className="sc-dlfnbm hYhRhc"
         onClick={[Function]}
@@ -1563,7 +1245,7 @@ exports[`sidebar renders resources that haven't been built yet 1`] = `
       </ul>
     </div>
     <div
-      className="sc-bdfBwQ jYVSUn"
+      className="sc-bdfBwQ bcRcZF is-filtersHidden"
       style={
         Object {
           "marginBottom": "-16px",
@@ -1571,114 +1253,6 @@ exports[`sidebar renders resources that haven't been built yet 1`] = `
         }
       }
     >
-      <ul
-        className="sc-gsTCUz jipOPh"
-      >
-        <label
-          className="MuiFormControlLabel-root"
-        >
-          <span
-            aria-disabled={false}
-            className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-2 MuiCheckbox-root makeStyles-root-1 PrivateSwitchBase-checked-3 Mui-checked"
-            onBlur={[Function]}
-            onDragLeave={[Function]}
-            onFocus={[Function]}
-            onKeyDown={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseLeave={[Function]}
-            onMouseUp={[Function]}
-            onTouchEnd={[Function]}
-            onTouchMove={[Function]}
-            onTouchStart={[Function]}
-            tabIndex={null}
-          >
-            <span
-              className="MuiIconButton-label"
-            >
-              <input
-                checked={true}
-                className="PrivateSwitchBase-input-5"
-                data-indeterminate={false}
-                id="resources"
-                name="resources"
-                onChange={[Function]}
-                type="checkbox"
-              />
-              <svg
-                aria-hidden={true}
-                className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
-                focusable="false"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  d="M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2V5c0-1.1-.89-2-2-2zm-9 14l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
-                />
-              </svg>
-            </span>
-            <span
-              className="MuiTouchRipple-root"
-            />
-          </span>
-          <span
-            className="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
-          >
-            Resources
-          </span>
-        </label>
-        <label
-          className="MuiFormControlLabel-root"
-        >
-          <span
-            aria-disabled={false}
-            className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-2 MuiCheckbox-root makeStyles-root-1 PrivateSwitchBase-checked-3 Mui-checked"
-            onBlur={[Function]}
-            onDragLeave={[Function]}
-            onFocus={[Function]}
-            onKeyDown={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseLeave={[Function]}
-            onMouseUp={[Function]}
-            onTouchEnd={[Function]}
-            onTouchMove={[Function]}
-            onTouchStart={[Function]}
-            tabIndex={null}
-          >
-            <span
-              className="MuiIconButton-label"
-            >
-              <input
-                checked={true}
-                className="PrivateSwitchBase-input-5"
-                data-indeterminate={false}
-                id="tests"
-                name="tests"
-                onChange={[Function]}
-                type="checkbox"
-              />
-              <svg
-                aria-hidden={true}
-                className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
-                focusable="false"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  d="M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2V5c0-1.1-.89-2-2-2zm-9 14l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
-                />
-              </svg>
-            </span>
-            <span
-              className="MuiTouchRipple-root"
-            />
-          </span>
-          <span
-            className="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
-          >
-            Tests
-          </span>
-        </label>
-      </ul>
       <button
         className="sc-dlfnbm hYhRhc"
         onClick={[Function]}

--- a/web/src/__snapshots__/Sidebar.test.tsx.snap
+++ b/web/src/__snapshots__/Sidebar.test.tsx.snap
@@ -41,6 +41,130 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
         </li>
       </ul>
     </div>
+    <div
+      className="sc-bdfBwQ jYVSUn"
+      style={
+        Object {
+          "marginBottom": "-16px",
+          "marginTop": "24px",
+        }
+      }
+    >
+      <ul
+        className="sc-gsTCUz jipOPh"
+      >
+        <label
+          className="MuiFormControlLabel-root"
+        >
+          <span
+            aria-disabled={false}
+            className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-2 MuiCheckbox-root makeStyles-root-1 PrivateSwitchBase-checked-3 Mui-checked"
+            onBlur={[Function]}
+            onDragLeave={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+            onTouchEnd={[Function]}
+            onTouchMove={[Function]}
+            onTouchStart={[Function]}
+            tabIndex={null}
+          >
+            <span
+              className="MuiIconButton-label"
+            >
+              <input
+                checked={true}
+                className="PrivateSwitchBase-input-5"
+                data-indeterminate={false}
+                id="resources"
+                name="resources"
+                onChange={[Function]}
+                type="checkbox"
+              />
+              <svg
+                aria-hidden={true}
+                className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2V5c0-1.1-.89-2-2-2zm-9 14l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
+                />
+              </svg>
+            </span>
+            <span
+              className="MuiTouchRipple-root"
+            />
+          </span>
+          <span
+            className="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
+          >
+            Resources
+          </span>
+        </label>
+        <label
+          className="MuiFormControlLabel-root"
+        >
+          <span
+            aria-disabled={false}
+            className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-2 MuiCheckbox-root makeStyles-root-1 PrivateSwitchBase-checked-3 Mui-checked"
+            onBlur={[Function]}
+            onDragLeave={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+            onTouchEnd={[Function]}
+            onTouchMove={[Function]}
+            onTouchStart={[Function]}
+            tabIndex={null}
+          >
+            <span
+              className="MuiIconButton-label"
+            >
+              <input
+                checked={true}
+                className="PrivateSwitchBase-input-5"
+                data-indeterminate={false}
+                id="tests"
+                name="tests"
+                onChange={[Function]}
+                type="checkbox"
+              />
+              <svg
+                aria-hidden={true}
+                className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2V5c0-1.1-.89-2-2-2zm-9 14l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
+                />
+              </svg>
+            </span>
+            <span
+              className="MuiTouchRipple-root"
+            />
+          </span>
+          <span
+            className="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
+          >
+            Tests
+          </span>
+        </label>
+      </ul>
+      <button
+        className="sc-dlfnbm hYhRhc"
+        onClick={[Function]}
+      >
+        Alerts on Top
+      </button>
+    </div>
     <div>
       <div
         className="sc-hHftDr keXJQh"
@@ -861,6 +985,124 @@ exports[`sidebar renders empty resource list without crashing 1`] = `
         </li>
       </ul>
     </div>
+    <div
+      className="sc-bdfBwQ jYVSUn"
+      style={
+        Object {
+          "marginBottom": "-16px",
+          "marginTop": "24px",
+        }
+      }
+    >
+      <ul
+        className="sc-gsTCUz jipOPh"
+      >
+        <label
+          className="MuiFormControlLabel-root"
+        >
+          <span
+            aria-disabled={false}
+            className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-2 MuiCheckbox-root makeStyles-root-1 PrivateSwitchBase-checked-3 Mui-checked"
+            onBlur={[Function]}
+            onDragLeave={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+            onTouchEnd={[Function]}
+            onTouchMove={[Function]}
+            onTouchStart={[Function]}
+            tabIndex={null}
+          >
+            <span
+              className="MuiIconButton-label"
+            >
+              <input
+                checked={true}
+                className="PrivateSwitchBase-input-5"
+                data-indeterminate={false}
+                id="resources"
+                name="resources"
+                onChange={[Function]}
+                type="checkbox"
+              />
+              <svg
+                aria-hidden={true}
+                className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2V5c0-1.1-.89-2-2-2zm-9 14l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
+                />
+              </svg>
+            </span>
+          </span>
+          <span
+            className="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
+          >
+            Resources
+          </span>
+        </label>
+        <label
+          className="MuiFormControlLabel-root"
+        >
+          <span
+            aria-disabled={false}
+            className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-2 MuiCheckbox-root makeStyles-root-1 PrivateSwitchBase-checked-3 Mui-checked"
+            onBlur={[Function]}
+            onDragLeave={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+            onTouchEnd={[Function]}
+            onTouchMove={[Function]}
+            onTouchStart={[Function]}
+            tabIndex={null}
+          >
+            <span
+              className="MuiIconButton-label"
+            >
+              <input
+                checked={true}
+                className="PrivateSwitchBase-input-5"
+                data-indeterminate={false}
+                id="tests"
+                name="tests"
+                onChange={[Function]}
+                type="checkbox"
+              />
+              <svg
+                aria-hidden={true}
+                className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2V5c0-1.1-.89-2-2-2zm-9 14l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
+                />
+              </svg>
+            </span>
+          </span>
+          <span
+            className="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
+          >
+            Tests
+          </span>
+        </label>
+      </ul>
+      <button
+        className="sc-dlfnbm hYhRhc"
+        onClick={[Function]}
+      >
+        Alerts on Top
+      </button>
+    </div>
     <div>
       <div
         className="sc-hHftDr keXJQh"
@@ -916,6 +1158,130 @@ exports[`sidebar renders list of resources 1`] = `
           </div>
         </li>
       </ul>
+    </div>
+    <div
+      className="sc-bdfBwQ jYVSUn"
+      style={
+        Object {
+          "marginBottom": "-16px",
+          "marginTop": "24px",
+        }
+      }
+    >
+      <ul
+        className="sc-gsTCUz jipOPh"
+      >
+        <label
+          className="MuiFormControlLabel-root"
+        >
+          <span
+            aria-disabled={false}
+            className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-2 MuiCheckbox-root makeStyles-root-1 PrivateSwitchBase-checked-3 Mui-checked"
+            onBlur={[Function]}
+            onDragLeave={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+            onTouchEnd={[Function]}
+            onTouchMove={[Function]}
+            onTouchStart={[Function]}
+            tabIndex={null}
+          >
+            <span
+              className="MuiIconButton-label"
+            >
+              <input
+                checked={true}
+                className="PrivateSwitchBase-input-5"
+                data-indeterminate={false}
+                id="resources"
+                name="resources"
+                onChange={[Function]}
+                type="checkbox"
+              />
+              <svg
+                aria-hidden={true}
+                className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2V5c0-1.1-.89-2-2-2zm-9 14l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
+                />
+              </svg>
+            </span>
+            <span
+              className="MuiTouchRipple-root"
+            />
+          </span>
+          <span
+            className="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
+          >
+            Resources
+          </span>
+        </label>
+        <label
+          className="MuiFormControlLabel-root"
+        >
+          <span
+            aria-disabled={false}
+            className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-2 MuiCheckbox-root makeStyles-root-1 PrivateSwitchBase-checked-3 Mui-checked"
+            onBlur={[Function]}
+            onDragLeave={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+            onTouchEnd={[Function]}
+            onTouchMove={[Function]}
+            onTouchStart={[Function]}
+            tabIndex={null}
+          >
+            <span
+              className="MuiIconButton-label"
+            >
+              <input
+                checked={true}
+                className="PrivateSwitchBase-input-5"
+                data-indeterminate={false}
+                id="tests"
+                name="tests"
+                onChange={[Function]}
+                type="checkbox"
+              />
+              <svg
+                aria-hidden={true}
+                className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2V5c0-1.1-.89-2-2-2zm-9 14l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
+                />
+              </svg>
+            </span>
+            <span
+              className="MuiTouchRipple-root"
+            />
+          </span>
+          <span
+            className="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
+          >
+            Tests
+          </span>
+        </label>
+      </ul>
+      <button
+        className="sc-dlfnbm hYhRhc"
+        onClick={[Function]}
+      >
+        Alerts on Top
+      </button>
     </div>
     <div>
       <div
@@ -1195,6 +1561,130 @@ exports[`sidebar renders resources that haven't been built yet 1`] = `
           </div>
         </li>
       </ul>
+    </div>
+    <div
+      className="sc-bdfBwQ jYVSUn"
+      style={
+        Object {
+          "marginBottom": "-16px",
+          "marginTop": "24px",
+        }
+      }
+    >
+      <ul
+        className="sc-gsTCUz jipOPh"
+      >
+        <label
+          className="MuiFormControlLabel-root"
+        >
+          <span
+            aria-disabled={false}
+            className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-2 MuiCheckbox-root makeStyles-root-1 PrivateSwitchBase-checked-3 Mui-checked"
+            onBlur={[Function]}
+            onDragLeave={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+            onTouchEnd={[Function]}
+            onTouchMove={[Function]}
+            onTouchStart={[Function]}
+            tabIndex={null}
+          >
+            <span
+              className="MuiIconButton-label"
+            >
+              <input
+                checked={true}
+                className="PrivateSwitchBase-input-5"
+                data-indeterminate={false}
+                id="resources"
+                name="resources"
+                onChange={[Function]}
+                type="checkbox"
+              />
+              <svg
+                aria-hidden={true}
+                className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2V5c0-1.1-.89-2-2-2zm-9 14l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
+                />
+              </svg>
+            </span>
+            <span
+              className="MuiTouchRipple-root"
+            />
+          </span>
+          <span
+            className="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
+          >
+            Resources
+          </span>
+        </label>
+        <label
+          className="MuiFormControlLabel-root"
+        >
+          <span
+            aria-disabled={false}
+            className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-2 MuiCheckbox-root makeStyles-root-1 PrivateSwitchBase-checked-3 Mui-checked"
+            onBlur={[Function]}
+            onDragLeave={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+            onTouchEnd={[Function]}
+            onTouchMove={[Function]}
+            onTouchStart={[Function]}
+            tabIndex={null}
+          >
+            <span
+              className="MuiIconButton-label"
+            >
+              <input
+                checked={true}
+                className="PrivateSwitchBase-input-5"
+                data-indeterminate={false}
+                id="tests"
+                name="tests"
+                onChange={[Function]}
+                type="checkbox"
+              />
+              <svg
+                aria-hidden={true}
+                className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.11 0 2-.9 2-2V5c0-1.1-.89-2-2-2zm-9 14l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
+                />
+              </svg>
+            </span>
+            <span
+              className="MuiTouchRipple-root"
+            />
+          </span>
+          <span
+            className="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
+          >
+            Tests
+          </span>
+        </label>
+      </ul>
+      <button
+        className="sc-dlfnbm hYhRhc"
+        onClick={[Function]}
+      >
+        Alerts on Top
+      </button>
     </div>
     <div>
       <div


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/7453991/107390821-1565e400-6ac6-11eb-90ca-044ec0f32aed.png)

I'm not sure if it's poor form to simply set `visibility: hidden` rather than omit the checkboxes entirely - it's certainly vastly easier than changing a bunch of css to keep the 'alerts on top' toggle in place when the filter checkboxes are absent.