### PR TITLE
cli: add a helper for querying the tilt server

### DIFF
--- a/internal/cli/alpha.go
+++ b/internal/cli/alpha.go
@@ -13,6 +13,7 @@ The APIs of these commands may change frequently.
 	}
 
 	addCommand(result, newTiltfileResultCmd())
+	addCommand(result, newKubeconfigPathCmd())
 
 	return result
 }

--- a/internal/cli/kubeconfig_path.go
+++ b/internal/cli/kubeconfig_path.go
@@ -1,0 +1,73 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+
+	"github.com/spf13/cobra"
+
+	"github.com/tilt-dev/tilt/pkg/model"
+)
+
+type kubeconfigPathCmd struct {
+}
+
+var _ tiltCmd = &kubeconfigPathCmd{}
+
+func newKubeconfigPathCmd() *kubeconfigPathCmd {
+	return &kubeconfigPathCmd{}
+}
+
+func (c *kubeconfigPathCmd) name() model.TiltSubcommand { return "kubeconfig-path" }
+
+func (c *kubeconfigPathCmd) register() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "kubeconfig-path",
+		Short:   "Prints out a path to a KUBECONFIG for querying the Tilt apiserver",
+		Example: "KUBECONFIG=$(tilt alpha kubeconfig-path) kubectl api-resources",
+	}
+
+	addConnectServerFlags(cmd)
+
+	return cmd
+}
+
+func (c *kubeconfigPathCmd) run(ctx context.Context, args []string) error {
+	tmpfile, err := ioutil.TempFile("", "tilt-kubeconfig")
+	if err != nil {
+		return err
+	}
+	defer tmpfile.Close()
+
+	// Don't worry the password isn't real.
+	// The tilt-apiserver binds on localhost only by default with no auth.
+	_, err = fmt.Fprintf(tmpfile, `apiVersion: v1
+clusters:
+- cluster:
+    insecure-skip-tls-verify: true
+    server: http://%s:%d
+  name: tilt-apiserver
+contexts:
+- context:
+    cluster: tilt-apiserver
+    user: tilt-apiserver
+  name: tilt-apiserver
+current-context: tilt-apiserver
+kind: Config
+preferences: {}
+users:
+- name: tilt-apiserver
+  user:
+    username: corgi
+    password: charge!!!
+`, provideWebHost(), provideWebPort())
+
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("%s", tmpfile.Name())
+
+	return nil
+}

--- a/internal/cli/tiltfile_result.go
+++ b/internal/cli/tiltfile_result.go
@@ -52,8 +52,10 @@ func (c *tiltfileResultCmd) name() model.TiltSubcommand { return "tiltfile-resul
 func (c *tiltfileResultCmd) register() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "tiltfile-result",
-		Short: "Exec the Tiltfile and print data about execution. By default, prints Tiltfile execution results as JSON (note: the API is unstable and may change); can also print timings of Tiltfile Builtin calls.",
-		Long: `Exec the Tiltfile and print data about execution. By default, prints Tiltfile execution results as JSON (note: the API is unstable and may change); can also print timings of Tiltfile Builtin calls.
+		Short: "Exec the Tiltfile and print data about execution",
+		Long: `Exec the Tiltfile and print data about execution.
+
+By default, prints Tiltfile execution results as JSON (note: the API is unstable and may change); can also print timings of Tiltfile Builtin calls.
 
 Exit code 0: successful Tiltfile evaluation (data printed to stdout)
 Exit code 1: some failure in setup, printing results, etc. (any logs printed to stderr)


### PR DESCRIPTION
Hello @maiamcc, @milas,

Please review the following commits I made in branch nicks/ch11415:

51fba76dff22887331fe382ddf2e3beddcfb08c8 (2021-02-18 11:57:17 -0500)
cli: add a helper for querying the tilt server

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics