### PR TITLE
ui/sidebar: change filter naming and behavior to make it clear that tests are a type of resource [ch11349]

### DIFF
--- a/web/src/OverviewSidebarOptions.test.tsx
+++ b/web/src/OverviewSidebarOptions.test.tsx
@@ -11,8 +11,8 @@ import {
   AlertsOnTopToggle,
   FilterOptionList,
   OverviewSidebarOptions,
-  TestsHiddenSegmentedControl,
-  TestsOnlySegmentedControl,
+  TestsHiddenToggle,
+  TestsOnlyToggle,
 } from "./OverviewSidebarOptions"
 import PathBuilder from "./PathBuilder"
 import SidebarItemView from "./SidebarItemView"
@@ -51,22 +51,22 @@ export function assertSidebarItemsAndOptions(
 
   let optSetter = sidebar.find(OverviewSidebarOptions)
   expect(optSetter).toHaveLength(1)
-  expect(
-    optSetter.find(TestsHiddenSegmentedControl).hasClass("is-enabled")
-  ).toEqual(expectTestsHidden)
-  expect(
-    optSetter.find(TestsOnlySegmentedControl).hasClass("is-enabled")
-  ).toEqual(expectTestsOnly)
+  expect(optSetter.find(TestsHiddenToggle).hasClass("is-enabled")).toEqual(
+    expectTestsHidden
+  )
+  expect(optSetter.find(TestsOnlyToggle).hasClass("is-enabled")).toEqual(
+    expectTestsOnly
+  )
   expect(optSetter.find(AlertsOnTopToggle).hasClass("is-enabled")).toEqual(
     expectAlertsOnTop
   )
 }
 
 function clickTestsHiddenControl(root: ReactWrapper) {
-  root.find(TestsHiddenSegmentedControl).simulate("click")
+  root.find(TestsHiddenToggle).simulate("click")
 }
 function clickTestsOnlyControl(root: ReactWrapper) {
-  root.find(TestsOnlySegmentedControl).simulate("click")
+  root.find(TestsOnlyToggle).simulate("click")
 }
 
 const allNames = ["(Tiltfile)", "vigoda", "snack", "beep", "boop"]

