### PR TITLE
filewatch: refactor tests to rely on state vs actions

### DIFF
--- a/internal/engine/fswatch/fake_watcher.go
+++ b/internal/engine/fswatch/fake_watcher.go
@@ -69,11 +69,13 @@ func (w *FakeMultiWatcher) loop() {
 			if !ok {
 				return
 			}
+			w.mu.Lock()
 			for _, watcher := range w.watchers {
 				if watcher.matches(e.Path()) {
 					watcher.inboundCh <- e
 				}
 			}
+			w.mu.Unlock()
 		case e, ok := <-w.Errors:
 			if !ok {
 				return


### PR DESCRIPTION
This will make the tests easier to migrate to an apiserver world,
but the real motivation is for splitting the actions between the
create and reconcile, which results in more complex store interactions
across multiple subscribers that isn't practical to test using the
testing store.

This uses the "real" store with a minimal reducer that just handles
FileWatch actions.

New assertions have also been added that verify the FileWatch spec
is created as expected and also serve to force synchronization on
the naturally async store, so that the tests are still as deterministic
as possible.