### PR TITLE
engine: Write Cmd objects to the EngineState

### DIFF
--- a/internal/engine/local/actions.go
+++ b/internal/engine/local/actions.go
@@ -1,21 +1,21 @@
 package local
 
-import (
-	"github.com/tilt-dev/tilt/pkg/model"
-)
-
-type LocalServeStatusAction struct {
-	ManifestName model.ManifestName
-	Status       model.RuntimeStatus
-	PID          int // 0 if there's no process running
-	SpanID       model.LogSpanID
+type CmdCreateAction struct {
+	Cmd *Cmd
 }
 
-func (LocalServeStatusAction) Action() {}
-
-type LocalServeReadinessProbeAction struct {
-	ManifestName model.ManifestName
-	Ready        bool
+func NewCmdCreateAction(cmd *Cmd) CmdCreateAction {
+	return CmdCreateAction{Cmd: cmd.DeepCopy()}
 }
 
-func (LocalServeReadinessProbeAction) Action() {}
+func (CmdCreateAction) Action() {}
+
+type CmdUpdateAction struct {
+	Cmd *Cmd
+}
+
+func NewCmdUpdateAction(cmd *Cmd) CmdUpdateAction {
+	return CmdUpdateAction{Cmd: cmd.DeepCopy()}
+}
+
+func (CmdUpdateAction) Action() {}

--- a/internal/engine/local/controller.go
+++ b/internal/engine/local/controller.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/tilt-dev/probe/pkg/probe"
 	"github.com/tilt-dev/probe/pkg/prober"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/tilt-dev/tilt/internal/store"
 	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
@@ -24,6 +26,8 @@ type Controller struct {
 	procs         map[model.ManifestName]*currentProcess
 	procCount     int
 	proberManager ProberManager
+	cmds          map[types.NamespacedName]*Cmd
+	mu            sync.Mutex
 }
 
 var _ store.Subscriber = &Controller{}
@@ -34,6 +38,7 @@ func NewController(execer Execer, proberManager ProberManager) *Controller {
 		execer:        execer,
 		procs:         make(map[model.ManifestName]*currentProcess),
 		proberManager: proberManager,
+		cmds:          make(map[types.NamespacedName]*Cmd),
 	}
 }
 
@@ -115,6 +120,12 @@ func (c *Controller) shouldStart(spec ServeSpec, proc *currentProcess) bool {
 
 func (c *Controller) stop(name model.ManifestName) {
 	proc := c.procs[name]
+	if proc.cmdName.Name != "" {
+		c.mu.Lock()
+		delete(c.cmds, proc.cmdName)
+		c.mu.Unlock()
+	}
+
 	// change the process's current number so that any further events received by the existing process will be considered out of date
 	proc.incrProcNum()
 	if proc.cancelFunc == nil {
@@ -150,18 +161,36 @@ func (c *Controller) start(ctx context.Context, spec ServeSpec, st store.RStore)
 	proc.procNum = c.procCount
 	ctx, proc.cancelFunc = context.WithCancel(ctx)
 
-	w := LocalServeLogActionWriter{
-		store:        st,
-		manifestName: spec.ManifestName,
-		procNum:      proc.procNum,
-	}
-	ctx = logger.CtxWithLogHandler(ctx, w)
-
 	statusCh := make(chan statusAndMetadata)
 
+	cmdName := fmt.Sprintf("%s-serve-%d", spec.ManifestName, c.procCount)
 	spanID := SpanIDForServeLog(proc.procNum)
+	name := types.NamespacedName{Name: cmdName}
+	proc.cmdName = name
+
+	cmd := &Cmd{
+		ObjectMeta: ObjectMeta{
+			Name: cmdName,
+			Annotations: map[string]string{
+				v1alpha1.AnnotationSpanID: string(spanID),
+			},
+			Labels: map[string]string{
+				v1alpha1.LabelManifest: spec.ManifestName.String(),
+			},
+		},
+		Spec: CmdSpec{
+			Args:           spec.ServeCmd.Argv,
+			Dir:            spec.ServeCmd.Dir,
+			Env:            spec.ServeCmd.Env,
+			ReadinessProbe: spec.ReadinessProbe,
+		},
+	}
+	c.createCmd(st, name, cmd)
+
+	ctx = store.MustObjectLogHandler(ctx, st, cmd)
+
 	if spec.ReadinessProbe != nil {
-		statusChangeFunc := processReadinessProbeStatusChange(ctx, st, spec.ManifestName, proc.stillHasSameProcNum())
+		statusChangeFunc := c.processReadinessProbeStatusChange(ctx, st, name, proc.stillHasSameProcNum())
 		resultLoggerFunc := processReadinessProbeResultLogger(ctx, proc.stillHasSameProcNum())
 		probeWorker, err := probeWorkerFromSpec(
 			c.proberManager,
@@ -170,22 +199,28 @@ func (c *Controller) start(ctx context.Context, spec ServeSpec, st store.RStore)
 			resultLoggerFunc)
 		if err != nil {
 			logger.Get(ctx).Errorf("Invalid readiness probe: %v", err)
-			st.Dispatch(LocalServeStatusAction{
-				ManifestName: spec.ManifestName,
-				Status:       model.RuntimeStatusError,
-				SpanID:       spanID,
+			c.updateStatus(st, name, func(status *CmdStatus) {
+				*status = CmdStatus{
+					Terminated: &CmdStateTerminated{
+						ExitCode: 1,
+						Reason:   fmt.Sprintf("Invalid readiness probe: %v", err),
+					},
+				}
 			})
 			return
 		}
 		proc.probeWorker = probeWorker
 	}
 
-	go processStatuses(ctx, statusCh, st, spec.ManifestName, proc)
+	startedAt := metav1.Now()
+	go c.processStatuses(ctx, statusCh, st, proc, name, startedAt)
 
 	proc.doneCh = c.execer.Start(ctx, spec.ServeCmd, logger.Get(ctx).Writer(logger.InfoLvl), statusCh, spanID)
 }
 
-func processReadinessProbeStatusChange(ctx context.Context, st store.RStore, manifestName model.ManifestName, stillHasSameProcNum func() bool) probe.StatusChangedFunc {
+func (c *Controller) processReadinessProbeStatusChange(ctx context.Context, st store.RStore, name types.NamespacedName, stillHasSameProcNum func() bool) probe.StatusChangedFunc {
+	existingReady := false
+
 	return func(status prober.Result, output string) {
 		if !stillHasSameProcNum() {
 			return
@@ -197,10 +232,10 @@ func processReadinessProbeStatusChange(ctx context.Context, st store.RStore, man
 		}
 
 		ready := status == prober.Success || status == prober.Warning
-		st.Dispatch(LocalServeReadinessProbeAction{
-			ManifestName: manifestName,
-			Ready:        ready,
-		})
+		if existingReady != ready {
+			existingReady = ready
+			c.updateStatus(st, name, func(status *CmdStatus) { status.Ready = ready })
+		}
 	}
 }
 
@@ -240,12 +275,40 @@ func processReadinessProbeResultLogger(ctx context.Context, stillHasSameProcNum 
 	}
 }
 
-func processStatuses(
+// Create the cmd.
+func (c *Controller) createCmd(st store.RStore, name types.NamespacedName, cmd *Cmd) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.cmds[name] = cmd
+	st.Dispatch(NewCmdCreateAction(cmd))
+}
+
+// Update the stored status.
+//
+// In a real K8s controller, this would be a queue to make sure we don't miss updates.
+//
+// update() -> a pure function that applies a delta to the status object.
+func (c *Controller) updateStatus(st store.RStore, name types.NamespacedName, update func(status *CmdStatus)) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	cmd, ok := c.cmds[name]
+	if !ok {
+		return
+	}
+
+	update(&cmd.Status)
+	st.Dispatch(NewCmdUpdateAction(cmd))
+}
+
+func (c *Controller) processStatuses(
 	ctx context.Context,
 	statusCh chan statusAndMetadata,
 	st store.RStore,
-	manifestName model.ManifestName,
-	proc *currentProcess) {
+	proc *currentProcess,
+	name types.NamespacedName,
+	startedAt metav1.Time) {
 
 	var initProbeWorker sync.Once
 	stillHasSameProcNum := proc.stillHasSameProcNum()
@@ -255,27 +318,35 @@ func processStatuses(
 			continue
 		}
 
-		var runtimeStatus model.RuntimeStatus
-		if sm.status == Error {
-			runtimeStatus = model.RuntimeStatusError
+		if sm.status == Error || sm.status == Done {
+			c.updateStatus(st, name, func(status *CmdStatus) {
+				status.Waiting = nil
+				status.Running = nil
+				status.Terminated = &CmdStateTerminated{
+					PID:        int32(sm.pid),
+					Reason:     sm.reason,
+					ExitCode:   int32(sm.exitCode),
+					StartedAt:  startedAt,
+					FinishedAt: metav1.NewTime(time.Now()),
+				}
+			})
 		} else if sm.status == Running {
 			if proc.probeWorker != nil {
 				initProbeWorker.Do(func() {
 					go proc.probeWorker.Run(ctx)
 				})
-				runtimeStatus = model.RuntimeStatusPending
-			} else {
-				runtimeStatus = model.RuntimeStatusOK
 			}
-		}
 
-		if runtimeStatus != "" {
-			// TODO(matt) when we get an error, the dot is red in the web ui, but green in the TUI
-			st.Dispatch(LocalServeStatusAction{
-				ManifestName: manifestName,
-				Status:       runtimeStatus,
-				PID:          sm.pid,
-				SpanID:       sm.spanID,
+			c.updateStatus(st, name, func(status *CmdStatus) {
+				status.Waiting = nil
+				status.Running = &CmdStateRunning{
+					PID:       int32(sm.pid),
+					StartedAt: startedAt,
+				}
+
+				if proc.probeWorker == nil {
+					status.Ready = true
+				}
 			})
 		}
 	}
@@ -291,6 +362,7 @@ type currentProcess struct {
 	// closed when the process finishes executing, intentionally or not
 	doneCh      chan struct{}
 	probeWorker *probe.Worker
+	cmdName     types.NamespacedName
 
 	mu sync.Mutex
 }
@@ -316,17 +388,6 @@ func (p *currentProcess) currentProcNum() int {
 	return p.procNum
 }
 
-type LocalServeLogActionWriter struct {
-	store        store.RStore
-	manifestName model.ManifestName
-	procNum      int
-}
-
-func (w LocalServeLogActionWriter) Write(level logger.Level, fields logger.Fields, p []byte) error {
-	w.store.Dispatch(store.NewLogAction(w.manifestName, SpanIDForServeLog(w.procNum), level, fields, p))
-	return nil
-}
-
 func SpanIDForServeLog(procNum int) logstore.SpanID {
 	return logstore.SpanID(fmt.Sprintf("localserve:%d", procNum))
 }
@@ -340,9 +401,11 @@ type ServeSpec struct {
 }
 
 type statusAndMetadata struct {
-	pid    int
-	status status
-	spanID model.LogSpanID
+	pid      int
+	status   status
+	spanID   model.LogSpanID
+	exitCode int
+	reason   string
 }
 
 type status int

--- a/internal/engine/local/controller_test.go
+++ b/internal/engine/local/controller_test.go
@@ -2,7 +2,7 @@ package local
 
 import (
 	"context"
-	"fmt"
+	"io"
 	"strings"
 	"testing"
 	"time"
@@ -17,12 +17,15 @@ import (
 	"github.com/tilt-dev/tilt/pkg/model"
 )
 
+var timeout = time.Second
+var interval = 5 * time.Millisecond
+
 func TestNoop(t *testing.T) {
 	f := newFixture(t)
 	defer f.teardown()
 
 	f.step()
-	f.assertNoStatus()
+	assert.Equal(t, 0, f.st.CmdCount())
 }
 
 func TestUpdate(t *testing.T) {
@@ -32,19 +35,17 @@ func TestUpdate(t *testing.T) {
 	t1 := time.Unix(1, 0)
 	f.resource("foo", "true", ".", t1)
 	f.step()
-	f.assertStatus("foo", model.RuntimeStatusOK, 1)
+	f.assertCmdMatches("foo-serve-1", func(cmd *Cmd) bool {
+		return cmd.Status.Running != nil
+	})
 
 	t2 := time.Unix(2, 0)
 	f.resource("foo", "false", ".", t2)
 	f.step()
-	f.assertStatus("foo", model.RuntimeStatusOK, 2)
-	f.assertNoAction("error for cancel", func(action store.Action) bool {
-		a, ok := action.(LocalServeStatusAction)
-		if !ok {
-			return false
-		}
-		return a.ManifestName == "foo" && a.Status == model.RuntimeStatusError
+	f.assertCmdMatches("foo-serve-2", func(cmd *Cmd) bool {
+		return cmd.Status.Running != nil
 	})
+
 	f.fe.RequireNoKnownProcess(t, "true")
 	f.assertLogMessage("foo", "Starting cmd false")
 	f.assertLogMessage("foo", "cmd true canceled")
@@ -57,7 +58,9 @@ func TestServe(t *testing.T) {
 	t1 := time.Unix(1, 0)
 	f.resource("foo", "sleep 60", "testdir", t1)
 	f.step()
-	f.assertStatus("foo", model.RuntimeStatusOK, 1)
+	f.assertCmdMatches("foo-serve-1", func(cmd *Cmd) bool {
+		return cmd.Status.Running != nil && cmd.Status.Ready
+	})
 
 	require.Equal(t, "testdir", f.fe.processes["sleep 60"].workdir)
 
@@ -81,14 +84,8 @@ func TestServeReadinessProbe(t *testing.T) {
 
 	f.resourceFromTarget("foo", localTarget, t1)
 	f.step()
-	f.assertAction("did not find readiness probe action", func(action store.Action) bool {
-		probeAction, ok := action.(LocalServeReadinessProbeAction)
-		if !ok ||
-			probeAction.ManifestName != "foo" ||
-			probeAction.Ready != true {
-			return false
-		}
-		return true
+	f.assertCmdMatches("foo-serve-1", func(cmd *Cmd) bool {
+		return cmd.Status.Running != nil && cmd.Status.Ready
 	})
 	f.assertLogMessage("foo", "[readiness probe: success] fake probe succeeded")
 
@@ -115,7 +112,9 @@ func TestServeReadinessProbeInvalidSpec(t *testing.T) {
 	f.resourceFromTarget("foo", localTarget, t1)
 	f.step()
 
-	f.assertStatus("foo", model.RuntimeStatusError, 1)
+	f.assertCmdMatches("foo-serve-1", func(cmd *Cmd) bool {
+		return cmd.Status.Terminated != nil && cmd.Status.Terminated.ExitCode == 1
+	})
 
 	f.assertLogMessage("foo", "Invalid readiness probe: port number out of range: 70000")
 	assert.Equal(t, 0, f.fpm.ProbeCount())
@@ -128,13 +127,18 @@ func TestFailure(t *testing.T) {
 	t1 := time.Unix(1, 0)
 	f.resource("foo", "true", ".", t1)
 	f.step()
-	f.assertStatus("foo", model.RuntimeStatusOK, 1)
+	f.assertCmdMatches("foo-serve-1", func(cmd *Cmd) bool {
+		return cmd.Status.Running != nil
+	})
+
 	f.assertLogMessage("foo", "Starting cmd true")
 
 	err := f.fe.stop("true", 5)
 	require.NoError(t, err)
+	f.assertCmdMatches("foo-serve-1", func(cmd *Cmd) bool {
+		return cmd.Status.Terminated != nil && cmd.Status.Terminated.ExitCode == 5
+	})
 
-	f.assertStatus("foo", model.RuntimeStatusError, 1)
 	f.assertLogMessage("foo", "cmd true exited with code 5")
 }
 
@@ -167,10 +171,50 @@ func TestTearDown(t *testing.T) {
 	f.fe.RequireNoKnownProcess(t, "bar.sh")
 }
 
+type testStore struct {
+	*store.TestingStore
+	out io.Writer
+}
+
+func NewTestingStore(out io.Writer) *testStore {
+	return &testStore{
+		TestingStore: store.NewTestingStore(),
+		out:          out,
+	}
+}
+
+func (s *testStore) Cmd(name string) *Cmd {
+	st := s.RLockState()
+	defer s.RUnlockState()
+	return st.Cmds[name]
+}
+
+func (s *testStore) CmdCount() int {
+	st := s.RLockState()
+	defer s.RUnlockState()
+	return len(st.Cmds)
+}
+
+func (s *testStore) Dispatch(action store.Action) {
+	s.TestingStore.Dispatch(action)
+
+	st := s.LockMutableStateForTesting()
+	defer s.UnlockMutableState()
+
+	switch action := action.(type) {
+	case store.LogAction:
+		_, _ = s.out.Write(action.Message())
+	case CmdCreateAction:
+		HandleCmdCreateAction(st, action)
+	case CmdUpdateAction:
+		HandleCmdUpdateAction(st, action)
+	}
+}
+
 type fixture struct {
 	t      *testing.T
-	st     *store.TestingStore
-	state  store.EngineState
+	out    *bufsync.ThreadSafeBuffer
+	st     *testStore
 	fe     *FakeExecer
 	fpm    *FakeProberManager
 	c      *Controller
@@ -183,16 +227,15 @@ func newFixture(t *testing.T) *fixture {
 	out := bufsync.NewThreadSafeBuffer()
 	l := logger.NewLogger(logger.VerboseLvl, out)
 	ctx = logger.WithLogger(ctx, l)
+	st := NewTestingStore(out)
 
 	fe := NewFakeExecer()
 	fpm := NewFakeProberManager()
 
 	return &fixture{
-		t:  t,
-		st: store.NewTestingStore(),
-		state: store.EngineState{
-			ManifestTargets: make(map[model.ManifestName]*store.ManifestTarget),
-		},
+		t:      t,
+		st:     st,
+		out:    out,
 		fe:     fe,
 		fpm:    fpm,
 		c:      NewController(fe, fpm),
@@ -217,7 +260,10 @@ func (f *fixture) resourceFromTarget(name string, target model.TargetSpec, lastD
 	m := model.Manifest{
 		Name: n,
 	}.WithDeployTarget(target)
-	f.state.UpsertManifestTarget(&store.ManifestTarget{
+
+	st := f.st.LockMutableStateForTesting()
+	defer f.st.UnlockMutableState()
+	st.UpsertManifestTarget(&store.ManifestTarget{
 		Manifest: m,
 		State: &store.ManifestState{
 			LastSuccessfulDeployTime: lastDeploy,
@@ -227,65 +273,14 @@ func (f *fixture) resourceFromTarget(name string, target model.TargetSpec, lastD
 
 func (f *fixture) step() {
 	f.st.ClearActions()
-	f.st.SetState(f.state)
 	f.c.OnChange(f.ctx, f.st, store.LegacyChangeSummary())
-}
-
-func (f *fixture) assertNoStatus() {
-	actions := f.st.Actions()
-	if len(actions) > 0 {
-		f.t.Fatalf("expected no actions")
-	}
-}
-
-func (f *fixture) assertAction(msg string, pred func(action store.Action) bool) {
-	ctx, cancel := context.WithTimeout(f.ctx, time.Second)
-	defer cancel()
-
-	for {
-		actions := f.st.Actions()
-		for _, action := range actions {
-			if pred(action) {
-				return
-			}
-		}
-		select {
-		case <-ctx.Done():
-			f.t.Fatalf("%s. seen actions: %v", msg, actions)
-		case <-time.After(20 * time.Millisecond):
-		}
-	}
-}
-
-func (f *fixture) assertNoAction(msg string, pred func(action store.Action) bool) {
-	for _, action := range f.st.Actions() {
-		require.Falsef(f.t, pred(action), "%s", msg)
-	}
-}
-
-func (f *fixture) assertStatus(name string, status model.RuntimeStatus, sequenceNum int) {
-	msg := fmt.Sprintf("didn't find name %s, status %v, sequence %d", name, status, sequenceNum)
-	pred := func(action store.Action) bool {
-		stAction, ok := action.(LocalServeStatusAction)
-		if !ok ||
-			stAction.ManifestName != model.ManifestName(name) ||
-			stAction.Status != status {
-			return false
-		}
-		return true
-	}
-
-	f.assertAction(msg, pred)
 }
 
 func (f *fixture) assertLogMessage(name string, messages ...string) {
 	for _, m := range messages {
-		msg := fmt.Sprintf("didn't find name %s, message %s", name, m)
-		pred := func(action store.Action) bool {
-			a, ok := action.(store.LogAction)
-			return ok && strings.Contains(string(a.Message()), m)
-		}
-		f.assertAction(msg, pred)
+		assert.Eventually(f.t, func() bool {
+			return strings.Contains(f.out.String(), m)
+		}, timeout, interval)
 	}
 }
 
@@ -307,4 +302,14 @@ func (f *fixture) waitForLogEventContaining(message string) store.LogAction {
 		case <-time.After(20 * time.Millisecond):
 		}
 	}
+}
+
+func (f *fixture) assertCmdMatches(name string, matcher func(cmd *Cmd) bool) {
+	assert.Eventually(f.t, func() bool {
+		cmd := f.st.Cmd(name)
+		if cmd == nil {
+			return false
+		}
+		return matcher(cmd)
+	}, timeout, interval)
 }

--- a/internal/engine/local/reducers.go
+++ b/internal/engine/local/reducers.go
@@ -1,0 +1,88 @@
+package local
+
+import (
+	"time"
+
+	"github.com/tilt-dev/tilt/internal/store"
+	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
+	"github.com/tilt-dev/tilt/pkg/model"
+)
+
+// When the Cmd controller updates a command, check to see
+// what parts of the EngineState care about that command.
+//
+// If the local serve cmd is watching the cmd, update
+// the local runtime state to match the cmd status.
+func HandleCmdUpdateAction(state *store.EngineState, action CmdUpdateAction) {
+	cmd := action.Cmd
+	mn := model.ManifestName(cmd.Labels[v1alpha1.LabelManifest])
+	mt, ok := state.ManifestTargets[mn]
+	if !ok {
+		delete(state.Cmds, cmd.Name)
+		return
+	}
+
+	ms := mt.State
+	lrs := ms.LocalRuntimeState()
+	if lrs.CmdName != cmd.Name {
+		delete(state.Cmds, cmd.Name)
+		return
+	}
+
+	state.Cmds[action.Cmd.Name] = cmd
+
+	spec := cmd.Spec
+	status := cmd.Status
+	if status.Running != nil {
+		lrs.PID = int(cmd.Status.Running.PID)
+
+		// Currently, Cmd is only used for servers.
+		// Make the Status OK when the readiness probe passes (if there is one).
+		if spec.ReadinessProbe == nil || cmd.Status.Ready {
+			lrs.Status = model.RuntimeStatusOK
+		} else {
+			lrs.Status = model.RuntimeStatusPending
+		}
+
+	} else if status.Terminated != nil {
+		// Currently, CMD is only used for servers,
+		// so any termination is an error.
+		lrs.PID = int(status.Terminated.PID)
+		lrs.Status = model.RuntimeStatusError
+
+	} else {
+		lrs.Status = model.RuntimeStatusPending
+	}
+
+	if lrs.Ready != cmd.Status.Ready {
+		lrs.Ready = cmd.Status.Ready
+		if lrs.Ready {
+			lrs.LastReadyOrSucceededTime = time.Now()
+		}
+	}
+	lrs.SpanID = model.LogSpanID(cmd.ObjectMeta.Annotations[v1alpha1.AnnotationSpanID])
+
+	ms.RuntimeState = lrs
+}
+
+// When the local controller creates a new command, link
+// that command to the Local runtime state.
+func HandleCmdCreateAction(state *store.EngineState, action CmdCreateAction) {
+	cmd := action.Cmd
+	mn := model.ManifestName(cmd.Labels[v1alpha1.LabelManifest])
+	mt, ok := state.ManifestTargets[mn]
+	if !ok {
+		return
+	}
+
+	ms := mt.State
+	lrs := ms.LocalRuntimeState()
+	if lrs.CmdName != "" {
+		delete(state.Cmds, lrs.CmdName)
+	}
+
+	lrs.CmdName = cmd.Name
+	ms.RuntimeState = lrs
+
+	HandleCmdUpdateAction(state, CmdUpdateAction{Cmd: cmd})
+}

--- a/internal/engine/local/types.go
+++ b/internal/engine/local/types.go
@@ -1,0 +1,14 @@
+package local
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
+)
+
+type Cmd = v1alpha1.Cmd
+type CmdStatus = v1alpha1.CmdStatus
+type CmdSpec = v1alpha1.CmdSpec
+type CmdStateTerminated = v1alpha1.CmdStateTerminated
+type CmdStateRunning = v1alpha1.CmdStateRunning
+type ObjectMeta = metav1.ObjectMeta

--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -166,10 +166,6 @@ func upperReducerFn(ctx context.Context, state *store.EngineState, action store.
 		handlePanicAction(state, action)
 	case server.SetTiltfileArgsAction:
 		handleSetTiltfileArgsAction(state, action)
-	case local.LocalServeStatusAction:
-		handleLocalServeStatusAction(ctx, state, action)
-	case local.LocalServeReadinessProbeAction:
-		handleLocalServeReadinessProbeAction(ctx, state, action)
 	case store.LogAction:
 		handleLogAction(state, action)
 	case exit.Action:
@@ -182,6 +178,10 @@ func upperReducerFn(ctx context.Context, state *store.EngineState, action store.
 		handleMetricsDashboardAction(state, action)
 	case server.OverrideTriggerModeAction:
 		handleOverrideTriggerModeAction(ctx, state, action)
+	case local.CmdCreateAction:
+		local.HandleCmdCreateAction(state, action)
+	case local.CmdUpdateAction:
+		local.HandleCmdUpdateAction(state, action)
 	default:
 		state.FatalError = fmt.Errorf("unrecognized action: %T", action)
 	}
@@ -759,46 +759,6 @@ func handlePanicAction(state *store.EngineState, action store.PanicAction) {
 
 func handleSetTiltfileArgsAction(state *store.EngineState, action server.SetTiltfileArgsAction) {
 	state.UserConfigState = state.UserConfigState.WithArgs(action.Args)
-}
-
-func handleLocalServeStatusAction(ctx context.Context, state *store.EngineState, action local.LocalServeStatusAction) {
-	mt, ok := state.ManifestTargets[action.ManifestName]
-	if !ok {
-		logger.Get(ctx).Infof("got runtime status information for unknown local resource %s", action.ManifestName)
-	}
-	ms := mt.State
-
-	lrs := ms.LocalRuntimeState()
-
-	if action.Status == model.RuntimeStatusError {
-		lrs.Ready = false
-	}
-
-	lrs.Status = action.Status
-	lrs.PID = action.PID
-	lrs.SpanID = action.SpanID
-	ms.RuntimeState = lrs
-}
-
-func handleLocalServeReadinessProbeAction(ctx context.Context, state *store.EngineState, action local.LocalServeReadinessProbeAction) {
-	ms, ok := state.ManifestState(action.ManifestName)
-	if !ok {
-		logger.Get(ctx).Infof("got readiness probe information for unknown local resource %s", action.ManifestName)
-	}
-
-	lrs := ms.LocalRuntimeState()
-	lrs.Ready = action.Ready
-	if action.Ready {
-		lrs.LastReadyOrSucceededTime = time.Now()
-		if lrs.Status == "" || lrs.Status == model.RuntimeStatusPending {
-			// only transition to OK if currently pending AND ready
-			lrs.Status = model.RuntimeStatusOK
-		}
-	} else if lrs.Status == "" || lrs.Status == model.RuntimeStatusOK {
-		// only transition to pending if currently OK and NOT ready
-		lrs.Status = model.RuntimeStatusPending
-	}
-	ms.RuntimeState = lrs
 }
 
 func handleDockerComposeEvent(ctx context.Context, engineState *store.EngineState, action dcwatch.EventAction) {

--- a/internal/store/engine_state.go
+++ b/internal/store/engine_state.go
@@ -116,6 +116,10 @@ type EngineState struct {
 	MetricsServing  MetricsServing
 
 	UserConfigState model.UserConfigState
+
+	// API-server-based data models. Stored in EngineState
+	// to assist in migration.
+	Cmds map[string]*Cmd
 }
 
 type CloudStatus struct {
@@ -473,6 +477,7 @@ func NewState() *EngineState {
 		ret.AnalyticsEnvOpt = analytics.OptOut
 	}
 
+	ret.Cmds = make(map[string]*Cmd)
 	return ret
 }
 

--- a/internal/store/logger.go
+++ b/internal/store/logger.go
@@ -2,8 +2,14 @@ package store
 
 import (
 	"context"
+	"fmt"
 
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
 	"github.com/tilt-dev/tilt/pkg/logger"
+	"github.com/tilt-dev/tilt/pkg/model"
 )
 
 func NewLogActionLogger(ctx context.Context, dispatch func(action Action)) logger.Logger {
@@ -12,4 +18,50 @@ func NewLogActionLogger(ctx context.Context, dispatch func(action Action)) logge
 		dispatch(NewGlobalLogAction(level, b))
 		return nil
 	})
+}
+
+// Read labels and annotations of the given API object to determine where to log,
+// panicking if there's no info available.
+func MustObjectLogHandler(ctx context.Context, st RStore, obj runtime.Object) context.Context {
+	ctx, err := WithObjectLogHandler(ctx, st, obj)
+	if err != nil {
+		panic(err)
+	}
+	return ctx
+}
+
+// Read labels and annotations of the given API object to determine where to log.
+func WithObjectLogHandler(ctx context.Context, st RStore, obj runtime.Object) (context.Context, error) {
+	meta, err := meta.Accessor(obj)
+	if err != nil {
+		return nil, fmt.Errorf("object missing log info: %T", obj)
+	}
+
+	mn := meta.GetLabels()[v1alpha1.LabelManifest]
+	if mn == "" {
+		return nil, fmt.Errorf("object missing manifest label")
+	}
+
+	spanID := meta.GetAnnotations()[v1alpha1.AnnotationSpanID]
+	if spanID == "" {
+		return nil, fmt.Errorf("object missing span id annotation")
+	}
+
+	w := apiLogWriter{
+		store:        st,
+		manifestName: model.ManifestName(mn),
+		spanID:       model.LogSpanID(spanID),
+	}
+	return logger.CtxWithLogHandler(ctx, w), nil
+}
+
+type apiLogWriter struct {
+	store        RStore
+	manifestName model.ManifestName
+	spanID       model.LogSpanID
+}
+
+func (w apiLogWriter) Write(level logger.Level, fields logger.Fields, p []byte) error {
+	w.store.Dispatch(NewLogAction(w.manifestName, w.spanID, level, fields, p))
+	return nil
 }

--- a/internal/store/runtime_state.go
+++ b/internal/store/runtime_state.go
@@ -37,6 +37,7 @@ type RuntimeState interface {
 type ProbeState int
 
 type LocalRuntimeState struct {
+	CmdName                  string
 	Status                   model.RuntimeStatus
 	PID                      int
 	SpanID                   model.LogSpanID

--- a/internal/store/types.go
+++ b/internal/store/types.go
@@ -1,0 +1,5 @@
+package store
+
+import "github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
+
+type Cmd = v1alpha1.Cmd

--- a/pkg/apis/core/v1alpha1/register.go
+++ b/pkg/apis/core/v1alpha1/register.go
@@ -29,6 +29,14 @@ const GroupName = "core.tilt.dev"
 
 const Version = "v1alpha1"
 
+// The label on any object that identifies which manifest
+// its logs should appear under.
+const LabelManifest = "tilt.dev/resource"
+
+// An annotation on any object that identifies which span id
+// its logs should appear under.
+const AnnotationSpanID = "tilt.dev/log-span-id"
+
 // SchemeGroupVersion is group version used to register these objects
 var SchemeGroupVersion = schema.GroupVersion{Group: GroupName, Version: Version}
 

--- a/web/storybook.tiltfile
+++ b/web/storybook.tiltfile
@@ -1,7 +1,8 @@
 local_resource(
   'storybook',
   serve_cmd='yarn run storybook -- --ci',
-  links=['http://localhost:9009'])
+  links=['http://localhost:9009'],
+  readiness_probe=probe(http_get=http_get_action(port=9009)))
 
 local_resource(
   'check/prettier',


### PR DESCRIPTION
Hello @milas, @ellenkorbes,

Please review the following commits I made in branch nicks/action-time:

8f6df154b2785d368e945a1b97aedcc22c3bcab1 (2021-03-03 18:34:08 -0500)
engine: Write Cmd objects to the EngineState
This is alternative proposal for how to move to the new API,
where we write the objects to the engine state first,
then convert to a controller second.

This also contains some standardization w/r/t how we do logging
in this new system.

7c142e686ed75cbddfe345c422e15b703bdbee18 (2021-03-03 17:02:23 -0500)
apis: add reason to CmdStatus, remove manifest

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics