### PR TITLE
engine: switch from Kubernetes Probe API to our fork

### DIFF
--- a/internal/engine/local/controller.go
+++ b/internal/engine/local/controller.go
@@ -9,12 +9,11 @@ import (
 	"sync"
 	"time"
 
-	v1 "k8s.io/api/core/v1"
-
 	"github.com/tilt-dev/probe/pkg/probe"
 	"github.com/tilt-dev/probe/pkg/prober"
 
 	"github.com/tilt-dev/tilt/internal/store"
+	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
 	"github.com/tilt-dev/tilt/pkg/logger"
 	"github.com/tilt-dev/tilt/pkg/model"
 	"github.com/tilt-dev/tilt/pkg/model/logstore"
@@ -337,7 +336,7 @@ type ServeSpec struct {
 	ManifestName   model.ManifestName
 	ServeCmd       model.Cmd
 	TriggerTime    time.Time // TriggerTime is how Runner knows to restart; if it's newer than the TriggerTime of the currently running command, then Runner should restart it
-	ReadinessProbe *v1.Probe
+	ReadinessProbe *v1alpha1.Probe
 }
 
 type statusAndMetadata struct {

--- a/internal/engine/local/controller_test.go
+++ b/internal/engine/local/controller_test.go
@@ -9,11 +9,10 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
 
 	"github.com/tilt-dev/tilt/internal/store"
 	"github.com/tilt-dev/tilt/internal/testutils/bufsync"
+	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
 	"github.com/tilt-dev/tilt/pkg/logger"
 	"github.com/tilt-dev/tilt/pkg/model"
 )
@@ -73,10 +72,10 @@ func TestServeReadinessProbe(t *testing.T) {
 
 	c := model.ToHostCmdInDir("sleep 60", "testdir")
 	localTarget := model.NewLocalTarget("foo", model.Cmd{}, c, nil)
-	localTarget.ReadinessProbe = &v1.Probe{
+	localTarget.ReadinessProbe = &v1alpha1.Probe{
 		TimeoutSeconds: 5,
-		Handler: v1.Handler{
-			Exec: &v1.ExecAction{Command: []string{"sleep", "15"}},
+		Handler: v1alpha1.Handler{
+			Exec: &v1alpha1.ExecAction{Command: []string{"sleep", "15"}},
 		},
 	}
 
@@ -106,10 +105,10 @@ func TestServeReadinessProbeInvalidSpec(t *testing.T) {
 
 	c := model.ToHostCmdInDir("sleep 60", "testdir")
 	localTarget := model.NewLocalTarget("foo", model.Cmd{}, c, nil)
-	localTarget.ReadinessProbe = &v1.Probe{
-		Handler: v1.Handler{HTTPGet: &v1.HTTPGetAction{
+	localTarget.ReadinessProbe = &v1alpha1.Probe{
+		Handler: v1alpha1.Handler{HTTPGet: &v1alpha1.HTTPGetAction{
 			// port > 65535
-			Port: intstr.FromInt(70000),
+			Port: 70000,
 		}},
 	}
 

--- a/internal/tiltfile/local_resource.go
+++ b/internal/tiltfile/local_resource.go
@@ -6,13 +6,13 @@ import (
 
 	"github.com/pkg/errors"
 	"go.starlark.net/starlark"
-	v1 "k8s.io/api/core/v1"
 
 	"github.com/tilt-dev/tilt/internal/tiltfile/links"
 	"github.com/tilt-dev/tilt/internal/tiltfile/probe"
 	"github.com/tilt-dev/tilt/internal/tiltfile/starkit"
 
 	"github.com/tilt-dev/tilt/internal/tiltfile/value"
+	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
 	"github.com/tilt-dev/tilt/pkg/model"
 )
 
@@ -35,7 +35,7 @@ type localResource struct {
 	tags   []string
 	isTest bool
 
-	readinessProbe *v1.Probe
+	readinessProbe *v1alpha1.Probe
 }
 
 func (s *tiltfileState) localResource(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -41,6 +41,7 @@ import (
 	"github.com/tilt-dev/tilt/internal/tiltfile/k8scontext"
 	"github.com/tilt-dev/tilt/internal/tiltfile/testdata"
 	"github.com/tilt-dev/tilt/internal/yaml"
+	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
 	"github.com/tilt-dev/tilt/pkg/logger"
 	"github.com/tilt-dev/tilt/pkg/model"
 )
@@ -6451,7 +6452,7 @@ func serveCmdArray(dir string, argv []string, env []string) serveCmdHelper {
 }
 
 type readinessProbeHelper struct {
-	probeSpec *v1.Probe
+	probeSpec *v1alpha1.Probe
 }
 
 type localTargetHelper struct {

--- a/pkg/model/local_target.go
+++ b/pkg/model/local_target.go
@@ -3,9 +3,8 @@ package model
 import (
 	"fmt"
 
-	v1 "k8s.io/api/core/v1"
-
 	"github.com/tilt-dev/tilt/internal/sliceutils"
+	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
 )
 
 type LocalTarget struct {
@@ -26,7 +25,7 @@ type LocalTarget struct {
 	Tags   []string // eventually we might want tags to be more widespread -- stored on manifest maybe?
 	IsTest bool     // does this target represent a Test?
 
-	ReadinessProbe *v1.Probe
+	ReadinessProbe *v1alpha1.Probe
 }
 
 var _ TargetSpec = LocalTarget{}
@@ -74,7 +73,7 @@ func (lt LocalTarget) WithTags(tags []string) LocalTarget {
 	return lt
 }
 
-func (lt LocalTarget) WithReadinessProbe(probeSpec *v1.Probe) LocalTarget {
+func (lt LocalTarget) WithReadinessProbe(probeSpec *v1alpha1.Probe) LocalTarget {
 	lt.ReadinessProbe = probeSpec
 	return lt
 }


### PR DESCRIPTION
Hello @milas,

Please review the following commits I made in branch nicks/probe2:

d4eaba75fea3e9b985f0ef533369803b17265870 (2021-02-26 13:25:31 -0500)
engine: switch from Kubernetes Probe API to our fork

e34d60fcd444c8e817daeb02366f574dfb782c11 (2021-02-26 13:19:19 -0500)
apis: fork probe data model

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics