### PR TITLE
cli: fix json errors on engine dump

### DIFF
--- a/internal/store/engine_state.go
+++ b/internal/store/engine_state.go
@@ -121,8 +121,8 @@ type EngineState struct {
 
 	// API-server-based data models. Stored in EngineState
 	// to assist in migration.
-	Cmds        map[string]*Cmd
-	FileWatches map[types.NamespacedName]*filewatches.FileWatch
+	Cmds        map[string]*Cmd                                 `json:"-"`
+	FileWatches map[types.NamespacedName]*filewatches.FileWatch `json:"-"`
 }
 
 type CloudStatus struct {


### PR DESCRIPTION
~~Add a custom encoder for `types.NamespacedName`.~~

Hide new apiserver types from the engine dump output. These types
should only be used by querying the apiserver rather than relying
on this debugging command.

(The actual error is due to JSON serialization of
`types.NamespacedName`; an earlier version of this change made
that serialize correctly but has been reverted since we don't
want to serialize it at all.)

Closes #4316.