### PR TITLE
web: Fix Sidebar item layout bugs

### DIFF
--- a/web/src/OverviewItemView.tsx
+++ b/web/src/OverviewItemView.tsx
@@ -188,7 +188,7 @@ let RuntimeBoxStack = styled.div`
   flex-grow: 1;
   flex-shrink: 1;
   // To truncate long resource names…
-  min-width: 0; // Override default that accomodates width of content
+  min-width: 0; // Override default, so width can be less than content
 `
 
 let InnerRuntimeBox = styled.div`

--- a/web/src/OverviewItemView.tsx
+++ b/web/src/OverviewItemView.tsx
@@ -187,6 +187,8 @@ let RuntimeBoxStack = styled.div`
   flex-direction: column;
   flex-grow: 1;
   flex-shrink: 1;
+  // To truncate long resource names…
+  min-width: 0; // Override default that accomodates width of content
 `
 
 let InnerRuntimeBox = styled.div`
@@ -219,9 +221,6 @@ let OverviewItemNameRoot = styled(OverviewItemText)`
   font-family: ${Font.sansSerif};
   font-weight: 600;
   z-index: 1; // Appear above the .isBuilding gradient
-  // TODO: Allow flex-grow: 1 to work with text truncation
-  // For now, a hack that sacrifices some width but ensures truncation:
-  max-width: 240px;
 `
 
 let OverviewItemNameTruncate = styled.span`

--- a/web/src/SidebarIcon.tsx
+++ b/web/src/SidebarIcon.tsx
@@ -46,6 +46,7 @@ let glowDark = keyframes`
 
 let SidebarIconRoot = styled.div`
   display: flex;
+  flex-shrink: 0;
   align-items: center;
   justify-content: center;
   width: ${Width.statusIcon}px;

--- a/web/src/SidebarItemView.tsx
+++ b/web/src/SidebarItemView.tsx
@@ -98,7 +98,7 @@ let SidebarItemInnerBox = styled.div`
   flex-direction: column;
   flex-grow: 1;
   // To truncate long resource names…
-  min-width: 0; // Override default that accomodates width of content
+  min-width: 0; // Override default, so width can be less than content
 `
 
 let SidebarItemRuntimeBox = styled.div`

--- a/web/src/SidebarItemView.tsx
+++ b/web/src/SidebarItemView.tsx
@@ -97,6 +97,9 @@ let SidebarItemInnerBox = styled.div`
   display: flex;
   flex-direction: column;
   flex-grow: 1;
+  // Long Resource names need to be truncated.
+  // Override default where flex item can't be less wide than its content:
+  min-width: 0;
 `
 
 let SidebarItemRuntimeBox = styled.div`
@@ -121,13 +124,15 @@ let SidebarItemBuildBox = styled.div`
 let SidebarItemText = styled.div`
   display: flex;
   align-items: center;
-  flex-grow: 1;
   white-space: nowrap;
   overflow: hidden;
   opacity: ${ColorAlpha.almostOpaque};
-  // TODO: Allow flex-grow: 1 to work with text truncation
-  // For now, a hack that sacrifices some width but ensures truncation:
-  max-width: 140px;
+`
+
+let SidebarPinBox = styled.div`
+  display: flex;
+  align-items: stretch;
+  flex-grow: 1;
 `
 
 let SidebarItemAllRoot = styled(SidebarItemRoot)`
@@ -204,6 +209,7 @@ let SidebarItemTimeAgo = styled.span`
 let SidebarItemActions = styled.div`
   display: flex;
   flex-direction: column;
+  flex-shrink: 0;
 `
 
 export function triggerUpdate(name: string, action: string) {
@@ -343,7 +349,9 @@ export default function SidebarItemView(props: SidebarItemViewProps) {
               alertCount={item.runtimeAlertCount}
             />
             <SidebarItemName name={item.name} />
-            <SidebarPinButton resourceName={item.name} />
+            <SidebarPinBox>
+              <SidebarPinButton resourceName={item.name} />
+            </SidebarPinBox>
             <SidebarItemTimeAgo>
               {hasSuccessfullyDeployed ? timeAgo : "—"}
             </SidebarItemTimeAgo>

--- a/web/src/SidebarItemView.tsx
+++ b/web/src/SidebarItemView.tsx
@@ -97,9 +97,8 @@ let SidebarItemInnerBox = styled.div`
   display: flex;
   flex-direction: column;
   flex-grow: 1;
-  // Long Resource names need to be truncated.
-  // Override default where flex item can't be less wide than its content:
-  min-width: 0;
+  // To truncate long resource names…
+  min-width: 0; // Override default that accomodates width of content
 `
 
 let SidebarItemRuntimeBox = styled.div`

--- a/web/src/SidebarPinButton.tsx
+++ b/web/src/SidebarPinButton.tsx
@@ -10,7 +10,6 @@ let PinButton = styled.button`
   padding: 0;
   background-color: transparent;
   align-items: center;
-  justify-content: flex-start;
   margin-right: 5px;
 `
 

--- a/web/src/__snapshots__/Sidebar.test.tsx.snap
+++ b/web/src/__snapshots__/Sidebar.test.tsx.snap
@@ -2,38 +2,38 @@
 
 exports[`sidebar abbreviates durations under a minute 1`] = `
 <nav
-  className="sc-idOhPF iTKLMY Sidebar-resources "
+  className="sc-dIUggk grSaCL Sidebar-resources "
 >
   <div
-    className="sc-dIUggk"
+    className="sc-hHftDr"
   >
     <div>
       <div
-        className="sc-hHftDr keXJQh"
+        className="sc-dmlrTW iTieuF"
       >
         
       </div>
       <ul
-        className="sc-dmlrTW hlOBcH"
+        className="sc-kfzAmx khbJgg"
       >
         <li
-          className="sc-pFZIQ sc-bqyKva eaCWvj chAPtx"
+          className="sc-pFZIQ sc-kstrdz eaCWvj gajrif"
         >
           <div
-            className="sc-jrAGrp sc-kstrdz ghJJLs ddZWsj isSelected"
+            className="sc-jrAGrp sc-hBEYos ghJJLs gVXwBF isSelected"
             onClick={[Function]}
             role="button"
             tabIndex={-1}
           >
             <div
-              className="sc-hKgILt llJRGz isNone"
+              className="sc-hKgILt iMooxb isNone"
             >
               <svg>
                 checkmark-small.svg
               </svg>
             </div>
             <div
-              className="sc-dQppl sc-hBEYos WObNq iTSjDx"
+              className="sc-dQppl sc-fodVxV frNjEq hMCDIC"
             >
               All
             </div>
@@ -59,12 +59,12 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
     </div>
     <div>
       <div
-        className="sc-hHftDr keXJQh"
+        className="sc-dmlrTW iTieuF"
       >
         resources
       </div>
       <ul
-        className="sc-dmlrTW hlOBcH"
+        className="sc-kfzAmx khbJgg"
       >
         <li
           className="sc-pFZIQ eaCWvj u-showPinOnHover  isBuilding"
@@ -77,14 +77,14 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
             tabIndex={-1}
           >
             <div
-              className="sc-kEjbxe lmWnSg"
+              className="sc-kEjbxe fazjKk"
             >
               <div
                 className="sc-iqHYGH juiiLS"
               >
                 <div
                   aria-describedby={null}
-                  className="sc-hKgILt llJRGz isHealthy"
+                  className="sc-hKgILt iMooxb isHealthy"
                   onBlur={[Function]}
                   onFocus={[Function]}
                   onMouseLeave={[Function]}
@@ -98,28 +98,32 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
                   </span>
                 </div>
                 <div
-                  className="sc-dQppl sc-hBEYos WObNq iTSjDx"
+                  className="sc-dQppl sc-fodVxV frNjEq hMCDIC"
                   title="resource4"
                 >
                   <span
-                    className="sc-fodVxV koVHVI"
+                    className="sc-fFubgz dbrUMP"
                   >
                     resource4
                   </span>
                 </div>
-                <button
-                  className="sc-eCssSg fpUUlJ"
-                  onClick={[Function]}
-                  title="Pin to Top"
+                <div
+                  className="sc-bqyKva eItknN"
                 >
-                  <svg
-                    className="sc-gKsewC MUSWU"
+                  <button
+                    className="sc-eCssSg fZtIvG"
+                    onClick={[Function]}
+                    title="Pin to Top"
                   >
-                    pin.svg
-                  </svg>
-                </button>
+                    <svg
+                      className="sc-gKsewC MUSWU"
+                    >
+                      pin.svg
+                    </svg>
+                  </button>
+                </div>
                 <span
-                  className="sc-fFubgz kVVGTW"
+                  className="sc-bkzZxe dGllbM"
                 >
                   <time
                     dateTime="2017-12-21T15:36:03.000Z"
@@ -134,7 +138,7 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
               >
                 <div
                   aria-describedby={null}
-                  className="sc-hKgILt llJRGz isHealthy"
+                  className="sc-hKgILt iMooxb isHealthy"
                   onBlur={[Function]}
                   onFocus={[Function]}
                   onMouseLeave={[Function]}
@@ -148,14 +152,14 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
                   </span>
                 </div>
                 <div
-                  className="sc-dQppl WObNq"
+                  className="sc-dQppl frNjEq"
                 >
                   Completed in 12s, with issues
                 </div>
               </div>
             </div>
             <div
-              className="sc-bkzZxe ePArPG"
+              className="sc-idOhPF csSihC"
             >
               <button
                 className="sc-iBPRYJ cjfxil"
@@ -186,14 +190,14 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
             tabIndex={-1}
           >
             <div
-              className="sc-kEjbxe lmWnSg"
+              className="sc-kEjbxe fazjKk"
             >
               <div
                 className="sc-iqHYGH juiiLS"
               >
                 <div
                   aria-describedby={null}
-                  className="sc-hKgILt llJRGz isHealthy"
+                  className="sc-hKgILt iMooxb isHealthy"
                   onBlur={[Function]}
                   onFocus={[Function]}
                   onMouseLeave={[Function]}
@@ -207,28 +211,32 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
                   </span>
                 </div>
                 <div
-                  className="sc-dQppl sc-hBEYos WObNq iTSjDx"
+                  className="sc-dQppl sc-fodVxV frNjEq hMCDIC"
                   title="resource9"
                 >
                   <span
-                    className="sc-fodVxV koVHVI"
+                    className="sc-fFubgz dbrUMP"
                   >
                     resource9
                   </span>
                 </div>
-                <button
-                  className="sc-eCssSg fpUUlJ"
-                  onClick={[Function]}
-                  title="Pin to Top"
+                <div
+                  className="sc-bqyKva eItknN"
                 >
-                  <svg
-                    className="sc-gKsewC MUSWU"
+                  <button
+                    className="sc-eCssSg fZtIvG"
+                    onClick={[Function]}
+                    title="Pin to Top"
                   >
-                    pin.svg
-                  </svg>
-                </button>
+                    <svg
+                      className="sc-gKsewC MUSWU"
+                    >
+                      pin.svg
+                    </svg>
+                  </button>
+                </div>
                 <span
-                  className="sc-fFubgz kVVGTW"
+                  className="sc-bkzZxe dGllbM"
                 >
                   <time
                     dateTime="2017-12-21T15:35:58.000Z"
@@ -243,7 +251,7 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
               >
                 <div
                   aria-describedby={null}
-                  className="sc-hKgILt llJRGz isHealthy"
+                  className="sc-hKgILt iMooxb isHealthy"
                   onBlur={[Function]}
                   onFocus={[Function]}
                   onMouseLeave={[Function]}
@@ -257,14 +265,14 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
                   </span>
                 </div>
                 <div
-                  className="sc-dQppl WObNq"
+                  className="sc-dQppl frNjEq"
                 >
                   Completed in 12s, with issues
                 </div>
               </div>
             </div>
             <div
-              className="sc-bkzZxe ePArPG"
+              className="sc-idOhPF csSihC"
             >
               <button
                 className="sc-iBPRYJ cjfxil"
@@ -295,14 +303,14 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
             tabIndex={-1}
           >
             <div
-              className="sc-kEjbxe lmWnSg"
+              className="sc-kEjbxe fazjKk"
             >
               <div
                 className="sc-iqHYGH juiiLS"
               >
                 <div
                   aria-describedby={null}
-                  className="sc-hKgILt llJRGz isHealthy"
+                  className="sc-hKgILt iMooxb isHealthy"
                   onBlur={[Function]}
                   onFocus={[Function]}
                   onMouseLeave={[Function]}
@@ -316,28 +324,32 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
                   </span>
                 </div>
                 <div
-                  className="sc-dQppl sc-hBEYos WObNq iTSjDx"
+                  className="sc-dQppl sc-fodVxV frNjEq hMCDIC"
                   title="resource19"
                 >
                   <span
-                    className="sc-fodVxV koVHVI"
+                    className="sc-fFubgz dbrUMP"
                   >
                     resource19
                   </span>
                 </div>
-                <button
-                  className="sc-eCssSg fpUUlJ"
-                  onClick={[Function]}
-                  title="Pin to Top"
+                <div
+                  className="sc-bqyKva eItknN"
                 >
-                  <svg
-                    className="sc-gKsewC MUSWU"
+                  <button
+                    className="sc-eCssSg fZtIvG"
+                    onClick={[Function]}
+                    title="Pin to Top"
                   >
-                    pin.svg
-                  </svg>
-                </button>
+                    <svg
+                      className="sc-gKsewC MUSWU"
+                    >
+                      pin.svg
+                    </svg>
+                  </button>
+                </div>
                 <span
-                  className="sc-fFubgz kVVGTW"
+                  className="sc-bkzZxe dGllbM"
                 >
                   <time
                     dateTime="2017-12-21T15:35:48.000Z"
@@ -352,7 +364,7 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
               >
                 <div
                   aria-describedby={null}
-                  className="sc-hKgILt llJRGz isHealthy"
+                  className="sc-hKgILt iMooxb isHealthy"
                   onBlur={[Function]}
                   onFocus={[Function]}
                   onMouseLeave={[Function]}
@@ -366,14 +378,14 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
                   </span>
                 </div>
                 <div
-                  className="sc-dQppl WObNq"
+                  className="sc-dQppl frNjEq"
                 >
                   Completed in 12s, with issues
                 </div>
               </div>
             </div>
             <div
-              className="sc-bkzZxe ePArPG"
+              className="sc-idOhPF csSihC"
             >
               <button
                 className="sc-iBPRYJ cjfxil"
@@ -404,14 +416,14 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
             tabIndex={-1}
           >
             <div
-              className="sc-kEjbxe lmWnSg"
+              className="sc-kEjbxe fazjKk"
             >
               <div
                 className="sc-iqHYGH juiiLS"
               >
                 <div
                   aria-describedby={null}
-                  className="sc-hKgILt llJRGz isHealthy"
+                  className="sc-hKgILt iMooxb isHealthy"
                   onBlur={[Function]}
                   onFocus={[Function]}
                   onMouseLeave={[Function]}
@@ -425,28 +437,32 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
                   </span>
                 </div>
                 <div
-                  className="sc-dQppl sc-hBEYos WObNq iTSjDx"
+                  className="sc-dQppl sc-fodVxV frNjEq hMCDIC"
                   title="resource29"
                 >
                   <span
-                    className="sc-fodVxV koVHVI"
+                    className="sc-fFubgz dbrUMP"
                   >
                     resource29
                   </span>
                 </div>
-                <button
-                  className="sc-eCssSg fpUUlJ"
-                  onClick={[Function]}
-                  title="Pin to Top"
+                <div
+                  className="sc-bqyKva eItknN"
                 >
-                  <svg
-                    className="sc-gKsewC MUSWU"
+                  <button
+                    className="sc-eCssSg fZtIvG"
+                    onClick={[Function]}
+                    title="Pin to Top"
                   >
-                    pin.svg
-                  </svg>
-                </button>
+                    <svg
+                      className="sc-gKsewC MUSWU"
+                    >
+                      pin.svg
+                    </svg>
+                  </button>
+                </div>
                 <span
-                  className="sc-fFubgz kVVGTW"
+                  className="sc-bkzZxe dGllbM"
                 >
                   <time
                     dateTime="2017-12-21T15:35:38.000Z"
@@ -461,7 +477,7 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
               >
                 <div
                   aria-describedby={null}
-                  className="sc-hKgILt llJRGz isHealthy"
+                  className="sc-hKgILt iMooxb isHealthy"
                   onBlur={[Function]}
                   onFocus={[Function]}
                   onMouseLeave={[Function]}
@@ -475,14 +491,14 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
                   </span>
                 </div>
                 <div
-                  className="sc-dQppl WObNq"
+                  className="sc-dQppl frNjEq"
                 >
                   Completed in 12s, with issues
                 </div>
               </div>
             </div>
             <div
-              className="sc-bkzZxe ePArPG"
+              className="sc-idOhPF csSihC"
             >
               <button
                 className="sc-iBPRYJ cjfxil"
@@ -513,14 +529,14 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
             tabIndex={-1}
           >
             <div
-              className="sc-kEjbxe lmWnSg"
+              className="sc-kEjbxe fazjKk"
             >
               <div
                 className="sc-iqHYGH juiiLS"
               >
                 <div
                   aria-describedby={null}
-                  className="sc-hKgILt llJRGz isHealthy"
+                  className="sc-hKgILt iMooxb isHealthy"
                   onBlur={[Function]}
                   onFocus={[Function]}
                   onMouseLeave={[Function]}
@@ -534,28 +550,32 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
                   </span>
                 </div>
                 <div
-                  className="sc-dQppl sc-hBEYos WObNq iTSjDx"
+                  className="sc-dQppl sc-fodVxV frNjEq hMCDIC"
                   title="resource39"
                 >
                   <span
-                    className="sc-fodVxV koVHVI"
+                    className="sc-fFubgz dbrUMP"
                   >
                     resource39
                   </span>
                 </div>
-                <button
-                  className="sc-eCssSg fpUUlJ"
-                  onClick={[Function]}
-                  title="Pin to Top"
+                <div
+                  className="sc-bqyKva eItknN"
                 >
-                  <svg
-                    className="sc-gKsewC MUSWU"
+                  <button
+                    className="sc-eCssSg fZtIvG"
+                    onClick={[Function]}
+                    title="Pin to Top"
                   >
-                    pin.svg
-                  </svg>
-                </button>
+                    <svg
+                      className="sc-gKsewC MUSWU"
+                    >
+                      pin.svg
+                    </svg>
+                  </button>
+                </div>
                 <span
-                  className="sc-fFubgz kVVGTW"
+                  className="sc-bkzZxe dGllbM"
                 >
                   <time
                     dateTime="2017-12-21T15:35:28.000Z"
@@ -570,7 +590,7 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
               >
                 <div
                   aria-describedby={null}
-                  className="sc-hKgILt llJRGz isHealthy"
+                  className="sc-hKgILt iMooxb isHealthy"
                   onBlur={[Function]}
                   onFocus={[Function]}
                   onMouseLeave={[Function]}
@@ -584,14 +604,14 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
                   </span>
                 </div>
                 <div
-                  className="sc-dQppl WObNq"
+                  className="sc-dQppl frNjEq"
                 >
                   Completed in 12s, with issues
                 </div>
               </div>
             </div>
             <div
-              className="sc-bkzZxe ePArPG"
+              className="sc-idOhPF csSihC"
             >
               <button
                 className="sc-iBPRYJ cjfxil"
@@ -622,14 +642,14 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
             tabIndex={-1}
           >
             <div
-              className="sc-kEjbxe lmWnSg"
+              className="sc-kEjbxe fazjKk"
             >
               <div
                 className="sc-iqHYGH juiiLS"
               >
                 <div
                   aria-describedby={null}
-                  className="sc-hKgILt llJRGz isHealthy"
+                  className="sc-hKgILt iMooxb isHealthy"
                   onBlur={[Function]}
                   onFocus={[Function]}
                   onMouseLeave={[Function]}
@@ -643,28 +663,32 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
                   </span>
                 </div>
                 <div
-                  className="sc-dQppl sc-hBEYos WObNq iTSjDx"
+                  className="sc-dQppl sc-fodVxV frNjEq hMCDIC"
                   title="resource49"
                 >
                   <span
-                    className="sc-fodVxV koVHVI"
+                    className="sc-fFubgz dbrUMP"
                   >
                     resource49
                   </span>
                 </div>
-                <button
-                  className="sc-eCssSg fpUUlJ"
-                  onClick={[Function]}
-                  title="Pin to Top"
+                <div
+                  className="sc-bqyKva eItknN"
                 >
-                  <svg
-                    className="sc-gKsewC MUSWU"
+                  <button
+                    className="sc-eCssSg fZtIvG"
+                    onClick={[Function]}
+                    title="Pin to Top"
                   >
-                    pin.svg
-                  </svg>
-                </button>
+                    <svg
+                      className="sc-gKsewC MUSWU"
+                    >
+                      pin.svg
+                    </svg>
+                  </button>
+                </div>
                 <span
-                  className="sc-fFubgz kVVGTW"
+                  className="sc-bkzZxe dGllbM"
                 >
                   <time
                     dateTime="2017-12-21T15:35:18.000Z"
@@ -679,7 +703,7 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
               >
                 <div
                   aria-describedby={null}
-                  className="sc-hKgILt llJRGz isHealthy"
+                  className="sc-hKgILt iMooxb isHealthy"
                   onBlur={[Function]}
                   onFocus={[Function]}
                   onMouseLeave={[Function]}
@@ -693,14 +717,14 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
                   </span>
                 </div>
                 <div
-                  className="sc-dQppl WObNq"
+                  className="sc-dQppl frNjEq"
                 >
                   Completed in 12s, with issues
                 </div>
               </div>
             </div>
             <div
-              className="sc-bkzZxe ePArPG"
+              className="sc-idOhPF csSihC"
             >
               <button
                 className="sc-iBPRYJ cjfxil"
@@ -731,14 +755,14 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
             tabIndex={-1}
           >
             <div
-              className="sc-kEjbxe lmWnSg"
+              className="sc-kEjbxe fazjKk"
             >
               <div
                 className="sc-iqHYGH juiiLS"
               >
                 <div
                   aria-describedby={null}
-                  className="sc-hKgILt llJRGz isHealthy"
+                  className="sc-hKgILt iMooxb isHealthy"
                   onBlur={[Function]}
                   onFocus={[Function]}
                   onMouseLeave={[Function]}
@@ -752,28 +776,32 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
                   </span>
                 </div>
                 <div
-                  className="sc-dQppl sc-hBEYos WObNq iTSjDx"
+                  className="sc-dQppl sc-fodVxV frNjEq hMCDIC"
                   title="resource54"
                 >
                   <span
-                    className="sc-fodVxV koVHVI"
+                    className="sc-fFubgz dbrUMP"
                   >
                     resource54
                   </span>
                 </div>
-                <button
-                  className="sc-eCssSg fpUUlJ"
-                  onClick={[Function]}
-                  title="Pin to Top"
+                <div
+                  className="sc-bqyKva eItknN"
                 >
-                  <svg
-                    className="sc-gKsewC MUSWU"
+                  <button
+                    className="sc-eCssSg fZtIvG"
+                    onClick={[Function]}
+                    title="Pin to Top"
                   >
-                    pin.svg
-                  </svg>
-                </button>
+                    <svg
+                      className="sc-gKsewC MUSWU"
+                    >
+                      pin.svg
+                    </svg>
+                  </button>
+                </div>
                 <span
-                  className="sc-fFubgz kVVGTW"
+                  className="sc-bkzZxe dGllbM"
                 >
                   <time
                     dateTime="2017-12-21T15:35:13.000Z"
@@ -788,7 +816,7 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
               >
                 <div
                   aria-describedby={null}
-                  className="sc-hKgILt llJRGz isHealthy"
+                  className="sc-hKgILt iMooxb isHealthy"
                   onBlur={[Function]}
                   onFocus={[Function]}
                   onMouseLeave={[Function]}
@@ -802,14 +830,14 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
                   </span>
                 </div>
                 <div
-                  className="sc-dQppl WObNq"
+                  className="sc-dQppl frNjEq"
                 >
                   Completed in 12s, with issues
                 </div>
               </div>
             </div>
             <div
-              className="sc-bkzZxe ePArPG"
+              className="sc-idOhPF csSihC"
             >
               <button
                 className="sc-iBPRYJ cjfxil"
@@ -838,38 +866,38 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
 
 exports[`sidebar renders empty resource list without crashing 1`] = `
 <nav
-  className="sc-idOhPF iTKLMY Sidebar-resources "
+  className="sc-dIUggk grSaCL Sidebar-resources "
 >
   <div
-    className="sc-dIUggk"
+    className="sc-hHftDr"
   >
     <div>
       <div
-        className="sc-hHftDr keXJQh"
+        className="sc-dmlrTW iTieuF"
       >
         
       </div>
       <ul
-        className="sc-dmlrTW hlOBcH"
+        className="sc-kfzAmx khbJgg"
       >
         <li
-          className="sc-pFZIQ sc-bqyKva eaCWvj chAPtx"
+          className="sc-pFZIQ sc-kstrdz eaCWvj gajrif"
         >
           <div
-            className="sc-jrAGrp sc-kstrdz ghJJLs ddZWsj isSelected"
+            className="sc-jrAGrp sc-hBEYos ghJJLs gVXwBF isSelected"
             onClick={[Function]}
             role="button"
             tabIndex={-1}
           >
             <div
-              className="sc-hKgILt llJRGz isNone"
+              className="sc-hKgILt iMooxb isNone"
             >
               <svg>
                 checkmark-small.svg
               </svg>
             </div>
             <div
-              className="sc-dQppl sc-hBEYos WObNq iTSjDx"
+              className="sc-dQppl sc-fodVxV frNjEq hMCDIC"
             >
               All
             </div>
@@ -895,12 +923,12 @@ exports[`sidebar renders empty resource list without crashing 1`] = `
     </div>
     <div>
       <div
-        className="sc-hHftDr keXJQh"
+        className="sc-dmlrTW iTieuF"
       >
         resources
       </div>
       <ul
-        className="sc-dmlrTW hlOBcH"
+        className="sc-kfzAmx khbJgg"
       />
     </div>
   </div>
@@ -910,38 +938,38 @@ exports[`sidebar renders empty resource list without crashing 1`] = `
 
 exports[`sidebar renders list of resources 1`] = `
 <nav
-  className="sc-idOhPF iTKLMY Sidebar-resources "
+  className="sc-dIUggk grSaCL Sidebar-resources "
 >
   <div
-    className="sc-dIUggk"
+    className="sc-hHftDr"
   >
     <div>
       <div
-        className="sc-hHftDr keXJQh"
+        className="sc-dmlrTW iTieuF"
       >
         
       </div>
       <ul
-        className="sc-dmlrTW hlOBcH"
+        className="sc-kfzAmx khbJgg"
       >
         <li
-          className="sc-pFZIQ sc-bqyKva eaCWvj chAPtx"
+          className="sc-pFZIQ sc-kstrdz eaCWvj gajrif"
         >
           <div
-            className="sc-jrAGrp sc-kstrdz ghJJLs ddZWsj isSelected"
+            className="sc-jrAGrp sc-hBEYos ghJJLs gVXwBF isSelected"
             onClick={[Function]}
             role="button"
             tabIndex={-1}
           >
             <div
-              className="sc-hKgILt llJRGz isNone"
+              className="sc-hKgILt iMooxb isNone"
             >
               <svg>
                 checkmark-small.svg
               </svg>
             </div>
             <div
-              className="sc-dQppl sc-hBEYos WObNq iTSjDx"
+              className="sc-dQppl sc-fodVxV frNjEq hMCDIC"
             >
               All
             </div>
@@ -967,12 +995,12 @@ exports[`sidebar renders list of resources 1`] = `
     </div>
     <div>
       <div
-        className="sc-hHftDr keXJQh"
+        className="sc-dmlrTW iTieuF"
       >
         resources
       </div>
       <ul
-        className="sc-dmlrTW hlOBcH"
+        className="sc-kfzAmx khbJgg"
       >
         <li
           className="sc-pFZIQ eaCWvj u-showPinOnHover  isBuilding"
@@ -985,14 +1013,14 @@ exports[`sidebar renders list of resources 1`] = `
             tabIndex={-1}
           >
             <div
-              className="sc-kEjbxe lmWnSg"
+              className="sc-kEjbxe fazjKk"
             >
               <div
                 className="sc-iqHYGH juiiLS"
               >
                 <div
                   aria-describedby={null}
-                  className="sc-hKgILt llJRGz isHealthy"
+                  className="sc-hKgILt iMooxb isHealthy"
                   onBlur={[Function]}
                   onFocus={[Function]}
                   onMouseLeave={[Function]}
@@ -1006,28 +1034,32 @@ exports[`sidebar renders list of resources 1`] = `
                   </span>
                 </div>
                 <div
-                  className="sc-dQppl sc-hBEYos WObNq iTSjDx"
+                  className="sc-dQppl sc-fodVxV frNjEq hMCDIC"
                   title="vigoda"
                 >
                   <span
-                    className="sc-fodVxV koVHVI"
+                    className="sc-fFubgz dbrUMP"
                   >
                     vigoda
                   </span>
                 </div>
-                <button
-                  className="sc-eCssSg fpUUlJ"
-                  onClick={[Function]}
-                  title="Pin to Top"
+                <div
+                  className="sc-bqyKva eItknN"
                 >
-                  <svg
-                    className="sc-gKsewC MUSWU"
+                  <button
+                    className="sc-eCssSg fZtIvG"
+                    onClick={[Function]}
+                    title="Pin to Top"
                   >
-                    pin.svg
-                  </svg>
-                </button>
+                    <svg
+                      className="sc-gKsewC MUSWU"
+                    >
+                      pin.svg
+                    </svg>
+                  </button>
+                </div>
                 <span
-                  className="sc-fFubgz kVVGTW"
+                  className="sc-bkzZxe dGllbM"
                 >
                   <time
                     dateTime="2017-12-21T15:36:07.000Z"
@@ -1042,7 +1074,7 @@ exports[`sidebar renders list of resources 1`] = `
               >
                 <div
                   aria-describedby={null}
-                  className="sc-hKgILt llJRGz isUnhealthy"
+                  className="sc-hKgILt iMooxb isUnhealthy"
                   onBlur={[Function]}
                   onFocus={[Function]}
                   onMouseLeave={[Function]}
@@ -1058,14 +1090,14 @@ exports[`sidebar renders list of resources 1`] = `
                   </svg>
                 </div>
                 <div
-                  className="sc-dQppl WObNq"
+                  className="sc-dQppl frNjEq"
                 >
                   Update error
                 </div>
               </div>
             </div>
             <div
-              className="sc-bkzZxe ePArPG"
+              className="sc-idOhPF csSihC"
             >
               <button
                 className="sc-iBPRYJ cjfxil"
@@ -1096,14 +1128,14 @@ exports[`sidebar renders list of resources 1`] = `
             tabIndex={-1}
           >
             <div
-              className="sc-kEjbxe lmWnSg"
+              className="sc-kEjbxe fazjKk"
             >
               <div
                 className="sc-iqHYGH juiiLS"
               >
                 <div
                   aria-describedby={null}
-                  className="sc-hKgILt llJRGz isHealthy"
+                  className="sc-hKgILt iMooxb isHealthy"
                   onBlur={[Function]}
                   onFocus={[Function]}
                   onMouseLeave={[Function]}
@@ -1117,28 +1149,32 @@ exports[`sidebar renders list of resources 1`] = `
                   </span>
                 </div>
                 <div
-                  className="sc-dQppl sc-hBEYos WObNq iTSjDx"
+                  className="sc-dQppl sc-fodVxV frNjEq hMCDIC"
                   title="snack"
                 >
                   <span
-                    className="sc-fodVxV koVHVI"
+                    className="sc-fFubgz dbrUMP"
                   >
                     snack
                   </span>
                 </div>
-                <button
-                  className="sc-eCssSg fpUUlJ"
-                  onClick={[Function]}
-                  title="Pin to Top"
+                <div
+                  className="sc-bqyKva eItknN"
                 >
-                  <svg
-                    className="sc-gKsewC MUSWU"
+                  <button
+                    className="sc-eCssSg fZtIvG"
+                    onClick={[Function]}
+                    title="Pin to Top"
                   >
-                    pin.svg
-                  </svg>
-                </button>
+                    <svg
+                      className="sc-gKsewC MUSWU"
+                    >
+                      pin.svg
+                    </svg>
+                  </button>
+                </div>
                 <span
-                  className="sc-fFubgz kVVGTW"
+                  className="sc-bkzZxe dGllbM"
                 >
                   <time
                     dateTime="2017-12-21T15:35:57.000Z"
@@ -1153,7 +1189,7 @@ exports[`sidebar renders list of resources 1`] = `
               >
                 <div
                   aria-describedby={null}
-                  className="sc-hKgILt llJRGz isUnhealthy"
+                  className="sc-hKgILt iMooxb isUnhealthy"
                   onBlur={[Function]}
                   onFocus={[Function]}
                   onMouseLeave={[Function]}
@@ -1169,14 +1205,14 @@ exports[`sidebar renders list of resources 1`] = `
                   </svg>
                 </div>
                 <div
-                  className="sc-dQppl WObNq"
+                  className="sc-dQppl frNjEq"
                 >
                   Update error
                 </div>
               </div>
             </div>
             <div
-              className="sc-bkzZxe ePArPG"
+              className="sc-idOhPF csSihC"
             >
               <button
                 className="sc-iBPRYJ cjfxil"
@@ -1205,38 +1241,38 @@ exports[`sidebar renders list of resources 1`] = `
 
 exports[`sidebar renders resources that haven't been built yet 1`] = `
 <nav
-  className="sc-idOhPF iTKLMY Sidebar-resources "
+  className="sc-dIUggk grSaCL Sidebar-resources "
 >
   <div
-    className="sc-dIUggk"
+    className="sc-hHftDr"
   >
     <div>
       <div
-        className="sc-hHftDr keXJQh"
+        className="sc-dmlrTW iTieuF"
       >
         
       </div>
       <ul
-        className="sc-dmlrTW hlOBcH"
+        className="sc-kfzAmx khbJgg"
       >
         <li
-          className="sc-pFZIQ sc-bqyKva eaCWvj chAPtx"
+          className="sc-pFZIQ sc-kstrdz eaCWvj gajrif"
         >
           <div
-            className="sc-jrAGrp sc-kstrdz ghJJLs ddZWsj isSelected"
+            className="sc-jrAGrp sc-hBEYos ghJJLs gVXwBF isSelected"
             onClick={[Function]}
             role="button"
             tabIndex={-1}
           >
             <div
-              className="sc-hKgILt llJRGz isNone"
+              className="sc-hKgILt iMooxb isNone"
             >
               <svg>
                 checkmark-small.svg
               </svg>
             </div>
             <div
-              className="sc-dQppl sc-hBEYos WObNq iTSjDx"
+              className="sc-dQppl sc-fodVxV frNjEq hMCDIC"
             >
               All
             </div>
@@ -1262,12 +1298,12 @@ exports[`sidebar renders resources that haven't been built yet 1`] = `
     </div>
     <div>
       <div
-        className="sc-hHftDr keXJQh"
+        className="sc-dmlrTW iTieuF"
       >
         resources
       </div>
       <ul
-        className="sc-dmlrTW hlOBcH"
+        className="sc-kfzAmx khbJgg"
       >
         <li
           className="sc-pFZIQ eaCWvj u-showPinOnHover  isBuilding"
@@ -1280,14 +1316,14 @@ exports[`sidebar renders resources that haven't been built yet 1`] = `
             tabIndex={-1}
           >
             <div
-              className="sc-kEjbxe lmWnSg"
+              className="sc-kEjbxe fazjKk"
             >
               <div
                 className="sc-iqHYGH juiiLS"
               >
                 <div
                   aria-describedby={null}
-                  className="sc-hKgILt llJRGz isHealthy"
+                  className="sc-hKgILt iMooxb isHealthy"
                   onBlur={[Function]}
                   onFocus={[Function]}
                   onMouseLeave={[Function]}
@@ -1301,28 +1337,32 @@ exports[`sidebar renders resources that haven't been built yet 1`] = `
                   </span>
                 </div>
                 <div
-                  className="sc-dQppl sc-hBEYos WObNq iTSjDx"
+                  className="sc-dQppl sc-fodVxV frNjEq hMCDIC"
                   title="vigoda"
                 >
                   <span
-                    className="sc-fodVxV koVHVI"
+                    className="sc-fFubgz dbrUMP"
                   >
                     vigoda
                   </span>
                 </div>
-                <button
-                  className="sc-eCssSg fpUUlJ"
-                  onClick={[Function]}
-                  title="Pin to Top"
+                <div
+                  className="sc-bqyKva eItknN"
                 >
-                  <svg
-                    className="sc-gKsewC MUSWU"
+                  <button
+                    className="sc-eCssSg fZtIvG"
+                    onClick={[Function]}
+                    title="Pin to Top"
                   >
-                    pin.svg
-                  </svg>
-                </button>
+                    <svg
+                      className="sc-gKsewC MUSWU"
+                    >
+                      pin.svg
+                    </svg>
+                  </button>
+                </div>
                 <span
-                  className="sc-fFubgz kVVGTW"
+                  className="sc-bkzZxe dGllbM"
                 >
                   —
                 </span>
@@ -1332,7 +1372,7 @@ exports[`sidebar renders resources that haven't been built yet 1`] = `
               >
                 <div
                   aria-describedby={null}
-                  className="sc-hKgILt llJRGz isBuilding"
+                  className="sc-hKgILt iMooxb isBuilding"
                   onBlur={[Function]}
                   onFocus={[Function]}
                   onMouseLeave={[Function]}
@@ -1346,14 +1386,14 @@ exports[`sidebar renders resources that haven't been built yet 1`] = `
                   </span>
                 </div>
                 <div
-                  className="sc-dQppl WObNq"
+                  className="sc-dQppl frNjEq"
                 >
                   Updating…
                 </div>
               </div>
             </div>
             <div
-              className="sc-bkzZxe ePArPG"
+              className="sc-idOhPF csSihC"
             >
               <button
                 className="sc-iBPRYJ cjfxil"
@@ -1384,14 +1424,14 @@ exports[`sidebar renders resources that haven't been built yet 1`] = `
             tabIndex={-1}
           >
             <div
-              className="sc-kEjbxe lmWnSg"
+              className="sc-kEjbxe fazjKk"
             >
               <div
                 className="sc-iqHYGH juiiLS"
               >
                 <div
                   aria-describedby={null}
-                  className="sc-hKgILt llJRGz isHealthy"
+                  className="sc-hKgILt iMooxb isHealthy"
                   onBlur={[Function]}
                   onFocus={[Function]}
                   onMouseLeave={[Function]}
@@ -1405,28 +1445,32 @@ exports[`sidebar renders resources that haven't been built yet 1`] = `
                   </span>
                 </div>
                 <div
-                  className="sc-dQppl sc-hBEYos WObNq iTSjDx"
+                  className="sc-dQppl sc-fodVxV frNjEq hMCDIC"
                   title="snack"
                 >
                   <span
-                    className="sc-fodVxV koVHVI"
+                    className="sc-fFubgz dbrUMP"
                   >
                     snack
                   </span>
                 </div>
-                <button
-                  className="sc-eCssSg fpUUlJ"
-                  onClick={[Function]}
-                  title="Pin to Top"
+                <div
+                  className="sc-bqyKva eItknN"
                 >
-                  <svg
-                    className="sc-gKsewC MUSWU"
+                  <button
+                    className="sc-eCssSg fZtIvG"
+                    onClick={[Function]}
+                    title="Pin to Top"
                   >
-                    pin.svg
-                  </svg>
-                </button>
+                    <svg
+                      className="sc-gKsewC MUSWU"
+                    >
+                      pin.svg
+                    </svg>
+                  </button>
+                </div>
                 <span
-                  className="sc-fFubgz kVVGTW"
+                  className="sc-bkzZxe dGllbM"
                 >
                   —
                 </span>
@@ -1436,7 +1480,7 @@ exports[`sidebar renders resources that haven't been built yet 1`] = `
               >
                 <div
                   aria-describedby={null}
-                  className="sc-hKgILt llJRGz isBuilding"
+                  className="sc-hKgILt iMooxb isBuilding"
                   onBlur={[Function]}
                   onFocus={[Function]}
                   onMouseLeave={[Function]}
@@ -1450,14 +1494,14 @@ exports[`sidebar renders resources that haven't been built yet 1`] = `
                   </span>
                 </div>
                 <div
-                  className="sc-dQppl WObNq"
+                  className="sc-dQppl frNjEq"
                 >
                   Updating…
                 </div>
               </div>
             </div>
             <div
-              className="sc-bkzZxe ePArPG"
+              className="sc-idOhPF csSihC"
             >
               <button
                 className="sc-iBPRYJ cjfxil"

--- a/web/src/__snapshots__/Sidebar.test.tsx.snap
+++ b/web/src/__snapshots__/Sidebar.test.tsx.snap
@@ -77,7 +77,7 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
             tabIndex={-1}
           >
             <div
-              className="sc-kEjbxe fazjKk"
+              className="sc-kEjbxe gpekhu"
             >
               <div
                 className="sc-iqHYGH juiiLS"
@@ -190,7 +190,7 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
             tabIndex={-1}
           >
             <div
-              className="sc-kEjbxe fazjKk"
+              className="sc-kEjbxe gpekhu"
             >
               <div
                 className="sc-iqHYGH juiiLS"
@@ -303,7 +303,7 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
             tabIndex={-1}
           >
             <div
-              className="sc-kEjbxe fazjKk"
+              className="sc-kEjbxe gpekhu"
             >
               <div
                 className="sc-iqHYGH juiiLS"
@@ -416,7 +416,7 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
             tabIndex={-1}
           >
             <div
-              className="sc-kEjbxe fazjKk"
+              className="sc-kEjbxe gpekhu"
             >
               <div
                 className="sc-iqHYGH juiiLS"
@@ -529,7 +529,7 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
             tabIndex={-1}
           >
             <div
-              className="sc-kEjbxe fazjKk"
+              className="sc-kEjbxe gpekhu"
             >
               <div
                 className="sc-iqHYGH juiiLS"
@@ -642,7 +642,7 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
             tabIndex={-1}
           >
             <div
-              className="sc-kEjbxe fazjKk"
+              className="sc-kEjbxe gpekhu"
             >
               <div
                 className="sc-iqHYGH juiiLS"
@@ -755,7 +755,7 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
             tabIndex={-1}
           >
             <div
-              className="sc-kEjbxe fazjKk"
+              className="sc-kEjbxe gpekhu"
             >
               <div
                 className="sc-iqHYGH juiiLS"
@@ -1013,7 +1013,7 @@ exports[`sidebar renders list of resources 1`] = `
             tabIndex={-1}
           >
             <div
-              className="sc-kEjbxe fazjKk"
+              className="sc-kEjbxe gpekhu"
             >
               <div
                 className="sc-iqHYGH juiiLS"
@@ -1128,7 +1128,7 @@ exports[`sidebar renders list of resources 1`] = `
             tabIndex={-1}
           >
             <div
-              className="sc-kEjbxe fazjKk"
+              className="sc-kEjbxe gpekhu"
             >
               <div
                 className="sc-iqHYGH juiiLS"
@@ -1316,7 +1316,7 @@ exports[`sidebar renders resources that haven't been built yet 1`] = `
             tabIndex={-1}
           >
             <div
-              className="sc-kEjbxe fazjKk"
+              className="sc-kEjbxe gpekhu"
             >
               <div
                 className="sc-iqHYGH juiiLS"
@@ -1424,7 +1424,7 @@ exports[`sidebar renders resources that haven't been built yet 1`] = `
             tabIndex={-1}
           >
             <div
-              className="sc-kEjbxe fazjKk"
+              className="sc-kEjbxe gpekhu"
             >
               <div
                 className="sc-iqHYGH juiiLS"


### PR DESCRIPTION
Long resource names no longer break the layout!

| Before | After |
|---|---|
| <img width="323" alt="Screen Shot 2021-02-04 at 5 52 12 PM" src="https://user-images.githubusercontent.com/20349/107713522-6974f200-6c99-11eb-8d4b-8a5090ff4173.png"> | <img width="319" alt="Screen Shot 2021-02-11 at 6 43 50 PM" src="https://user-images.githubusercontent.com/20349/107713575-8c070b00-6c99-11eb-9805-293a52dab69a.png"> |

&nbsp;
Also, the pin position looks more intentional:

| Before | After |
|---|---|
|<img width="357" alt="Screen Shot 2021-02-11 at 6 47 48 PM" src="https://user-images.githubusercontent.com/20349/107713656-bce74000-6c99-11eb-98b5-502cd46a3870.png"> | <img width="332" alt="Screen Shot 2021-02-11 at 6 48 06 PM" src="https://user-images.githubusercontent.com/20349/107713663-c07ac700-6c99-11eb-979c-5e855030a2af.png">|