--- a/web/src/OverviewSidebarOptions.test.tsx
+++ b/web/src/OverviewSidebarOptions.test.tsx
@@ -133,7 +133,7 @@ describe("overview sidebar options", () => {
   })
 
   it("shows filter options when no tests are present if filter options are non-default", () => {
-    sidebarOptionsAccessor.set({ ...defaultOptions, showResources: false })
+    sidebarOptionsAccessor.set({ ...defaultOptions, testsHidden: false })
     const root = mount(
       <tiltfileKeyContext.Provider value="test">
         {TwoResources()}

--- a/web/src/OverviewSidebarOptions.tsx
+++ b/web/src/OverviewSidebarOptions.tsx
@@ -39,13 +39,13 @@ const useStyles = makeStyles({
   },
 })
 
-let testFilterControlsBorderRadius = "3px"
+const segmentedControlsBorderRadius = "3px"
 
 const ResourceFilterSegmentedControls = styled.div`
   margin-left: ${SizeUnit(0.25)};
 `
 
-const ResourceFilterSegmentedControl = styled.button`
+const ResourceFilterToggle = styled.button`
   ${mixinResetButtonStyle}
   color: ${Color.grayLightest};
   background-color: ${Color.gray};
@@ -62,16 +62,14 @@ const ResourceFilterSegmentedControl = styled.button`
   }
 `
 
-export const TestsHiddenSegmentedControl = styled(
-  ResourceFilterSegmentedControl
-)`
-  border-top-left-radius: ${testFilterControlsBorderRadius};
-  border-bottom-left-radius: ${testFilterControlsBorderRadius};
+export const TestsHiddenToggle = styled(ResourceFilterToggle)`
+  border-top-left-radius: ${segmentedControlsBorderRadius};
+  border-bottom-left-radius: ${segmentedControlsBorderRadius};
 `
 
-export const TestsOnlySegmentedControl = styled(ResourceFilterSegmentedControl)`
-  border-top-right-radius: ${testFilterControlsBorderRadius};
-  border-bottom-right-radius: ${testFilterControlsBorderRadius};
+export const TestsOnlyToggle = styled(ResourceFilterToggle)`
+  border-top-right-radius: ${segmentedControlsBorderRadius};
+  border-bottom-right-radius: ${segmentedControlsBorderRadius};
 `
 
 export const AlertsOnTopToggle = styled.button`
@@ -133,18 +131,18 @@ function filterOptions(props: OverviewSidebarOptionsProps) {
     <FilterOptionList>
       Tests:
       <ResourceFilterSegmentedControls>
-        <TestsHiddenSegmentedControl
+        <TestsHiddenToggle
           className={props.options.testsHidden ? "is-enabled" : ""}
           onClick={(e) => toggleTestsHidden(props)}
         >
           Hidden
-        </TestsHiddenSegmentedControl>
-        <TestsOnlySegmentedControl
+        </TestsHiddenToggle>
+        <TestsOnlyToggle
           className={props.options.testsOnly ? "is-enabled" : ""}
           onClick={(e) => toggleTestsOnly(props)}
         >
           Only
-        </TestsOnlySegmentedControl>
+        </TestsOnlyToggle>
       </ResourceFilterSegmentedControls>
     </FilterOptionList>
   )

--- a/web/src/OverviewSidebarOptions.tsx
+++ b/web/src/OverviewSidebarOptions.tsx
@@ -1,8 +1,4 @@
-import Checkbox from "@material-ui/core/Checkbox"
-import FormControlLabel from "@material-ui/core/FormControlLabel"
 import { makeStyles } from "@material-ui/core/styles"
-import CheckBoxIcon from "@material-ui/icons/CheckBox"
-import CheckBoxOutlineBlankIcon from "@material-ui/icons/CheckBoxOutlineBlank"
 import React, { Dispatch, SetStateAction } from "react"
 import styled from "styled-components"
 import {
@@ -33,6 +29,7 @@ const OverviewSidebarOptionsRoot = styled.div`
 export const FilterOptionList = styled.ul`
   ${mixinResetListStyle}
   display: flex;
+  align-items: center;
   user-select: none; // Prevent unsightly highlighting on the label
 `
 
@@ -41,6 +38,37 @@ const useStyles = makeStyles({
     color: Color.offWhite,
   },
 })
+
+let testFilterControlsBorderRadius = "3px"
+
+const TestFilterSegmentedControls = styled.div`
+  margin-left: ${SizeUnit(0.25)};
+`
+
+export const TestFilterSegmentedControl = styled.button`
+  ${mixinResetButtonStyle}
+  color: ${Color.grayLightest};
+  background-color: ${Color.gray};
+  padding: ${SizeUnit(0.125)} ${SizeUnit(0.25)};
+  font-size: ${FontSize.smallester};
+
+  &.is-enabled {
+    color: ${Color.grayDarkest};
+    background-color: ${Color.offWhite};
+  }
+
+  &:first-child {
+    border-top-left-radius: ${testFilterControlsBorderRadius};
+    border-bottom-left-radius: ${testFilterControlsBorderRadius};
+  }
+  &:last-child {
+    border-top-right-radius: ${testFilterControlsBorderRadius};
+    border-bottom-right-radius: ${testFilterControlsBorderRadius};
+  }
+  & + & {
+    border-left: 2px solid ${Color.grayDark};
+  }
+`
 
 export const AlertsOnTopToggle = styled.button`
   ${mixinResetButtonStyle}
@@ -71,18 +99,27 @@ function setAlertsOnTop(
   })
 }
 
-function setShowTests(props: OverviewSidebarOptionsProps, showTests: boolean) {
+function toggleTestsOnly(props: OverviewSidebarOptionsProps) {
   props.setOptions((prevOptions) => {
-    return { ...prevOptions, showTests: showTests }
+    // Always set the option you're not currently toggling to 'false', because both
+    // of these settings cannot be 'true' at the same time
+    return {
+      ...prevOptions,
+      testsHidden: false,
+      testsOnly: !prevOptions.testsOnly,
+    }
   })
 }
 
-function setShowResources(
-  props: OverviewSidebarOptionsProps,
-  showResources: boolean
-) {
+function toggleTestsHidden(props: OverviewSidebarOptionsProps) {
   props.setOptions((prevOptions) => {
-    return { ...prevOptions, showResources: showResources }
+    // Always set the option you're not currently toggling to 'false', because both
+    // of these settings cannot be 'true' at the same time
+    return {
+      ...prevOptions,
+      testsHidden: !prevOptions.testsHidden,
+      testsOnly: false,
+    }
   })
 }
 
@@ -90,38 +127,21 @@ function filterOptions(props: OverviewSidebarOptionsProps) {
   const classes = useStyles()
   return (
     <FilterOptionList>
-      <FormControlLabel
-        control={
-          <Checkbox
-            className={classes.root}
-            color={"default"}
-            icon={<CheckBoxOutlineBlankIcon fontSize="small" />}
-            checkedIcon={<CheckBoxIcon fontSize="small" />}
-            checked={props.options.showResources}
-            onClick={(e) =>
-              setShowResources(props, !props.options.showResources)
-            }
-            name="resources"
-            id="resources"
-          />
-        }
-        label="Resources"
-      />
-      <FormControlLabel
-        control={
-          <Checkbox
-            className={classes.root}
-            color={"default"}
-            icon={<CheckBoxOutlineBlankIcon fontSize="small" />}
-            checkedIcon={<CheckBoxIcon fontSize="small" />}
-            checked={props.options.showTests}
-            onClick={(e) => setShowTests(props, !props.options.showTests)}
-            name="tests"
-            id="tests"
-          />
-        }
-        label="Tests"
-      />
+      Tests:
+      <TestFilterSegmentedControls>
+        <TestFilterSegmentedControl
+          className={props.options.testsHidden ? "is-enabled" : ""}
+          onClick={(e) => toggleTestsHidden(props)}
+        >
+          Hidden
+        </TestFilterSegmentedControl>
+        <TestFilterSegmentedControl
+          className={props.options.testsOnly ? "is-enabled" : ""}
+          onClick={(e) => toggleTestsOnly(props)}
+        >
+          Only
+        </TestFilterSegmentedControl>
+      </TestFilterSegmentedControls>
     </FilterOptionList>
   )
 }
@@ -131,7 +151,7 @@ export function OverviewSidebarOptions(
 ): JSX.Element {
   return (
     <OverviewSidebarOptionsRoot
-      style={{ marginTop: SizeUnit(0.75), marginBottom: SizeUnit(-0.5) }}
+      style={{ marginTop: SizeUnit(0.75) }}
       className={!props.showFilters ? "is-filtersHidden" : ""}
     >
       {props.showFilters ? filterOptions(props) : null}

--- a/web/src/OverviewSidebarOptions.tsx
+++ b/web/src/OverviewSidebarOptions.tsx
@@ -39,7 +39,7 @@ const useStyles = makeStyles({
   },
 })
 
-const segmentedControlsBorderRadius = "3px"
+const toggleBorderRadius = "3px"
 
 const ResourceFilterSegmentedControls = styled.div`
   margin-left: ${SizeUnit(0.25)};
@@ -63,13 +63,13 @@ const ResourceFilterToggle = styled.button`
 `
 
 export const TestsHiddenToggle = styled(ResourceFilterToggle)`
-  border-top-left-radius: ${segmentedControlsBorderRadius};
-  border-bottom-left-radius: ${segmentedControlsBorderRadius};
+  border-top-left-radius: ${toggleBorderRadius};
+  border-bottom-left-radius: ${toggleBorderRadius};
 `
 
 export const TestsOnlyToggle = styled(ResourceFilterToggle)`
-  border-top-right-radius: ${segmentedControlsBorderRadius};
-  border-bottom-right-radius: ${segmentedControlsBorderRadius};
+  border-top-right-radius: ${toggleBorderRadius};
+  border-bottom-right-radius: ${toggleBorderRadius};
 `
 
 export const AlertsOnTopToggle = styled.button`
@@ -77,7 +77,7 @@ export const AlertsOnTopToggle = styled.button`
   color: ${Color.grayLightest};
   background-color: ${Color.gray};
   padding: ${SizeUnit(0.125)} ${SizeUnit(0.25)};
-  border-radius: 3px;
+  border-radius: ${toggleBorderRadius};
   font-size: ${FontSize.smallester};
 
   &.is-enabled {

--- a/web/src/OverviewSidebarOptions.tsx
+++ b/web/src/OverviewSidebarOptions.tsx
@@ -41,11 +41,11 @@ const useStyles = makeStyles({
 
 let testFilterControlsBorderRadius = "3px"
 
-const TestFilterSegmentedControls = styled.div`
+const ResourceFilterSegmentedControls = styled.div`
   margin-left: ${SizeUnit(0.25)};
 `
 
-export const TestFilterSegmentedControl = styled.button`
+const ResourceFilterSegmentedControl = styled.button`
   ${mixinResetButtonStyle}
   color: ${Color.grayLightest};
   background-color: ${Color.gray};
@@ -57,17 +57,21 @@ export const TestFilterSegmentedControl = styled.button`
     background-color: ${Color.offWhite};
   }
 
-  &:first-child {
-    border-top-left-radius: ${testFilterControlsBorderRadius};
-    border-bottom-left-radius: ${testFilterControlsBorderRadius};
-  }
-  &:last-child {
-    border-top-right-radius: ${testFilterControlsBorderRadius};
-    border-bottom-right-radius: ${testFilterControlsBorderRadius};
-  }
   & + & {
     border-left: 2px solid ${Color.grayDark};
   }
+`
+
+export const TestsHiddenSegmentedControl = styled(
+  ResourceFilterSegmentedControl
+)`
+  border-top-left-radius: ${testFilterControlsBorderRadius};
+  border-bottom-left-radius: ${testFilterControlsBorderRadius};
+`
+
+export const TestsOnlySegmentedControl = styled(ResourceFilterSegmentedControl)`
+  border-top-right-radius: ${testFilterControlsBorderRadius};
+  border-bottom-right-radius: ${testFilterControlsBorderRadius};
 `
 
 export const AlertsOnTopToggle = styled.button`
@@ -128,20 +132,20 @@ function filterOptions(props: OverviewSidebarOptionsProps) {
   return (
     <FilterOptionList>
       Tests:
-      <TestFilterSegmentedControls>
-        <TestFilterSegmentedControl
+      <ResourceFilterSegmentedControls>
+        <TestsHiddenSegmentedControl
           className={props.options.testsHidden ? "is-enabled" : ""}
           onClick={(e) => toggleTestsHidden(props)}
         >
           Hidden
-        </TestFilterSegmentedControl>
-        <TestFilterSegmentedControl
+        </TestsHiddenSegmentedControl>
+        <TestsOnlySegmentedControl
           className={props.options.testsOnly ? "is-enabled" : ""}
           onClick={(e) => toggleTestsOnly(props)}
         >
           Only
-        </TestFilterSegmentedControl>
-      </TestFilterSegmentedControls>
+        </TestsOnlySegmentedControl>
+      </ResourceFilterSegmentedControls>
     </FilterOptionList>
   )
 }

--- a/web/src/SidebarResources.test.tsx
+++ b/web/src/SidebarResources.test.tsx
@@ -141,17 +141,17 @@ describe("SidebarResources", () => {
   const loadCases: [string, SidebarOptions, string[]][] = [
     [
       "showResources",
-      { showResources: false, showTests: true, alertsOnTop: false },
+      { testsHidden: false, testsOnly: true, alertsOnTop: false },
       ["a", "b"],
     ],
     [
       "showTests",
-      { showResources: true, showTests: false, alertsOnTop: false },
+      { testsHidden: true, testsOnly: false, alertsOnTop: false },
       ["vigoda"],
     ],
     [
       "alertsOnTop",
-      { showResources: true, showTests: true, alertsOnTop: true },
+      { testsHidden: true, testsOnly: true, alertsOnTop: true },
       ["vigoda", "a", "b"],
     ],
   ]
@@ -182,8 +182,8 @@ describe("SidebarResources", () => {
       assertSidebarItemsAndOptions(
         root,
         expectedItems,
-        options.showResources,
-        options.showTests,
+        options.testsHidden,
+        options.testsOnly,
         options.alertsOnTop
       )
     }
@@ -192,12 +192,12 @@ describe("SidebarResources", () => {
   const saveCases: [string, SidebarOptions][] = [
     [
       "showResources",
-      { showResources: false, showTests: true, alertsOnTop: true },
+      { testsHidden: false, testsOnly: true, alertsOnTop: true },
     ],
-    ["showTests", { showResources: true, showTests: false, alertsOnTop: true }],
+    ["showTests", { testsHidden: true, testsOnly: false, alertsOnTop: true }],
     [
       "alertsOnTop",
-      { showResources: true, showTests: true, alertsOnTop: false },
+      { testsHidden: true, testsOnly: true, alertsOnTop: false },
     ],
   ]
   test.each(saveCases)(
@@ -223,12 +223,12 @@ describe("SidebarResources", () => {
       )
 
       let resToggle = root.find("input#resources")
-      if (resToggle.props().checked != expectedOptions.showResources) {
+      if (resToggle.props().checked != expectedOptions.testsHidden) {
         resToggle.simulate("click")
       }
 
       let testToggle = root.find("input#tests")
-      if (testToggle.props().checked != expectedOptions.showTests) {
+      if (testToggle.props().checked != expectedOptions.testsOnly) {
         testToggle.simulate("click")
       }
 

--- a/web/src/SidebarResources.test.tsx
+++ b/web/src/SidebarResources.test.tsx
@@ -4,7 +4,11 @@ import React from "react"
 import { MemoryRouter } from "react-router"
 import { expectIncr } from "./analytics_test_helpers"
 import { accessorsForTesting, tiltfileKeyContext } from "./LocalStorage"
-import { AlertsOnTopToggle } from "./OverviewSidebarOptions"
+import {
+  AlertsOnTopToggle,
+  TestsHiddenSegmentedControl,
+  TestsOnlySegmentedControl,
+} from "./OverviewSidebarOptions"
 import { assertSidebarItemsAndOptions } from "./OverviewSidebarOptions.test"
 import PathBuilder from "./PathBuilder"
 import SidebarItem from "./SidebarItem"
@@ -140,18 +144,18 @@ describe("SidebarResources", () => {
 
   const loadCases: [string, SidebarOptions, string[]][] = [
     [
-      "showResources",
+      "tests only",
       { testsHidden: false, testsOnly: true, alertsOnTop: false },
       ["a", "b"],
     ],
     [
-      "showTests",
+      "tests hidden",
       { testsHidden: true, testsOnly: false, alertsOnTop: false },
       ["vigoda"],
     ],
     [
       "alertsOnTop",
-      { testsHidden: true, testsOnly: true, alertsOnTop: true },
+      { testsHidden: false, testsOnly: false, alertsOnTop: true },
       ["vigoda", "a", "b"],
     ],
   ]
@@ -190,14 +194,11 @@ describe("SidebarResources", () => {
   )
 
   const saveCases: [string, SidebarOptions][] = [
-    [
-      "showResources",
-      { testsHidden: false, testsOnly: true, alertsOnTop: true },
-    ],
-    ["showTests", { testsHidden: true, testsOnly: false, alertsOnTop: true }],
+    ["testsHidden", { testsHidden: true, testsOnly: false, alertsOnTop: true }],
+    ["testsOnly", { testsHidden: false, testsOnly: true, alertsOnTop: true }],
     [
       "alertsOnTop",
-      { testsHidden: true, testsOnly: true, alertsOnTop: false },
+      { testsHidden: false, testsOnly: false, alertsOnTop: false },
     ],
   ]
   test.each(saveCases)(
@@ -222,14 +223,18 @@ describe("SidebarResources", () => {
         </MemoryRouter>
       )
 
-      let resToggle = root.find("input#resources")
-      if (resToggle.props().checked != expectedOptions.testsHidden) {
-        resToggle.simulate("click")
+      let testsHiddenControl = root.find(TestsHiddenSegmentedControl)
+      if (
+        testsHiddenControl.hasClass("is-enabled") != expectedOptions.testsHidden
+      ) {
+        testsHiddenControl.simulate("click")
       }
 
-      let testToggle = root.find("input#tests")
-      if (testToggle.props().checked != expectedOptions.testsOnly) {
-        testToggle.simulate("click")
+      let testsOnlyControl = root.find(TestsOnlySegmentedControl)
+      if (
+        testsOnlyControl.hasClass("is-enabled") != expectedOptions.testsOnly
+      ) {
+        testsOnlyControl.simulate("click")
       }
 
       let aotToggle = root.find(AlertsOnTopToggle)

--- a/web/src/SidebarResources.test.tsx
+++ b/web/src/SidebarResources.test.tsx
@@ -6,8 +6,8 @@ import { expectIncr } from "./analytics_test_helpers"
 import { accessorsForTesting, tiltfileKeyContext } from "./LocalStorage"
 import {
   AlertsOnTopToggle,
-  TestsHiddenSegmentedControl,
-  TestsOnlySegmentedControl,
+  TestsHiddenToggle,
+  TestsOnlyToggle,
 } from "./OverviewSidebarOptions"
 import { assertSidebarItemsAndOptions } from "./OverviewSidebarOptions.test"
 import PathBuilder from "./PathBuilder"
@@ -223,14 +223,14 @@ describe("SidebarResources", () => {
         </MemoryRouter>
       )
 
-      let testsHiddenControl = root.find(TestsHiddenSegmentedControl)
+      let testsHiddenControl = root.find(TestsHiddenToggle)
       if (
         testsHiddenControl.hasClass("is-enabled") != expectedOptions.testsHidden
       ) {
         testsHiddenControl.simulate("click")
       }
 
-      let testsOnlyControl = root.find(TestsOnlySegmentedControl)
+      let testsOnlyControl = root.find(TestsOnlyToggle)
       if (
         testsOnlyControl.hasClass("is-enabled") != expectedOptions.testsOnly
       ) {

--- a/web/src/SidebarResources.tsx
+++ b/web/src/SidebarResources.tsx
@@ -132,7 +132,6 @@ export class SidebarResources extends React.Component<SidebarProps> {
 
     if (options.alertsOnTop) {
       filteredItems.sort(sortByHasAlerts)
-    } else {
     }
 
     let listItems = filteredItems.map((item) => (

--- a/web/src/SidebarResources.tsx
+++ b/web/src/SidebarResources.tsx
@@ -58,8 +58,8 @@ type SidebarProps = {
 }
 
 export const defaultOptions: SidebarOptions = {
-  showResources: true,
-  showTests: true,
+  testsHidden: false,
+  testsOnly: false,
   alertsOnTop: false,
 }
 
@@ -120,17 +120,18 @@ export class SidebarResources extends React.Component<SidebarProps> {
     //   (e.g., in case there were previously tests and the user deselected resources)
     const showFilters =
       this.props.items.some((item) => item.isTest) ||
-      options.showResources !== defaultOptions.showResources ||
-      options.showTests !== defaultOptions.showTests
+      options.testsHidden !== defaultOptions.testsHidden ||
+      options.testsOnly !== defaultOptions.testsOnly
 
     // TODO: what do we do when we filter out the selected item? Pinned item(s)?
     //       and what effect does this have on keyboard shortcuts? :(
-    let filteredItems = this.props.items.filter(
-      (item) =>
-        (!item.isTest && options.showResources) ||
-        (item.isTest && options.showTests) ||
-        item.isTiltfile
-    )
+    let filteredItems = this.props.items
+    if (options.testsHidden) {
+      filteredItems = this.props.items.filter((item) => !item.isTest)
+    } else if (options.testsOnly) {
+      // This filters out the Tiltfile, is that what we want?
+      filteredItems = this.props.items.filter((item) => item.isTest)
+    }
 
     if (options.alertsOnTop) {
       filteredItems.sort(sortByHasAlerts)

--- a/web/src/SidebarResources.tsx
+++ b/web/src/SidebarResources.tsx
@@ -123,18 +123,16 @@ export class SidebarResources extends React.Component<SidebarProps> {
       options.testsHidden !== defaultOptions.testsHidden ||
       options.testsOnly !== defaultOptions.testsOnly
 
-    // TODO: what do we do when we filter out the selected item? Pinned item(s)?
-    //       and what effect does this have on keyboard shortcuts? :(
-    let filteredItems = this.props.items
+    let filteredItems = [...this.props.items]
     if (options.testsHidden) {
       filteredItems = this.props.items.filter((item) => !item.isTest)
     } else if (options.testsOnly) {
-      // This filters out the Tiltfile, is that what we want?
       filteredItems = this.props.items.filter((item) => item.isTest)
     }
 
     if (options.alertsOnTop) {
       filteredItems.sort(sortByHasAlerts)
+    } else {
     }
 
     let listItems = filteredItems.map((item) => (

--- a/web/src/__snapshots__/Sidebar.test.tsx.snap
+++ b/web/src/__snapshots__/Sidebar.test.tsx.snap
@@ -50,7 +50,7 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
       }
     >
       <button
-        className="sc-gKsewC jRJBDl"
+        className="sc-gKsewC gQFzAy"
         onClick={[Function]}
       >
         Alerts on Top
@@ -913,7 +913,7 @@ exports[`sidebar renders empty resource list without crashing 1`] = `
       }
     >
       <button
-        className="sc-gKsewC jRJBDl"
+        className="sc-gKsewC gQFzAy"
         onClick={[Function]}
       >
         Alerts on Top
@@ -984,7 +984,7 @@ exports[`sidebar renders list of resources 1`] = `
       }
     >
       <button
-        className="sc-gKsewC jRJBDl"
+        className="sc-gKsewC gQFzAy"
         onClick={[Function]}
       >
         Alerts on Top
@@ -1286,7 +1286,7 @@ exports[`sidebar renders resources that haven't been built yet 1`] = `
       }
     >
       <button
-        className="sc-gKsewC jRJBDl"
+        className="sc-gKsewC gQFzAy"
         onClick={[Function]}
       >
         Alerts on Top

--- a/web/src/__snapshots__/Sidebar.test.tsx.snap
+++ b/web/src/__snapshots__/Sidebar.test.tsx.snap
@@ -2,38 +2,38 @@
 
 exports[`sidebar abbreviates durations under a minute 1`] = `
 <nav
-  className="sc-dIUggk grSaCL Sidebar-resources "
+  className="sc-fKFyDc iXLYud Sidebar-resources "
 >
   <div
-    className="sc-hHftDr"
+    className="sc-bBXqnf"
   >
     <div>
       <div
-        className="sc-dmlrTW iTieuF"
+        className="sc-iwyYcG fXFHir"
       >
         
       </div>
       <ul
-        className="sc-kfzAmx khbJgg"
+        className="sc-cxFLnm jlNuLB"
       >
         <li
-          className="sc-pFZIQ sc-kstrdz eaCWvj gajrif"
+          className="sc-crrsfI sc-bkzZxe jItnSg gzVHhL"
         >
           <div
-            className="sc-jrAGrp sc-hBEYos ghJJLs gVXwBF isSelected"
+            className="sc-dQppl sc-idOhPF btfhxN kwjnVr isSelected"
             onClick={[Function]}
             role="button"
             tabIndex={-1}
           >
             <div
-              className="sc-hKgILt iMooxb isNone"
+              className="sc-iBPRYJ hwwEyI isNone"
             >
               <svg>
                 checkmark-small.svg
               </svg>
             </div>
             <div
-              className="sc-dQppl sc-fodVxV frNjEq hMCDIC"
+              className="sc-fodVxV sc-dIUggk iMcVO gmTuhM"
             >
               All
             </div>
@@ -45,13 +45,12 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
       className="sc-bdfBwQ bJwFId is-filtersHidden"
       style={
         Object {
-          "marginBottom": "-16px",
           "marginTop": "24px",
         }
       }
     >
       <button
-        className="sc-dlfnbm hYhRhc"
+        className="sc-gKsewC jRJBDl"
         onClick={[Function]}
       >
         Alerts on Top
@@ -59,32 +58,32 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
     </div>
     <div>
       <div
-        className="sc-dmlrTW iTieuF"
+        className="sc-iwyYcG fXFHir"
       >
         resources
       </div>
       <ul
-        className="sc-kfzAmx khbJgg"
+        className="sc-cxFLnm jlNuLB"
       >
         <li
-          className="sc-pFZIQ eaCWvj u-showPinOnHover  isBuilding"
+          className="sc-crrsfI jItnSg u-showPinOnHover  isBuilding"
         >
           <div
-            className="sc-jrAGrp ghJJLs  isBuilding"
+            className="sc-dQppl btfhxN  isBuilding"
             data-name="resource4"
             onClick={[Function]}
             role="button"
             tabIndex={-1}
           >
             <div
-              className="sc-kEjbxe gpekhu"
+              className="sc-bqyKva iOaTfz"
             >
               <div
-                className="sc-iqHYGH juiiLS"
+                className="sc-kstrdz eHNvIE"
               >
                 <div
                   aria-describedby={null}
-                  className="sc-hKgILt iMooxb isHealthy"
+                  className="sc-iBPRYJ hwwEyI isHealthy"
                   onBlur={[Function]}
                   onFocus={[Function]}
                   onMouseLeave={[Function]}
@@ -98,32 +97,32 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
                   </span>
                 </div>
                 <div
-                  className="sc-dQppl sc-fodVxV frNjEq hMCDIC"
+                  className="sc-fodVxV sc-dIUggk iMcVO gmTuhM"
                   title="resource4"
                 >
                   <span
-                    className="sc-fFubgz dbrUMP"
+                    className="sc-hHftDr gJoLEh"
                   >
                     resource4
                   </span>
                 </div>
                 <div
-                  className="sc-bqyKva eItknN"
+                  className="sc-fFubgz dtAnGh"
                 >
                   <button
-                    className="sc-eCssSg fZtIvG"
+                    className="sc-fubCfw gidPif"
                     onClick={[Function]}
                     title="Pin to Top"
                   >
                     <svg
-                      className="sc-gKsewC MUSWU"
+                      className="sc-jrAGrp fOOXsv"
                     >
                       pin.svg
                     </svg>
                   </button>
                 </div>
                 <span
-                  className="sc-bkzZxe dGllbM"
+                  className="sc-dmlrTW cMjcII"
                 >
                   <time
                     dateTime="2017-12-21T15:36:03.000Z"
@@ -134,11 +133,11 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
                 </span>
               </div>
               <div
-                className="sc-crrsfI bAJfaH"
+                className="sc-hBEYos fVbLmK"
               >
                 <div
                   aria-describedby={null}
-                  className="sc-hKgILt iMooxb isHealthy"
+                  className="sc-iBPRYJ hwwEyI isHealthy"
                   onBlur={[Function]}
                   onFocus={[Function]}
                   onMouseLeave={[Function]}
@@ -152,17 +151,17 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
                   </span>
                 </div>
                 <div
-                  className="sc-dQppl frNjEq"
+                  className="sc-fodVxV iMcVO"
                 >
                   Completed in 12s, with issues
                 </div>
               </div>
             </div>
             <div
-              className="sc-idOhPF csSihC"
+              className="sc-kfzAmx gYdoGx"
             >
               <button
-                className="sc-iBPRYJ cjfxil"
+                className="sc-kEjbxe gaYZpE"
                 disabled={true}
                 onClick={[Function]}
                 style={
@@ -180,24 +179,24 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
           </div>
         </li>
         <li
-          className="sc-pFZIQ eaCWvj u-showPinOnHover  isBuilding"
+          className="sc-crrsfI jItnSg u-showPinOnHover  isBuilding"
         >
           <div
-            className="sc-jrAGrp ghJJLs  isBuilding"
+            className="sc-dQppl btfhxN  isBuilding"
             data-name="resource9"
             onClick={[Function]}
             role="button"
             tabIndex={-1}
           >
             <div
-              className="sc-kEjbxe gpekhu"
+              className="sc-bqyKva iOaTfz"
             >
               <div
-                className="sc-iqHYGH juiiLS"
+                className="sc-kstrdz eHNvIE"
               >
                 <div
                   aria-describedby={null}
-                  className="sc-hKgILt iMooxb isHealthy"
+                  className="sc-iBPRYJ hwwEyI isHealthy"
                   onBlur={[Function]}
                   onFocus={[Function]}
                   onMouseLeave={[Function]}
@@ -211,32 +210,32 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
                   </span>
                 </div>
                 <div
-                  className="sc-dQppl sc-fodVxV frNjEq hMCDIC"
+                  className="sc-fodVxV sc-dIUggk iMcVO gmTuhM"
                   title="resource9"
                 >
                   <span
-                    className="sc-fFubgz dbrUMP"
+                    className="sc-hHftDr gJoLEh"
                   >
                     resource9
                   </span>
                 </div>
                 <div
-                  className="sc-bqyKva eItknN"
+                  className="sc-fFubgz dtAnGh"
                 >
                   <button
-                    className="sc-eCssSg fZtIvG"
+                    className="sc-fubCfw gidPif"
                     onClick={[Function]}
                     title="Pin to Top"
                   >
                     <svg
-                      className="sc-gKsewC MUSWU"
+                      className="sc-jrAGrp fOOXsv"
                     >
                       pin.svg
                     </svg>
                   </button>
                 </div>
                 <span
-                  className="sc-bkzZxe dGllbM"
+                  className="sc-dmlrTW cMjcII"
                 >
                   <time
                     dateTime="2017-12-21T15:35:58.000Z"
@@ -247,11 +246,11 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
                 </span>
               </div>
               <div
-                className="sc-crrsfI bAJfaH"
+                className="sc-hBEYos fVbLmK"
               >
                 <div
                   aria-describedby={null}
-                  className="sc-hKgILt iMooxb isHealthy"
+                  className="sc-iBPRYJ hwwEyI isHealthy"
                   onBlur={[Function]}
                   onFocus={[Function]}
                   onMouseLeave={[Function]}
@@ -265,17 +264,17 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
                   </span>
                 </div>
                 <div
-                  className="sc-dQppl frNjEq"
+                  className="sc-fodVxV iMcVO"
                 >
                   Completed in 12s, with issues
                 </div>
               </div>
             </div>
             <div
-              className="sc-idOhPF csSihC"
+              className="sc-kfzAmx gYdoGx"
             >
               <button
-                className="sc-iBPRYJ cjfxil"
+                className="sc-kEjbxe gaYZpE"
                 disabled={true}
                 onClick={[Function]}
                 style={
@@ -293,24 +292,24 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
           </div>
         </li>
         <li
-          className="sc-pFZIQ eaCWvj u-showPinOnHover  isBuilding"
+          className="sc-crrsfI jItnSg u-showPinOnHover  isBuilding"
         >
           <div
-            className="sc-jrAGrp ghJJLs  isBuilding"
+            className="sc-dQppl btfhxN  isBuilding"
             data-name="resource19"
             onClick={[Function]}
             role="button"
             tabIndex={-1}
           >
             <div
-              className="sc-kEjbxe gpekhu"
+              className="sc-bqyKva iOaTfz"
             >
               <div
-                className="sc-iqHYGH juiiLS"
+                className="sc-kstrdz eHNvIE"
               >
                 <div
                   aria-describedby={null}
-                  className="sc-hKgILt iMooxb isHealthy"
+                  className="sc-iBPRYJ hwwEyI isHealthy"
                   onBlur={[Function]}
                   onFocus={[Function]}
                   onMouseLeave={[Function]}
@@ -324,32 +323,32 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
                   </span>
                 </div>
                 <div
-                  className="sc-dQppl sc-fodVxV frNjEq hMCDIC"
+                  className="sc-fodVxV sc-dIUggk iMcVO gmTuhM"
                   title="resource19"
                 >
                   <span
-                    className="sc-fFubgz dbrUMP"
+                    className="sc-hHftDr gJoLEh"
                   >
                     resource19
                   </span>
                 </div>
                 <div
-                  className="sc-bqyKva eItknN"
+                  className="sc-fFubgz dtAnGh"
                 >
                   <button
-                    className="sc-eCssSg fZtIvG"
+                    className="sc-fubCfw gidPif"
                     onClick={[Function]}
                     title="Pin to Top"
                   >
                     <svg
-                      className="sc-gKsewC MUSWU"
+                      className="sc-jrAGrp fOOXsv"
                     >
                       pin.svg
                     </svg>
                   </button>
                 </div>
                 <span
-                  className="sc-bkzZxe dGllbM"
+                  className="sc-dmlrTW cMjcII"
                 >
                   <time
                     dateTime="2017-12-21T15:35:48.000Z"
@@ -360,11 +359,11 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
                 </span>
               </div>
               <div
-                className="sc-crrsfI bAJfaH"
+                className="sc-hBEYos fVbLmK"
               >
                 <div
                   aria-describedby={null}
-                  className="sc-hKgILt iMooxb isHealthy"
+                  className="sc-iBPRYJ hwwEyI isHealthy"
                   onBlur={[Function]}
                   onFocus={[Function]}
                   onMouseLeave={[Function]}
@@ -378,17 +377,17 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
                   </span>
                 </div>
                 <div
-                  className="sc-dQppl frNjEq"
+                  className="sc-fodVxV iMcVO"
                 >
                   Completed in 12s, with issues
                 </div>
               </div>
             </div>
             <div
-              className="sc-idOhPF csSihC"
+              className="sc-kfzAmx gYdoGx"
             >
               <button
-                className="sc-iBPRYJ cjfxil"
+                className="sc-kEjbxe gaYZpE"
                 disabled={true}
                 onClick={[Function]}
                 style={
@@ -406,24 +405,24 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
           </div>
         </li>
         <li
-          className="sc-pFZIQ eaCWvj u-showPinOnHover  isBuilding"
+          className="sc-crrsfI jItnSg u-showPinOnHover  isBuilding"
         >
           <div
-            className="sc-jrAGrp ghJJLs  isBuilding"
+            className="sc-dQppl btfhxN  isBuilding"
             data-name="resource29"
             onClick={[Function]}
             role="button"
             tabIndex={-1}
           >
             <div
-              className="sc-kEjbxe gpekhu"
+              className="sc-bqyKva iOaTfz"
             >
               <div
-                className="sc-iqHYGH juiiLS"
+                className="sc-kstrdz eHNvIE"
               >
                 <div
                   aria-describedby={null}
-                  className="sc-hKgILt iMooxb isHealthy"
+                  className="sc-iBPRYJ hwwEyI isHealthy"
                   onBlur={[Function]}
                   onFocus={[Function]}
                   onMouseLeave={[Function]}
@@ -437,32 +436,32 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
                   </span>
                 </div>
                 <div
-                  className="sc-dQppl sc-fodVxV frNjEq hMCDIC"
+                  className="sc-fodVxV sc-dIUggk iMcVO gmTuhM"
                   title="resource29"
                 >
                   <span
-                    className="sc-fFubgz dbrUMP"
+                    className="sc-hHftDr gJoLEh"
                   >
                     resource29
                   </span>
                 </div>
                 <div
-                  className="sc-bqyKva eItknN"
+                  className="sc-fFubgz dtAnGh"
                 >
                   <button
-                    className="sc-eCssSg fZtIvG"
+                    className="sc-fubCfw gidPif"
                     onClick={[Function]}
                     title="Pin to Top"
                   >
                     <svg
-                      className="sc-gKsewC MUSWU"
+                      className="sc-jrAGrp fOOXsv"
                     >
                       pin.svg
                     </svg>
                   </button>
                 </div>
                 <span
-                  className="sc-bkzZxe dGllbM"
+                  className="sc-dmlrTW cMjcII"
                 >
                   <time
                     dateTime="2017-12-21T15:35:38.000Z"
@@ -473,11 +472,11 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
                 </span>
               </div>
               <div
-                className="sc-crrsfI bAJfaH"
+                className="sc-hBEYos fVbLmK"
               >
                 <div
                   aria-describedby={null}
-                  className="sc-hKgILt iMooxb isHealthy"
+                  className="sc-iBPRYJ hwwEyI isHealthy"
                   onBlur={[Function]}
                   onFocus={[Function]}
                   onMouseLeave={[Function]}
@@ -491,17 +490,17 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
                   </span>
                 </div>
                 <div
-                  className="sc-dQppl frNjEq"
+                  className="sc-fodVxV iMcVO"
                 >
                   Completed in 12s, with issues
                 </div>
               </div>
             </div>
             <div
-              className="sc-idOhPF csSihC"
+              className="sc-kfzAmx gYdoGx"
             >
               <button
-                className="sc-iBPRYJ cjfxil"
+                className="sc-kEjbxe gaYZpE"
                 disabled={true}
                 onClick={[Function]}
                 style={
@@ -519,24 +518,24 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
           </div>
         </li>
         <li
-          className="sc-pFZIQ eaCWvj u-showPinOnHover  isBuilding"
+          className="sc-crrsfI jItnSg u-showPinOnHover  isBuilding"
         >
           <div
-            className="sc-jrAGrp ghJJLs  isBuilding"
+            className="sc-dQppl btfhxN  isBuilding"
             data-name="resource39"
             onClick={[Function]}
             role="button"
             tabIndex={-1}
           >
             <div
-              className="sc-kEjbxe gpekhu"
+              className="sc-bqyKva iOaTfz"
             >
               <div
-                className="sc-iqHYGH juiiLS"
+                className="sc-kstrdz eHNvIE"
               >
                 <div
                   aria-describedby={null}
-                  className="sc-hKgILt iMooxb isHealthy"
+                  className="sc-iBPRYJ hwwEyI isHealthy"
                   onBlur={[Function]}
                   onFocus={[Function]}
                   onMouseLeave={[Function]}
@@ -550,32 +549,32 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
                   </span>
                 </div>
                 <div
-                  className="sc-dQppl sc-fodVxV frNjEq hMCDIC"
+                  className="sc-fodVxV sc-dIUggk iMcVO gmTuhM"
                   title="resource39"
                 >
                   <span
-                    className="sc-fFubgz dbrUMP"
+                    className="sc-hHftDr gJoLEh"
                   >
                     resource39
                   </span>
                 </div>
                 <div
-                  className="sc-bqyKva eItknN"
+                  className="sc-fFubgz dtAnGh"
                 >
                   <button
-                    className="sc-eCssSg fZtIvG"
+                    className="sc-fubCfw gidPif"
                     onClick={[Function]}
                     title="Pin to Top"
                   >
                     <svg
-                      className="sc-gKsewC MUSWU"
+                      className="sc-jrAGrp fOOXsv"
                     >
                       pin.svg
                     </svg>
                   </button>
                 </div>
                 <span
-                  className="sc-bkzZxe dGllbM"
+                  className="sc-dmlrTW cMjcII"
                 >
                   <time
                     dateTime="2017-12-21T15:35:28.000Z"
@@ -586,11 +585,11 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
                 </span>
               </div>
               <div
-                className="sc-crrsfI bAJfaH"
+                className="sc-hBEYos fVbLmK"
               >
                 <div
                   aria-describedby={null}
-                  className="sc-hKgILt iMooxb isHealthy"
+                  className="sc-iBPRYJ hwwEyI isHealthy"
                   onBlur={[Function]}
                   onFocus={[Function]}
                   onMouseLeave={[Function]}
@@ -604,17 +603,17 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
                   </span>
                 </div>
                 <div
-                  className="sc-dQppl frNjEq"
+                  className="sc-fodVxV iMcVO"
                 >
                   Completed in 12s, with issues
                 </div>
               </div>
             </div>
             <div
-              className="sc-idOhPF csSihC"
+              className="sc-kfzAmx gYdoGx"
             >
               <button
-                className="sc-iBPRYJ cjfxil"
+                className="sc-kEjbxe gaYZpE"
                 disabled={true}
                 onClick={[Function]}
                 style={
@@ -632,24 +631,24 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
           </div>
         </li>
         <li
-          className="sc-pFZIQ eaCWvj u-showPinOnHover  isBuilding"
+          className="sc-crrsfI jItnSg u-showPinOnHover  isBuilding"
         >
           <div
-            className="sc-jrAGrp ghJJLs  isBuilding"
+            className="sc-dQppl btfhxN  isBuilding"
             data-name="resource49"
             onClick={[Function]}
             role="button"
             tabIndex={-1}
           >
             <div
-              className="sc-kEjbxe gpekhu"
+              className="sc-bqyKva iOaTfz"
             >
               <div
-                className="sc-iqHYGH juiiLS"
+                className="sc-kstrdz eHNvIE"
               >
                 <div
                   aria-describedby={null}
-                  className="sc-hKgILt iMooxb isHealthy"
+                  className="sc-iBPRYJ hwwEyI isHealthy"
                   onBlur={[Function]}
                   onFocus={[Function]}
                   onMouseLeave={[Function]}
@@ -663,32 +662,32 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
                   </span>
                 </div>
                 <div
-                  className="sc-dQppl sc-fodVxV frNjEq hMCDIC"
+                  className="sc-fodVxV sc-dIUggk iMcVO gmTuhM"
                   title="resource49"
                 >
                   <span
-                    className="sc-fFubgz dbrUMP"
+                    className="sc-hHftDr gJoLEh"
                   >
                     resource49
                   </span>
                 </div>
                 <div
-                  className="sc-bqyKva eItknN"
+                  className="sc-fFubgz dtAnGh"
                 >
                   <button
-                    className="sc-eCssSg fZtIvG"
+                    className="sc-fubCfw gidPif"
                     onClick={[Function]}
                     title="Pin to Top"
                   >
                     <svg
-                      className="sc-gKsewC MUSWU"
+                      className="sc-jrAGrp fOOXsv"
                     >
                       pin.svg
                     </svg>
                   </button>
                 </div>
                 <span
-                  className="sc-bkzZxe dGllbM"
+                  className="sc-dmlrTW cMjcII"
                 >
                   <time
                     dateTime="2017-12-21T15:35:18.000Z"
@@ -699,11 +698,11 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
                 </span>
               </div>
               <div
-                className="sc-crrsfI bAJfaH"
+                className="sc-hBEYos fVbLmK"
               >
                 <div
                   aria-describedby={null}
-                  className="sc-hKgILt iMooxb isHealthy"
+                  className="sc-iBPRYJ hwwEyI isHealthy"
                   onBlur={[Function]}
                   onFocus={[Function]}
                   onMouseLeave={[Function]}
@@ -717,17 +716,17 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
                   </span>
                 </div>
                 <div
-                  className="sc-dQppl frNjEq"
+                  className="sc-fodVxV iMcVO"
                 >
                   Completed in 12s, with issues
                 </div>
               </div>
             </div>
             <div
-              className="sc-idOhPF csSihC"
+              className="sc-kfzAmx gYdoGx"
             >
               <button
-                className="sc-iBPRYJ cjfxil"
+                className="sc-kEjbxe gaYZpE"
                 disabled={true}
                 onClick={[Function]}
                 style={
@@ -745,24 +744,24 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
           </div>
         </li>
         <li
-          className="sc-pFZIQ eaCWvj u-showPinOnHover  isBuilding"
+          className="sc-crrsfI jItnSg u-showPinOnHover  isBuilding"
         >
           <div
-            className="sc-jrAGrp ghJJLs  isBuilding"
+            className="sc-dQppl btfhxN  isBuilding"
             data-name="resource54"
             onClick={[Function]}
             role="button"
             tabIndex={-1}
           >
             <div
-              className="sc-kEjbxe gpekhu"
+              className="sc-bqyKva iOaTfz"
             >
               <div
-                className="sc-iqHYGH juiiLS"
+                className="sc-kstrdz eHNvIE"
               >
                 <div
                   aria-describedby={null}
-                  className="sc-hKgILt iMooxb isHealthy"
+                  className="sc-iBPRYJ hwwEyI isHealthy"
                   onBlur={[Function]}
                   onFocus={[Function]}
                   onMouseLeave={[Function]}
@@ -776,32 +775,32 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
                   </span>
                 </div>
                 <div
-                  className="sc-dQppl sc-fodVxV frNjEq hMCDIC"
+                  className="sc-fodVxV sc-dIUggk iMcVO gmTuhM"
                   title="resource54"
                 >
                   <span
-                    className="sc-fFubgz dbrUMP"
+                    className="sc-hHftDr gJoLEh"
                   >
                     resource54
                   </span>
                 </div>
                 <div
-                  className="sc-bqyKva eItknN"
+                  className="sc-fFubgz dtAnGh"
                 >
                   <button
-                    className="sc-eCssSg fZtIvG"
+                    className="sc-fubCfw gidPif"
                     onClick={[Function]}
                     title="Pin to Top"
                   >
                     <svg
-                      className="sc-gKsewC MUSWU"
+                      className="sc-jrAGrp fOOXsv"
                     >
                       pin.svg
                     </svg>
                   </button>
                 </div>
                 <span
-                  className="sc-bkzZxe dGllbM"
+                  className="sc-dmlrTW cMjcII"
                 >
                   <time
                     dateTime="2017-12-21T15:35:13.000Z"
@@ -812,11 +811,11 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
                 </span>
               </div>
               <div
-                className="sc-crrsfI bAJfaH"
+                className="sc-hBEYos fVbLmK"
               >
                 <div
                   aria-describedby={null}
-                  className="sc-hKgILt iMooxb isHealthy"
+                  className="sc-iBPRYJ hwwEyI isHealthy"
                   onBlur={[Function]}
                   onFocus={[Function]}
                   onMouseLeave={[Function]}
@@ -830,17 +829,17 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
                   </span>
                 </div>
                 <div
-                  className="sc-dQppl frNjEq"
+                  className="sc-fodVxV iMcVO"
                 >
                   Completed in 12s, with issues
                 </div>
               </div>
             </div>
             <div
-              className="sc-idOhPF csSihC"
+              className="sc-kfzAmx gYdoGx"
             >
               <button
-                className="sc-iBPRYJ cjfxil"
+                className="sc-kEjbxe gaYZpE"
                 disabled={true}
                 onClick={[Function]}
                 style={
@@ -866,38 +865,38 @@ exports[`sidebar abbreviates durations under a minute 1`] = `
 
 exports[`sidebar renders empty resource list without crashing 1`] = `
 <nav
-  className="sc-dIUggk grSaCL Sidebar-resources "
+  className="sc-fKFyDc iXLYud Sidebar-resources "
 >
   <div
-    className="sc-hHftDr"
+    className="sc-bBXqnf"
   >
     <div>
       <div
-        className="sc-dmlrTW iTieuF"
+        className="sc-iwyYcG fXFHir"
       >
         
       </div>
       <ul
-        className="sc-kfzAmx khbJgg"
+        className="sc-cxFLnm jlNuLB"
       >
         <li
-          className="sc-pFZIQ sc-kstrdz eaCWvj gajrif"
+          className="sc-crrsfI sc-bkzZxe jItnSg gzVHhL"
         >
           <div
-            className="sc-jrAGrp sc-hBEYos ghJJLs gVXwBF isSelected"
+            className="sc-dQppl sc-idOhPF btfhxN kwjnVr isSelected"
             onClick={[Function]}
             role="button"
             tabIndex={-1}
           >
             <div
-              className="sc-hKgILt iMooxb isNone"
+              className="sc-iBPRYJ hwwEyI isNone"
             >
               <svg>
                 checkmark-small.svg
               </svg>
             </div>
             <div
-              className="sc-dQppl sc-fodVxV frNjEq hMCDIC"
+              className="sc-fodVxV sc-dIUggk iMcVO gmTuhM"
             >
               All
             </div>
@@ -909,13 +908,12 @@ exports[`sidebar renders empty resource list without crashing 1`] = `
       className="sc-bdfBwQ bJwFId is-filtersHidden"
       style={
         Object {
-          "marginBottom": "-16px",
           "marginTop": "24px",
         }
       }
     >
       <button
-        className="sc-dlfnbm hYhRhc"
+        className="sc-gKsewC jRJBDl"
         onClick={[Function]}
       >
         Alerts on Top
@@ -923,12 +921,12 @@ exports[`sidebar renders empty resource list without crashing 1`] = `
     </div>
     <div>
       <div
-        className="sc-dmlrTW iTieuF"
+        className="sc-iwyYcG fXFHir"
       >
         resources
       </div>
       <ul
-        className="sc-kfzAmx khbJgg"
+        className="sc-cxFLnm jlNuLB"
       />
     </div>
   </div>
@@ -938,38 +936,38 @@ exports[`sidebar renders empty resource list without crashing 1`] = `
 
 exports[`sidebar renders list of resources 1`] = `
 <nav
-  className="sc-dIUggk grSaCL Sidebar-resources "
+  className="sc-fKFyDc iXLYud Sidebar-resources "
 >
   <div
-    className="sc-hHftDr"
+    className="sc-bBXqnf"
   >
     <div>
       <div
-        className="sc-dmlrTW iTieuF"
+        className="sc-iwyYcG fXFHir"
       >
         
       </div>
       <ul
-        className="sc-kfzAmx khbJgg"
+        className="sc-cxFLnm jlNuLB"
       >
         <li
-          className="sc-pFZIQ sc-kstrdz eaCWvj gajrif"
+          className="sc-crrsfI sc-bkzZxe jItnSg gzVHhL"
         >
           <div
-            className="sc-jrAGrp sc-hBEYos ghJJLs gVXwBF isSelected"
+            className="sc-dQppl sc-idOhPF btfhxN kwjnVr isSelected"
             onClick={[Function]}
             role="button"
             tabIndex={-1}
           >
             <div
-              className="sc-hKgILt iMooxb isNone"
+              className="sc-iBPRYJ hwwEyI isNone"
             >
               <svg>
                 checkmark-small.svg
               </svg>
             </div>
             <div
-              className="sc-dQppl sc-fodVxV frNjEq hMCDIC"
+              className="sc-fodVxV sc-dIUggk iMcVO gmTuhM"
             >
               All
             </div>
@@ -981,13 +979,12 @@ exports[`sidebar renders list of resources 1`] = `
       className="sc-bdfBwQ bJwFId is-filtersHidden"
       style={
         Object {
-          "marginBottom": "-16px",
           "marginTop": "24px",
         }
       }
     >
       <button
-        className="sc-dlfnbm hYhRhc"
+        className="sc-gKsewC jRJBDl"
         onClick={[Function]}
       >
         Alerts on Top
@@ -995,32 +992,32 @@ exports[`sidebar renders list of resources 1`] = `
     </div>
     <div>
       <div
-        className="sc-dmlrTW iTieuF"
+        className="sc-iwyYcG fXFHir"
       >
         resources
       </div>
       <ul
-        className="sc-kfzAmx khbJgg"
+        className="sc-cxFLnm jlNuLB"
       >
         <li
-          className="sc-pFZIQ eaCWvj u-showPinOnHover  isBuilding"
+          className="sc-crrsfI jItnSg u-showPinOnHover  isBuilding"
         >
           <div
-            className="sc-jrAGrp ghJJLs  isBuilding"
+            className="sc-dQppl btfhxN  isBuilding"
             data-name="vigoda"
             onClick={[Function]}
             role="button"
             tabIndex={-1}
           >
             <div
-              className="sc-kEjbxe gpekhu"
+              className="sc-bqyKva iOaTfz"
             >
               <div
-                className="sc-iqHYGH juiiLS"
+                className="sc-kstrdz eHNvIE"
               >
                 <div
                   aria-describedby={null}
-                  className="sc-hKgILt iMooxb isHealthy"
+                  className="sc-iBPRYJ hwwEyI isHealthy"
                   onBlur={[Function]}
                   onFocus={[Function]}
                   onMouseLeave={[Function]}
@@ -1034,32 +1031,32 @@ exports[`sidebar renders list of resources 1`] = `
                   </span>
                 </div>
                 <div
-                  className="sc-dQppl sc-fodVxV frNjEq hMCDIC"
+                  className="sc-fodVxV sc-dIUggk iMcVO gmTuhM"
                   title="vigoda"
                 >
                   <span
-                    className="sc-fFubgz dbrUMP"
+                    className="sc-hHftDr gJoLEh"
                   >
                     vigoda
                   </span>
                 </div>
                 <div
-                  className="sc-bqyKva eItknN"
+                  className="sc-fFubgz dtAnGh"
                 >
                   <button
-                    className="sc-eCssSg fZtIvG"
+                    className="sc-fubCfw gidPif"
                     onClick={[Function]}
                     title="Pin to Top"
                   >
                     <svg
-                      className="sc-gKsewC MUSWU"
+                      className="sc-jrAGrp fOOXsv"
                     >
                       pin.svg
                     </svg>
                   </button>
                 </div>
                 <span
-                  className="sc-bkzZxe dGllbM"
+                  className="sc-dmlrTW cMjcII"
                 >
                   <time
                     dateTime="2017-12-21T15:36:07.000Z"
@@ -1070,11 +1067,11 @@ exports[`sidebar renders list of resources 1`] = `
                 </span>
               </div>
               <div
-                className="sc-crrsfI bAJfaH"
+                className="sc-hBEYos fVbLmK"
               >
                 <div
                   aria-describedby={null}
-                  className="sc-hKgILt iMooxb isUnhealthy"
+                  className="sc-iBPRYJ hwwEyI isUnhealthy"
                   onBlur={[Function]}
                   onFocus={[Function]}
                   onMouseLeave={[Function]}
@@ -1090,17 +1087,17 @@ exports[`sidebar renders list of resources 1`] = `
                   </svg>
                 </div>
                 <div
-                  className="sc-dQppl frNjEq"
+                  className="sc-fodVxV iMcVO"
                 >
                   Update error
                 </div>
               </div>
             </div>
             <div
-              className="sc-idOhPF csSihC"
+              className="sc-kfzAmx gYdoGx"
             >
               <button
-                className="sc-iBPRYJ cjfxil"
+                className="sc-kEjbxe gaYZpE"
                 disabled={true}
                 onClick={[Function]}
                 style={
@@ -1118,24 +1115,24 @@ exports[`sidebar renders list of resources 1`] = `
           </div>
         </li>
         <li
-          className="sc-pFZIQ eaCWvj u-showPinOnHover  isBuilding"
+          className="sc-crrsfI jItnSg u-showPinOnHover  isBuilding"
         >
           <div
-            className="sc-jrAGrp ghJJLs  isBuilding"
+            className="sc-dQppl btfhxN  isBuilding"
             data-name="snack"
             onClick={[Function]}
             role="button"
             tabIndex={-1}
           >
             <div
-              className="sc-kEjbxe gpekhu"
+              className="sc-bqyKva iOaTfz"
             >
               <div
-                className="sc-iqHYGH juiiLS"
+                className="sc-kstrdz eHNvIE"
               >
                 <div
                   aria-describedby={null}
-                  className="sc-hKgILt iMooxb isHealthy"
+                  className="sc-iBPRYJ hwwEyI isHealthy"
                   onBlur={[Function]}
                   onFocus={[Function]}
                   onMouseLeave={[Function]}
@@ -1149,32 +1146,32 @@ exports[`sidebar renders list of resources 1`] = `
                   </span>
                 </div>
                 <div
-                  className="sc-dQppl sc-fodVxV frNjEq hMCDIC"
+                  className="sc-fodVxV sc-dIUggk iMcVO gmTuhM"
                   title="snack"
                 >
                   <span
-                    className="sc-fFubgz dbrUMP"
+                    className="sc-hHftDr gJoLEh"
                   >
                     snack
                   </span>
                 </div>
                 <div
-                  className="sc-bqyKva eItknN"
+                  className="sc-fFubgz dtAnGh"
                 >
                   <button
-                    className="sc-eCssSg fZtIvG"
+                    className="sc-fubCfw gidPif"
                     onClick={[Function]}
                     title="Pin to Top"
                   >
                     <svg
-                      className="sc-gKsewC MUSWU"
+                      className="sc-jrAGrp fOOXsv"
                     >
                       pin.svg
                     </svg>
                   </button>
                 </div>
                 <span
-                  className="sc-bkzZxe dGllbM"
+                  className="sc-dmlrTW cMjcII"
                 >
                   <time
                     dateTime="2017-12-21T15:35:57.000Z"
@@ -1185,11 +1182,11 @@ exports[`sidebar renders list of resources 1`] = `
                 </span>
               </div>
               <div
-                className="sc-crrsfI bAJfaH"
+                className="sc-hBEYos fVbLmK"
               >
                 <div
                   aria-describedby={null}
-                  className="sc-hKgILt iMooxb isUnhealthy"
+                  className="sc-iBPRYJ hwwEyI isUnhealthy"
                   onBlur={[Function]}
                   onFocus={[Function]}
                   onMouseLeave={[Function]}
@@ -1205,17 +1202,17 @@ exports[`sidebar renders list of resources 1`] = `
                   </svg>
                 </div>
                 <div
-                  className="sc-dQppl frNjEq"
+                  className="sc-fodVxV iMcVO"
                 >
                   Update error
                 </div>
               </div>
             </div>
             <div
-              className="sc-idOhPF csSihC"
+              className="sc-kfzAmx gYdoGx"
             >
               <button
-                className="sc-iBPRYJ cjfxil"
+                className="sc-kEjbxe gaYZpE"
                 disabled={true}
                 onClick={[Function]}
                 style={
@@ -1241,38 +1238,38 @@ exports[`sidebar renders list of resources 1`] = `
 
 exports[`sidebar renders resources that haven't been built yet 1`] = `
 <nav
-  className="sc-dIUggk grSaCL Sidebar-resources "
+  className="sc-fKFyDc iXLYud Sidebar-resources "
 >
   <div
-    className="sc-hHftDr"
+    className="sc-bBXqnf"
   >
     <div>
       <div
-        className="sc-dmlrTW iTieuF"
+        className="sc-iwyYcG fXFHir"
       >
         
       </div>
       <ul
-        className="sc-kfzAmx khbJgg"
+        className="sc-cxFLnm jlNuLB"
       >
         <li
-          className="sc-pFZIQ sc-kstrdz eaCWvj gajrif"
+          className="sc-crrsfI sc-bkzZxe jItnSg gzVHhL"
         >
           <div
-            className="sc-jrAGrp sc-hBEYos ghJJLs gVXwBF isSelected"
+            className="sc-dQppl sc-idOhPF btfhxN kwjnVr isSelected"
             onClick={[Function]}
             role="button"
             tabIndex={-1}
           >
             <div
-              className="sc-hKgILt iMooxb isNone"
+              className="sc-iBPRYJ hwwEyI isNone"
             >
               <svg>
                 checkmark-small.svg
               </svg>
             </div>
             <div
-              className="sc-dQppl sc-fodVxV frNjEq hMCDIC"
+              className="sc-fodVxV sc-dIUggk iMcVO gmTuhM"
             >
               All
             </div>
@@ -1284,13 +1281,12 @@ exports[`sidebar renders resources that haven't been built yet 1`] = `
       className="sc-bdfBwQ bJwFId is-filtersHidden"
       style={
         Object {
-          "marginBottom": "-16px",
           "marginTop": "24px",
         }
       }
     >
       <button
-        className="sc-dlfnbm hYhRhc"
+        className="sc-gKsewC jRJBDl"
         onClick={[Function]}
       >
         Alerts on Top
@@ -1298,32 +1294,32 @@ exports[`sidebar renders resources that haven't been built yet 1`] = `
     </div>
     <div>
       <div
-        className="sc-dmlrTW iTieuF"
+        className="sc-iwyYcG fXFHir"
       >
         resources
       </div>
       <ul
-        className="sc-kfzAmx khbJgg"
+        className="sc-cxFLnm jlNuLB"
       >
         <li
-          className="sc-pFZIQ eaCWvj u-showPinOnHover  isBuilding"
+          className="sc-crrsfI jItnSg u-showPinOnHover  isBuilding"
         >
           <div
-            className="sc-jrAGrp ghJJLs  isBuilding"
+            className="sc-dQppl btfhxN  isBuilding"
             data-name="vigoda"
             onClick={[Function]}
             role="button"
             tabIndex={-1}
           >
             <div
-              className="sc-kEjbxe gpekhu"
+              className="sc-bqyKva iOaTfz"
             >
               <div
-                className="sc-iqHYGH juiiLS"
+                className="sc-kstrdz eHNvIE"
               >
                 <div
                   aria-describedby={null}
-                  className="sc-hKgILt iMooxb isHealthy"
+                  className="sc-iBPRYJ hwwEyI isHealthy"
                   onBlur={[Function]}
                   onFocus={[Function]}
                   onMouseLeave={[Function]}
@@ -1337,42 +1333,42 @@ exports[`sidebar renders resources that haven't been built yet 1`] = `
                   </span>
                 </div>
                 <div
-                  className="sc-dQppl sc-fodVxV frNjEq hMCDIC"
+                  className="sc-fodVxV sc-dIUggk iMcVO gmTuhM"
                   title="vigoda"
                 >
                   <span
-                    className="sc-fFubgz dbrUMP"
+                    className="sc-hHftDr gJoLEh"
                   >
                     vigoda
                   </span>
                 </div>
                 <div
-                  className="sc-bqyKva eItknN"
+                  className="sc-fFubgz dtAnGh"
                 >
                   <button
-                    className="sc-eCssSg fZtIvG"
+                    className="sc-fubCfw gidPif"
                     onClick={[Function]}
                     title="Pin to Top"
                   >
                     <svg
-                      className="sc-gKsewC MUSWU"
+                      className="sc-jrAGrp fOOXsv"
                     >
                       pin.svg
                     </svg>
                   </button>
                 </div>
                 <span
-                  className="sc-bkzZxe dGllbM"
+                  className="sc-dmlrTW cMjcII"
                 >
                   —
                 </span>
               </div>
               <div
-                className="sc-crrsfI bAJfaH"
+                className="sc-hBEYos fVbLmK"
               >
                 <div
                   aria-describedby={null}
-                  className="sc-hKgILt iMooxb isBuilding"
+                  className="sc-iBPRYJ hwwEyI isBuilding"
                   onBlur={[Function]}
                   onFocus={[Function]}
                   onMouseLeave={[Function]}
@@ -1386,17 +1382,17 @@ exports[`sidebar renders resources that haven't been built yet 1`] = `
                   </span>
                 </div>
                 <div
-                  className="sc-dQppl frNjEq"
+                  className="sc-fodVxV iMcVO"
                 >
                   Updating…
                 </div>
               </div>
             </div>
             <div
-              className="sc-idOhPF csSihC"
+              className="sc-kfzAmx gYdoGx"
             >
               <button
-                className="sc-iBPRYJ cjfxil"
+                className="sc-kEjbxe gaYZpE"
                 disabled={true}
                 onClick={[Function]}
                 style={
@@ -1414,24 +1410,24 @@ exports[`sidebar renders resources that haven't been built yet 1`] = `
           </div>
         </li>
         <li
-          className="sc-pFZIQ eaCWvj u-showPinOnHover  isBuilding"
+          className="sc-crrsfI jItnSg u-showPinOnHover  isBuilding"
         >
           <div
-            className="sc-jrAGrp ghJJLs  isBuilding"
+            className="sc-dQppl btfhxN  isBuilding"
             data-name="snack"
             onClick={[Function]}
             role="button"
             tabIndex={-1}
           >
             <div
-              className="sc-kEjbxe gpekhu"
+              className="sc-bqyKva iOaTfz"
             >
               <div
-                className="sc-iqHYGH juiiLS"
+                className="sc-kstrdz eHNvIE"
               >
                 <div
                   aria-describedby={null}
-                  className="sc-hKgILt iMooxb isHealthy"
+                  className="sc-iBPRYJ hwwEyI isHealthy"
                   onBlur={[Function]}
                   onFocus={[Function]}
                   onMouseLeave={[Function]}
@@ -1445,42 +1441,42 @@ exports[`sidebar renders resources that haven't been built yet 1`] = `
                   </span>
                 </div>
                 <div
-                  className="sc-dQppl sc-fodVxV frNjEq hMCDIC"
+                  className="sc-fodVxV sc-dIUggk iMcVO gmTuhM"
                   title="snack"
                 >
                   <span
-                    className="sc-fFubgz dbrUMP"
+                    className="sc-hHftDr gJoLEh"
                   >
                     snack
                   </span>
                 </div>
                 <div
-                  className="sc-bqyKva eItknN"
+                  className="sc-fFubgz dtAnGh"
                 >
                   <button
-                    className="sc-eCssSg fZtIvG"
+                    className="sc-fubCfw gidPif"
                     onClick={[Function]}
                     title="Pin to Top"
                   >
                     <svg
-                      className="sc-gKsewC MUSWU"
+                      className="sc-jrAGrp fOOXsv"
                     >
                       pin.svg
                     </svg>
                   </button>
                 </div>
                 <span
-                  className="sc-bkzZxe dGllbM"
+                  className="sc-dmlrTW cMjcII"
                 >
                   —
                 </span>
               </div>
               <div
-                className="sc-crrsfI bAJfaH"
+                className="sc-hBEYos fVbLmK"
               >
                 <div
                   aria-describedby={null}
-                  className="sc-hKgILt iMooxb isBuilding"
+                  className="sc-iBPRYJ hwwEyI isBuilding"
                   onBlur={[Function]}
                   onFocus={[Function]}
                   onMouseLeave={[Function]}
@@ -1494,17 +1490,17 @@ exports[`sidebar renders resources that haven't been built yet 1`] = `
                   </span>
                 </div>
                 <div
-                  className="sc-dQppl frNjEq"
+                  className="sc-fodVxV iMcVO"
                 >
                   Updating…
                 </div>
               </div>
             </div>
             <div
-              className="sc-idOhPF csSihC"
+              className="sc-kfzAmx gYdoGx"
             >
               <button
-                className="sc-iBPRYJ cjfxil"
+                className="sc-kEjbxe gaYZpE"
                 disabled={true}
                 onClick={[Function]}
                 style={

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -143,8 +143,8 @@ export enum ResourceName {
 
 export type SidebarOptions = {
   // Which cards to show in sidebar
-  showResources: boolean
-  showTests: boolean
+  testsHidden: boolean
+  testsOnly: boolean
 
   // Sorting options
   alertsOnTop: boolean


### PR DESCRIPTION
fyi han, the very last commit of this bunch is a shot at renaming
because lines were getting long and names were feeling clunky,
but if you object (do you have a more specific understanding of
"toggle" than I do?) lmk and i can put it back