### PR TITLE
apis: use MicroTime instead of Time

### DIFF
--- a/internal/controllers/core/cmd/controller.go
+++ b/internal/controllers/core/cmd/controller.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/tilt-dev/probe/pkg/probe"
 	"github.com/tilt-dev/probe/pkg/prober"
@@ -146,7 +145,7 @@ func (c *Controller) reconcile(ctx context.Context, name types.NamespacedName) e
 		proc.probeWorker = probeWorker
 	}
 
-	startedAt := metav1.Now()
+	startedAt := metav1.NowMicro()
 	go c.processStatuses(ctx, statusCh, proc, name, startedAt)
 
 	serveCmd := model.Cmd{
@@ -264,7 +263,7 @@ func (c *Controller) processStatuses(
 	statusCh chan statusAndMetadata,
 	proc *currentProcess,
 	name types.NamespacedName,
-	startedAt metav1.Time) {
+	startedAt metav1.MicroTime) {
 
 	var initProbeWorker sync.Once
 	stillHasSameProcNum := proc.stillHasSameProcNum()
@@ -283,7 +282,7 @@ func (c *Controller) processStatuses(
 					Reason:     sm.reason,
 					ExitCode:   int32(sm.exitCode),
 					StartedAt:  startedAt,
-					FinishedAt: metav1.NewTime(time.Now()),
+					FinishedAt: metav1.NowMicro(),
 				}
 			})
 		} else if sm.status == Running {

--- a/internal/engine/fswatch/watchmanager.go
+++ b/internal/engine/fswatch/watchmanager.go
@@ -224,7 +224,7 @@ func (w *WatchManager) dispatchFileChangesLoop(
 				return
 			}
 
-			now := metav1.Now()
+			now := metav1.NowMicro()
 			w.mu.Lock()
 			event := filewatches.FileEvent{Time: *now.DeepCopy()}
 			for _, fsEvent := range fsEvents {

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -4394,7 +4394,7 @@ func (f *testFixture) completeBuildForManifest(m model.Manifest) {
 }
 
 func (f *testFixture) triggerFileChange(targetID model.TargetID, paths ...string) {
-	now := metav1.Now()
+	now := metav1.NowMicro()
 	f.store.Dispatch(fswatch.FileWatchUpdateStatusAction{
 		Name: types.NamespacedName{Name: targetID.String()},
 		Status: &filewatches.FileWatchStatus{

--- a/pkg/apis/core/v1alpha1/cmd_types.go
+++ b/pkg/apis/core/v1alpha1/cmd_types.go
@@ -161,7 +161,7 @@ type CmdStateRunning struct {
 	PID int32 `json:"pid"`
 
 	// Time at which the command was last started.
-	StartedAt metav1.Time `json:"startedAt,omitempty"`
+	StartedAt metav1.MicroTime `json:"startedAt,omitempty"`
 }
 
 // CmdStateTerminated is a terminated state of a local command.
@@ -173,10 +173,10 @@ type CmdStateTerminated struct {
 	ExitCode int32 `json:"exitCode"`
 
 	// Time at which previous execution of the command started
-	StartedAt metav1.Time `json:"startedAt,omitempty"`
+	StartedAt metav1.MicroTime `json:"startedAt,omitempty"`
 
 	// Time at which the command last terminated
-	FinishedAt metav1.Time `json:"finishedAt,omitempty"`
+	FinishedAt metav1.MicroTime `json:"finishedAt,omitempty"`
 
 	// (brief) reason the process is terminated
 	// +optional

--- a/pkg/apis/core/v1alpha1/filewatch_types.go
+++ b/pkg/apis/core/v1alpha1/filewatch_types.go
@@ -141,7 +141,7 @@ type FileWatchStatus struct {
 	//
 	// If the specifics of which files changed are not important, this field can be used as a watermark without
 	// needing to inspect FileEvents.
-	LastEventTime *metav1.Time `json:"lastEventTime,omitempty"`
+	LastEventTime *metav1.MicroTime `json:"lastEventTime,omitempty"`
 	// FileEvents summarizes batches of file changes (create, modify, or delete) that have been seen in ascending
 	// chronological order. Only the most recent 20 events are included.
 	FileEvents []FileEvent `json:"fileEvents"`
@@ -155,7 +155,7 @@ type FileEvent struct {
 	//
 	// This will NOT exactly match any inode attributes (e.g. ctime, mtime) at the filesystem level and is purely
 	// informational or for use as an opaque watermark.
-	Time metav1.Time `json:"time"`
+	Time metav1.MicroTime `json:"time"`
 	// SeenFiles is a list of paths which changed (create, modify, or delete).
 	SeenFiles []string `json:"seenFiles"`
 }

--- a/pkg/openapi/zz_generated.openapi.go
+++ b/pkg/openapi/zz_generated.openapi.go
@@ -277,7 +277,7 @@ func schema_pkg_apis_core_v1alpha1_CmdStateRunning(ref common.ReferenceCallback)
 						SchemaProps: spec.SchemaProps{
 							Description: "Time at which the command was last started.",
 							Default:     map[string]interface{}{},
-							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Time"),
+							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.MicroTime"),
 						},
 					},
 				},
@@ -285,7 +285,7 @@ func schema_pkg_apis_core_v1alpha1_CmdStateRunning(ref common.ReferenceCallback)
 			},
 		},
 		Dependencies: []string{
-			"k8s.io/apimachinery/pkg/apis/meta/v1.Time"},
+			"k8s.io/apimachinery/pkg/apis/meta/v1.MicroTime"},
 	}
 }
 
@@ -316,14 +316,14 @@ func schema_pkg_apis_core_v1alpha1_CmdStateTerminated(ref common.ReferenceCallba
 						SchemaProps: spec.SchemaProps{
 							Description: "Time at which previous execution of the command started",
 							Default:     map[string]interface{}{},
-							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Time"),
+							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.MicroTime"),
 						},
 					},
 					"finishedAt": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Time at which the command last terminated",
 							Default:     map[string]interface{}{},
-							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Time"),
+							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.MicroTime"),
 						},
 					},
 					"reason": {
@@ -338,7 +338,7 @@ func schema_pkg_apis_core_v1alpha1_CmdStateTerminated(ref common.ReferenceCallba
 			},
 		},
 		Dependencies: []string{
-			"k8s.io/apimachinery/pkg/apis/meta/v1.Time"},
+			"k8s.io/apimachinery/pkg/apis/meta/v1.MicroTime"},
 	}
 }
 
