### PR TITLE
store: add a mechanism to summarize changes

### DIFF
--- a/internal/cloud/cloud_status_manager.go
+++ b/internal/cloud/cloud_status_manager.go
@@ -170,7 +170,7 @@ func (c *CloudStatusManager) needsLookup(requestKey statusRequestKey) bool {
 		requestKey != c.lastRequestKey
 }
 
-func (c *CloudStatusManager) OnChange(ctx context.Context, st store.RStore) {
+func (c *CloudStatusManager) OnChange(ctx context.Context, st store.RStore, _ store.ChangeSummary) {
 	state := st.RLockState()
 	defer st.RUnlockState()
 

--- a/internal/cloud/cloud_status_manager_test.go
+++ b/internal/cloud/cloud_status_manager_test.go
@@ -128,13 +128,13 @@ func TestStatusRefresh(t *testing.T) {
 
 	f.st.ClearActions()
 
-	f.um.OnChange(f.ctx, f.st)
+	f.um.OnChange(f.ctx, f.st, store.LegacyChangeSummary())
 	store.AssertNoActionOfType(t, reflect.TypeOf(store.TiltCloudStatusReceivedAction{}), f.st.Actions)
 
 	// check that we periodically refresh
 	f.clock.Advance(24 * time.Hour)
 
-	f.um.OnChange(f.ctx, f.st)
+	f.um.OnChange(f.ctx, f.st, store.LegacyChangeSummary())
 	a = store.WaitForAction(t, reflect.TypeOf(store.TiltCloudStatusReceivedAction{}), f.st.Actions)
 	require.Equal(t, expected, a)
 }
@@ -173,7 +173,7 @@ func (f *cloudStatusManagerTestFixture) Run(mutateState func(state *store.Engine
 	}
 	mutateState(&state)
 	f.st.SetState(state)
-	f.um.OnChange(f.ctx, f.st)
+	f.um.OnChange(f.ctx, f.st, store.LegacyChangeSummary())
 }
 
 func (f *cloudStatusManagerTestFixture) waitForRequest(expectedURL string) http.Request {

--- a/internal/controllers/builder.go
+++ b/internal/controllers/builder.go
@@ -33,7 +33,7 @@ func NewControllerBuilder(tscm *TiltServerControllerManager, controllers []Contr
 var _ store.Subscriber = &ControllerBuilder{}
 var _ store.SetUpper = &ControllerBuilder{}
 
-func (c *ControllerBuilder) OnChange(_ context.Context, _ store.RStore) {}
+func (c *ControllerBuilder) OnChange(_ context.Context, _ store.RStore, _ store.ChangeSummary) {}
 
 func (c *ControllerBuilder) SetUp(_ context.Context, _ store.RStore) error {
 	mgr := c.tscm.GetManager()

--- a/internal/controllers/core/cmd/controller_old.go
+++ b/internal/controllers/core/cmd/controller_old.go
@@ -37,7 +37,7 @@ func NewControllerOld(execer Execer, proberManager ProberManager) *ControllerOld
 	}
 }
 
-func (c *ControllerOld) OnChange(ctx context.Context, st store.RStore) {
+func (c *ControllerOld) OnChange(ctx context.Context, st store.RStore, _ store.ChangeSummary) {
 	specs := c.determineServeSpecs(ctx, st)
 	c.update(ctx, specs, st)
 }

--- a/internal/controllers/core/cmd/controller_test.go
+++ b/internal/controllers/core/cmd/controller_test.go
@@ -228,7 +228,7 @@ func (f *fixture) resourceFromTarget(name string, target model.TargetSpec, lastD
 func (f *fixture) step() {
 	f.st.ClearActions()
 	f.st.SetState(f.state)
-	f.c.OnChange(f.ctx, f.st)
+	f.c.OnChange(f.ctx, f.st, store.LegacyChangeSummary())
 }
 
 func (f *fixture) assertNoStatus() {

--- a/internal/controllers/manager.go
+++ b/internal/controllers/manager.go
@@ -89,4 +89,5 @@ func (m *TiltServerControllerManager) TearDown(_ context.Context) {
 }
 
 // OnChange is a no-op but used to get initialized in upper along with the API server
-func (m *TiltServerControllerManager) OnChange(_ context.Context, _ store.RStore) {}
+func (m *TiltServerControllerManager) OnChange(_ context.Context, _ store.RStore, _ store.ChangeSummary) {
+}

--- a/internal/engine/analytics/analytics_reporter.go
+++ b/internal/engine/analytics/analytics_reporter.go
@@ -21,7 +21,7 @@ type AnalyticsReporter struct {
 	started bool
 }
 
-func (ar *AnalyticsReporter) OnChange(ctx context.Context, st store.RStore) {
+func (ar *AnalyticsReporter) OnChange(ctx context.Context, st store.RStore, _ store.ChangeSummary) {
 	if ar.started {
 		return
 	}

--- a/internal/engine/analytics/analytics_updater.go
+++ b/internal/engine/analytics/analytics_updater.go
@@ -30,7 +30,7 @@ func NewAnalyticsUpdater(ta *analytics.TiltAnalytics, cmdTags CmdTags) *Analytic
 	}
 }
 
-func (sub *AnalyticsUpdater) OnChange(ctx context.Context, st store.RStore) {
+func (sub *AnalyticsUpdater) OnChange(ctx context.Context, st store.RStore, _ store.ChangeSummary) {
 	state := st.RLockState()
 	defer st.RUnlockState()
 

--- a/internal/engine/analytics/analytics_updater_test.go
+++ b/internal/engine/analytics/analytics_updater_test.go
@@ -20,7 +20,7 @@ func TestOnChange(t *testing.T) {
 	au := NewAnalyticsUpdater(a, cmdUpTags)
 	st := store.NewTestingStore()
 	setUserOpt(st, analytics.OptOut)
-	au.OnChange(context.Background(), st)
+	au.OnChange(context.Background(), st, store.LegacyChangeSummary())
 
 	assert.Equal(t, []analytics.Opt{analytics.OptOut}, to.Calls())
 }
@@ -35,7 +35,7 @@ func TestReportOnOptIn(t *testing.T) {
 	au := NewAnalyticsUpdater(a, cmdUpTags)
 	st := store.NewTestingStore()
 	setUserOpt(st, analytics.OptIn)
-	au.OnChange(context.Background(), st)
+	au.OnChange(context.Background(), st, store.LegacyChangeSummary())
 
 	assert.Equal(t, []analytics.Opt{analytics.OptOut, analytics.OptIn}, to.Calls())
 	if assert.Equal(t, 1, len(mem.Counts)) {
@@ -45,10 +45,10 @@ func TestReportOnOptIn(t *testing.T) {
 
 	// opt-out then back in again, and make sure it doesn't get re-reported.
 	setUserOpt(st, analytics.OptOut)
-	au.OnChange(context.Background(), st)
+	au.OnChange(context.Background(), st, store.LegacyChangeSummary())
 
 	setUserOpt(st, analytics.OptIn)
-	au.OnChange(context.Background(), st)
+	au.OnChange(context.Background(), st, store.LegacyChangeSummary())
 	assert.Equal(t, 1, len(mem.Counts))
 }
 

--- a/internal/engine/buildcontroller.go
+++ b/internal/engine/buildcontroller.go
@@ -80,7 +80,7 @@ func (c *BuildController) DisableForTesting() {
 	c.disabledForTesting = true
 }
 
-func (c *BuildController) OnChange(ctx context.Context, st store.RStore) {
+func (c *BuildController) OnChange(ctx context.Context, st store.RStore, _ store.ChangeSummary) {
 	if c.disabledForTesting {
 		return
 	}

--- a/internal/engine/configs/configs_controller.go
+++ b/internal/engine/configs/configs_controller.go
@@ -182,7 +182,7 @@ func (cc *ConfigsController) loadTiltfile(ctx context.Context, st store.RStore, 
 	})
 }
 
-func (cc *ConfigsController) OnChange(ctx context.Context, st store.RStore) {
+func (cc *ConfigsController) OnChange(ctx context.Context, st store.RStore, _ store.ChangeSummary) {
 	if cc.disabledForTesting {
 		return
 	}

--- a/internal/engine/configs/configs_controller_test.go
+++ b/internal/engine/configs/configs_controller_test.go
@@ -34,7 +34,7 @@ func TestConfigsController(t *testing.T) {
 
 	bar := manifestbuilder.New(f, "bar").WithK8sYAML(testyaml.SanchoYAML).Build()
 	f.setManifestResult(bar)
-	f.cc.OnChange(f.ctx, f.st)
+	f.cc.OnChange(f.ctx, f.st, store.LegacyChangeSummary())
 
 	expected := &ConfigsReloadedAction{
 		Manifests:  []model.Manifest{bar},
@@ -58,7 +58,7 @@ func TestConfigsControllerDockerNotConnected(t *testing.T) {
 		WithImageTarget(NewSanchoDockerBuildImageTarget(f)).
 		Build()
 	f.setManifestResult(bar)
-	f.cc.OnChange(f.ctx, f.st)
+	f.cc.OnChange(f.ctx, f.st, store.LegacyChangeSummary())
 
 	if assert.Error(t, f.st.end.Err) {
 		assert.Equal(t, "Failed to connect to Docker: connection-error", f.st.end.Err.Error())
@@ -77,7 +77,7 @@ func TestConfigsControllerDockerNotConnectedButNotRequired(t *testing.T) {
 		WithK8sYAML(testyaml.SanchoYAML).
 		Build()
 	f.setManifestResult(bar)
-	f.cc.OnChange(f.ctx, f.st)
+	f.cc.OnChange(f.ctx, f.st, store.LegacyChangeSummary())
 
 	assert.NoError(t, f.st.end.Err)
 }
@@ -94,7 +94,7 @@ func TestBuildReasonTrigger(t *testing.T) {
 	f.st.UnlockMutableState()
 
 	f.setManifestResult(bar)
-	f.cc.OnChange(f.ctx, f.st)
+	f.cc.OnChange(f.ctx, f.st, store.LegacyChangeSummary())
 
 	assert.True(t, f.st.start.Reason.Has(model.BuildReasonFlagTriggerWeb),
 		"expected build reason has flag: TriggerWeb")
@@ -105,7 +105,7 @@ func TestErrorLog(t *testing.T) {
 	defer f.TearDown()
 
 	f.tfl.Result = tiltfile.TiltfileLoadResult{Error: fmt.Errorf("The goggles do nothing!")}
-	f.cc.OnChange(f.ctx, f.st)
+	f.cc.OnChange(f.ctx, f.st, store.LegacyChangeSummary())
 
 	assert.Contains(f.T(), f.st.out.String(), "ERROR LEVEL: The goggles do nothing!")
 }

--- a/internal/engine/dcwatch/event_watcher.go
+++ b/internal/engine/dcwatch/event_watcher.go
@@ -32,7 +32,7 @@ func (w *EventWatcher) needsWatch(st store.RStore) bool {
 	return state.EngineMode.WatchesRuntime() && !w.watching
 }
 
-func (w *EventWatcher) OnChange(ctx context.Context, st store.RStore) {
+func (w *EventWatcher) OnChange(ctx context.Context, st store.RStore, _ store.ChangeSummary) {
 	if !w.needsWatch(st) {
 		return
 	}

--- a/internal/engine/dockerprune/docker_pruner.go
+++ b/internal/engine/dockerprune/docker_pruner.go
@@ -63,7 +63,7 @@ func (dp *DockerPruner) SetUp(ctx context.Context, _ store.RStore) error {
 	return nil
 }
 
-func (dp *DockerPruner) OnChange(ctx context.Context, st store.RStore) {
+func (dp *DockerPruner) OnChange(ctx context.Context, st store.RStore, _ store.ChangeSummary) {
 	if dp.disabledForTesting || dp.disabledOnSetup {
 		return
 	}

--- a/internal/engine/dockerprune/docker_pruner_test.go
+++ b/internal/engine/dockerprune/docker_pruner_test.go
@@ -227,7 +227,7 @@ func TestDockerPrunerSinceNBuilds(t *testing.T) {
 	f.dp.lastPruneBuildCount = 5
 	f.dp.lastPruneTime = twoHrsAgo()
 
-	f.dp.OnChange(f.ctx, f.st)
+	f.dp.OnChange(f.ctx, f.st, store.LegacyChangeSummary())
 
 	f.assertPrune()
 }
@@ -240,7 +240,7 @@ func TestDockerPrunerNotEnoughBuilds(t *testing.T) {
 	f.dp.lastPruneBuildCount = 5
 	f.dp.lastPruneTime = twoHrsAgo()
 
-	f.dp.OnChange(f.ctx, f.st)
+	f.dp.OnChange(f.ctx, f.st, store.LegacyChangeSummary())
 
 	f.assertNoPrune()
 }
@@ -251,7 +251,7 @@ func TestDockerPrunerSinceInterval(t *testing.T) {
 	f.withDockerPruneSettings(true, 0, 0, 30*time.Minute)
 	f.dp.lastPruneTime = twoHrsAgo()
 
-	f.dp.OnChange(f.ctx, f.st)
+	f.dp.OnChange(f.ctx, f.st, store.LegacyChangeSummary())
 
 	f.assertPrune()
 }
@@ -262,7 +262,7 @@ func TestDockerPrunerSinceDefaultInterval(t *testing.T) {
 	f.withDockerPruneSettings(true, 0, 0, 0)
 	f.dp.lastPruneTime = time.Now().Add(-1 * (model.DockerPruneDefaultInterval + time.Minute))
 
-	f.dp.OnChange(f.ctx, f.st)
+	f.dp.OnChange(f.ctx, f.st, store.LegacyChangeSummary())
 
 	f.assertPrune()
 }
@@ -273,7 +273,7 @@ func TestDockerPrunerNotEnoughTimeElapsed(t *testing.T) {
 	f.withDockerPruneSettings(true, 0, 0, 3*time.Hour)
 	f.dp.lastPruneTime = twoHrsAgo()
 
-	f.dp.OnChange(f.ctx, f.st)
+	f.dp.OnChange(f.ctx, f.st, store.LegacyChangeSummary())
 
 	f.assertNoPrune()
 }
@@ -284,7 +284,7 @@ func TestDockerPrunerSinceDefaultIntervalNotEnoughTime(t *testing.T) {
 	f.withDockerPruneSettings(true, 0, 0, 0)
 	f.dp.lastPruneTime = time.Now().Add(-1 * model.DockerPruneDefaultInterval).Add(20 * time.Minute)
 
-	f.dp.OnChange(f.ctx, f.st)
+	f.dp.OnChange(f.ctx, f.st, store.LegacyChangeSummary())
 
 	f.assertNoPrune()
 }
@@ -295,7 +295,7 @@ func TestDockerPrunerFirstRun(t *testing.T) {
 	f.withBuildCount(5)
 	f.withDockerPruneSettings(true, 0, 10, 0)
 
-	f.dp.OnChange(f.ctx, f.st)
+	f.dp.OnChange(f.ctx, f.st, store.LegacyChangeSummary())
 
 	f.assertPrune()
 }
@@ -306,7 +306,7 @@ func TestDockerPrunerFirstRunButNoCompletedBuilds(t *testing.T) {
 	f.withBuildCount(0)
 	f.withDockerPruneSettings(true, 0, 10, 0)
 
-	f.dp.OnChange(f.ctx, f.st)
+	f.dp.OnChange(f.ctx, f.st, store.LegacyChangeSummary())
 
 	f.assertNoPrune()
 }
@@ -317,7 +317,7 @@ func TestDockerPrunerNoDockerManifests(t *testing.T) {
 	f.withBuildCount(11)
 	f.withDockerPruneSettings(true, 0, 5, 0)
 
-	f.dp.OnChange(f.ctx, f.st)
+	f.dp.OnChange(f.ctx, f.st, store.LegacyChangeSummary())
 
 	f.assertNoPrune()
 }
@@ -327,7 +327,7 @@ func TestDockerPrunerDisabled(t *testing.T) {
 	f.withDockerManifestAlreadyBuilt()
 	f.withDockerPruneSettings(false, 0, 0, 0)
 
-	f.dp.OnChange(f.ctx, f.st)
+	f.dp.OnChange(f.ctx, f.st, store.LegacyChangeSummary())
 
 	f.assertNoPrune()
 }
@@ -339,7 +339,7 @@ func TestDockerPrunerCurrentlyBuilding(t *testing.T) {
 	f.withDockerPruneSettings(true, 0, 0, time.Hour)
 	f.dp.lastPruneTime = twoHrsAgo()
 
-	f.dp.OnChange(f.ctx, f.st)
+	f.dp.OnChange(f.ctx, f.st, store.LegacyChangeSummary())
 
 	f.assertNoPrune()
 }
@@ -350,7 +350,7 @@ func TestDockerPrunerPendingBuild(t *testing.T) {
 	f.withDockerPruneSettings(true, 0, 0, time.Hour)
 	f.dp.lastPruneTime = twoHrsAgo()
 
-	f.dp.OnChange(f.ctx, f.st)
+	f.dp.OnChange(f.ctx, f.st, store.LegacyChangeSummary())
 
 	f.assertNoPrune()
 }
@@ -362,7 +362,7 @@ func TestDockerPrunerMaxAgeFromSettings(t *testing.T) {
 	maxAge := time.Hour
 	f.withDockerPruneSettings(true, maxAge, 10, 0)
 
-	f.dp.OnChange(f.ctx, f.st)
+	f.dp.OnChange(f.ctx, f.st, store.LegacyChangeSummary())
 
 	f.assertPrune()
 	untilVals := f.dCli.ContainersPruneFilters.Get("until")

--- a/internal/engine/exit/controller.go
+++ b/internal/engine/exit/controller.go
@@ -126,7 +126,7 @@ func (c *Controller) isRuntimeDone(mt *store.ManifestTarget) bool {
 	return true
 }
 
-func (c *Controller) OnChange(ctx context.Context, store store.RStore) {
+func (c *Controller) OnChange(ctx context.Context, store store.RStore, _ store.ChangeSummary) {
 	action := c.shouldExit(store)
 	if action.ExitSignal {
 		store.Dispatch(action)

--- a/internal/engine/exit/controller_test.go
+++ b/internal/engine/exit/controller_test.go
@@ -36,7 +36,7 @@ func TestExitControlAllSuccess(t *testing.T) {
 		})
 	})
 
-	f.c.OnChange(f.ctx, f.store)
+	f.c.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
 	assert.False(t, f.store.exitSignal)
 
 	f.store.WithState(func(state *store.EngineState) {
@@ -47,7 +47,7 @@ func TestExitControlAllSuccess(t *testing.T) {
 	})
 
 	// Verify that completing the second build causes an exit
-	f.c.OnChange(f.ctx, f.store)
+	f.c.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
 	assert.True(t, f.store.exitSignal)
 	assert.Nil(t, f.store.exitError)
 }
@@ -64,7 +64,7 @@ func TestExitControlFirstFailure(t *testing.T) {
 		state.UpsertManifestTarget(store.NewManifestTarget(m2))
 	})
 
-	f.c.OnChange(f.ctx, f.store)
+	f.c.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
 	assert.False(t, f.store.exitSignal)
 
 	f.store.WithState(func(state *store.EngineState) {
@@ -76,7 +76,7 @@ func TestExitControlFirstFailure(t *testing.T) {
 	})
 
 	// Verify that if one build fails with an error, it fails immediately.
-	f.c.OnChange(f.ctx, f.store)
+	f.c.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
 	assert.True(t, f.store.exitSignal)
 }
 
@@ -101,7 +101,7 @@ func TestExitControlCIFirstRuntimeFailure(t *testing.T) {
 		})
 	})
 
-	f.c.OnChange(f.ctx, f.store)
+	f.c.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
 	assert.False(t, f.store.exitSignal)
 
 	f.store.WithState(func(state *store.EngineState) {
@@ -116,7 +116,7 @@ func TestExitControlCIFirstRuntimeFailure(t *testing.T) {
 	})
 
 	// Verify that if one pod fails with an error, it fails immediately.
-	f.c.OnChange(f.ctx, f.store)
+	f.c.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
 	assert.True(t, f.store.exitSignal)
 	require.Error(t, f.store.exitError)
 	assert.Contains(t, f.store.exitError.Error(),
@@ -145,7 +145,7 @@ func TestExitControlCISuccess(t *testing.T) {
 		state.ManifestTargets["fe"].State.RuntimeState = store.NewK8sRuntimeStateWithPods(m, readyPod("pod-a"))
 	})
 
-	f.c.OnChange(f.ctx, f.store)
+	f.c.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
 	assert.False(t, f.store.exitSignal)
 
 	f.store.WithState(func(state *store.EngineState) {
@@ -154,7 +154,7 @@ func TestExitControlCISuccess(t *testing.T) {
 	})
 
 	// Verify that if one pod fails with an error, it fails immediately.
-	f.c.OnChange(f.ctx, f.store)
+	f.c.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
 	assert.True(t, f.store.exitSignal)
 	assert.Nil(t, f.store.exitError)
 }
@@ -174,7 +174,7 @@ func TestExitControlCIJobSuccess(t *testing.T) {
 		state.ManifestTargets["fe"].State.RuntimeState = store.NewK8sRuntimeStateWithPods(m, readyPod("pod-a"))
 	})
 
-	f.c.OnChange(f.ctx, f.store)
+	f.c.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
 	assert.False(t, f.store.exitSignal)
 
 	f.store.WithState(func(state *store.EngineState) {
@@ -183,7 +183,7 @@ func TestExitControlCIJobSuccess(t *testing.T) {
 	})
 
 	// Verify that if one pod fails with an error, it fails immediately.
-	f.c.OnChange(f.ctx, f.store)
+	f.c.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
 	assert.True(t, f.store.exitSignal)
 	assert.Nil(t, f.store.exitError)
 }
@@ -208,7 +208,7 @@ func TestExitControlCIDontBlockOnAutoInitFalse(t *testing.T) {
 		state.UpsertManifestTarget(store.NewManifestTarget(manifestAutoInitFalse))
 	})
 
-	f.c.OnChange(f.ctx, f.store)
+	f.c.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
 	assert.False(t, f.store.exitSignal)
 
 	f.store.WithState(func(state *store.EngineState) {
@@ -217,7 +217,7 @@ func TestExitControlCIDontBlockOnAutoInitFalse(t *testing.T) {
 	})
 
 	// Verify that if one pod fails with an error, it fails immediately.
-	f.c.OnChange(f.ctx, f.store)
+	f.c.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
 	assert.True(t, f.store.exitSignal)
 	assert.Nil(t, f.store.exitError)
 }

--- a/internal/engine/fswatch/watchmanager.go
+++ b/internal/engine/fswatch/watchmanager.go
@@ -233,7 +233,7 @@ func (w *WatchManager) TargetWatchCount() int {
 	return len(w.targetWatches)
 }
 
-func (w *WatchManager) OnChange(ctx context.Context, st store.RStore) {
+func (w *WatchManager) OnChange(ctx context.Context, st store.RStore, _ store.ChangeSummary) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 

--- a/internal/engine/fswatch/watchmanager_test.go
+++ b/internal/engine/fswatch/watchmanager_test.go
@@ -100,7 +100,7 @@ func TestWatchManager_IgnoreOutputsImageRefs(t *testing.T) {
 			Build()
 		state.UpsertManifestTarget(store.NewManifestTarget(m))
 	})
-	f.wm.OnChange(f.ctx, f.store)
+	f.wm.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
 
 	f.ChangeFile(t, "included.txt")
 	f.ChangeFile(t, "ref.txt")
@@ -175,7 +175,7 @@ func TestWatchManager_IgnoreWatchSettings(t *testing.T) {
 			Patterns:  []string{"**/foo"},
 		})
 	})
-	f.wm.OnChange(f.ctx, f.store)
+	f.wm.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
 
 	f.ChangeFile(t, filepath.Join("bar", "foo"))
 
@@ -324,7 +324,7 @@ func (f *wmFixture) SetManifestTarget(target model.DockerComposeTarget) {
 	state := f.store.LockMutableStateForTesting()
 	state.UpsertManifestTarget(&mt)
 	f.store.UnlockMutableState()
-	f.wm.OnChange(f.ctx, f.store)
+	f.wm.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
 }
 
 func (f *wmFixture) SetTiltIgnoreContents(s string) {
@@ -337,7 +337,7 @@ func (f *wmFixture) SetTiltIgnoreContents(s string) {
 		Patterns:  patterns,
 	}
 	f.store.UnlockMutableState()
-	f.wm.OnChange(f.ctx, f.store)
+	f.wm.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
 }
 
 func targetFilesChangedActionsToPaths(actions []TargetFilesChangedAction) []string {

--- a/internal/engine/k8srollout/podmonitor.go
+++ b/internal/engine/k8srollout/podmonitor.go
@@ -62,7 +62,7 @@ func (m *PodMonitor) diff(st store.RStore) []podStatus {
 	return updates
 }
 
-func (m *PodMonitor) OnChange(ctx context.Context, st store.RStore) {
+func (m *PodMonitor) OnChange(ctx context.Context, st store.RStore, _ store.ChangeSummary) {
 	updates := m.diff(st)
 	for _, update := range updates {
 		ctx := logger.CtxWithLogHandler(ctx, podStatusWriter{

--- a/internal/engine/k8srollout/podmonitor_test.go
+++ b/internal/engine/k8srollout/podmonitor_test.go
@@ -57,7 +57,7 @@ func TestMonitorReady(t *testing.T) {
 		model.Manifest{Name: "server"}, p))
 	f.store.SetState(*state)
 
-	f.pm.OnChange(f.ctx, f.store)
+	f.pm.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
 
 	assertSnapshot(t, f.out.String())
 }

--- a/internal/engine/k8swatch/event_watch_manager.go
+++ b/internal/engine/k8swatch/event_watch_manager.go
@@ -69,7 +69,7 @@ func (m *EventWatchManager) diff(st store.RStore) eventWatchTaskList {
 	}
 }
 
-func (m *EventWatchManager) OnChange(ctx context.Context, st store.RStore) {
+func (m *EventWatchManager) OnChange(ctx context.Context, st store.RStore, _ store.ChangeSummary) {
 	taskList := m.diff(st)
 
 	m.mu.Lock()

--- a/internal/engine/k8swatch/pod_watch.go
+++ b/internal/engine/k8swatch/pod_watch.go
@@ -92,7 +92,7 @@ func (w *PodWatcher) diff(ctx context.Context, st store.RStore) podWatchTaskList
 	}
 }
 
-func (w *PodWatcher) OnChange(ctx context.Context, st store.RStore) {
+func (w *PodWatcher) OnChange(ctx context.Context, st store.RStore, _ store.ChangeSummary) {
 	taskList := w.diff(ctx, st)
 
 	w.mu.Lock()

--- a/internal/engine/k8swatch/pod_watch_test.go
+++ b/internal/engine/k8swatch/pod_watch_test.go
@@ -71,7 +71,7 @@ func TestPodWatch(t *testing.T) {
 
 	manifest := f.addManifestWithSelectors("server")
 
-	f.pw.OnChange(f.ctx, f.store)
+	f.pw.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
 
 	pb := podbuilder.New(t, manifest)
 	p := pb.Build()
@@ -91,7 +91,7 @@ func TestPodWatchChangeEventBeforeUID(t *testing.T) {
 
 	manifest := f.addManifestWithSelectors("server")
 
-	f.pw.OnChange(f.ctx, f.store)
+	f.pw.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
 
 	pb := podbuilder.New(t, manifest)
 	p := pb.Build()
@@ -116,7 +116,7 @@ func TestPodWatchResourceVersionStringLessThan(t *testing.T) {
 
 	manifest := f.addManifestWithSelectors("server")
 
-	f.pw.OnChange(f.ctx, f.store)
+	f.pw.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
 
 	pb := podbuilder.New(t, manifest).WithResourceVersion("9")
 
@@ -143,7 +143,7 @@ func TestPodWatchExtraSelectors(t *testing.T) {
 	ls2 := labels.Set{"baz": "quu"}.AsSelector()
 	manifest := f.addManifestWithSelectors("server", ls1, ls2)
 
-	f.pw.OnChange(f.ctx, f.store)
+	f.pw.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
 
 	p := podbuilder.New(t, manifest).
 		WithPodLabel("foo", "bar").
@@ -162,7 +162,7 @@ func TestPodWatchHandleSelectorChange(t *testing.T) {
 	ls1 := labels.Set{"foo": "bar"}.AsSelector()
 	manifest := f.addManifestWithSelectors("server1", ls1)
 
-	f.pw.OnChange(f.ctx, f.store)
+	f.pw.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
 
 	p := podbuilder.New(t, manifest).
 		WithPodLabel("foo", "bar").
@@ -177,7 +177,7 @@ func TestPodWatchHandleSelectorChange(t *testing.T) {
 	manifest2 := f.addManifestWithSelectors("server2", ls2)
 	f.removeManifest("server1")
 
-	f.pw.OnChange(f.ctx, f.store)
+	f.pw.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
 
 	pb2 := podbuilder.New(t, manifest2).WithPodID("pod2")
 	p2 := pb2.Build()
@@ -215,7 +215,7 @@ func TestPodsDispatchedInOrder(t *testing.T) {
 	defer f.TearDown()
 	manifest := f.addManifestWithSelectors("server")
 
-	f.pw.OnChange(f.ctx, f.store)
+	f.pw.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
 
 	pb := podbuilder.New(t, manifest)
 
@@ -253,7 +253,7 @@ func TestPodWatchReadd(t *testing.T) {
 
 	manifest := f.addManifestWithSelectors("server")
 
-	f.pw.OnChange(f.ctx, f.store)
+	f.pw.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
 
 	pb := podbuilder.New(t, manifest)
 	p := pb.Build()
@@ -264,12 +264,12 @@ func TestPodWatchReadd(t *testing.T) {
 	f.assertObservedPods(p)
 
 	f.removeManifest("server")
-	f.pw.OnChange(f.ctx, f.store)
+	f.pw.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
 
 	f.pods = nil
 	_ = f.addManifestWithSelectors("server")
 	f.addDeployedUID(manifest, pb.DeploymentUID())
-	f.pw.OnChange(f.ctx, f.store)
+	f.pw.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
 
 	// Make sure the pods are re-broadcast.
 	// Even though the pod didn't change when the manifest was
@@ -405,7 +405,7 @@ func (f *pwFixture) TearDown() {
 }
 
 func (f *pwFixture) addDeployedUID(m model.Manifest, uid types.UID) {
-	defer f.pw.OnChange(f.ctx, f.store)
+	defer f.pw.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
 
 	state := f.store.LockMutableStateForTesting()
 	defer f.store.UnlockMutableState()

--- a/internal/engine/k8swatch/service_watch.go
+++ b/internal/engine/k8swatch/service_watch.go
@@ -42,7 +42,7 @@ func (w *ServiceWatcher) diff(st store.RStore) watcherTaskList {
 	return w.watcherKnownState.createTaskList(state)
 }
 
-func (w *ServiceWatcher) OnChange(ctx context.Context, st store.RStore) {
+func (w *ServiceWatcher) OnChange(ctx context.Context, st store.RStore, _ store.ChangeSummary) {
 	taskList := w.diff(st)
 
 	w.mu.Lock()

--- a/internal/engine/k8swatch/service_watch_test.go
+++ b/internal/engine/k8swatch/service_watch_test.go
@@ -63,7 +63,7 @@ func TestServiceWatchUIDDelayed(t *testing.T) {
 	uid := types.UID("fake-uid")
 	manifest := f.addManifest("server")
 
-	f.sw.OnChange(f.ctx, f.store)
+	f.sw.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
 
 	ls := k8s.ManagedByTiltSelector()
 	s := servicebuilder.New(f.t, manifest).
@@ -93,7 +93,7 @@ func (f *swFixture) addManifest(manifestName model.ManifestName) model.Manifest 
 }
 
 func (f *swFixture) addDeployedUID(m model.Manifest, uid types.UID) {
-	defer f.sw.OnChange(f.ctx, f.store)
+	defer f.sw.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
 
 	state := f.store.LockMutableStateForTesting()
 	defer f.store.UnlockMutableState()

--- a/internal/engine/local/controller.go
+++ b/internal/engine/local/controller.go
@@ -37,7 +37,7 @@ func NewController(execer Execer, proberManager ProberManager) *Controller {
 	}
 }
 
-func (c *Controller) OnChange(ctx context.Context, st store.RStore) {
+func (c *Controller) OnChange(ctx context.Context, st store.RStore, _ store.ChangeSummary) {
 	specs := c.determineServeSpecs(ctx, st)
 	c.update(ctx, specs, st)
 }

--- a/internal/engine/local/controller_test.go
+++ b/internal/engine/local/controller_test.go
@@ -228,7 +228,7 @@ func (f *fixture) resourceFromTarget(name string, target model.TargetSpec, lastD
 func (f *fixture) step() {
 	f.st.ClearActions()
 	f.st.SetState(f.state)
-	f.c.OnChange(f.ctx, f.st)
+	f.c.OnChange(f.ctx, f.st, store.LegacyChangeSummary())
 }
 
 func (f *fixture) assertNoStatus() {

--- a/internal/engine/metrics/controller.go
+++ b/internal/engine/metrics/controller.go
@@ -41,6 +41,8 @@ type Controller struct {
 	gitRemote git.GitRemote
 }
 
+var _ store.Subscriber = &Controller{}
+
 func NewController(exporter *DeferredExporter, tiltBuild model.TiltBuild, gitRemote git.GitRemote) *Controller {
 	return &Controller{
 		exporter:  exporter,
@@ -60,7 +62,7 @@ func (c *Controller) newMetricsState(rStore store.RStore) MetricsState {
 	}
 }
 
-func (c *Controller) OnChange(ctx context.Context, rStore store.RStore) {
+func (c *Controller) OnChange(ctx context.Context, rStore store.RStore, _ store.ChangeSummary) {
 	newMetricsState := c.newMetricsState(rStore)
 	oldMetricsState := c.metrics
 	if newMetricsState == oldMetricsState {

--- a/internal/engine/metrics/controller_test.go
+++ b/internal/engine/metrics/controller_test.go
@@ -22,24 +22,24 @@ func TestEnableMetrics(t *testing.T) {
 	ms := model.DefaultMetricsSettings()
 	ms.Enabled = true
 	f.st.SetState(newLoggedInEngineState(ms))
-	f.mc.OnChange(f.ctx, f.st)
+	f.mc.OnChange(f.ctx, f.st, store.LegacyChangeSummary())
 
 	remote := f.exp.remote
 	assert.NotNil(t, remote)
 
-	f.mc.OnChange(f.ctx, f.st)
+	f.mc.OnChange(f.ctx, f.st, store.LegacyChangeSummary())
 	assert.Same(t, remote, f.exp.remote)
 
 	// Verify that changing the metrics settings creates a new remote exporter.
 	ms.Insecure = true
 	f.st.SetState(newLoggedInEngineState(ms))
-	f.mc.OnChange(f.ctx, f.st)
+	f.mc.OnChange(f.ctx, f.st, store.LegacyChangeSummary())
 	assert.NotSame(t, remote, f.exp.remote)
 
 	// Verify that disabling the metrics settings nulls out the remote exporter.
 	ms.Enabled = false
 	f.st.SetState(newLoggedInEngineState(ms))
-	f.mc.OnChange(f.ctx, f.st)
+	f.mc.OnChange(f.ctx, f.st, store.LegacyChangeSummary())
 	assert.Nil(t, f.exp.remote)
 }
 

--- a/internal/engine/metrics/mode_controller.go
+++ b/internal/engine/metrics/mode_controller.go
@@ -29,6 +29,8 @@ type ModeController struct {
 	initialized bool
 }
 
+var _ store.Subscriber = &ModeController{}
+
 func NewModeController(host model.WebHost, userPrefs user.PrefsInterface) *ModeController {
 	return &ModeController{host: host, userPrefs: userPrefs}
 }
@@ -116,7 +118,7 @@ func (c *ModeController) checkReady(ctx context.Context, rStore store.RStore) {
 	})
 }
 
-func (c *ModeController) OnChange(ctx context.Context, rStore store.RStore) {
+func (c *ModeController) OnChange(ctx context.Context, rStore store.RStore, _ store.ChangeSummary) {
 	c.initialize(ctx, rStore)
 	c.checkReady(ctx, rStore)
 }

--- a/internal/engine/metrics/mode_controller_test.go
+++ b/internal/engine/metrics/mode_controller_test.go
@@ -21,7 +21,7 @@ func TestEnableLocalMetrics(t *testing.T) {
 	os.Setenv("TILT_METRICS", "local")
 	defer os.Unsetenv("TILT_METRICS")
 
-	f.mc.OnChange(f.ctx, f.st)
+	f.mc.OnChange(f.ctx, f.st, store.LegacyChangeSummary())
 	assert.Equal(t, model.MetricsDefault, f.st.action.Serving.Mode)
 
 	// Insert a K8s resource into the state store, and make sure that
@@ -32,7 +32,7 @@ func TestEnableLocalMetrics(t *testing.T) {
 			Build()
 		state.UpsertManifestTarget(store.NewManifestTarget(m))
 	})
-	f.mc.OnChange(f.ctx, f.st)
+	f.mc.OnChange(f.ctx, f.st, store.LegacyChangeSummary())
 
 	if assert.NotNil(t, f.st.action) {
 		assert.Equal(t, model.MetricsLocal, f.st.action.Serving.Mode)
@@ -49,7 +49,7 @@ func TestSetLocalMetrics(t *testing.T) {
 			Build()
 		state.UpsertManifestTarget(store.NewManifestTarget(m))
 	})
-	f.mc.OnChange(f.ctx, f.st)
+	f.mc.OnChange(f.ctx, f.st, store.LegacyChangeSummary())
 	assert.Equal(t, model.MetricsDefault, f.st.action.Serving.Mode)
 
 	f.mc.SetUserMode(f.ctx, f.st, model.MetricsLocal)

--- a/internal/engine/portforward/controller.go
+++ b/internal/engine/portforward/controller.go
@@ -96,7 +96,7 @@ func (m *Controller) diff(ctx context.Context, st store.RStore) (toStart []portF
 	return toStart, toShutdown
 }
 
-func (m *Controller) OnChange(ctx context.Context, st store.RStore) {
+func (m *Controller) OnChange(ctx context.Context, st store.RStore, _ store.ChangeSummary) {
 	toStart, toShutdown := m.diff(ctx, st)
 	for _, entry := range toShutdown {
 		entry.cancel()

--- a/internal/engine/portforward/controller_test.go
+++ b/internal/engine/portforward/controller_test.go
@@ -290,7 +290,7 @@ func newPLCFixture(t *testing.T) *plcFixture {
 }
 
 func (f *plcFixture) onChange() {
-	f.plc.OnChange(f.ctx, f.st)
+	f.plc.OnChange(f.ctx, f.st, store.LegacyChangeSummary())
 	time.Sleep(10 * time.Millisecond)
 }
 

--- a/internal/engine/runtimelog/docker_compose_log_manager.go
+++ b/internal/engine/runtimelog/docker_compose_log_manager.go
@@ -95,7 +95,7 @@ func (m *DockerComposeLogManager) diff(ctx context.Context, st store.RStore) (se
 	return setup, teardown
 }
 
-func (m *DockerComposeLogManager) OnChange(ctx context.Context, st store.RStore) {
+func (m *DockerComposeLogManager) OnChange(ctx context.Context, st store.RStore, _ store.ChangeSummary) {
 	setup, teardown := m.diff(ctx, st)
 	for _, watch := range teardown {
 		watch.cancel()

--- a/internal/engine/runtimelog/podlogmanager.go
+++ b/internal/engine/runtimelog/podlogmanager.go
@@ -196,7 +196,7 @@ func (m *PodLogManager) shouldStreamContainerLogs(c store.Container, key podLogK
 
 }
 
-func (m *PodLogManager) OnChange(ctx context.Context, st store.RStore) {
+func (m *PodLogManager) OnChange(ctx context.Context, st store.RStore, _ store.ChangeSummary) {
 	setup, teardown := m.diff(ctx, st)
 	for _, watch := range teardown {
 		watch.cancel()

--- a/internal/engine/runtimelog/podlogmanager_test.go
+++ b/internal/engine/runtimelog/podlogmanager_test.go
@@ -43,7 +43,7 @@ func TestLogs(t *testing.T) {
 		model.Manifest{Name: "server"}, p))
 	f.store.UnlockMutableState()
 
-	f.plm.OnChange(f.ctx, f.store)
+	f.plm.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
 	f.AssertOutputContains("hello world!")
 	assert.Equal(t, start, f.kClient.LastPodLogStartTime)
 }
@@ -64,7 +64,7 @@ func TestLogActions(t *testing.T) {
 		model.Manifest{Name: "server"}, p))
 	f.store.UnlockMutableState()
 
-	f.plm.OnChange(f.ctx, f.store)
+	f.plm.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
 	f.ConsumeLogActionsUntil("hello world!")
 }
 
@@ -84,7 +84,7 @@ func TestLogsFailed(t *testing.T) {
 		model.Manifest{Name: "server"}, p))
 	f.store.UnlockMutableState()
 
-	f.plm.OnChange(f.ctx, f.store)
+	f.plm.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
 	f.AssertOutputContains("Error streaming server logs")
 	assert.Contains(t, f.out.String(), "my-error")
 }
@@ -105,13 +105,13 @@ func TestLogsCanceledUnexpectedly(t *testing.T) {
 		model.Manifest{Name: "server"}, p))
 	f.store.UnlockMutableState()
 
-	f.plm.OnChange(f.ctx, f.store)
+	f.plm.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
 	f.AssertOutputContains("hello world!\n")
 
 	// Previous log stream has finished, so the first pod watch has been canceled,
 	// but not cleaned up; check that we start a new watch .OnChange
 	f.kClient.SetLogsForPodContainer(podID, cName, "goodbye world!\n")
-	f.plm.OnChange(f.ctx, f.store)
+	f.plm.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
 	f.AssertOutputContains("goodbye world!\n")
 }
 
@@ -135,7 +135,7 @@ func TestMultiContainerLogs(t *testing.T) {
 		model.Manifest{Name: "server"}, p))
 	f.store.UnlockMutableState()
 
-	f.plm.OnChange(f.ctx, f.store)
+	f.plm.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
 	f.AssertOutputContains("hello world!")
 	f.AssertOutputContains("goodbye world!")
 }
@@ -179,7 +179,7 @@ func TestContainerPrefixes(t *testing.T) {
 		podSingleC))
 	f.store.UnlockMutableState()
 
-	f.plm.OnChange(f.ctx, f.store)
+	f.plm.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
 
 	// Make sure we have expected logs
 	f.AssertOutputContains("hello world!")
@@ -213,8 +213,8 @@ func TestTerminatedContainerLogs(t *testing.T) {
 
 	// Fire OnChange twice, because we used to have a bug where
 	// we'd immediately teardown the log watch on the terminated container.
-	f.plm.OnChange(f.ctx, f.store)
-	f.plm.OnChange(f.ctx, f.store)
+	f.plm.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
+	f.plm.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
 
 	f.AssertOutputContains("hello world!")
 
@@ -222,7 +222,7 @@ func TestTerminatedContainerLogs(t *testing.T) {
 	// closes the log stream.
 	f.kClient.SetLogsForPodContainer(podID, cName, "hello world!\ngoodbye world!\n")
 
-	f.plm.OnChange(f.ctx, f.store)
+	f.plm.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
 	f.AssertOutputContains("hello world!")
 	f.AssertOutputDoesNotContain("goodbye world!")
 }
@@ -262,7 +262,7 @@ func TestLogReconnection(t *testing.T) {
 		state.TiltStartTime = startTime
 	})
 
-	f.plm.OnChange(f.ctx, f.store)
+	f.plm.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
 
 	_, _ = writer.Write([]byte("hello world!"))
 	f.AssertOutputContains("hello world!")
@@ -330,7 +330,7 @@ func TestInitContainerLogs(t *testing.T) {
 	f.kClient.SetLogsForPodContainer(podID, cNameInit, "init world!")
 	f.kClient.SetLogsForPodContainer(podID, cNameNormal, "hello world!")
 
-	f.plm.OnChange(f.ctx, f.store)
+	f.plm.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
 
 	f.AssertOutputContains(cNameInit.String())
 	f.AssertOutputContains("init world!")
@@ -367,7 +367,7 @@ func TestIstioContainerLogs(t *testing.T) {
 	f.kClient.SetLogsForPodContainer(podID, istioSidecar, "hello istio!")
 	f.kClient.SetLogsForPodContainer(podID, cNormal, "hello world!")
 
-	f.plm.OnChange(f.ctx, f.store)
+	f.plm.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
 
 	f.AssertOutputDoesNotContain("istio")
 	f.AssertOutputContains("hello world!")

--- a/internal/engine/telemetry/controller.go
+++ b/internal/engine/telemetry/controller.go
@@ -30,7 +30,7 @@ func NewController(clock build.Clock, spans tracer.SpanSource) *Controller {
 	}
 }
 
-func (t *Controller) OnChange(ctx context.Context, st store.RStore) {
+func (t *Controller) OnChange(ctx context.Context, st store.RStore, _ store.ChangeSummary) {
 	state := st.RLockState()
 	ts := state.TelemetrySettings
 	tc := ts.Cmd

--- a/internal/engine/telemetry/controller_test.go
+++ b/internal/engine/telemetry/controller_test.go
@@ -191,7 +191,7 @@ func (tcf *tcFixture) run() {
 	tc := NewController(tcf.clock, tcf.sc)
 	tc.lastRunAt = tcf.lastRun
 	tcf.controller = tc
-	tc.OnChange(tcf.ctx, tcf.st)
+	tc.OnChange(tcf.ctx, tcf.st, store.LegacyChangeSummary())
 }
 
 func (tcf *tcFixture) assertNoLogs() {

--- a/internal/engine/telemetry/start_tracker.go
+++ b/internal/engine/telemetry/start_tracker.go
@@ -18,7 +18,7 @@ func NewStartTracker(tracer trace.Tracer) *StartTracker {
 	return &StartTracker{tracer: tracer, startFinished: false}
 }
 
-func (c *StartTracker) OnChange(ctx context.Context, st store.RStore) {
+func (c *StartTracker) OnChange(ctx context.Context, st store.RStore, _ store.ChangeSummary) {
 	if c.startFinished {
 		return
 	}

--- a/internal/engine/telemetry/start_tracker_test.go
+++ b/internal/engine/telemetry/start_tracker_test.go
@@ -27,7 +27,7 @@ func TestStart(t *testing.T) {
 		model.ManifestName("test"): mt,
 	}}
 	st.SetState(engineState)
-	cst.OnChange(ctx, st)
+	cst.OnChange(ctx, st, store.LegacyChangeSummary())
 
 	// first run span should be started
 	span, exists := ft.spans["first_run"]
@@ -35,7 +35,7 @@ func TestStart(t *testing.T) {
 	assert.False(t, span.ended)
 
 	// first run span should still not be ended
-	cst.OnChange(ctx, st)
+	cst.OnChange(ctx, st, store.LegacyChangeSummary())
 	span, exists = ft.spans["first_run"]
 	require.True(t, exists)
 	assert.False(t, span.ended)
@@ -43,14 +43,14 @@ func TestStart(t *testing.T) {
 	engineState.CompletedBuildCount = 1
 	engineState.ManifestTargets[manifest.ManifestName()].State.BuildHistory = append(engineState.ManifestTargets[manifest.ManifestName()].State.BuildHistory, model.BuildRecord{StartTime: time.Now()})
 	st.SetState(engineState)
-	cst.OnChange(ctx, st)
+	cst.OnChange(ctx, st, store.LegacyChangeSummary())
 
 	// first run span should be ended
 	span, exists = ft.spans["first_run"]
 	require.True(t, exists)
 	assert.True(t, span.ended)
 
-	cst.OnChange(ctx, st)
+	cst.OnChange(ctx, st, store.LegacyChangeSummary())
 
 	// first run span should still be ended
 	span, exists = ft.spans["first_run"]

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -4395,7 +4395,7 @@ type fixtureSub struct {
 	ch chan bool
 }
 
-func (s fixtureSub) OnChange(ctx context.Context, st store.RStore) {
+func (s fixtureSub) OnChange(ctx context.Context, st store.RStore, _ store.ChangeSummary) {
 	s.ch <- true
 }
 

--- a/internal/hud/fake_hud.go
+++ b/internal/hud/fake_hud.go
@@ -39,7 +39,7 @@ func (h *FakeHud) Run(ctx context.Context, dispatch func(action store.Action), r
 	return ctx.Err()
 }
 
-func (h *FakeHud) OnChange(ctx context.Context, st store.RStore) {
+func (h *FakeHud) OnChange(ctx context.Context, st store.RStore, _ store.ChangeSummary) {
 	state := st.RLockState()
 	view := store.StateToView(state, st.StateMutex())
 	st.RUnlockState()

--- a/internal/hud/hud.go
+++ b/internal/hud/hud.go
@@ -261,7 +261,7 @@ func (h *Hud) isEnabled(st store.RStore) bool {
 	return state.TerminalMode == store.TerminalModeHUD
 }
 
-func (h *Hud) OnChange(ctx context.Context, st store.RStore) {
+func (h *Hud) OnChange(ctx context.Context, st store.RStore, _ store.ChangeSummary) {
 	if !h.isEnabled(st) {
 		return
 	}

--- a/internal/hud/prompt/prompt.go
+++ b/internal/hud/prompt/prompt.go
@@ -103,7 +103,7 @@ func (p *TerminalPrompt) TearDown(ctx context.Context) {
 	}
 }
 
-func (p *TerminalPrompt) OnChange(ctx context.Context, st store.RStore) {
+func (p *TerminalPrompt) OnChange(ctx context.Context, st store.RStore, _ store.ChangeSummary) {
 	if !p.isEnabled(st) {
 		return
 	}

--- a/internal/hud/prompt/prompt_test.go
+++ b/internal/hud/prompt/prompt_test.go
@@ -22,7 +22,7 @@ func TestOpenBrowser(t *testing.T) {
 	f := newFixture()
 	defer f.TearDown()
 
-	f.prompt.OnChange(f.ctx, f.st)
+	f.prompt.OnChange(f.ctx, f.st, store.LegacyChangeSummary())
 
 	assert.Contains(t, f.out.String(), "(space) to open the browser")
 
@@ -34,7 +34,7 @@ func TestOpenStream(t *testing.T) {
 	f := newFixture()
 	defer f.TearDown()
 
-	f.prompt.OnChange(f.ctx, f.st)
+	f.prompt.OnChange(f.ctx, f.st, store.LegacyChangeSummary())
 
 	assert.Contains(t, f.out.String(), "(s) to stream logs")
 
@@ -48,7 +48,7 @@ func TestOpenHUD(t *testing.T) {
 	f := newFixture()
 	defer f.TearDown()
 
-	f.prompt.OnChange(f.ctx, f.st)
+	f.prompt.OnChange(f.ctx, f.st, store.LegacyChangeSummary())
 
 	assert.Contains(t, f.out.String(), "(t) to open legacy terminal mode")
 
@@ -63,7 +63,7 @@ func TestInitOutput(t *testing.T) {
 	defer f.TearDown()
 
 	f.prompt.SetInitOutput(bytes.NewBuffer([]byte("this is a warning\n")))
-	f.prompt.OnChange(f.ctx, f.st)
+	f.prompt.OnChange(f.ctx, f.st, store.LegacyChangeSummary())
 
 	assert.Contains(t, f.out.String(), `this is a warning
 

--- a/internal/hud/server/controller.go
+++ b/internal/hud/server/controller.go
@@ -54,7 +54,7 @@ func (s *HeadsUpServerController) TearDown(ctx context.Context) {
 	_ = s.apiServer.Shutdown(ctx)
 }
 
-func (s *HeadsUpServerController) OnChange(ctx context.Context, st store.RStore) {
+func (s *HeadsUpServerController) OnChange(ctx context.Context, st store.RStore, _ store.ChangeSummary) {
 }
 
 // Merge the APIServer and the Tilt Web server into a single handler,

--- a/internal/hud/server/websocket.go
+++ b/internal/hud/server/websocket.go
@@ -128,7 +128,7 @@ func (ws *WebsocketSubscriber) updateClientCheckpoint(msg *proto_webview.AckWebs
 	return nil
 }
 
-func (ws *WebsocketSubscriber) OnChange(ctx context.Context, s store.RStore) {
+func (ws *WebsocketSubscriber) OnChange(ctx context.Context, s store.RStore, _ store.ChangeSummary) {
 	checkpoint := ws.readClientCheckpoint()
 
 	state := s.RLockState()
@@ -189,7 +189,7 @@ func (s *HeadsUpServer) ViewWebsocket(w http.ResponseWriter, req *http.Request) 
 	ws := NewWebsocketSubscriber(s.ctx, conn)
 
 	// Fire a fake OnChange event to initialize the connection.
-	ws.OnChange(s.ctx, s.store)
+	ws.OnChange(s.ctx, s.store, store.LegacyChangeSummary())
 	_ = s.store.AddSubscriber(s.ctx, ws)
 
 	ws.Stream(s.ctx, s.store)

--- a/internal/hud/server/websocket_test.go
+++ b/internal/hud/server/websocket_test.go
@@ -33,10 +33,10 @@ func TestWebsocketCloseOnReadErr(t *testing.T) {
 		close(done)
 	}()
 
-	st.NotifySubscribers(ctx)
+	st.NotifySubscribers(ctx, store.LegacyChangeSummary())
 	conn.AssertNextWriteMsg(t).Ack()
 
-	st.NotifySubscribers(ctx)
+	st.NotifySubscribers(ctx, store.LegacyChangeSummary())
 	conn.AssertNextWriteMsg(t).Ack()
 
 	conn.readCh <- readerOrErr{err: fmt.Errorf("read error")}
@@ -59,7 +59,7 @@ func TestWebsocketReadErrDuringMsg(t *testing.T) {
 		close(done)
 	}()
 
-	st.NotifySubscribers(ctx)
+	st.NotifySubscribers(ctx, store.LegacyChangeSummary())
 
 	m := conn.AssertNextWriteMsg(t)
 
@@ -91,7 +91,7 @@ func TestWebsocketNextWriterError(t *testing.T) {
 		close(done)
 	}()
 
-	st.NotifySubscribers(ctx)
+	st.NotifySubscribers(ctx, store.LegacyChangeSummary())
 	time.Sleep(10 * time.Millisecond)
 
 	conn.readCh <- readerOrErr{err: fmt.Errorf("read error")}

--- a/internal/hud/terminal_stream.go
+++ b/internal/hud/terminal_stream.go
@@ -24,7 +24,7 @@ func (h *TerminalStream) TearDown(ctx context.Context) {
 		return
 	}
 
-	h.OnChange(ctx, h.store)
+	h.OnChange(ctx, h.store, store.LegacyChangeSummary())
 
 	state := h.store.RLockState()
 	uncompleted := state.LogStore.IsLastSegmentUncompleted()
@@ -41,7 +41,7 @@ func (h *TerminalStream) isEnabled(st store.RStore) bool {
 	return state.TerminalMode == store.TerminalModeStream
 }
 
-func (h *TerminalStream) OnChange(ctx context.Context, st store.RStore) {
+func (h *TerminalStream) OnChange(ctx context.Context, st store.RStore, _ store.ChangeSummary) {
 	if !h.isEnabled(st) {
 		return
 	}

--- a/internal/store/actions.go
+++ b/internal/store/actions.go
@@ -34,6 +34,10 @@ type LogAction struct {
 
 func (LogAction) Action() {}
 
+func (LogAction) Summarize(s *ChangeSummary) {
+	s.Log = true
+}
+
 func (le LogAction) ManifestName() model.ManifestName {
 	return le.mn
 }

--- a/internal/store/helpers_test.go
+++ b/internal/store/helpers_test.go
@@ -31,7 +31,8 @@ func newFakeSubscriber() *fakeSubscriber {
 }
 
 type onChangeCall struct {
-	done chan bool
+	done    chan bool
+	summary ChangeSummary
 }
 
 func (f *fakeSubscriber) assertOnChangeCount(t *testing.T, count int) {
@@ -62,8 +63,8 @@ func (f *fakeSubscriber) assertOnChange(t *testing.T) {
 	}
 }
 
-func (f *fakeSubscriber) OnChange(ctx context.Context, st RStore) {
-	call := onChangeCall{done: make(chan bool)}
+func (f *fakeSubscriber) OnChange(ctx context.Context, st RStore, summary ChangeSummary) {
+	call := onChangeCall{done: make(chan bool), summary: summary}
 	f.onChange <- call
 	<-call.done
 }

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -36,6 +36,29 @@ func TestBroadcastActions(t *testing.T) {
 	f.WaitUntilDone()
 }
 
+func TestLogOnly(t *testing.T) {
+	f := newFixture(t)
+
+	s := newFakeSubscriber()
+	_ = f.store.AddSubscriber(f.ctx, s)
+
+	f.Start()
+
+	f.store.Dispatch(CompletedBuildAction{})
+	call := <-s.onChange
+	assert.False(t, call.summary.IsLogOnly())
+	assert.True(t, call.summary.Legacy)
+	close(call.done)
+
+	f.store.Dispatch(LogAction{})
+	call = <-s.onChange
+	assert.True(t, call.summary.IsLogOnly())
+	close(call.done)
+
+	f.store.Dispatch(DoneAction{})
+	f.WaitUntilDone()
+}
+
 func TestBroadcastActionsBatching(t *testing.T) {
 	f := newFixture(t)
 

--- a/internal/store/summary.go
+++ b/internal/store/summary.go
@@ -1,0 +1,27 @@
+package store
+
+import "github.com/google/go-cmp/cmp"
+
+// Summarize the changes to the EngineState since the last change.
+type ChangeSummary struct {
+	// True if we saw one or more legacy actions that don't know how
+	// to summarize their changes.
+	Legacy bool
+
+	// True if this change added logs.
+	Log bool
+}
+
+func (s ChangeSummary) IsLogOnly() bool {
+	return cmp.Equal(s, ChangeSummary{Log: true})
+}
+
+func LegacyChangeSummary() ChangeSummary {
+	return ChangeSummary{Legacy: true}
+}
+
+type Summarizer interface {
+	Action
+
+	Summarize(summary *ChangeSummary)
+}


### PR DESCRIPTION
Hello @maiamcc, @landism, @milas,

Please review the following commits I made in branch nicks/summarize:

322e26319790773e3b7badb6726669dc9e77ccaf (2021-03-04 18:20:51 -0500)
store: add a mechanism to summarize changes
The goal of this is to help us move more towards a system like
Kubernetes (https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.8.2/pkg/reconcile#Request)
where the system tells us which object is changing, rather
than writing lots of code to figure it out on our own.

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics