### PR TITLE
scripts: update release image to go 1.14

### DIFF
--- a/scripts/release.Dockerfile
+++ b/scripts/release.Dockerfile
@@ -4,7 +4,7 @@
 # 1) Better leverage OS-specific C headers
 # 2) Be able to do releases from a CI job
 
-FROM dockercore/golang-cross:1.13.15
+FROM gcr.io/windmill-public-containers/golang-cross:1.14.12
 
 ENV GORELEASER_VERSION=0.127.0
 ENV GORELEASER_SHA=bf7e0f34d1d46041f302a0dd773a5c70ff7476c147d3a30659a5a11e823bccbd


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/go14:

c68c0df2a404e37c42b77bb43a35971270e69508 (2021-02-19 18:37:01 -0500)
scripts: update release image to go 1.14

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics