### PR TITLE
server: use unbuffered memory connections for testing, which seem to be more robust

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -69,7 +69,7 @@ require (
 	github.com/tilt-dev/go-get v0.0.0-20200911222649-1acd29546527
 	github.com/tilt-dev/localregistry-go v0.0.0-20200615231835-07e386f4ebd7
 	github.com/tilt-dev/probe v0.2.0
-	github.com/tilt-dev/tilt-apiserver v0.2.1
+	github.com/tilt-dev/tilt-apiserver v0.2.2
 	github.com/tilt-dev/wmclient v0.0.0-20201109174454-1839d0355fbc
 	github.com/tonistiigi/units v0.0.0-20180711220420-6950e57a87ea
 	github.com/whilp/git-urls v0.0.0-20160530060445-31bac0d230fa

--- a/go.sum
+++ b/go.sum
@@ -1237,8 +1237,8 @@ github.com/tilt-dev/opencensus-go v0.22.5-0.20200904175236-275b1754f353 h1:lxM1v
 github.com/tilt-dev/opencensus-go v0.22.5-0.20200904175236-275b1754f353/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
 github.com/tilt-dev/probe v0.2.0 h1:2kLs+xNjv6OYoR7OLCQELV6+/Ce0gqOC856qKfN/TB4=
 github.com/tilt-dev/probe v0.2.0/go.mod h1:N4FSqESyYQuc9GwIaIoHS5cIUDznIUwDkG6y4kQVXQY=
-github.com/tilt-dev/tilt-apiserver v0.2.1 h1:mt5XZ0g4TYiOB8jtMIsBFwBlOl7MgGZqzsP5maJBdz8=
-github.com/tilt-dev/tilt-apiserver v0.2.1/go.mod h1:5JegGavWDV+CrTD1w9QWFekMQwctZmbkQumHd4aqsT8=
+github.com/tilt-dev/tilt-apiserver v0.2.2 h1:ZzMjWH/oZCpqc294/SocHMm872n9BLZETBAEze8Kz1g=
+github.com/tilt-dev/tilt-apiserver v0.2.2/go.mod h1:5JegGavWDV+CrTD1w9QWFekMQwctZmbkQumHd4aqsT8=
 github.com/tilt-dev/wmclient v0.0.0-20201109174454-1839d0355fbc h1:wGkAoZhrvnmq93B4W2v+agiPl7xzqUaxXkxmKrwJ6bc=
 github.com/tilt-dev/wmclient v0.0.0-20201109174454-1839d0355fbc/go.mod h1:n01fG3LbImzxBP3GGCTHkgXuPeJusWg6xv0QYGm9HtE=
 github.com/timakin/bodyclose v0.0.0-20190930140734-f7f2e9bca95e/go.mod h1:Qimiffbc6q9tBWlVV6x0P9sat/ao1xEkREYPPj9hphk=

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -17,7 +17,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/akutz/memconn"
 	"github.com/docker/distribution/reference"
 	dockertypes "github.com/docker/docker/api/types"
 	"github.com/google/uuid"
@@ -3764,7 +3763,7 @@ func newTestFixture(t *testing.T) *testFixture {
 	dcw := dcwatch.NewEventWatcher(fakeDcc, dockerClient)
 	dclm := runtimelog.NewDockerComposeLogManager(fakeDcc)
 	pm := NewProfilerManager()
-	serverOptions, err := server.ProvideTiltServerOptions(ctx, "localhost", 0, model.TiltBuild{}, &memconn.Provider{})
+	serverOptions, err := server.ProvideTiltServerOptions(ctx, "localhost", 0, model.TiltBuild{}, server.ProvideMemConn())
 	require.NoError(t, err)
 	hudsc := server.ProvideHeadsUpServerController(0, serverOptions, &server.HeadsUpServer{}, assets.NewFakeServer(), model.WebURL{})
 	ewm := k8swatch.NewEventWatchManager(kCli, of, ns)

--- a/internal/hud/server/apiserver.go
+++ b/internal/hud/server/apiserver.go
@@ -24,12 +24,12 @@ type APIServerConfig = apiserver.Config
 type DynamicInterface = dynamic.Interface
 type Interface = tiltapi.Interface
 
-func ProvideMemConn() *memconn.Provider {
-	return &memconn.Provider{}
+func ProvideMemConn() apiserver.ConnProvider {
+	return apiserver.NetworkConnProvider(&memconn.Provider{}, "memu")
 }
 
 // Configures the Tilt API server.
-func ProvideTiltServerOptions(ctx context.Context, host model.WebHost, port model.WebPort, tiltBuild model.TiltBuild, memconn *memconn.Provider) (*APIServerConfig, error) {
+func ProvideTiltServerOptions(ctx context.Context, host model.WebHost, port model.WebPort, tiltBuild model.TiltBuild, memconn apiserver.ConnProvider) (*APIServerConfig, error) {
 	w := logger.Get(ctx).Writer(logger.DebugLvl)
 	builder := builder.NewServerBuilder().
 		WithOutputWriter(w)

--- a/vendor/github.com/tilt-dev/tilt-apiserver/pkg/server/apiserver/apiserver.go
+++ b/vendor/github.com/tilt-dev/tilt-apiserver/pkg/server/apiserver/apiserver.go
@@ -17,9 +17,6 @@ limitations under the License.
 package apiserver
 
 import (
-	"context"
-	"net"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -28,12 +25,6 @@ import (
 	"k8s.io/apiserver/pkg/authorization/authorizerfactory"
 	genericapiserver "k8s.io/apiserver/pkg/server"
 )
-
-type ConnProvider interface {
-	Dial(network, address string) (net.Conn, error)
-	DialContext(ctx context.Context, network, address string) (net.Conn, error)
-	Listen(network, address string) (net.Listener, error)
-}
 
 func NewScheme() *runtime.Scheme {
 	scheme := runtime.NewScheme()

--- a/vendor/github.com/tilt-dev/tilt-apiserver/pkg/server/apiserver/conn.go
+++ b/vendor/github.com/tilt-dev/tilt-apiserver/pkg/server/apiserver/conn.go
@@ -1,0 +1,37 @@
+package apiserver
+
+import (
+	"context"
+	"net"
+)
+
+type ConnProvider interface {
+	Dial(network, address string) (net.Conn, error)
+	DialContext(ctx context.Context, network, address string) (net.Conn, error)
+	Listen(network, address string) (net.Listener, error)
+}
+
+// Creates a ConnProvider where all connections are redirected over a particular
+// network. Useful for use with memconn, which uses "memb" and "memu"
+// as in-memory networks.
+func NetworkConnProvider(p ConnProvider, network string) ConnProvider {
+	return networkConnProvider{
+		delegate: p,
+		network:  network,
+	}
+}
+
+type networkConnProvider struct {
+	delegate ConnProvider
+	network  string
+}
+
+func (p networkConnProvider) Dial(network, address string) (net.Conn, error) {
+	return p.delegate.Dial(p.network, address)
+}
+func (p networkConnProvider) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
+	return p.delegate.DialContext(ctx, p.network, address)
+}
+func (p networkConnProvider) Listen(network, address string) (net.Listener, error) {
+	return p.delegate.Listen(p.network, address)
+}

--- a/vendor/github.com/tilt-dev/tilt-apiserver/pkg/server/start/start.go
+++ b/vendor/github.com/tilt-dev/tilt-apiserver/pkg/server/start/start.go
@@ -139,7 +139,7 @@ func (o *TiltServerOptions) Config() (*apiserver.Config, error) {
 			o.ServingOptions.BindPort = 80 // Create a fake port.
 		}
 
-		l, err := o.ConnProvider.Listen("memb", fmt.Sprintf("%s:%d", o.ServingOptions.BindAddress, o.ServingOptions.BindPort))
+		l, err := o.ConnProvider.Listen("tcp", fmt.Sprintf("%s:%d", o.ServingOptions.BindAddress, o.ServingOptions.BindPort))
 		if err != nil {
 			return nil, err
 		}
@@ -179,7 +179,7 @@ func (o TiltServerOptions) LoopbackClientConfig() *rest.Config {
 	}
 	if o.ConnProvider != nil {
 		result.Dial = func(ctx context.Context, network, address string) (net.Conn, error) {
-			return o.ConnProvider.DialContext(ctx, "memb", address)
+			return o.ConnProvider.DialContext(ctx, network, address)
 		}
 	}
 	return result

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -518,7 +518,7 @@ github.com/tilt-dev/localregistry-go
 ## explicit
 github.com/tilt-dev/probe/pkg/probe
 github.com/tilt-dev/probe/pkg/prober
-# github.com/tilt-dev/tilt-apiserver v0.2.1
+# github.com/tilt-dev/tilt-apiserver v0.2.2
 ## explicit
 github.com/tilt-dev/tilt-apiserver/pkg/server/apiserver
 github.com/tilt-dev/tilt-apiserver/pkg/server/builder


### PR DESCRIPTION
Hello @milas,

Please review the following commits I made in branch nicks/memconn:

f384e12d1a2de7f0646c93842141bdbc018dba1d (2021-03-03 11:23:19 -0500)
server: use unbuffered memory connections for testing, which seem to be more robust

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics