### PR TITLE
containerupdate: improved error messaging when the file system isn't writable

### DIFF
--- a/internal/engine/build_and_deployer.go
+++ b/internal/engine/build_and_deployer.go
@@ -105,8 +105,10 @@ func (composite *CompositeBuildAndDeployer) BuildAndDeploy(ctx context.Context, 
 		} else {
 			lastUnexpectedErr = err
 			if isLiveUpdate {
-				l.Warnf("Live Update failed with unexpected error:\n\t%v\n"+
-					"Falling back to a full image build + deploy\n", err)
+				// Indent the error message.
+				errMsg := strings.Replace(strings.TrimSpace(fmt.Sprintf("%v", err)), "\n", "\n\t", -1)
+				l.Warnf("Live Update failed with unexpected error:\n\t%s\n"+
+					"Falling back to a full image build + deploy", errMsg)
 			} else if i+1 < len(composite.builders) {
 				logger.Get(ctx).Infof("got unexpected error during build/deploy: %v", err)
 			}

--- a/internal/k8s/fake_client.go
+++ b/internal/k8s/fake_client.go
@@ -72,8 +72,9 @@ type FakeK8sClient struct {
 	listCallCount           int
 	listReturnsEmpty        bool
 
-	ExecCalls  []ExecCall
-	ExecErrors []error
+	ExecCalls   []ExecCall
+	ExecOutputs []io.Reader
+	ExecErrors  []error
 }
 
 type ExecCall struct {
@@ -456,6 +457,12 @@ func (c *FakeK8sClient) Exec(ctx context.Context, podID PodID, cName container.N
 		Cmd:   cmd,
 		Stdin: stdinBytes,
 	})
+
+	if len(c.ExecOutputs) > 0 {
+		out := c.ExecOutputs[0]
+		c.ExecOutputs = c.ExecOutputs[1:]
+		_, _ = io.Copy(stdout, out)
+	}
 
 	if len(c.ExecErrors) > 0 {
 		err = c.ExecErrors[0]

--- a/web/src/LogPaneLine.scss
+++ b/web/src/LogPaneLine.scss
@@ -37,6 +37,22 @@
   margin-top: 8px;
 }
 
+// Make spacing around "header" text more generous for legibility
+// We avoid padding on the parent .LogPaneLine, lest we squish .logLinePrefix
+.LogPaneLine.is-buildEvent-init .LogPaneLine-content {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+.LogPaneLine:not(.is-buildEvent-fallback) + .LogPaneLine.is-buildEvent-fallback .LogPaneLine-content {
+  padding-top: 8px;
+}
+.LogPaneLine.is-buildEvent-fallback .LogPaneLine-content {
+  padding-bottom: 8px;
+}
+.LogPaneLine.is-buildEvent-fallback + .LogPaneLine.is-buildEvent-fallback .LogPaneLine-content {
+  margin-top: -8px;
+}
+
 .LogPaneLine-alertNav {
   position: absolute;
   display: block;
@@ -90,13 +106,6 @@
   flex: 1;
   border-left: $logLine-separator-height solid $color-gray;
   overflow-wrap: anywhere;
-
-  // Make spacing around "header" text more generous for legibility
-  // We avoid padding on the parent .LogPaneLine, lest we squish .logLinePrefix
-  .LogPaneLine.is-buildEvent & {
-    padding-top: 4px;
-    padding-bottom: 4px;
-  }
 
   // A left border draws your eye to notable log lines
   // Placed right of the prefix, so it's always just next to the log text

--- a/web/src/OverviewLogPane.stories.tsx
+++ b/web/src/OverviewLogPane.stories.tsx
@@ -129,6 +129,38 @@ export const BuildFallbackLines = () => {
   )
 }
 
+export const BuildFallbackLinesLong = () => {
+  let logStore = new LogStore()
+  let lines = [
+    { text: "Start build\n", fields: { buildEvent: "init" } },
+    "Build log 1\n",
+    "Build log 2\n",
+    {
+      text:
+        "Fallback build 1 Fallback build 1 Fallback build 1 Fallback build 1 Fallback build 1 Fallback build 1 Fallback build 1 Fallback build 1\n",
+      fields: { buildEvent: "fallback" },
+    },
+    {
+      text:
+        "Fallback build 2 Fallback build 2 Fallback build 2 Fallback build 2 Fallback build 2 Fallback build 2 Fallback build 2 Fallback build 2\n",
+      fields: { buildEvent: "fallback" },
+    },
+    {
+      text:
+        "Fallback build 3 Fallback build 3 Fallback build 3 Fallback build 3 Fallback build 3 Fallback build 3 Fallback build 3 Fallback build 3 Fallback build 3\n",
+      fields: { buildEvent: "fallback" },
+    },
+    "Build log 3\n",
+    "Build log 4\n",
+  ]
+  appendLines(logStore, "fe", ...lines)
+  return (
+    <LogStoreProvider value={logStore}>
+      <OverviewLogPane manifestName="fe" filterSet={defaultFilter} />
+    </LogStoreProvider>
+  )
+}
+
 export const ProgressLines = (args: any) => {
   let [logStore, setLogStore] = useState(new LogStore())
   let lines = [


### PR DESCRIPTION
Hello @maiamcc, @landism,

Please review the following commits I made in branch nicks/ch11396:

63fa3751e92f147ee790ed4b289951ff45823a66 (2021-02-16 18:20:57 -0500)
containerupdate: improved error messaging when the file system isn't writable
Fixes https://github.com/tilt-dev/tilt/issues/4206

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics