### PR TITLE
tiltfile: add os.path.relpath

### DIFF
--- a/internal/tiltfile/os/os.go
+++ b/internal/tiltfile/os/os.go
@@ -169,10 +169,13 @@ func abspath(t *starlark.Thread, path string) (starlark.Value, error) {
 }
 
 func relpath(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-	var basepath, targpath string
+	var targpath string
+	basepath := starkit.AbsWorkingDir(thread) // by default, relative to CWD
+
+	// Matches syntax of Python's os.path.relpath()
 	if err := starkit.UnpackArgs(thread, fn.Name(), args, kwargs,
-		"basepath", &basepath,
-		"targpath", &targpath); err != nil {
+		"targpath", &targpath,
+		"basepath?", &basepath); err != nil {
 		return nil, err
 	}
 	relPath, err := filepath.Rel(basepath, targpath)

--- a/internal/tiltfile/os/os.go
+++ b/internal/tiltfile/os/os.go
@@ -34,6 +34,10 @@ func (e Extension) OnStart(env *starkit.Environment) error {
 	if err != nil {
 		return err
 	}
+	err = env.AddBuiltin("os.path.relpath", relpath)
+	if err != nil {
+		return err
+	}
 	err = addPathBuiltin(env, "os.path.basename", basename)
 	if err != nil {
 		return err
@@ -162,6 +166,17 @@ func addPathBuiltin(env *starkit.Environment, name string,
 
 func abspath(t *starlark.Thread, path string) (starlark.Value, error) {
 	return starlark.String(starkit.AbsPath(t, path)), nil
+}
+
+func relpath(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var basepath, targpath string
+	if err := starkit.UnpackArgs(thread, fn.Name(), args, kwargs,
+		"basepath", &basepath,
+		"targpath", &targpath); err != nil {
+		return nil, err
+	}
+	relPath, err := filepath.Rel(basepath, targpath)
+	return starlark.String(relPath), err
 }
 
 func basename(t *starlark.Thread, path string) (starlark.Value, error) {

--- a/internal/tiltfile/os/os_test.go
+++ b/internal/tiltfile/os/os_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -199,30 +200,40 @@ print(path)
 
 // NOTE(maia): `relpath` tests use raw strings (`r'stuff'`) so that Windows tests pass
 // (otherwise Starlark sees invalid escape sequences in Windows filespaths and gets mad)
-func TestRelpath(t *testing.T) {
+// Also, we use filepath.Rel to get expected path so it works on all OS's.
+func TestRelpathDefaultCWD(t *testing.T) {
 	f := NewFixture(t)
 	f.UseRealFS()
 
-	f.File("Tiltfile", fmt.Sprintf(`
-print(os.path.relpath(os.getcwd(), r'%s'))
-`, f.JoinPath("beep/boop")))
+	targpath := f.JoinPath("beep/boop")
+	expected, err := filepath.Rel(f.Path(), targpath)
+	assert.NoError(t, err)
 
-	_, err := f.ExecFile("Tiltfile")
+	f.File("Tiltfile", fmt.Sprintf(`
+print(os.path.relpath(r'%s'))
+`, targpath))
+
+	_, err = f.ExecFile("Tiltfile")
 	require.NoError(t, err)
-	assert.Equal(t, "beep/boop\n", f.PrintOutput())
+	assert.Equal(t, expected, strings.TrimSpace(f.PrintOutput()))
 }
 
 func TestRelpathToDifferentDir(t *testing.T) {
 	f := NewFixture(t)
 	f.UseRealFS()
 
+	targpath := f.JoinPath("beep/boop")
+	basepath := f.JoinPath("beep/")
+	expected, err := filepath.Rel(basepath, targpath)
+	assert.NoError(t, err)
+
 	f.File("Tiltfile", fmt.Sprintf(`
 print(os.path.relpath(r'%s', r'%s'))
-`, f.JoinPath("beep/"), f.JoinPath("beep/boop")))
+`, targpath, basepath))
 
-	_, err := f.ExecFile("Tiltfile")
+	_, err = f.ExecFile("Tiltfile")
 	require.NoError(t, err)
-	assert.Equal(t, "boop\n", f.PrintOutput())
+	assert.Equal(t, expected, strings.TrimSpace(f.PrintOutput()))
 }
 
 func TestRelpathImpossible(t *testing.T) {
@@ -230,7 +241,7 @@ func TestRelpathImpossible(t *testing.T) {
 	f.UseRealFS()
 
 	f.File("Tiltfile", `
-print(os.path.relpath(os.getcwd(), 'some/nonsense/path'))
+print(os.path.relpath('some/nonsense/path'))
 `)
 	_, err := f.ExecFile("Tiltfile")
 	require.Error(t, err)
@@ -241,30 +252,40 @@ func TestRelpathUpADir(t *testing.T) {
 	f := NewFixture(t)
 	f.UseRealFS()
 
+	targpath := f.JoinPath("beep/boop")
+	basepath := f.JoinPath("foo")
+	expected, err := filepath.Rel(basepath, targpath)
+	assert.NoError(t, err)
+
 	f.File("foo/Tiltfile", fmt.Sprintf(`
-print(os.path.relpath(os.getcwd(), r'%s'))
+print(os.path.relpath(r'%s'))
 `, f.JoinPath("beep/boop")))
 
-	_, err := f.ExecFile("foo/Tiltfile")
+	_, err = f.ExecFile("foo/Tiltfile")
 	require.NoError(t, err)
-	assert.Equal(t, "../beep/boop\n", f.PrintOutput())
+	assert.Equal(t, expected, strings.TrimSpace(f.PrintOutput()))
 }
 
 func TestRelpathLoad(t *testing.T) {
 	f := NewFixture(t)
 	f.UseRealFS()
 
+	targpath := f.JoinPath("foo/beep/boop")
+	basepath := f.JoinPath("foo")
+	expected, err := filepath.Rel(basepath, targpath)
+	assert.NoError(t, err)
+
 	f.File("foo/Tiltfile", fmt.Sprintf(`
-path = os.path.relpath(os.getcwd(), r'%s')
+path = os.path.relpath(r'%s')
 `, f.JoinPath("foo/beep/boop")))
 
 	f.File("Tiltfile", `
 load('./foo/Tiltfile', 'path')
 print(path)
 `)
-	_, err := f.ExecFile("Tiltfile")
+	_, err = f.ExecFile("Tiltfile")
 	require.NoError(t, err)
-	assert.Equal(t, "beep/boop\n", f.PrintOutput())
+	assert.Equal(t, expected, strings.TrimSpace(f.PrintOutput()))
 }
 
 func TestBasename(t *testing.T) {

--- a/internal/tiltfile/os/os_test.go
+++ b/internal/tiltfile/os/os_test.go
@@ -197,12 +197,14 @@ print(path)
 	assert.Equal(t, fmt.Sprintf("%s\n", f.JoinPath("bar")), f.PrintOutput())
 }
 
+// NOTE(maia): `relpath` tests use raw strings (`r'stuff'`) so that Windows tests pass
+// (otherwise Starlark sees invalid escape sequences in Windows filespaths and gets mad)
 func TestRelpath(t *testing.T) {
 	f := NewFixture(t)
 	f.UseRealFS()
 
 	f.File("Tiltfile", fmt.Sprintf(`
-print(os.path.relpath(os.getcwd(), '%s'))
+print(os.path.relpath(os.getcwd(), r'%s'))
 `, f.JoinPath("beep/boop")))
 
 	_, err := f.ExecFile("Tiltfile")
@@ -215,7 +217,7 @@ func TestRelpathToDifferentDir(t *testing.T) {
 	f.UseRealFS()
 
 	f.File("Tiltfile", fmt.Sprintf(`
-print(os.path.relpath('%s', '%s'))
+print(os.path.relpath(r'%s', r'%s'))
 `, f.JoinPath("beep/"), f.JoinPath("beep/boop")))
 
 	_, err := f.ExecFile("Tiltfile")
@@ -240,7 +242,7 @@ func TestRelpathUpADir(t *testing.T) {
 	f.UseRealFS()
 
 	f.File("foo/Tiltfile", fmt.Sprintf(`
-print(os.path.relpath(os.getcwd(), '%s'))
+print(os.path.relpath(os.getcwd(), r'%s'))
 `, f.JoinPath("beep/boop")))
 
 	_, err := f.ExecFile("foo/Tiltfile")
@@ -253,7 +255,7 @@ func TestRelpathLoad(t *testing.T) {
 	f.UseRealFS()
 
 	f.File("foo/Tiltfile", fmt.Sprintf(`
-path = os.path.relpath(os.getcwd(), '%s')
+path = os.path.relpath(os.getcwd(), r'%s')
 `, f.JoinPath("foo/beep/boop")))
 
 	f.File("Tiltfile", `


### PR DESCRIPTION
this would have been useful for the [Tests In Tilt code snippets](https://docs.tilt.dev/tests_in_tilt.html#go-tests-by-package) i was writing for docs, so I implemented it