### PR TITLE
test: move helm tests into their own file, and skip them on short tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,17 +50,17 @@ endif
 test: test-go test-js
 
 # skip some tests that are slow and not always relevant
-# TODO(matt) skipdockercomposetests only skips the tiltfile DC tests at the moment
+# TODO(matt) skiplargetiltfiletests only skips the tiltfile DC+Helm tests at the moment
 # we might also want to skip the ones in engine
 shorttest:
-	go test -mod vendor -p $(GO_PARALLEL_JOBS) -tags skipcontainertests,skipdockercomposetests -timeout 60s ./...
+	go test -mod vendor -p $(GO_PARALLEL_JOBS) -tags skipcontainertests,skiplargetiltfiletests -timeout 60s ./...
 
 shorttestsum:
 ifneq ($(CIRCLECI),true)
-	gotestsum -- -mod vendor -p $(GO_PARALLEL_JOBS) -tags skipcontainertests,skipdockercomposetests -timeout 60s ./...
+	gotestsum -- -mod vendor -p $(GO_PARALLEL_JOBS) -tags skipcontainertests,skiplargetiltfiletests -timeout 60s ./...
 else
 	mkdir -p test-results
-	gotestsum --format standard-quiet --junitfile test-results/unit-tests.xml -- ./... -mod vendor -count 1 -p $(GO_PARALLEL_JOBS) -tags skipcontainertests,skipdockercomposetests -timeout 60s
+	gotestsum --format standard-quiet --junitfile test-results/unit-tests.xml -- ./... -mod vendor -count 1 -p $(GO_PARALLEL_JOBS) -tags skipcontainertests,skiplargetiltfiletests -timeout 60s
 endif
 
 integration:

--- a/internal/tiltfile/tiltfile_docker_compose_test.go
+++ b/internal/tiltfile/tiltfile_docker_compose_test.go
@@ -1,4 +1,4 @@
-//+build !skipdockercomposetests
+//+build !skiplargetiltfiletests
 
 package tiltfile
 

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"runtime"
 	"sort"
@@ -1415,146 +1414,6 @@ x = 2
 	f.load()
 }
 
