### PR TITLE
test: add extra newline to error message

### DIFF
--- a/internal/containerupdate/exec_updater_test.go
+++ b/internal/containerupdate/exec_updater_test.go
@@ -121,7 +121,7 @@ func TestUpdateContainerRunsFailure(t *testing.T) {
 func TestUpdateContainerPermissionDenied(t *testing.T) {
 	f := newExecFixture(t)
 
-	f.kCli.ExecOutputs = []io.Reader{strings.NewReader("tar: app/index.js: Cannot open: File exists")}
+	f.kCli.ExecOutputs = []io.Reader{strings.NewReader("tar: app/index.js: Cannot open: File exists\n")}
 	f.kCli.ExecErrors = []error{exec.CodeExitError{Err: fmt.Errorf("command terminated with exit code 2"), Code: 1}}
 
 	err := f.ecu.UpdateContainer(f.ctx, TestContainerInfo, newReader("hello world"), nil, cmds, true)


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/test-error:

fa5ef94be3666552b899eed1c5a4ad9fa7a08da4 (2021-02-22 12:14:18 -0500)
test: add extra newline to error message
This is a workaround for https://github.com/golang/go/issues/38063,
where Go incorrectly reports test results if the test output doesn't
end in newlines

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics