### PR TITLE
test: fix lint errors on Darwin (macOS)

### DIFF
--- a/internal/watch/paths.go
+++ b/internal/watch/paths.go
@@ -10,17 +10,6 @@ import (
 	"github.com/tilt-dev/tilt/internal/ospath"
 )
 
-func greatestExistingAncestors(paths []string) ([]string, error) {
-	result := []string{}
-	for _, p := range paths {
-		newP, err := greatestExistingAncestor(p)
-		if err != nil {
-			return nil, fmt.Errorf("Finding ancestor of %s: %v", p, err)
-		}
-		result = append(result, newP)
-	}
-	return result, nil
-}
 func greatestExistingAncestor(path string) (string, error) {
 	if path == string(filepath.Separator) ||
 		path == fmt.Sprintf("%s%s", filepath.VolumeName(path), string(filepath.Separator)) {

--- a/internal/watch/watcher_naive.go
+++ b/internal/watch/watcher_naive.go
@@ -303,3 +303,15 @@ func newWatcher(paths []string, ignore PathMatcher, l logger.Logger) (*naiveNoti
 }
 
 var _ Notify = &naiveNotify{}
+
+func greatestExistingAncestors(paths []string) ([]string, error) {
+	result := []string{}
+	for _, p := range paths {
+		newP, err := greatestExistingAncestor(p)
+		if err != nil {
+			return nil, fmt.Errorf("Finding ancestor of %s: %v", p, err)
+		}
+		result = append(result, newP)
+	}
+	return result, nil
+}


### PR DESCRIPTION
Unused code linter isn't particularly smart about platform build
tags, so since this func is only used by the "naive" (non-macOS)
file watcher, it needs to live with that or it gets flagged as
dead code when linting on macOS.