### PR TITLE
tests: verify file watches/restart for local_resource integration test

### DIFF
--- a/integration/local_resource/Tiltfile
+++ b/integration/local_resource/Tiltfile
@@ -5,7 +5,7 @@ p = probe(initial_delay_secs=0,
           failure_threshold=1,
           exec=exec_action(command=['./probe.sh']))
 
-local_resource('foo', serve_cmd='./hello.sh foo', readiness_probe=p)
+local_resource('foo', serve_cmd='./hello.sh foo', deps=['greeting'], readiness_probe=p)
 
 # readiness probe explicitly set to None
 local_resource('bar', serve_cmd='./hello.sh bar',

--- a/integration/local_resource/hello.sh
+++ b/integration/local_resource/hello.sh
@@ -12,6 +12,11 @@ fi
 
 n=1
 msg="$*"
+greeting="hello"
+
+if [[ -f greeting ]]; then
+  greeting=$(cat greeting)
+fi
 
 cleanup() {
   echo "cleaning up: $msg"
@@ -22,7 +27,7 @@ cleanup() {
 trap cleanup SIGTERM
 
 while true; do
-  echo "hello! $msg #$n"
+  echo "$greeting! $msg #$n"
   # run sleep in the background so the main thread is not blocked
   # otherwise, the signal handler doesn't run until the current sleep
   # finishes


### PR DESCRIPTION
Add a single file dep and change it, ensuring that the service is
restarted appropriately.

[ch11614]