### PR TITLE
tests: avoid surprises with system PATH precedence

### DIFF
--- a/integration/fixture_test.go
+++ b/integration/fixture_test.go
@@ -5,6 +5,7 @@ package integration
 import (
 	"context"
 	"fmt"
+	"go/build"
 	"io"
 	"io/ioutil"
 	"os"
@@ -81,7 +82,9 @@ func (f *fixture) testDirPath(s string) string {
 
 func (f *fixture) installTilt() {
 	f.t.Helper()
-	cmd := exec.CommandContext(f.ctx, "go", "install", "-mod", "vendor", "github.com/tilt-dev/tilt/cmd/tilt")
+	// use the current GOROOT to pick which Go to build with
+	goBin := filepath.Join(build.Default.GOROOT, "bin", "go")
+	cmd := exec.CommandContext(f.ctx, goBin, "install", "-mod", "vendor", "github.com/tilt-dev/tilt/cmd/tilt")
 	cmd.Dir = packageDir
 	f.runOrFail(cmd, "Building tilt")
 }

--- a/integration/tilt.go
+++ b/integration/tilt.go
@@ -2,10 +2,12 @@ package integration
 
 import (
 	"fmt"
+	"go/build"
 	"io"
 	"net"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
@@ -24,7 +26,11 @@ func NewTiltDriver() *TiltDriver {
 }
 
 func (d *TiltDriver) cmd(args []string, out io.Writer) *exec.Cmd {
-	cmd := exec.Command("tilt", args...)
+	// rely on the Tilt binary in GOPATH that should have been created by `go install` from the
+	// fixture to avoid accidentally picking up a system install of tilt with higher precedence
+	// on system PATH
+	tiltBin := filepath.Join(build.Default.GOPATH, "bin", "tilt")
+	cmd := exec.Command(tiltBin, args...)
 	cmd.Stdout = out
 	cmd.Stderr = out
 	cmd.Env = os.Environ()


### PR DESCRIPTION
Use `build` to get the `GOROOT`/`GOPATH` and construct absolute
paths to avoid running against the wrong binary if there's a `tilt`
binary with higher path precedence than the one built in the test
(e.g. Tilt install in `/usr/local/bin` from Homebrew or other source,
which could be before `GOPATH/bin` in system `PATH`).

This also allows easily running integration tests if you've got
multiple go installs (e.g. from `go get golang.org/dl/go1.xx.x`)
where the running install is not the default in the system `PATH`.
Previously, you'd get errors about mismatched Go toolchains when
trying to build Tilt as part of the integration test.

It might be better in the future to `go build -o` instead of `go install`
and specifically run the built binary by absolute path, but that involved
a bit more refactoring + work to clean up the generated binaries
(especially since `/tmp` isn't a good place for that since it's often
mounted `noexec` on Linux).