### PR TITLE
web: remove blue outlines on clicks

### DIFF
--- a/web/src/HUD.tsx
+++ b/web/src/HUD.tsx
@@ -1,5 +1,6 @@
 import { History, UnregisterCallback } from "history"
 import React, { Component } from "react"
+import ReactOutlineManager from "react-outline-manager"
 import { useHistory } from "react-router"
 import { Route, RouteComponentProps, Switch } from "react-router-dom"
 import { incr, navigationToTags } from "./analytics"
@@ -266,17 +267,19 @@ export default class HUD extends Component<HudProps, HudState> {
     return (
       <tiltfileKeyContext.Provider value={view.tiltfileKey}>
         <SidebarPinContextProvider>
-          <OverviewNavProvider validateTab={validateTab}>
-            <div className={hudClasses.join(" ")}>
-              <AnalyticsNudge needsNudge={needsNudge} />
-              <SocketBar state={this.state.socketState} />
-              {fatalErrorModal}
-              {errorModal}
-              {shareSnapshotModal}
+          <ReactOutlineManager>
+            <OverviewNavProvider validateTab={validateTab}>
+              <div className={hudClasses.join(" ")}>
+                <AnalyticsNudge needsNudge={needsNudge} />
+                <SocketBar state={this.state.socketState} />
+                {fatalErrorModal}
+                {errorModal}
+                {shareSnapshotModal}
 
-              {this.renderOverviewSwitch()}
-            </div>
-          </OverviewNavProvider>
+                {this.renderOverviewSwitch()}
+              </div>
+            </OverviewNavProvider>
+          </ReactOutlineManager>
         </SidebarPinContextProvider>
       </tiltfileKeyContext.Provider>
     )


### PR DESCRIPTION
### Problem

After clicking some things, we end up with these ugly blue outlines:
![image](https://user-images.githubusercontent.com/7453991/109035187-61a04f00-7696-11eb-80e3-60b3580f6038.png)

### Solution

Wrap everything in react-outline-manager to hide those. (we were already using this on this part of the header in the old UI)

### References
* https://www.npmjs.com/package/react-outline-manager?activeTab=readme
* https://www.tpgi.com/how-to-remove-css-outlines-in-an-accessible-manner/