-func TestHelm(t *testing.T) {
-	f := newFixture(t)
-	defer f.TearDown()
-
-	f.setupHelm()
-
-	f.file("Tiltfile", `
-yml = helm('helm')
-k8s_yaml(yml)
-`)
-
-	f.load()
-
-	f.assertNextManifestUnresourced("chart-helloworld-chart")
-	f.assertConfigFiles(
-		"Tiltfile",
-		".tiltignore",
-		"helm",
-	)
-}
-
-func TestHelmArgs(t *testing.T) {
-	f := newFixture(t)
-	defer f.TearDown()
-
-	f.setupHelm()
-
-	f.file("Tiltfile", `
-yml = helm('./helm', name='rose-quartz', namespace='garnet', values=['./dev/helm/values-dev.yaml'])
-k8s_yaml(yml)
-`)
-
-	f.load()
-
-	m := f.assertNextManifestUnresourced("rose-quartz-helloworld-chart")
-	yaml := m.K8sTarget().YAML
-	assert.Contains(t, yaml, "release: rose-quartz")
-	assert.Contains(t, yaml, "namespace: garnet")
-	assert.Contains(t, yaml, "namespaceLabel: garnet")
-	assert.Contains(t, yaml, "name: nginx-dev")
-
-	entities, err := k8s.ParseYAMLFromString(yaml)
-	require.NoError(t, err)
-
-	names := k8s.UniqueNames(entities, 2)
-	expectedNames := []string{"rose-quartz-helloworld-chart:service"}
-	assert.ElementsMatch(t, expectedNames, names)
-
-	f.assertConfigFiles("./helm/", "./dev/helm/values-dev.yaml", ".tiltignore", "Tiltfile")
-}
-
-func TestHelmNamespaceFlagDoesNotInsertNSEntityIfNSInChart(t *testing.T) {
-	f := newFixture(t)
-	defer f.TearDown()
-
-	f.setupHelm()
-
-	valuesWithNamespace := `
-namespace:
-  enabled: true
-  name: foobarbaz`
-	f.file("helm/extra_values.yaml", valuesWithNamespace)
-
-	f.file("Tiltfile", `
-yml = helm('./helm', name='rose-quartz', namespace="foobarbaz", values=['./helm/extra_values.yaml'])
-k8s_yaml(yml)
-`)
-
-	f.load()
-
-	m := f.assertNextManifestUnresourced("foobarbaz", "rose-quartz-helloworld-chart")
-	yaml := m.K8sTarget().YAML
-
-	entities, err := k8s.ParseYAMLFromString(yaml)
-	require.NoError(t, err)
-	require.Len(t, entities, 2)
-	e := entities[0]
-	require.Equal(t, "Namespace", e.GVK().Kind)
-	assert.Equal(t, "foobarbaz", e.Name())
-	assert.Equal(t, "indeed", e.Labels()["somePersistedLabel"],
-		"label originally specified in chart YAML should persist")
-}
-
-func TestHelmNamespaceFlagInsertsNSEntityIfDifferentNSInChart(t *testing.T) {
-	f := newFixture(t)
-	defer f.TearDown()
-
-	f.setupHelm()
-
-	valuesWithNamespace := `
-namespace:
-  enabled: true
-  name: not-the-one-specified-in-flag` // what kind of jerk would do this?
-	f.file("helm/extra_values.yaml", valuesWithNamespace)
-
-	f.file("Tiltfile", `
-yml = helm('./helm', name='rose-quartz', namespace="foobarbaz", values=['./helm/extra_values.yaml'])
-k8s_yaml(yml)
-`)
-
-	f.load()
-
-	f.assertNextManifestUnresourced("not-the-one-specified-in-flag", "rose-quartz-helloworld-chart")
-}
-
-func TestHelmInvalidDirectory(t *testing.T) {
-	f := newFixture(t)
-	defer f.TearDown()
-
-	f.file("Tiltfile", `
-yml = helm('helm')
-k8s_yaml(yml)
-`)
-
-	f.loadErrString("Could not read Helm chart directory")
-}
-
-func TestHelmFromRepoPath(t *testing.T) {
-	f := newFixture(t)
-	defer f.TearDown()
-
-	f.gitInit(".")
-	f.setupHelm()
-
-	f.file("Tiltfile", `
-r = local_git_repo('.')
-yml = helm(r.paths('helm'))
-k8s_yaml(yml)
-`)
-
-	f.load()
-
-	f.assertNextManifestUnresourced("chart-helloworld-chart")
-	f.assertConfigFiles(
-		"Tiltfile",
-		".tiltignore",
-		"helm",
-	)
-}
-
 func TestEmptyDockerfileDockerBuild(t *testing.T) {
 	f := newFixture(t)
 	defer f.TearDown()
@@ -2253,28 +2112,6 @@ func TestYamlErrorFromReadFile(t *testing.T) {
 k8s_yaml(read_file('foo.yaml'))
 `)
 	f.loadErrString(fmt.Sprintf("file: %s", f.JoinPath("foo.yaml")))
-}
-
-func TestYamlErrorFromHelm(t *testing.T) {
-	f := newFixture(t)
-	defer f.TearDown()
-	f.setupHelm()
-	f.file("helm/templates/foo.yaml", "hi")
-	f.file("Tiltfile", `
-k8s_yaml(helm('helm'))
-`)
-
-	// TODO(dmiller): there should be a better assertion here
-
-	version, err := getHelmVersion()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if version == helmV2 {
-		f.loadErrString("from helm")
-	} else {
-		f.loadErrString("in helm")
-	}
 }
 
 func TestYamlErrorFromBlob(t *testing.T) {
@@ -3539,56 +3376,6 @@ trigger_mode(TRIGGER_MODE_MANUAL)
 trigger_mode(TRIGGER_MODE_MANUAL)
 `)
 	f.loadErrString("trigger_mode can only be called once")
-}
-
-func TestHelmSkipsTests(t *testing.T) {
-	f := newFixture(t)
-	defer f.TearDown()
-
-	f.setupHelmWithTest()
-	f.file("Tiltfile", `
-yml = helm('helm')
-k8s_yaml(yml)
-`)
-
-	f.load()
-
-	f.assertNextManifestUnresourced("chart-helloworld-chart")
-	f.assertConfigFiles(
-		"Tiltfile",
-		".tiltignore",
-		"helm",
-	)
-}
-
-// There's a major helm regression that's breaking everything
-// https://github.com/helm/helm/issues/6708
-func isBuggyHelm(t *testing.T) bool {
-	cmd := exec.Command("helm", "version", "-c", "--short")
-	out, err := cmd.Output()
-	if err != nil {
-		t.Fatalf("Error running helm: %v", err)
-	}
-
-	return strings.Contains(string(out), "v2.15.0")
-}
-
-func TestHelmIncludesRequirements(t *testing.T) {
-	if isBuggyHelm(t) {
-		t.Skipf("Helm v2.15.0 has a major regression, skipping test. See: https://github.com/helm/helm/issues/6708")
-	}
-
-	f := newFixture(t)
-	defer f.TearDown()
-
-	f.setupHelmWithRequirements()
-	f.file("Tiltfile", `
-yml = helm('helm')
-k8s_yaml(yml)
-`)
-
-	f.load()
-	f.assertNextManifest("chart-nginx-ingress-controller")
 }
 
 func TestK8sContext(t *testing.T) {


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/helm:

0a7a46bde6e0d569ef292e2ce274e3d1bce39e0b (2021-03-15 20:15:40 -0400)
test: move helm tests into their own file, and skip them on short tests
On windows, running Helm can take ~0.5 seconds,
which starts to blow up test times. Hoping this
will make the tests less flakey

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics