### PR TITLE
scripts: fix api-new-type to compute resource names properly

### DIFF
--- a/pkg/apis/core/v1alpha1/filewatch_types.go
+++ b/pkg/apis/core/v1alpha1/filewatch_types.go
@@ -77,7 +77,7 @@ func (in *FileWatch) GetGroupVersionResource() schema.GroupVersionResource {
 	return schema.GroupVersionResource{
 		Group:    "core.tilt.dev",
 		Version:  "v1alpha1",
-		Resource: "fileWatchs",
+		Resource: "filewatches",
 	}
 }
 

--- a/scripts/api-new-type.sh
+++ b/scripts/api-new-type.sh
@@ -13,19 +13,24 @@ if [[ "$TYPE_NAME" == "" ]]; then
     exit 1
 fi
 
+# Each type name has two forms
+# - the kind (DoThing)
+# - the resource (dothing)
+# where the first is used in YAML and the second is used in HTTP endpoints
+#
 # shellcheck disable=SC2001
-TYPE_NAME_LOWER=$(echo "$TYPE_NAME" | sed -e 's/^\(.\)/\L\1/')
+TYPE_NAME_LOWER=$(echo "$TYPE_NAME" | sed -e 's/^\(.*\)$/\L\1/g')
 if [[ "$TYPE_NAME" == "$TYPE_NAME_LOWER" ]]; then
     echo "Error: type name must be uppercase"
     exit 1
 fi
 
-TYPE_NAME_ALL_LOWER=$(echo "$TYPE_NAME" | sed -e 's/^\(.*\)/\L\1/')
-OUTPUT_FILE=pkg/apis/core/v1alpha1/"$TYPE_NAME_ALL_LOWER"_types.go
+OUTPUT_FILE=pkg/apis/core/v1alpha1/"$TYPE_NAME_LOWER"_types.go
 sed -e "s/Manifest/$TYPE_NAME/g" scripts/api-new-type-boilerplate.go.txt | \
     sed -e "s/manifest/$TYPE_NAME_LOWER/g" > \
     "$OUTPUT_FILE"
 
 echo "Successfully generated $TYPE_NAME: $OUTPUT_FILE"
 echo "Please add it to the list of types in pkg/apis/core/v1alpha1/register.go"
-echo "Run scripts/update-codegen.sh to generate clients for your new type"
+echo "To generate clients for your new type:"
+echo "> make update-codegen"


### PR DESCRIPTION
Hello @ellenkorbes, @milas,

Please review the following commits I made in branch nicks/kinds:

26441f88f85c68d654233097244f4a9986557a55 (2021-02-24 14:00:11 -0500)
scripts: fix api-new-type to compute resource names properly

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics