### PR TITLE
tiltfile: send analytics for extensions [ch1142]

### DIFF
--- a/internal/cli/wire_gen.go
+++ b/internal/cli/wire_gen.go
@@ -50,6 +50,7 @@ import (
 	"github.com/tilt-dev/tilt/internal/tiltfile"
 	"github.com/tilt-dev/tilt/internal/tiltfile/config"
 	"github.com/tilt-dev/tilt/internal/tiltfile/k8scontext"
+	"github.com/tilt-dev/tilt/internal/tiltfile/tiltextension"
 	"github.com/tilt-dev/tilt/internal/tiltfile/version"
 	"github.com/tilt-dev/tilt/internal/token"
 	"github.com/tilt-dev/tilt/internal/tracer"
@@ -82,13 +83,17 @@ func wireTiltfileResult(ctx context.Context, analytics2 *analytics.TiltAnalytics
 	tiltBuild := provideTiltInfo()
 	versionExtension := version.NewExtension(tiltBuild)
 	configExtension := config.NewExtension(subcommand)
+	tiltextensionExtension, err := tiltextension.ProvideExtension()
+	if err != nil {
+		return cmdTiltfileResultDeps{}, err
+	}
 	runtime := k8s.ProvideContainerRuntime(ctx, client)
 	clusterEnv := docker.ProvideClusterEnv(ctx, env, runtime, minikubeClient)
 	localEnv := docker.ProvideLocalEnv(ctx, clusterEnv)
 	dockerComposeClient := dockercompose.NewDockerComposeClient(localEnv)
 	webHost := provideWebHost()
 	defaults := _wireDefaultsValue
-	tiltfileLoader := tiltfile.ProvideTiltfileLoader(analytics2, client, extension, versionExtension, configExtension, dockerComposeClient, webHost, defaults, env)
+	tiltfileLoader := tiltfile.ProvideTiltfileLoader(analytics2, client, extension, versionExtension, configExtension, tiltextensionExtension, dockerComposeClient, webHost, defaults, env)
 	cliCmdTiltfileResultDeps := newTiltfileResultDeps(tiltfileLoader)
 	return cliCmdTiltfileResultDeps, nil
 }
@@ -128,10 +133,14 @@ func wireDockerPrune(ctx context.Context, analytics2 *analytics.TiltAnalytics, s
 	tiltBuild := provideTiltInfo()
 	versionExtension := version.NewExtension(tiltBuild)
 	configExtension := config.NewExtension(subcommand)
+	tiltextensionExtension, err := tiltextension.ProvideExtension()
+	if err != nil {
+		return dpDeps{}, err
+	}
 	dockerComposeClient := dockercompose.NewDockerComposeClient(localEnv)
 	webHost := provideWebHost()
 	defaults := _wireDefaultsValue
-	tiltfileLoader := tiltfile.ProvideTiltfileLoader(analytics2, client, extension, versionExtension, configExtension, dockerComposeClient, webHost, defaults, env)
+	tiltfileLoader := tiltfile.ProvideTiltfileLoader(analytics2, client, extension, versionExtension, configExtension, tiltextensionExtension, dockerComposeClient, webHost, defaults, env)
 	cliDpDeps := newDPDeps(switchCli, tiltfileLoader)
 	return cliDpDeps, nil
 }
@@ -222,8 +231,12 @@ func wireCmdUp(ctx context.Context, analytics3 *analytics.TiltAnalytics, cmdTags
 	tiltBuild := provideTiltInfo()
 	versionExtension := version.NewExtension(tiltBuild)
 	configExtension := config.NewExtension(subcommand)
+	tiltextensionExtension, err := tiltextension.ProvideExtension()
+	if err != nil {
+		return CmdUpDeps{}, err
+	}
 	defaults := _wireDefaultsValue
-	tiltfileLoader := tiltfile.ProvideTiltfileLoader(analytics3, client, extension, versionExtension, configExtension, dockerComposeClient, webHost, defaults, env)
+	tiltfileLoader := tiltfile.ProvideTiltfileLoader(analytics3, client, extension, versionExtension, configExtension, tiltextensionExtension, dockerComposeClient, webHost, defaults, env)
 	configsController := configs.NewConfigsController(tiltfileLoader, switchCli)
 	eventWatcher := dcwatch.NewEventWatcher(dockerComposeClient, localClient)
 	dockerComposeLogManager := runtimelog.NewDockerComposeLogManager(dockerComposeClient)
@@ -380,8 +393,12 @@ func wireCmdCI(ctx context.Context, analytics3 *analytics.TiltAnalytics, subcomm
 	tiltBuild := provideTiltInfo()
 	versionExtension := version.NewExtension(tiltBuild)
 	configExtension := config.NewExtension(subcommand)
+	tiltextensionExtension, err := tiltextension.ProvideExtension()
+	if err != nil {
+		return CmdCIDeps{}, err
+	}
 	defaults := _wireDefaultsValue
-	tiltfileLoader := tiltfile.ProvideTiltfileLoader(analytics3, client, extension, versionExtension, configExtension, dockerComposeClient, webHost, defaults, env)
+	tiltfileLoader := tiltfile.ProvideTiltfileLoader(analytics3, client, extension, versionExtension, configExtension, tiltextensionExtension, dockerComposeClient, webHost, defaults, env)
 	configsController := configs.NewConfigsController(tiltfileLoader, switchCli)
 	eventWatcher := dcwatch.NewEventWatcher(dockerComposeClient, localClient)
 	dockerComposeLogManager := runtimelog.NewDockerComposeLogManager(dockerComposeClient)
@@ -633,13 +650,17 @@ func wireDownDeps(ctx context.Context, tiltAnalytics *analytics.TiltAnalytics, s
 	tiltBuild := provideTiltInfo()
 	versionExtension := version.NewExtension(tiltBuild)
 	configExtension := config.NewExtension(subcommand)
+	tiltextensionExtension, err := tiltextension.ProvideExtension()
+	if err != nil {
+		return DownDeps{}, err
+	}
 	runtime := k8s.ProvideContainerRuntime(ctx, client)
 	clusterEnv := docker.ProvideClusterEnv(ctx, env, runtime, minikubeClient)
 	localEnv := docker.ProvideLocalEnv(ctx, clusterEnv)
 	dockerComposeClient := dockercompose.NewDockerComposeClient(localEnv)
 	webHost := provideWebHost()
 	defaults := _wireDefaultsValue
-	tiltfileLoader := tiltfile.ProvideTiltfileLoader(tiltAnalytics, client, extension, versionExtension, configExtension, dockerComposeClient, webHost, defaults, env)
+	tiltfileLoader := tiltfile.ProvideTiltfileLoader(tiltAnalytics, client, extension, versionExtension, configExtension, tiltextensionExtension, dockerComposeClient, webHost, defaults, env)
 	downDeps := ProvideDownDeps(tiltfileLoader, dockerComposeClient, client)
 	return downDeps, nil
 }

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -28,6 +28,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
+	"github.com/tilt-dev/tilt/internal/tiltfile/tiltextension"
+
 	"github.com/tilt-dev/wmclient/pkg/analytics"
 
 	tiltanalytics "github.com/tilt-dev/tilt/internal/analytics"
@@ -3757,7 +3759,8 @@ func newTestFixture(t *testing.T) *testFixture {
 	k8sContextExt := k8scontext.NewExtension("fake-context", env)
 	versionExt := version.NewExtension(model.TiltBuild{Version: "0.5.0"})
 	configExt := config.NewExtension("up")
-	tfl := tiltfile.ProvideTiltfileLoader(ta, kCli, k8sContextExt, versionExt, configExt, fakeDcc, "localhost", feature.MainDefaults, env)
+	tfl := tiltfile.ProvideTiltfileLoader(ta, kCli, k8sContextExt, versionExt, configExt,
+		tiltextension.NewFakeExtension(t, f.JoinPath("project")), fakeDcc, "localhost", feature.MainDefaults, env)
 	cc := configs.NewConfigsController(tfl, dockerClient)
 	dcw := dcwatch.NewEventWatcher(fakeDcc, dockerClient)
 	dclm := runtimelog.NewDockerComposeLogManager(fakeDcc)

--- a/internal/tiltfile/starkit/environment.go
+++ b/internal/tiltfile/starkit/environment.go
@@ -188,6 +188,9 @@ func (e *Environment) start(path string) (Model, error) {
 
 	_, err = e.exec(t, path)
 	model.BuiltinCalls = e.builtinCalls
+	for _, i := range e.loadInterceptors {
+		model.AnalyticsInfos = append(model.AnalyticsInfos, i.AnalyticsInfo()...)
+	}
 	return model, err
 }
 

--- a/internal/tiltfile/starkit/infos.go
+++ b/internal/tiltfile/starkit/infos.go
@@ -1,0 +1,20 @@
+package starkit
+
+// A dummy interface that allows to pass around additional info for sending to
+// analytics at the end of Tiltfile execution.
+type AnalyticsInfo interface {
+	AnalyticsInfo()
+}
+
+// Info on use of Extensions.
+type ExtensionsAnalyticsInfo struct {
+	ExtensionsLoaded map[string]bool
+}
+
+func NewExtensionsAnalyticsInfo() ExtensionsAnalyticsInfo {
+	return ExtensionsAnalyticsInfo{
+		ExtensionsLoaded: make(map[string]bool),
+	}
+}
+
+func (ExtensionsAnalyticsInfo) AnalyticsInfo() {}

--- a/internal/tiltfile/starkit/load_interceptor.go
+++ b/internal/tiltfile/starkit/load_interceptor.go
@@ -11,4 +11,7 @@ type LoadInterceptor interface {
 	// Ensure the content is present in the path returned
 	// Returns "" if this interceptor doesn't act on this path
 	LocalPath(t *starlark.Thread, path string) (string, error)
+
+	// Optionally, a LoadInterceptor can record some info to send to analytics later
+	AnalyticsInfo() []AnalyticsInfo
 }

--- a/internal/tiltfile/starkit/model.go
+++ b/internal/tiltfile/starkit/model.go
@@ -11,12 +11,14 @@ import (
 type Model struct {
 	state map[reflect.Type]interface{}
 
-	BuiltinCalls []BuiltinCall
+	BuiltinCalls   []BuiltinCall
+	AnalyticsInfos []AnalyticsInfo
 }
 
 func NewModel() Model {
 	return Model{
-		state: make(map[reflect.Type]interface{}),
+		state:          make(map[reflect.Type]interface{}),
+		AnalyticsInfos: []AnalyticsInfo{},
 	}
 }
 

--- a/internal/tiltfile/tiltextension/extension.go
+++ b/internal/tiltfile/tiltextension/extension.go
@@ -17,12 +17,14 @@ import (
 type Extension struct {
 	fetcher Fetcher
 	store   Store
+	info    starkit.ExtensionsAnalyticsInfo
 }
 
 func NewExtension(fetcher Fetcher, store Store) *Extension {
 	return &Extension{
 		fetcher: fetcher,
 		store:   store,
+		info:    starkit.NewExtensionsAnalyticsInfo(),
 	}
 }
 
@@ -66,7 +68,14 @@ func (e *Extension) LocalPath(t *starlark.Thread, arg string) (string, error) {
 		_ = e.fetcher.CleanUp()
 	}()
 
+	// Record that we loaded this extension
+	e.info.ExtensionsLoaded[moduleName] = true
+
 	return e.store.Write(ctx, contents)
+}
+
+func (e *Extension) AnalyticsInfo() []starkit.AnalyticsInfo {
+	return []starkit.AnalyticsInfo{e.info}
 }
 
 var _ starkit.LoadInterceptor = (*Extension)(nil)

--- a/internal/tiltfile/tiltextension/store_test.go
+++ b/internal/tiltfile/tiltextension/store_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -150,14 +149,4 @@ func (f *fixture) tearDown() {
 
 func (f *fixture) dirWithTiltfile(contents string) string {
 	return dirWithTiltfile(f.t, contents)
-}
-
-func dirWithTiltfile(t *testing.T, contents string) string {
-	dir, err := ioutil.TempDir("", "fakeFetcher")
-	require.NoError(t, err)
-
-	err = ioutil.WriteFile(filepath.Join(dir, "Tiltfile"), []byte(contents), os.FileMode(0644))
-	require.NoError(t, err)
-
-	return dir
 }

--- a/internal/tiltfile/tiltextension/testing.go
+++ b/internal/tiltfile/tiltextension/testing.go
@@ -1,0 +1,53 @@
+package tiltextension
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const testLibText = `
+def printFoo():
+  print("foo")
+`
+
+func dirWithTiltfile(t *testing.T, contents string) string {
+	dir, err := ioutil.TempDir("", "fakeFetcher")
+	require.NoError(t, err)
+
+	err = ioutil.WriteFile(filepath.Join(dir, "Tiltfile"), []byte(contents), os.FileMode(0644))
+	require.NoError(t, err)
+
+	return dir
+}
+
+type fakeFetcher struct {
+	t *testing.T
+}
+
+func (f *fakeFetcher) Fetch(ctx context.Context, moduleName string) (ModuleContents, error) {
+	if moduleName != "fetchable" {
+		return ModuleContents{}, fmt.Errorf("module %s can't be fetched because... reasons", moduleName)
+	}
+
+	return ModuleContents{
+		Name: "fetchable",
+		Dir:  dirWithTiltfile(f.t, testLibText),
+	}, nil
+}
+
+func (f *fakeFetcher) CleanUp() error {
+	return nil
+}
+
+func NewFakeExtension(t *testing.T, tmpdir string) *Extension {
+	return NewExtension(
+		&fakeFetcher{t: t},
+		NewLocalStore(tmpdir),
+	)
+}

--- a/internal/tiltfile/wire.go
+++ b/internal/tiltfile/wire.go
@@ -3,6 +3,8 @@ package tiltfile
 import (
 	"github.com/google/wire"
 
+	"github.com/tilt-dev/tilt/internal/tiltfile/tiltextension"
+
 	"github.com/tilt-dev/tilt/internal/tiltfile/config"
 	"github.com/tilt-dev/tilt/internal/tiltfile/k8scontext"
 	"github.com/tilt-dev/tilt/internal/tiltfile/version"
@@ -13,4 +15,5 @@ var WireSet = wire.NewSet(
 	k8scontext.NewExtension,
 	version.NewExtension,
 	config.NewExtension,
+	tiltextension.ProvideExtension,
 )


### PR DESCRIPTION
this feels kind of weird but is the best implementation i could think of that matches the generic-ness of `LoadInterceptors` (i.e. if in the future we have other different kinds of `LoadInterceptors` that want to send data back to analytics, we can pretty easily)

alternately i could
- wire the `analytics` object through to the Extension itself and record the info at the point at which we parse the extension path, which seems awful, or
- store the relevant info on the Extension and type check the `LoadInterceptors` to see if any are a `tiltextensions.Extension`, and THEN pull the data off, which seems counter to the pretty generic way `LoadInterceptors` are build right now (of course I don't precisely understand WHY the current generic-ness, so... ¯\_(ツ)_/¯ )
- ??