### PR TITLE
cli: Remove --watch=false flag, and update integration tests to not depend on it

### DIFF
--- a/integration/analytics_test.go
+++ b/integration/analytics_test.go
@@ -102,7 +102,7 @@ func TestOptedIn(t *testing.T) {
 
 	f.SetOpt(analytics.OptIn)
 
-	f.TiltUp("analytics")
+	f.TiltCI("analytics")
 
 	ctx, cancel := context.WithTimeout(f.ctx, time.Minute)
 	defer cancel()
@@ -121,7 +121,7 @@ func TestOptedIn(t *testing.T) {
 	// just check that a couple metrics were successfully reported rather than asserting an exhaustive list
 	// the goal is to ensure that analytics is working in general, not to test which specific metrics are reported
 	// and we don't want to have to update this every time we change which metrics we report
-	assert.Contains(t, observedEventNames, "tilt.cmd.up")
+	assert.Contains(t, observedEventNames, "tilt.cmd.ci")
 	assert.Contains(t, observedEventNames, "tilt.tiltfile.loaded")
 	assert.Contains(t, observedTimerNames, "tilt.tiltfile.load")
 }
@@ -132,7 +132,7 @@ func TestOptedOut(t *testing.T) {
 
 	f.SetOpt(analytics.OptOut)
 
-	f.TiltUp("analytics")
+	f.TiltCI("analytics")
 
 	ctx, cancel := context.WithTimeout(f.ctx, time.Minute)
 	defer cancel()
@@ -147,7 +147,7 @@ func TestOptDefault(t *testing.T) {
 
 	f.SetOpt(analytics.OptDefault)
 
-	f.TiltUp("analytics")
+	f.TiltCI("analytics")
 
 	ctx, cancel := context.WithTimeout(f.ctx, time.Minute)
 	defer cancel()
@@ -166,7 +166,7 @@ func TestOptDefault(t *testing.T) {
 	// just check that a couple metrics were successfully reported rather than asserting an exhaustive list
 	// the goal is to ensure that analytics is working in general, not to test which specific metrics are reported
 	// and we don't want to have to update this every time we change which metrics we report
-	assert.Contains(t, observedEventNames, "tilt.cmd.up")
+	assert.Contains(t, observedEventNames, "tilt.cmd.ci")
 	assert.Contains(t, observedEventNames, "tilt.tiltfile.loaded")
 	assert.Contains(t, observedTimerNames, "tilt.tiltfile.load")
 }

--- a/integration/configmap_test.go
+++ b/integration/configmap_test.go
@@ -15,7 +15,7 @@ func TestConfigMap(t *testing.T) {
 	f := newK8sFixture(t, "configmap")
 	defer f.TearDown()
 
-	f.TiltWatch()
+	f.TiltUp()
 
 	ctx, cancel := context.WithTimeout(f.ctx, time.Minute)
 	defer cancel()

--- a/integration/crash_test.go
+++ b/integration/crash_test.go
@@ -17,14 +17,14 @@ func TestCrash(t *testing.T) {
 	f := newK8sFixture(t, "oneup")
 	defer f.TearDown()
 
-	f.TiltWatch()
+	f.TiltUp()
 	require.NotZero(t, f.activeTiltUp.port)
 	time.Sleep(500 * time.Millisecond)
 
 	out := bytes.NewBuffer(nil)
 	// explicitly pass a port argument or the integration tests will pick a random unused one, thus defeating
 	// the point of the test
-	res, err := f.tilt.Up([]string{"--watch=false", fmt.Sprintf("--port=%d", f.activeTiltUp.port)}, out)
+	res, err := f.tilt.Up(out, fmt.Sprintf("--port=%d", f.activeTiltUp.port))
 	assert.NoError(t, err)
 	<-res.Done()
 	assert.Contains(t, out.String(), "Tilt cannot start")

--- a/integration/crd_test.go
+++ b/integration/crd_test.go
@@ -15,7 +15,7 @@ func TestCRD(t *testing.T) {
 	f := newK8sFixture(t, "crd")
 	defer f.TearDown()
 
-	f.TiltWatch()
+	f.TiltUp()
 
 	ctx, cancel := context.WithTimeout(f.ctx, time.Minute)
 	defer cancel()

--- a/integration/dcbuild_test.go
+++ b/integration/dcbuild_test.go
@@ -13,7 +13,7 @@ func TestDockerComposeImageBuild(t *testing.T) {
 	defer f.TearDown()
 
 	f.dockerKillAll("tilt")
-	f.TiltWatch()
+	f.TiltUp()
 
 	ctx, cancel := context.WithTimeout(f.ctx, time.Minute)
 	defer cancel()

--- a/integration/event_test.go
+++ b/integration/event_test.go
@@ -49,7 +49,7 @@ func TestEvent(t *testing.T) {
 	markNodeUnschedulable(f, node)
 	defer markNodeSchedulable(f, node)
 
-	f.TiltWatch()
+	f.TiltUp()
 
 	ctx, cancel := context.WithTimeout(f.ctx, time.Minute)
 	defer cancel()

--- a/integration/fixture_test.go
+++ b/integration/fixture_test.go
@@ -43,7 +43,6 @@ type fixture struct {
 	tilt          *TiltDriver
 	activeTiltUp  *TiltUpResponse
 	tearingDown   bool
-	tiltArgs      []string
 }
 
 func newFixture(t *testing.T, dir string) *fixture {
@@ -149,29 +148,6 @@ func (f *fixture) LogWriter() io.Writer {
 	return io.MultiWriter(f.logs, os.Stdout)
 }
 
-func (f *fixture) TiltUp(name string) {
-	args := []string{"--watch=false"}
-	if name != "" {
-		args = append(args, name)
-	}
-	response, err := f.tilt.Up(args, f.LogWriter())
-	if err != nil {
-		f.t.Fatalf("TiltUp %s: %v", name, err)
-	}
-	select {
-	case <-response.Done():
-		err := response.Err()
-		if err != nil {
-			f.t.Fatalf("TiltUp %s: %v", name, err)
-		}
-	case <-f.ctx.Done():
-		err := f.ctx.Err()
-		if err != nil {
-			f.t.Fatalf("TiltUp %s: %v", name, err)
-		}
-	}
-}
-
 func (f *fixture) TiltCI(args ...string) {
 	err := f.tilt.CI(f.LogWriter(), args...)
 	if err != nil {
@@ -179,18 +155,10 @@ func (f *fixture) TiltCI(args ...string) {
 	}
 }
 
-func (f *fixture) TiltWatch() {
-	response, err := f.tilt.Up(f.tiltArgs, f.LogWriter())
+func (f *fixture) TiltUp(args ...string) {
+	response, err := f.tilt.Up(f.LogWriter(), args...)
 	if err != nil {
-		f.t.Fatalf("TiltWatch: %v", err)
-	}
-	f.activeTiltUp = response
-}
-
-func (f *fixture) TiltWatchExec() {
-	response, err := f.tilt.Up(append([]string{"--update-mode=exec"}, f.tiltArgs...), f.LogWriter())
-	if err != nil {
-		f.t.Fatalf("TiltWatchExec: %v", err)
+		f.t.Fatalf("TiltUp: %v", err)
 	}
 	f.activeTiltUp = response
 }

--- a/integration/idempotent_test.go
+++ b/integration/idempotent_test.go
@@ -16,14 +16,14 @@ func TestIdempotent(t *testing.T) {
 	f := newK8sFixture(t, "idempotent")
 	defer f.TearDown()
 
-	f.TiltUp("idempotent")
+	f.TiltCI("idempotent")
 
 	ctx, cancel := context.WithTimeout(f.ctx, time.Minute)
 	defer cancel()
 	firstPods := f.WaitForAllPodsReady(ctx, "app=idempotent")
 
 	// Run it again, this time with a watch()
-	f.TiltWatch()
+	f.TiltUp()
 
 	// Wait until the port-forwarder sets up
 	ctx, cancel = context.WithTimeout(f.ctx, time.Minute)

--- a/integration/imagetags_test.go
+++ b/integration/imagetags_test.go
@@ -12,7 +12,7 @@ func TestImageTags(t *testing.T) {
 	f := newK8sFixture(t, "imagetags")
 	defer f.TearDown()
 
-	f.TiltWatch()
+	f.TiltUp()
 
 	timePerStage := time.Minute
 	ctx, cancel := context.WithTimeout(f.ctx, timePerStage)

--- a/integration/job_test.go
+++ b/integration/job_test.go
@@ -15,7 +15,7 @@ func TestJob(t *testing.T) {
 	defer f.TearDown()
 	f.SetRestrictedCredentials()
 
-	f.TiltWatch()
+	f.TiltUp()
 
 	ctx, cancel := context.WithTimeout(f.ctx, time.Minute)
 	defer cancel()

--- a/integration/live_update_after_crash_rebuild_test.go
+++ b/integration/live_update_after_crash_rebuild_test.go
@@ -23,7 +23,7 @@ func TestLiveUpdateAfterCrashRebuild(t *testing.T) {
 		withExpectedPhase(v1.PodRunning)
 	initialPods := pw.wait()
 
-	f.TiltWatch()
+	f.TiltUp()
 
 	fmt.Println("> Waiting for pods from initial build")
 

--- a/integration/live_update_base_image_test.go
+++ b/integration/live_update_base_image_test.go
@@ -14,7 +14,7 @@ func TestLiveUpdateBaseImage(t *testing.T) {
 	f := newK8sFixture(t, "live_update_base_image")
 	defer f.TearDown()
 
-	f.TiltWatch()
+	f.TiltUp()
 
 	timePerStage := time.Minute
 	ctx, cancel := context.WithTimeout(f.ctx, timePerStage)

--- a/integration/live_update_two_images_one_manifest_test.go
+++ b/integration/live_update_two_images_one_manifest_test.go
@@ -20,7 +20,7 @@ func TestLiveUpdateTwoImagesOneManifest(t *testing.T) {
 	f := newK8sFixture(t, "live_update_two_images_one_manifest")
 	defer f.TearDown()
 
-	f.TiltWatch()
+	f.TiltUp()
 
 	sparkleURL := "http://localhost:8100"
 	tadaURL := "http://localhost:8101"

--- a/integration/local_resource_test.go
+++ b/integration/local_resource_test.go
@@ -28,7 +28,7 @@ func TestLocalResource(t *testing.T) {
 	removeTestFiles()
 	t.Cleanup(removeTestFiles)
 
-	f.TiltWatch()
+	f.TiltUp()
 
 	const barServeLogMessage = "Running serve cmd: ./hello.sh bar"
 	const readinessProbeSuccessMessage = `[readiness probe: success] fake probe success message`

--- a/integration/onedc_test.go
+++ b/integration/onedc_test.go
@@ -13,7 +13,7 @@ func TestOneDockerCompose(t *testing.T) {
 	defer f.TearDown()
 
 	f.dockerKillAll("tilt")
-	f.TiltWatch()
+	f.TiltUp()
 
 	ctx, cancel := context.WithTimeout(f.ctx, time.Minute)
 	defer cancel()

--- a/integration/oneup_custom_test.go
+++ b/integration/oneup_custom_test.go
@@ -12,7 +12,7 @@ func TestOneUpCustom(t *testing.T) {
 	f := newK8sFixture(t, "oneup_custom")
 	defer f.TearDown()
 
-	f.TiltUp("oneup-custom")
+	f.TiltCI("oneup-custom")
 
 	// ForwardPort will fail if all the pods are not ready.
 	//

--- a/integration/onewatch_exec_test.go
+++ b/integration/onewatch_exec_test.go
@@ -15,7 +15,7 @@ func TestWatchExec(t *testing.T) {
 	f := newK8sFixture(t, "onewatch_exec")
 	defer f.TearDown()
 
-	f.TiltWatchExec()
+	f.TiltUp("--update-mode=exec")
 
 	fmt.Printf("Wait for pods ready\n")
 	ctx, cancel := context.WithTimeout(f.ctx, time.Minute)

--- a/integration/onewatch_test.go
+++ b/integration/onewatch_test.go
@@ -15,7 +15,7 @@ func TestOneWatch(t *testing.T) {
 	defer f.TearDown()
 	f.SetRestrictedCredentials()
 
-	f.TiltWatch()
+	f.TiltUp()
 
 	ctx, cancel := context.WithTimeout(f.ctx, time.Minute)
 	defer cancel()

--- a/integration/restart_process_different_user_test.go
+++ b/integration/restart_process_different_user_test.go
@@ -14,7 +14,7 @@ func TestRestartProcessDifferentUser(t *testing.T) {
 	f := newK8sFixture(t, "restart_process_different_user")
 	defer f.TearDown()
 
-	f.TiltWatch()
+	f.TiltUp()
 
 	ctx, cancel := context.WithTimeout(f.ctx, time.Minute)
 	defer cancel()

--- a/integration/same_img_multi_container_test.go
+++ b/integration/same_img_multi_container_test.go
@@ -14,7 +14,7 @@ func TestSameImgMultiContainer(t *testing.T) {
 	f := newK8sFixture(t, "same_img_multi_container")
 	defer f.TearDown()
 
-	f.TiltWatch()
+	f.TiltUp()
 
 	ctx, cancel := context.WithTimeout(f.ctx, time.Minute)
 	defer cancel()

--- a/integration/shortlived_pods_test.go
+++ b/integration/shortlived_pods_test.go
@@ -15,7 +15,7 @@ func TestShortlivedPods(t *testing.T) {
 	f := newK8sFixture(t, "shortlived_pods")
 	defer f.TearDown()
 
-	f.TiltWatch()
+	f.TiltUp()
 
 	ctx, cancel := context.WithTimeout(f.ctx, time.Minute)
 	defer cancel()

--- a/integration/tilt.go
+++ b/integration/tilt.go
@@ -64,7 +64,7 @@ func (d *TiltDriver) CI(out io.Writer, args ...string) error {
 	return cmd.Run()
 }
 
-func (d *TiltDriver) Up(args []string, out io.Writer) (*TiltUpResponse, error) {
+func (d *TiltDriver) Up(out io.Writer, args ...string) (*TiltUpResponse, error) {
 	mandatoryArgs := []string{"up",
 		// Can't attach a HUD or install browsers in headless mode
 		"--hud=false",

--- a/integration/tilt_args_test.go
+++ b/integration/tilt_args_test.go
@@ -14,9 +14,7 @@ func TestTiltArgs(t *testing.T) {
 	f := newFixture(t, "tilt_args")
 	defer f.TearDown()
 
-	f.tiltArgs = []string{"foo"}
-
-	f.TiltWatch()
+	f.TiltUp("foo")
 	require.NotZero(t, f.activeTiltUp.port)
 
 	err := f.logs.WaitUntilContains("foo run", 5*time.Second)

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -34,7 +34,6 @@ var webDevPort = 0
 var logActionsFlag bool = false
 
 type upCmd struct {
-	watch                bool
 	fileName             string
 	outputSnapshotOnExit string
 
@@ -43,9 +42,6 @@ type upCmd struct {
 	stream bool
 	// whether hud/legacy/stream flags were explicitly set or just got the default value
 	hudFlagExplicitlySet bool
-
-	//whether watch was explicitly set in the cmdline
-	watchFlagExplicitlySet bool
 }
 
 func (c *upCmd) name() model.TiltSubcommand { return "up" }
@@ -75,7 +71,6 @@ local resources--i.e. those using serve_cmd--are terminated when you exit Tilt.
 `,
 	}
 
-	cmd.Flags().BoolVar(&c.watch, "watch", true, "If true, services will be automatically rebuilt and redeployed when files change. Otherwise, each service will be started once.")
 	cmd.Flags().StringVar(&updateModeFlag, "update-mode", string(buildcontrol.UpdateModeAuto),
 		fmt.Sprintf("Control the strategy Tilt uses for updating instances. Possible values: %v", buildcontrol.AllUpdateModes))
 	cmd.Flags().BoolVar(&c.hud, "hud", true, "If true, tilt will open in HUD mode.")
@@ -91,7 +86,6 @@ local resources--i.e. those using serve_cmd--are terminated when you exit Tilt.
 
 	cmd.PreRun = func(cmd *cobra.Command, args []string) {
 		c.hudFlagExplicitlySet = cmd.Flag("hud").Changed
-		c.watchFlagExplicitlySet = cmd.Flag("watch").Changed
 	}
 
 	return cmd
@@ -142,11 +136,6 @@ func (c *upCmd) run(ctx context.Context, args []string) error {
 	log.Print(startLine)
 	log.Print(buildStamp())
 
-	//if --watch was set, warn user about deprecation
-	if c.watchFlagExplicitlySet {
-		logger.Get(ctx).Warnf("Flag --watch has been deprecated, it will be removed in future releases.")
-	}
-
 	if ok, reason := analytics.IsAnalyticsDisabledFromEnv(); ok {
 		log.Printf("Tilt analytics disabled: %s", reason)
 	}
@@ -175,9 +164,6 @@ func (c *upCmd) run(ctx context.Context, args []string) error {
 	defer cancel()
 
 	engineMode := store.EngineModeUp
-	if !c.watch {
-		engineMode = store.EngineModeApply
-	}
 
 	err = upper.Start(ctx, args, cmdUpDeps.TiltBuild, engineMode,
 		c.fileName, termMode, a.UserOpt(), cmdUpDeps.Token, string(cmdUpDeps.CloudAddress))


### PR DESCRIPTION
Hello @maiamcc, @landism,

Please review the following commits I made in branch nicks/watch:

a8331c3108c76e8f24eb6c0e0635aebadcb42965 (2021-03-15 18:59:13 -0400)
cli: Remove --watch=false flag, and update integration tests to not depend on it

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics