### PR TITLE
k8s: inject pull policies into crds

### DIFF
--- a/integration/crd/crd.yaml
+++ b/integration/crd/crd.yaml
@@ -19,6 +19,8 @@ spec:
                   type: string
                 nonImage:
                   type: string
+                imagePullPolicy:
+                  type: string
   scope: Namespaced
   names:
     plural: uselessmachines

--- a/integration/crd/um.yaml
+++ b/integration/crd/um.yaml
@@ -6,3 +6,4 @@ metadata:
 spec:
   image: bobo
   nonImage: bobo
+  imagePullPolicy: Always

--- a/integration/crd_test.go
+++ b/integration/crd_test.go
@@ -34,4 +34,5 @@ func TestCRD(t *testing.T) {
 	assert.Contains(t, contents, "name: bobo\n")
 	assert.Contains(t, contents, "nonImage: bobo\n")
 	assert.NotContains(t, contents, "image: bobo\n")
+	assert.Contains(t, contents, "imagePullPolicy: IfNotPresent\n")
 }

--- a/internal/k8s/image.go
+++ b/internal/k8s/image.go
@@ -75,7 +75,7 @@ func InjectImageDigest(entity K8sEntity, selector container.RefSelector, injectR
 	}
 
 	for _, locator := range locators {
-		entity, r, err = locator.Inject(entity, selector, injectRef)
+		entity, r, err = locator.Inject(entity, selector, injectRef, policy)
 		if err != nil {
 			return K8sEntity{}, false, err
 		}

--- a/internal/k8s/jsonpath/value.go
+++ b/internal/k8s/jsonpath/value.go
@@ -42,9 +42,13 @@ func (v *Value) Set(newV reflect.Value) {
 }
 
 func (v *Value) Sibling(name string) (val Value, ok bool) {
+	if !v.parentMap.IsValid() {
+		return Value{}, false
+	}
+
 	key := reflect.ValueOf(name)
 	sib := v.parentMap.MapIndex(key)
-	if sib == (reflect.Value{}) {
+	if !sib.IsValid() {
 		return Value{}, false
 	}
 

--- a/internal/k8s/jsonpath/value.go
+++ b/internal/k8s/jsonpath/value.go
@@ -40,3 +40,17 @@ func (v *Value) Set(newV reflect.Value) {
 	}
 	v.Value.Set(newV)
 }
+
+func (v *Value) Sibling(name string) (val Value, ok bool) {
+	key := reflect.ValueOf(name)
+	sib := v.parentMap.MapIndex(key)
+	if sib == (reflect.Value{}) {
+		return Value{}, false
+	}
+
+	return Value{
+		Value:        sib,
+		parentMap:    v.parentMap,
+		parentMapKey: key,
+	}, true
+}

--- a/internal/k8s/locator.go
+++ b/internal/k8s/locator.go
@@ -126,7 +126,7 @@ func (l *JSONPathImageLocator) Inject(e K8sEntity, selector container.RefSelecto
 			val.Set(reflect.ValueOf(container.FamiliarString(injectRef)))
 			modified = true
 
-			if pullPolicyVal, ok := val.Sibling(imagePullPolicyKey); ok {
+			if pullPolicyVal, ok := val.Sibling(imagePullPolicyKey); ok && pullPolicyVal.CanSet() {
 				pullPolicyVal.Set(reflect.ValueOf(string(pullPolicy)))
 			}
 		}

--- a/internal/k8s/locator_test.go
+++ b/internal/k8s/locator_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
 
 	"github.com/tilt-dev/tilt/internal/container"
 	"github.com/tilt-dev/tilt/internal/k8s/testyaml"
@@ -23,7 +24,7 @@ func TestCRDImageObjectInjection(t *testing.T) {
 	assert.Equal(t, "docker.io/library/frontend", images[0].String())
 
 	e, modified, err := locator.Inject(e, container.MustParseSelector("frontend"),
-		container.MustParseNamed("frontend:tilt-123"))
+		container.MustParseNamed("frontend:tilt-123"), v1.PullNever)
 	require.NoError(t, err)
 	assert.True(t, modified)
 
@@ -31,4 +32,27 @@ func TestCRDImageObjectInjection(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, len(images))
 	assert.Equal(t, "docker.io/library/frontend:tilt-123", images[0].String())
+}
+
+func TestCRDPullPolicyInjection(t *testing.T) {
+	entities, err := ParseYAMLFromString(testyaml.CRDContainerSpecYAML)
+	require.NoError(t, err)
+
+	e := entities[0]
+	selector := MustKindSelector("UselessMachine")
+	locator := MustJSONPathImageLocator(selector, "{.spec.containers[*].image}")
+	images, err := locator.Extract(e)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(images))
+	assert.Equal(t, "docker.io/library/frontend", images[0].String())
+
+	e, modified, err := locator.Inject(e, container.MustParseSelector("frontend"),
+		container.MustParseNamed("frontend:tilt-123"), v1.PullNever)
+	require.NoError(t, err)
+	require.True(t, modified)
+
+	spec := e.maybeUnstructuredMeta().Object["spec"].(map[string]interface{})
+	c := spec["containers"].([]interface{})[0].(map[string]interface{})
+	require.Equal(t, "frontend:tilt-123", c["image"])
+	require.Equal(t, "Never", c["imagePullPolicy"].(string))
 }

--- a/internal/k8s/testyaml/testyaml.go
+++ b/internal/k8s/testyaml/testyaml.go
@@ -1449,6 +1449,17 @@ spec:
     repo: frontend
 `
 
+const CRDContainerSpecYAML = `apiVersion: tilt.dev/v1alpha1
+kind: UselessMachine
+metadata:
+  name: um
+spec:
+  containers:
+  - name: frontend
+    image: frontend
+    imagePullPolicy: "Always"
+`
+
 const MyNamespaceYAML = `apiVersion: v1
 kind: Namespace
 metadata:


### PR DESCRIPTION
Fixes #4291

### Problem

For standard k8s objects, Tilt will inject an image pull policy. For CRDs, it will not.
It's relatively common for CRDs to use the normal k8s container spec, with "image" and "imagePullPolicy" fields. Tilt provides a way for users to configure how to inject the image ref, but leave users to their own devices when it comes to imagePullPolicy.

### Solution

If a CRD "image" field has an "imagePullPolicy" neighbor, inject the pull policy.

Note: the image object locator (where you specify, e.g., a repo and ref field) just ignores the pull policy. An obvious answer here is to add an option to specify the pull policy field. My weak gut instinct is it's not worth the effort to worry about that until someone complains. I'm happy to do that as well if someone has a different gut instinct.