### PR TITLE
web: fix broken nav for resources with URL unsafe names

### DIFF
--- a/web/src/HUD.tsx
+++ b/web/src/HUD.tsx
@@ -576,7 +576,7 @@ export default class HUD extends Component<HudProps, HudState> {
     let tiltCloudTeamName = view?.tiltCloudTeamName || null
     let isSnapshot = this.pathBuilder.isSnapshot()
     let sidebarRoute = (t: ResourceView, props: RouteComponentProps<any>) => {
-      let name = props.match.params.name
+      const name = decodeURIComponent(props.match.params?.name ?? "")
       return (
         <Sidebar isClosed={isSidebarClosed} toggleSidebar={this.toggleSidebar}>
           <SidebarAccount
@@ -630,7 +630,7 @@ export default class HUD extends Component<HudProps, HudState> {
     let isSnapshot = this.pathBuilder.isSnapshot()
 
     let traceRoute = (props: RouteComponentProps<any>) => {
-      let name = props.match.params?.name ?? ""
+      const name = decodeURIComponent(props.match.params?.name ?? "")
       let span = props.match.params?.span ?? ""
 
       let r = resources.find((r) => r.name === name)
@@ -657,7 +657,7 @@ export default class HUD extends Component<HudProps, HudState> {
     }
 
     let logsRoute = (props: RouteComponentProps<any>) => {
-      let name = props.match.params?.name ?? ""
+      const name = decodeURIComponent(props.match.params?.name ?? "")
       let r = resources.find((r) => r.name === name)
       if (r === undefined) {
         return <Route component={NotFound} />
@@ -682,7 +682,7 @@ export default class HUD extends Component<HudProps, HudState> {
     }
 
     let errorRoute = (props: RouteComponentProps<any>): React.ReactNode => {
-      let name = props.match.params ? props.match.params.name : ""
+      const name = decodeURIComponent(props.match.params?.name ?? "")
       let er = resources.find((r) => r.name === name)
       if (!er) {
         return <Route component={NotFound} />
@@ -696,7 +696,7 @@ export default class HUD extends Component<HudProps, HudState> {
       )
     }
     let facetsRoute = (props: RouteComponentProps<any>): React.ReactNode => {
-      let name = props.match.params ? props.match.params.name : ""
+      const name = decodeURIComponent(props.match.params?.name ?? "")
       let fr = resources.find((r) => r.name === name)
       if (!fr) {
         return <Route component={NotFound} />

--- a/web/src/TabNav.tsx
+++ b/web/src/TabNav.tsx
@@ -50,6 +50,7 @@ export function LegacyNavProvider(
   let pb = usePathBuilder()
   let { resourceView, children } = props
   let nav = (name: string) => {
+    name = encodeURIComponent(name)
     let all = name === "" || name === ResourceName.all
     if (all) {
       switch (resourceView) {
@@ -129,7 +130,9 @@ export function OverviewNavProvider(
   let matchResource = matchPath(history.location.pathname, {
     path: pb.path("/r/:name"),
   })
-  let candidateTab = (matchResource?.params as any)?.name || ""
+  let candidateTab = decodeURIComponent(
+    (matchResource?.params as any)?.name || ""
+  )
   if (candidateTab && validateTab(candidateTab)) {
     selectedTab = candidateTab
   } else {
@@ -175,7 +178,7 @@ export function OverviewNavProvider(
   }
 
   let openResource = (name: string, options?: { newTab: boolean }) => {
-    name = name || ResourceName.all
+    name = encodeURIComponent(name || ResourceName.all)
     let openNew = options?.newTab || false
     let url = pb.path(`/r/${name}/overview`)
     let newTabs


### PR DESCRIPTION
This just URI encodes the name - you'll get some ugly URLs
if your resources have crazy names, but c'est la vie.

For example:
	`foo` -> `/r/foo/overview`
	`a/b/c` -> `/r/a%2Fb%2Fc/overview`
	`🎉` -> `/r/🎉/overview`
	`alert("test")` -> `/r/alert("test")/overview`

<img width="856" alt="Screen Shot 2021-02-18 at 1 17 10 PM" src="https://user-images.githubusercontent.com/841263/108402681-d5041580-71eb-11eb-9713-bd106b70afaa.png">

Closes #4026.