@@ -438,13 +438,15 @@ func schema_pkg_apis_core_v1alpha1_FileEvent(ref common.ReferenceCallback) commo
 				Properties: map[string]spec.Schema{
 					"time": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.Time"),
+							Description: "Time is an approximate timestamp for a batch of file changes.\n\nThis will NOT exactly match any inode attributes (e.g. ctime, mtime) at the filesystem level and is purely informational or for use as an opaque watermark.",
+							Default:     map[string]interface{}{},
+							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.MicroTime"),
 						},
 					},
 					"seenFiles": {
 						SchemaProps: spec.SchemaProps{
-							Type: []string{"array"},
+							Description: "SeenFiles is a list of paths which changed (create, modify, or delete).",
+							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
@@ -461,7 +463,7 @@ func schema_pkg_apis_core_v1alpha1_FileEvent(ref common.ReferenceCallback) commo
 			},
 		},
 		Dependencies: []string{
-			"k8s.io/apimachinery/pkg/apis/meta/v1.Time"},
+			"k8s.io/apimachinery/pkg/apis/meta/v1.MicroTime"},
 	}
 }
 
@@ -615,12 +617,14 @@ func schema_pkg_apis_core_v1alpha1_FileWatchStatus(ref common.ReferenceCallback)
 				Properties: map[string]spec.Schema{
 					"lastEventTime": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.Time"),
+							Description: "LastEventTime is the timestamp of the most recent file event. It is nil if no events have been seen yet.\n\nIf the specifics of which files changed are not important, this field can be used as a watermark without needing to inspect FileEvents.",
+							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.MicroTime"),
 						},
 					},
 					"fileEvents": {
 						SchemaProps: spec.SchemaProps{
-							Type: []string{"array"},
+							Description: "FileEvents summarizes batches of file changes (create, modify, or delete) that have been seen in ascending chronological order. Only the most recent 20 events are included.",
+							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
@@ -633,8 +637,9 @@ func schema_pkg_apis_core_v1alpha1_FileWatchStatus(ref common.ReferenceCallback)
 					},
 					"error": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Description: "Error is set if there is a problem with the filesystem watch. If non-empty, consumers should assume that no filesystem events will be seen and that the file watcher is in a failed state.",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 				},
@@ -642,7 +647,7 @@ func schema_pkg_apis_core_v1alpha1_FileWatchStatus(ref common.ReferenceCallback)
 			},
 		},
 		Dependencies: []string{
-			"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1.FileEvent", "k8s.io/apimachinery/pkg/apis/meta/v1.Time"},
+			"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1.FileEvent", "k8s.io/apimachinery/pkg/apis/meta/v1.MicroTime"},
 	}
 }
 


### PR DESCRIPTION
Hello @milas,

Please review the following commits I made in branch nicks/microtime:

96be94cbef484cdac528fcccdd9bb8bc77fcd663 (2021-03-12 15:19:22 -0500)
apis: use MicroTime instead of Time
Currently, metav1.Time is only stored with second-level granularity,
which is probably not sufficient for this API.

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics