### PR TITLE
web: organize storybook sidebar

### DIFF
--- a/web/.storybook/preview.js
+++ b/web/.storybook/preview.js
@@ -1,1 +1,9 @@
 import "../src/index.scss"
+
+export const parameters = {
+  options: {
+    storySort: {
+      order: ['New UI', ['OverviewPane', 'OverviewResourcePane', 'Overview', 'Log View', 'Shared', '_To Review'], 'Legacy UI'], 
+    },
+  },
+};

--- a/web/src/AccountMenu.stories.tsx
+++ b/web/src/AccountMenu.stories.tsx
@@ -15,7 +15,7 @@ let Container = styled.div`
 `
 
 export default {
-  title: "AccountMenu",
+  title: "New UI/_To Review/AccountMenu",
   decorators: [
     (Story: any) => (
       <Container>

--- a/web/src/AccountMenu.stories.tsx
+++ b/web/src/AccountMenu.stories.tsx
@@ -15,7 +15,7 @@ let Container = styled.div`
 `
 
 export default {
-  title: "New UI/_To Review/AccountMenu",
+  title: "New UI/Shared/AccountMenu",
   decorators: [
     (Story: any) => (
       <Container>

--- a/web/src/AnalyticsNudge.stories.tsx
+++ b/web/src/AnalyticsNudge.stories.tsx
@@ -2,7 +2,7 @@ import React from "react"
 import AnalyticsNudge from "./AnalyticsNudge"
 
 export default {
-  title: "AnalyticsNudge",
+  title: "New UI/_To Review/AnalyticsNudge",
 }
 
 export const NeedsNudge = () => <AnalyticsNudge needsNudge={true} />

--- a/web/src/Button.stories.tsx
+++ b/web/src/Button.stories.tsx
@@ -4,7 +4,7 @@ import ButtonInput from "./ButtonInput"
 import ButtonLink from "./ButtonLink"
 
 export default {
-  title: "Button",
+  title: "New UI/_To Review/Button",
 }
 
 let BG = styled.div`

--- a/web/src/FatalErrorModal.stories.tsx
+++ b/web/src/FatalErrorModal.stories.tsx
@@ -6,7 +6,7 @@ const fakeOnClose = () => {}
 const longError = "ERROR\n".repeat(500)
 
 export default {
-  title: "FatalErrorModal",
+  title: "New UI/_To Review/FatalErrorModal",
 }
 
 export const ShortError = () => (

--- a/web/src/HUDLayout.stories.tsx
+++ b/web/src/HUDLayout.stories.tsx
@@ -106,7 +106,7 @@ function layoutTwoLevelNav() {
 }
 
 export default {
-  title: "HUDLayout",
+  title: "Legacy UI/HUDLayout",
 }
 
 export const Default = layoutDefault

--- a/web/src/HeroScreen.stories.tsx
+++ b/web/src/HeroScreen.stories.tsx
@@ -2,7 +2,7 @@ import React from "react"
 import HeroScreen from "./HeroScreen"
 
 export default {
-  title: "HeroScreen",
+  title: "New UI/_To Review/HeroScreen",
 }
 
 export const Loading = () => <HeroScreen message={"Loading…"} />

--- a/web/src/LogPane.stories.tsx
+++ b/web/src/LogPane.stories.tsx
@@ -48,7 +48,7 @@ function threeResources() {
 }
 
 export default {
-  title: "LogPane",
+  title: "Legacy UI/LogPane",
 }
 
 export const ThreeResources = threeResources

--- a/web/src/LogPaneLine.stories.tsx
+++ b/web/src/LogPaneLine.stories.tsx
@@ -68,7 +68,7 @@ function threeLines() {
 }
 
 export default {
-  title: "LogPaneLine",
+  title: "Legacy UI/LogPaneLine",
 }
 
 export const InfoLine = infoLine

--- a/web/src/MetricsDialog.stories.tsx
+++ b/web/src/MetricsDialog.stories.tsx
@@ -2,7 +2,7 @@ import React from "react"
 import MetricsDialog from "./MetricsDialog"
 
 export default {
-  title: "MetricsDialog",
+  title: "New UI/_To Review/MetricsDialog",
   argTypes: { onClose: { action: "closed" } },
 }
 

--- a/web/src/MetricsDialog.stories.tsx
+++ b/web/src/MetricsDialog.stories.tsx
@@ -2,7 +2,7 @@ import React from "react"
 import MetricsDialog from "./MetricsDialog"
 
 export default {
-  title: "New UI/_To Review/MetricsDialog",
+  title: "New UI/Shared/MetricsDialog",
   argTypes: { onClose: { action: "closed" } },
 }
 

--- a/web/src/MetricsPane.stories.tsx
+++ b/web/src/MetricsPane.stories.tsx
@@ -20,7 +20,7 @@ function graphs() {
 }
 
 export default {
-  title: "MetricsPane",
+  title: "New UI/_To Review/MetricsPane",
 }
 
 export const Teaser = teaser

--- a/web/src/OverviewActionBar.stories.tsx
+++ b/web/src/OverviewActionBar.stories.tsx
@@ -9,7 +9,7 @@ import { oneResource } from "./testdata"
 type Resource = Proto.webviewResource
 
 export default {
-  title: "OverviewActionBar",
+  title: "New UI/Log View/OverviewActionBar",
   decorators: [
     (Story: any, context: any) => {
       let level = context?.args?.level || ""

--- a/web/src/OverviewGrid.stories.tsx
+++ b/web/src/OverviewGrid.stories.tsx
@@ -7,7 +7,7 @@ import { nResourceView, tenResourceView, twoResourceView } from "./testdata"
 type Resource = Proto.webviewResource
 
 export default {
-  title: "OverviewGrid",
+  title: "New UI/Overview/OverviewGrid",
   decorators: [
     (Story: any) => (
       <MemoryRouter initialEntries={["/"]}>

--- a/web/src/OverviewItemView.stories.tsx
+++ b/web/src/OverviewItemView.stories.tsx
@@ -1,12 +1,12 @@
 import React from "react"
 import { MemoryRouter } from "react-router"
-import OverviewItemView,{
-OverviewItem,
-OverviewItemDetails,
-OverviewItemViewProps
+import OverviewItemView, {
+  OverviewItem,
+  OverviewItemDetails,
+  OverviewItemViewProps,
 } from "./OverviewItemView"
 import { oneResourceNoAlerts } from "./testdata"
-import { ResourceStatus,TriggerMode } from "./types"
+import { ResourceStatus, TriggerMode } from "./types"
 
 type Resource = Proto.webviewResource
 

--- a/web/src/OverviewItemView.stories.tsx
+++ b/web/src/OverviewItemView.stories.tsx
@@ -1,12 +1,12 @@
 import React from "react"
 import { MemoryRouter } from "react-router"
-import OverviewItemView, {
-  OverviewItem,
-  OverviewItemDetails,
-  OverviewItemViewProps,
+import OverviewItemView,{
+OverviewItem,
+OverviewItemDetails,
+OverviewItemViewProps
 } from "./OverviewItemView"
 import { oneResourceNoAlerts } from "./testdata"
-import { ResourceStatus, TriggerMode } from "./types"
+import { ResourceStatus,TriggerMode } from "./types"
 
 type Resource = Proto.webviewResource
 
@@ -81,7 +81,7 @@ function itemView(...options: optionFn[]) {
 }
 
 export default {
-  title: "OverviewItemView",
+  title: "New UI/Overview/OverviewItemView",
   decorators: [
     (Story: any) => (
       <MemoryRouter initialEntries={["/"]}>

--- a/web/src/OverviewLogPane.stories.tsx
+++ b/web/src/OverviewLogPane.stories.tsx
@@ -7,7 +7,7 @@ import { appendLines } from "./testlogs"
 import { LogLevel } from "./types"
 
 export default {
-  title: "OverviewLogPane",
+  title: "New UI/Overview/OverviewLogPane",
   decorators: [
     (Story: any) => (
       <MemoryRouter initialEntries={["/"]}>

--- a/web/src/OverviewPane.stories.tsx
+++ b/web/src/OverviewPane.stories.tsx
@@ -7,7 +7,7 @@ import { nResourceView, tenResourceView, twoResourceView } from "./testdata"
 type Resource = Proto.webviewResource
 
 export default {
-  title: "OverviewPane",
+  title: "New UI/OverviewPane",
   decorators: [
     (Story: any) => (
       <MemoryRouter initialEntries={["/"]}>

--- a/web/src/OverviewResourceBar.stories.tsx
+++ b/web/src/OverviewResourceBar.stories.tsx
@@ -12,7 +12,7 @@ import { UpdateStatus } from "./types"
 type Resource = Proto.webviewResource
 
 export default {
-  title: "OverviewResourceBar",
+  title: "New UI/Shared/OverviewResourceBar",
   decorators: [
     (Story: any) => (
       <MemoryRouter initialEntries={["/"]}>

--- a/web/src/OverviewResourcePane.stories.tsx
+++ b/web/src/OverviewResourcePane.stories.tsx
@@ -9,7 +9,7 @@ import { nResourceView, tenResourceView, twoResourceView } from "./testdata"
 type Resource = Proto.webviewResource
 
 export default {
-  title: "OverviewResourcePane",
+  title: "New UI/OverviewResourcePane",
   decorators: [
     (Story: any) => (
       <MemoryRouter initialEntries={["/"]}>

--- a/web/src/OverviewResourceSidebar.stories.tsx
+++ b/web/src/OverviewResourceSidebar.stories.tsx
@@ -17,7 +17,7 @@ type Resource = Proto.webviewResource
 let pathBuilder = PathBuilder.forTesting("localhost", "/")
 
 export default {
-  title: "OverviewResourceSidebar",
+  title: "New UI/Log View/OverviewResourceSidebar",
   decorators: [
     (Story: any) => (
       <MemoryRouter initialEntries={["/"]}>

--- a/web/src/OverviewTabBar.stories.tsx
+++ b/web/src/OverviewTabBar.stories.tsx
@@ -6,7 +6,7 @@ import { OverviewNavProvider } from "./TabNav"
 type Resource = Proto.webviewResource
 
 export default {
-  title: "OverviewTabBar",
+  title: "New UI/Shared/OverviewTabBar",
   decorators: [
     (Story: any, context: any) => {
       return (

--- a/web/src/SecondaryNav.stories.tsx
+++ b/web/src/SecondaryNav.stories.tsx
@@ -122,7 +122,7 @@ function traceNavLast() {
 }
 
 export default {
-  title: "SecondaryNav",
+  title: "Legacy UI/SecondaryNav",
 }
 
 export const Default = topBarDefault

--- a/web/src/ShareSnapshotModal.stories.tsx
+++ b/web/src/ShareSnapshotModal.stories.tsx
@@ -85,7 +85,7 @@ let withTeam = () => {
 }
 
 export default {
-  title: "ShareSnapshotModal",
+  title: "New UI/_To Review/ShareSnapshotModal",
 }
 
 export const SignedOut = signedOut

--- a/web/src/ShareSnapshotModal.stories.tsx
+++ b/web/src/ShareSnapshotModal.stories.tsx
@@ -85,7 +85,7 @@ let withTeam = () => {
 }
 
 export default {
-  title: "New UI/_To Review/ShareSnapshotModal",
+  title: "New UI/Shared/ShareSnapshotModal",
 }
 
 export const SignedOut = signedOut

--- a/web/src/ShortcutsDialog.stories.tsx
+++ b/web/src/ShortcutsDialog.stories.tsx
@@ -7,7 +7,7 @@ function onRequestClose() {
 }
 
 export default {
-  title: "New UI/_To Review/ShortcutsDialog",
+  title: "New UI/Shared/ShortcutsDialog",
   decorators: [
     (Story: any) => (
       <MemoryRouter initialEntries={["/"]}>

--- a/web/src/ShortcutsDialog.stories.tsx
+++ b/web/src/ShortcutsDialog.stories.tsx
@@ -7,7 +7,7 @@ function onRequestClose() {
 }
 
 export default {
-  title: "ShortcutsDialog",
+  title: "New UI/_To Review/ShortcutsDialog",
   decorators: [
     (Story: any) => (
       <MemoryRouter initialEntries={["/"]}>

--- a/web/src/Sidebar.stories.tsx
+++ b/web/src/Sidebar.stories.tsx
@@ -114,7 +114,7 @@ function oneItemWithStatus(status: ResourceStatus) {
 }
 
 export default {
-  title: "Sidebar",
+  title: "Legacy UI/Sidebar",
   decorators: [
     (Story: any) => (
       <MemoryRouter initialEntries={["/"]}>

--- a/web/src/SidebarAccount.stories.tsx
+++ b/web/src/SidebarAccount.stories.tsx
@@ -2,7 +2,7 @@ import React from "react"
 import SidebarAccount from "./SidebarAccount"
 
 export default {
-  title: "SidebarAccount",
+  title: "Legacy UI/SidebarAccount",
 }
 
 export const Default = () => (

--- a/web/src/SidebarItemView.stories.tsx
+++ b/web/src/SidebarItemView.stories.tsx
@@ -114,7 +114,7 @@ function itemView(...options: optionFn[]) {
 }
 
 export default {
-  title: "SidebarItemView",
+  title: "Legacy UI/SidebarItemView",
   args: { selected: false },
 }
 

--- a/web/src/SocketBar.stories.tsx
+++ b/web/src/SocketBar.stories.tsx
@@ -3,7 +3,7 @@ import SocketBar from "./SocketBar"
 import { SocketState } from "./types"
 
 export default {
-  title: "SocketBar",
+  title: "New UI/_To Review/SocketBar",
 }
 
 export const _Reconnecting = () => (

--- a/web/src/Tooltip.stories.tsx
+++ b/web/src/Tooltip.stories.tsx
@@ -2,7 +2,7 @@ import React from "react"
 import Tooltip from "./Tooltip"
 
 export default {
-  title: "Tooltip",
+  title: "New UI/_To Review/Tooltip",
 }
 
 export const Default = () => (

--- a/web/src/UpdateDialog.stories.tsx
+++ b/web/src/UpdateDialog.stories.tsx
@@ -7,7 +7,7 @@ function onRequestClose() {
 }
 
 export default {
-  title: "UpdateDialog",
+  title: "Legacy UI/UpdateDialog",
 }
 
 export const Dialog = () => (


### PR DESCRIPTION
I wanted to make it easier to browse Storybook!

| Before | After |
|---|---|
|<img width="229" alt="Screen Shot 2021-02-11 at 7 28 50 PM" src="https://user-images.githubusercontent.com/20349/107716553-a80dab00-6c9f-11eb-8f6d-74583912a352.png">|<img width="210" alt="Screen Shot 2021-02-11 at 7 41 36 PM" src="https://user-images.githubusercontent.com/20349/107717267-32a2da00-6ca1-11eb-95a3-1d2a5fa04203.png">|

