### PR TITLE
k8s: don't attach a service to a workload if it has no selectors [ch11448]

### DIFF
--- a/internal/k8s/label.go
+++ b/internal/k8s/label.go
@@ -172,7 +172,8 @@ func allowLabelChangesInOptionalSelector(obj runtime.Object) {
 	selectorField.Set(reflect.ValueOf(selector))
 }
 
-// SelectorMatchesLabels indicates whether the pod selector of the given entity matches the given label(s).
+// SelectorMatchesLabels indicates whether the pod selector of the given entity
+// matches the given label(s). For an empty selector, returns `false`.
 // Currently only supports Services, but may be expanded to support other types that
 // match pods via selectors.
 func (e K8sEntity) SelectorMatchesLabels(labels map[string]string) bool {
@@ -181,6 +182,11 @@ func (e K8sEntity) SelectorMatchesLabels(labels map[string]string) bool {
 		return false
 	}
 	selector := svc.Spec.Selector
+
+	if len(selector) == 0 {
+		return false
+	}
+
 	for k, selVal := range selector {
 		realVal, ok := labels[k]
 		if !ok || realVal != selVal {

--- a/internal/k8s/label_test.go
+++ b/internal/k8s/label_test.go
@@ -299,6 +299,7 @@ func TestSelectorMatchesLabels(t *testing.T) {
 		"tier":        "backend",
 		"foo":         "bar", // an extra label on the pod shouldn't affect the match
 	}
+
 	assert.True(t, svc.SelectorMatchesLabels(labels))
 
 	assert.False(t, dep.SelectorMatchesLabels(labels), "kind Deployment does not support SelectorMatchesLabels")
@@ -308,6 +309,11 @@ func TestSelectorMatchesLabels(t *testing.T) {
 
 	delete(labels, "app")
 	assert.False(t, svc.SelectorMatchesLabels(labels), "expected key missing")
+
+	service, ok := svc.Obj.(*v1.Service)
+	require.True(t, ok, "typing svc as k8s Service")
+	service.Spec.Selector = nil
+	assert.False(t, svc.SelectorMatchesLabels(labels), "empty selector should match nothing")
 }
 
 func TestMatchesMetadataLabels(t *testing.T) {

--- a/internal/tiltfile/tiltfile_state.go
+++ b/internal/tiltfile/tiltfile_state.go
@@ -427,7 +427,7 @@ func (s *tiltfileState) potentiallyK8sUnsafeBuiltin(f starkit.Function) starkit.
 			kubeContext := k8sContextState.KubeContext()
 			return nil, fmt.Errorf(`Refusing to run '%s' because %s might be a production kube context.
 If you're sure you want to continue add:
-allow_k8s_contexts('%s')
+	allow_k8s_contexts('%s')
 before this function call in your Tiltfile. Otherwise, switch k8s contexts and restart Tilt.`, fn.Name(), kubeContext, kubeContext)
 		}
 


### PR DESCRIPTION
Hello @landism, @nicks,

Please review the following commits I made in branch maiamcc/non-trivial-selector-matching:

54364a50c685db613d103c5bee24e34e164d9d4b (2021-02-23 17:52:49 -0500)
k8s: don't attach a service to a workload if it has no selectors [ch11448]

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics