### PR TITLE
web: import css for line colors

### DIFF
--- a/web/src/OverviewLogPane.tsx
+++ b/web/src/OverviewLogPane.tsx
@@ -2,6 +2,7 @@ import Anser from "anser"
 import React, { Component } from "react"
 import { useHistory } from "react-router"
 import styled, { keyframes } from "styled-components"
+import "./AnsiLine.scss" // for line color CSS classes
 import {
   FilterLevel,
   FilterSet,


### PR DESCRIPTION
Hello @maiamcc,

Please review the following commits I made in branch nicks/ch11471:

79e53db48dc2523d66acc566460c236a79279d77 (2021-02-24 20:22:54 -0500)
web: import css for line colors
unfortunately, it's not really possible to test this because
jest doesn't emulate CSS :\

fixes https://github.com/tilt-dev/tilt/issues/4240

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics