### PR TITLE
k8s: treat namespace:  = namespace: default when determining if k8s entities are duplicates

### DIFF
--- a/internal/k8s/entity.go
+++ b/internal/k8s/entity.go
@@ -89,7 +89,7 @@ func (e K8sEntity) ToObjectReference() v1.ObjectReference {
 		Kind:       kind,
 		APIVersion: apiVersion,
 		Name:       meta.GetName(),
-		Namespace:  meta.GetNamespace(),
+		Namespace:  e.Namespace().String(), // so that we normalize "" --> "default"
 		UID:        meta.GetUID(),
 	}
 }


### PR DESCRIPTION
was taking a second look at #3993 and @landism pointed out that duplicate entities shouldn't have been allowed in the first place, so I went digging and found this bug.