### PR TITLE
logstore: truncate chatty resources before non-chatty resources

### DIFF
--- a/pkg/model/logstore/logstore_test.go
+++ b/pkg/model/logstore/logstore_test.go
@@ -45,7 +45,7 @@ func TestAppendDifferentLevelsMultiLines(t *testing.T) {
 
 func TestLog_AppendOverLimit(t *testing.T) {
 	l := NewLogStore()
-	l.maxLogLengthInBytes = 100
+	l.maxLogLengthInBytes = 32
 
 	l.Append(newGlobalTestLogEvent("hello\n"), nil)
 	sb := strings.Builder{}
@@ -58,7 +58,19 @@ func TestLog_AppendOverLimit(t *testing.T) {
 
 	s := sb.String()
 	l.Append(newGlobalTestLogEvent(s), nil)
-	assert.Equal(t, s[:l.logTruncationTarget()], l.String())
+	assert.Equal(t, "x\nx\nx\nx\nx\nx\nx\nx\n", l.String())
+}
+
+func TestLog_TruncateChattySpansFirst(t *testing.T) {
+	l := NewLogStore()
+	l.maxLogLengthInBytes = 60
+
+	l.Append(newTestLogEvent("(tiltfile)", time.Now(), "Tiltfile Success"), nil)
+	for i := 0; i < 20; i++ {
+		l.Append(newTestLogEvent("noisy", time.Now(), "Noisy Log\n"), nil)
+	}
+
+	assert.Contains(t, l.String(), "Tiltfile Success")
 }
 
 func TestLogPrefix(t *testing.T) {


### PR DESCRIPTION
Hello @landism, @milas,

Please review the following commits I made in branch nicks/ch11384:

0bdb3cee474bbe2b9b3dd9f2ccb977fe6bd12684 (2021-02-15 19:14:30 -0500)
logstore: truncate chatty resources before non-chatty resources
This is a simple algorithm to give priority to truncating resources
with lots of logs.

Fixes https://github.com/tilt-dev/tilt/issues/3909

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics