### PR TITLE
filewatch: use change summary to simplify logic + be consistent

### DIFF
--- a/internal/engine/fswatch/action.go
+++ b/internal/engine/fswatch/action.go
@@ -19,6 +19,14 @@ type FileWatchCreateAction struct {
 	FileWatch *filewatches.FileWatch
 }
 
+func (a FileWatchCreateAction) Summarize(summary *store.ChangeSummary) {
+	if summary.FileWatchSpecs == nil {
+		summary.FileWatchSpecs = make(map[types.NamespacedName]bool)
+	}
+	key := types.NamespacedName{Namespace: a.FileWatch.GetNamespace(), Name: a.FileWatch.GetName()}
+	summary.FileWatchSpecs[key] = true
+}
+
 func (FileWatchCreateAction) Action() {}
 
 func NewFileWatchCreateAction(fw *filewatches.FileWatch) FileWatchCreateAction {
@@ -27,6 +35,14 @@ func NewFileWatchCreateAction(fw *filewatches.FileWatch) FileWatchCreateAction {
 
 type FileWatchUpdateAction struct {
 	FileWatch *filewatches.FileWatch
+}
+
+func (a FileWatchUpdateAction) Summarize(summary *store.ChangeSummary) {
+	if summary.FileWatchSpecs == nil {
+		summary.FileWatchSpecs = make(map[types.NamespacedName]bool)
+	}
+	key := types.NamespacedName{Namespace: a.FileWatch.GetNamespace(), Name: a.FileWatch.GetName()}
+	summary.FileWatchSpecs[key] = true
 }
 
 func (FileWatchUpdateAction) Action() {}
@@ -48,6 +64,13 @@ func NewFileWatchUpdateStatusAction(name types.NamespacedName, fwStatus *filewat
 
 type FileWatchDeleteAction struct {
 	Name types.NamespacedName
+}
+
+func (a FileWatchDeleteAction) Summarize(summary *store.ChangeSummary) {
+	if summary.FileWatchSpecs == nil {
+		summary.FileWatchSpecs = make(map[types.NamespacedName]bool)
+	}
+	summary.FileWatchSpecs[a.Name] = true
 }
 
 func (FileWatchDeleteAction) Action() {}

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -3913,12 +3913,7 @@ func (f *testFixture) Init(action InitAction) {
 	})
 
 	state := f.store.LockMutableStateForTesting()
-
-	expectedWatchCount := len(fswatch.SpecsForManifests(state.Manifests(), nil))
-	if len(state.ConfigFiles) > 0 {
-		// watchmanager also creates a watcher for config files
-		expectedWatchCount++
-	}
+	expectedWatchCount := len(fswatch.SpecsFromState(*state))
 	if f.overrideMaxParallelUpdates > 0 {
 		state.UpdateSettings = state.UpdateSettings.WithMaxParallelUpdates(f.overrideMaxParallelUpdates)
 	}

--- a/internal/store/summary.go
+++ b/internal/store/summary.go
@@ -1,6 +1,9 @@
 package store
 
-import "github.com/google/go-cmp/cmp"
+import (
+	"github.com/google/go-cmp/cmp"
+	"k8s.io/apimachinery/pkg/types"
+)
 
 // Summarize the changes to the EngineState since the last change.
 type ChangeSummary struct {
@@ -13,6 +16,9 @@ type ChangeSummary struct {
 
 	// Cmds with their specs changed.
 	CmdSpecs map[string]bool
+
+	// FileWatches with their specs changed.
+	FileWatchSpecs map[types.NamespacedName]bool
 }
 
 func (s ChangeSummary) IsLogOnly() bool {
@@ -28,6 +34,14 @@ func (s *ChangeSummary) Add(other ChangeSummary) {
 		}
 		for k, v := range other.CmdSpecs {
 			s.CmdSpecs[k] = v
+		}
+	}
+	if len(other.FileWatchSpecs) > 0 {
+		if s.FileWatchSpecs == nil {
+			s.FileWatchSpecs = make(map[types.NamespacedName]bool)
+		}
+		for k, v := range other.FileWatchSpecs {
+			s.FileWatchSpecs[k] = v
 		}
 	}
 }


### PR DESCRIPTION
This is largely just a cleanup that moves some stuff around and
further simplifies to make it look more like the Cmd controller(s).