### PR TITLE
filewatch: ensure absolute paths are always used

### DIFF
--- a/internal/engine/fswatch/watchmanager_test.go
+++ b/internal/engine/fswatch/watchmanager_test.go
@@ -36,7 +36,7 @@ func TestWatchManager_basic(t *testing.T) {
 		WithBuildPath(".")
 	f.SetManifestTarget(target)
 
-	f.RequireFileWatchSpecEqual(target.ID(), filewatches.FileWatchSpec{WatchedPaths: []string{"."}})
+	f.RequireFileWatchSpecEqual(target.ID(), filewatches.FileWatchSpec{WatchedPaths: []string{f.Path()}})
 
 	f.ChangeFile(t, "foo.txt")
 
@@ -72,9 +72,9 @@ func TestWatchManager_IgnoredLocalDirectories(t *testing.T) {
 	f.SetManifestTarget(target)
 
 	f.RequireFileWatchSpecEqual(target.ID(), filewatches.FileWatchSpec{
-		WatchedPaths: []string{"."},
+		WatchedPaths: []string{f.Path()},
 		Ignores: []filewatches.IgnoreDef{
-			{BasePath: "bar"},
+			{BasePath: f.JoinPath("bar")},
 		},
 	})
 
@@ -94,9 +94,9 @@ func TestWatchManager_Dockerignore(t *testing.T) {
 	f.SetManifestTarget(target)
 
 	f.RequireFileWatchSpecEqual(target.ID(), filewatches.FileWatchSpec{
-		WatchedPaths: []string{"."},
+		WatchedPaths: []string{f.Path()},
 		Ignores: []filewatches.IgnoreDef{
-			{BasePath: ".", Patterns: []string{"bar"}},
+			{BasePath: f.Path(), Patterns: []string{"bar"}},
 		},
 	})
 
@@ -150,14 +150,14 @@ func TestWatchManager_WatchesReappliedOnDockerComposeSyncChange(t *testing.T) {
 		WithBuildPath(".")
 	f.SetManifestTarget(target.WithIgnoredLocalDirectories([]string{"bar"}))
 	f.RequireFileWatchSpecEqual(target.ID(), filewatches.FileWatchSpec{
-		WatchedPaths: []string{"."},
+		WatchedPaths: []string{f.Path()},
 		Ignores: []filewatches.IgnoreDef{
-			{BasePath: "bar"},
+			{BasePath: f.JoinPath("bar")},
 		},
 	})
 
 	f.SetManifestTarget(target)
-	f.RequireFileWatchSpecEqual(target.ID(), filewatches.FileWatchSpec{WatchedPaths: []string{"."}})
+	f.RequireFileWatchSpecEqual(target.ID(), filewatches.FileWatchSpec{WatchedPaths: []string{f.Path()}})
 
 	f.ChangeFile(t, "bar")
 
@@ -175,14 +175,14 @@ func TestWatchManager_WatchesReappliedOnDockerIgnoreChange(t *testing.T) {
 		WithBuildPath(".")
 	f.SetManifestTarget(target.WithDockerignores([]model.Dockerignore{{LocalPath: ".", Patterns: []string{"bar"}}}))
 	f.RequireFileWatchSpecEqual(target.ID(), filewatches.FileWatchSpec{
-		WatchedPaths: []string{"."},
+		WatchedPaths: []string{f.Path()},
 		Ignores: []filewatches.IgnoreDef{
-			{BasePath: ".", Patterns: []string{"bar"}},
+			{BasePath: f.Path(), Patterns: []string{"bar"}},
 		},
 	})
 
 	f.SetManifestTarget(target)
-	f.RequireFileWatchSpecEqual(target.ID(), filewatches.FileWatchSpec{WatchedPaths: []string{"."}})
+	f.RequireFileWatchSpecEqual(target.ID(), filewatches.FileWatchSpec{WatchedPaths: []string{f.Path()}})
 
 	f.ChangeFile(t, "bar")
 
@@ -201,7 +201,7 @@ func TestWatchManager_IgnoreTiltIgnore(t *testing.T) {
 	f.SetManifestTarget(target)
 	f.SetTiltIgnoreContents("**/foo")
 	f.RequireFileWatchSpecEqual(target.ID(), filewatches.FileWatchSpec{
-		WatchedPaths: []string{"."},
+		WatchedPaths: []string{f.Path()},
 		Ignores: []filewatches.IgnoreDef{
 			{BasePath: f.Path(), Patterns: []string{"**/foo"}},
 		},
@@ -231,7 +231,7 @@ func TestWatchManager_IgnoreWatchSettings(t *testing.T) {
 	f.store.Dispatch(configs.ConfigsReloadedAction{})
 
 	f.RequireFileWatchSpecEqual(target.ID(), filewatches.FileWatchSpec{
-		WatchedPaths: []string{"."},
+		WatchedPaths: []string{f.Path()},
 		Ignores: []filewatches.IgnoreDef{
 			{BasePath: f.Path(), Patterns: []string{"**/foo"}},
 		},
@@ -252,7 +252,7 @@ func TestWatchManager_PickUpTiltIgnoreChanges(t *testing.T) {
 	f.SetManifestTarget(target)
 	f.SetTiltIgnoreContents("**/foo")
 	f.RequireFileWatchSpecEqual(target.ID(), filewatches.FileWatchSpec{
-		WatchedPaths: []string{"."},
+		WatchedPaths: []string{f.Path()},
 		Ignores: []filewatches.IgnoreDef{
 			{BasePath: f.Path(), Patterns: []string{"**/foo"}},
 		},
@@ -261,7 +261,7 @@ func TestWatchManager_PickUpTiltIgnoreChanges(t *testing.T) {
 
 	f.SetTiltIgnoreContents("**foo\n!bar/baz/foo")
 	f.RequireFileWatchSpecEqual(target.ID(), filewatches.FileWatchSpec{
-		WatchedPaths: []string{"."},
+		WatchedPaths: []string{f.Path()},
 		Ignores: []filewatches.IgnoreDef{
 			{BasePath: f.Path(), Patterns: []string{"**foo", "!bar/baz/foo"}},
 		},
@@ -280,7 +280,7 @@ func TestWatchManagerShortRead(t *testing.T) {
 	target := model.DockerComposeTarget{Name: "foo"}.
 		WithBuildPath(".")
 	f.SetManifestTarget(target)
-	f.RequireFileWatchSpecEqual(target.ID(), filewatches.FileWatchSpec{WatchedPaths: []string{"."}})
+	f.RequireFileWatchSpecEqual(target.ID(), filewatches.FileWatchSpec{WatchedPaths: []string{f.Path()}})
 
 	f.fakeMultiWatcher.Errors <- fmt.Errorf("short read on readEvents()")
 

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -3910,7 +3910,7 @@ func (f *testFixture) Init(action InitAction) {
 	})
 
 	state := f.store.LockMutableStateForTesting()
-	expectedWatchCount := len(fswatch.SpecsForManifests(state.Manifests(), nil))
+	expectedWatchCount := len(fswatch.SpecsForManifests(f.ctx, state.Manifests(), nil, f.store))
 	if len(state.ConfigFiles) > 0 {
 		// watchmanager also creates a watcher for config files
 		expectedWatchCount++

--- a/pkg/apis/core/v1alpha1/filewatch_types.go
+++ b/pkg/apis/core/v1alpha1/filewatch_types.go
@@ -65,7 +65,7 @@ type IgnoreDef struct {
 	//
 	// If no patterns are specified, everything under it will be recursively ignored.
 	BasePath string `json:"basePath"`
-	// Patterns are dockerignore style rules relative to the base path.
+	// Patterns are dockerignore style rules; they are always rooted by the base path.
 	//
 	// See https://docs.docker.com/engine/reference/builder/#dockerignore-file.
 	Patterns []string `json:"patterns,omitempty"`
@@ -118,13 +118,10 @@ func (in *FileWatch) Validate(_ context.Context) field.ErrorList {
 		if !filepath.IsAbs(ignoreDef.BasePath) {
 			fieldErrors = append(fieldErrors, field.Invalid(ignoreDefPath, ignoreDef.BasePath, "must be an absolute file path"))
 		}
-		// patterns can be empty, which means ignore the entire directory
-		for ignorePatternIndex, ignorePattern := range ignoreDef.Patterns {
-			ingorePatternPath := ignoreDefPath.Child("patterns").Index(ignorePatternIndex)
-			if filepath.IsAbs(ignorePattern) {
-				fieldErrors = append(fieldErrors, field.Invalid(ingorePatternPath, ignorePattern, "must be a relative file path"))
-			}
-		}
+		// no validation is done on the patterns:
+		// patterns can be empty, which means ignore the entire directory; they can also be "absolute" or relative,
+		// but are always rooted by the base path, e.g. base of /base with patterns [/foo, foo] means /base/foo in
+		// both cases
 	}
 	return fieldErrors
 }


### PR DESCRIPTION
There was no bug here - the relative paths _would_ get resolved
by the watchers deeper in the code.

However, the FileWatch API design is pushing to avoid implicit
relative paths based on Tilt's CWD; this makes the logic simpler
a lot of places, ensures that it's self-contained, and enables
future possibilities around daemon mode/multiple Tiltfiles (where
there is no longer "one" CWD).

The specs with relative paths being generated from manifests would
get rejected by the API server, so this is pre-empting that by
making sure they're valid and will migrate cleanly. A temporary
hack to explicitly call the validate logic also exists.

Any errors just get dispatched as warnings to the manifest logs
currently, as there's not a great way to do more robust error-handling
given how logic/responsibility is split; once things move into the API
server, especially as more controllers become responsible for creating
their own FileWatch objects (rather than relying on implicit logic to
generate them), it will be easier to handle errors further upstream,
e.g. put a resource into an error state upfront.