### PR TITLE
server: use apiserver safe values where appropriate

### DIFF
--- a/internal/engine/fswatch/action.go
+++ b/internal/engine/fswatch/action.go
@@ -149,7 +149,7 @@ func targetID(obj runtime.Object) (model.TargetID, error) {
 	if err != nil {
 		return model.TargetID{}, err
 	}
-	labelVal := metaObj.GetLabels()[filewatches.LabelTargetID]
+	labelVal := metaObj.GetAnnotations()[filewatches.AnnotationTargetID]
 	if labelVal == "" {
 		return model.TargetID{}, nil
 	}

--- a/internal/engine/fswatch/manifest_subscriber.go
+++ b/internal/engine/fswatch/manifest_subscriber.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"path/filepath"
 
+	"github.com/tilt-dev/tilt/pkg/apis"
+
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -36,7 +38,7 @@ func (w ManifestSubscriber) OnChange(_ context.Context, st store.RStore, summary
 
 	watchesToKeep := make(map[types.NamespacedName]bool)
 	for targetID, spec := range specsToProcess {
-		name := types.NamespacedName{Name: targetID.String()}
+		name := types.NamespacedName{Name: apis.SanitizeName(targetID.String())}
 		watchesToKeep[name] = true
 
 		existing := state.FileWatches[name]
@@ -54,8 +56,8 @@ func (w ManifestSubscriber) OnChange(_ context.Context, st store.RStore, summary
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: name.Namespace,
 					Name:      name.Name,
-					Labels: map[string]string{
-						filewatches.LabelTargetID: targetID.String(),
+					Annotations: map[string]string{
+						filewatches.AnnotationTargetID: targetID.String(),
 					},
 				},
 				Spec: *spec.DeepCopy(),

--- a/internal/engine/fswatch/watchmanager_test.go
+++ b/internal/engine/fswatch/watchmanager_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/tilt-dev/tilt/pkg/apis"
+
 	"github.com/docker/docker/builder/dockerignore"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
@@ -435,7 +437,7 @@ func (f *wmFixture) RequireFileWatchSpecEqual(targetID model.TargetID, spec file
 		fwd.actual = nil
 		st := f.store.RLockState()
 		defer f.store.RUnlockState()
-		fw, ok := st.FileWatches[types.NamespacedName{Name: targetID.String()}]
+		fw, ok := st.FileWatches[types.NamespacedName{Name: apis.SanitizeName(targetID.String())}]
 		if !ok {
 			return false
 		}

--- a/internal/engine/local/reducers.go
+++ b/internal/engine/local/reducers.go
@@ -28,7 +28,7 @@ func HandleCmdUpdateStatusAction(state *store.EngineState, action CmdUpdateStatu
 // If the local serve cmd is watching the cmd, update
 // the local runtime state to match the cmd status.
 func updateLocalRuntimeStatus(state *store.EngineState, cmd *v1alpha1.Cmd) {
-	mn := model.ManifestName(cmd.Labels[v1alpha1.LabelManifest])
+	mn := model.ManifestName(cmd.Annotations[v1alpha1.AnnotationManifest])
 	mt, ok := state.ManifestTargets[mn]
 	if !ok {
 		delete(state.Cmds, cmd.Name)
@@ -81,7 +81,7 @@ func updateLocalRuntimeStatus(state *store.EngineState, cmd *v1alpha1.Cmd) {
 // that command to the Local runtime state.
 func HandleCmdCreateAction(state *store.EngineState, action CmdCreateAction) {
 	cmd := action.Cmd
-	mn := model.ManifestName(cmd.Labels[v1alpha1.LabelManifest])
+	mn := model.ManifestName(cmd.Annotations[v1alpha1.AnnotationManifest])
 	mt, ok := state.ManifestTargets[mn]
 	if !ok {
 		return

--- a/internal/engine/local/servercontroller.go
+++ b/internal/engine/local/servercontroller.go
@@ -175,10 +175,8 @@ func (c *ServerController) reconcile(ctx context.Context, server CmdServer, st s
 				AnnotationOwnerName: name,
 				AnnotationOwnerKind: "CmdServer",
 
-				v1alpha1.AnnotationSpanID: string(spanID),
-			},
-			Labels: map[string]string{
-				v1alpha1.LabelManifest: name,
+				v1alpha1.AnnotationManifest: name,
+				v1alpha1.AnnotationSpanID:   string(spanID),
 			},
 		},
 		Spec: cmdSpec,

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -17,6 +17,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/tilt-dev/tilt/pkg/apis"
+
 	"github.com/docker/distribution/reference"
 	dockertypes "github.com/docker/docker/api/types"
 	"github.com/google/uuid"
@@ -4396,7 +4398,7 @@ func (f *testFixture) completeBuildForManifest(m model.Manifest) {
 func (f *testFixture) triggerFileChange(targetID model.TargetID, paths ...string) {
 	now := metav1.NowMicro()
 	f.store.Dispatch(fswatch.FileWatchUpdateStatusAction{
-		Name: types.NamespacedName{Name: targetID.String()},
+		Name: types.NamespacedName{Name: apis.SanitizeName(targetID.String())},
 		Status: &filewatches.FileWatchStatus{
 			LastEventTime: now.DeepCopy(),
 			FileEvents: []filewatches.FileEvent{

--- a/internal/store/logger.go
+++ b/internal/store/logger.go
@@ -39,7 +39,7 @@ func WithObjectLogHandler(ctx context.Context, st RStore, obj runtime.Object) (c
 
 	// It's ok if the manifest or span id don't exist, they will just
 	// get dumped in the global log.
-	mn := meta.GetLabels()[v1alpha1.LabelManifest]
+	mn := meta.GetAnnotations()[v1alpha1.AnnotationManifest]
 	spanID := meta.GetAnnotations()[v1alpha1.AnnotationSpanID]
 	w := apiLogWriter{
 		store:        st,

--- a/pkg/apis/core/v1alpha1/register.go
+++ b/pkg/apis/core/v1alpha1/register.go
@@ -30,12 +30,11 @@ const GroupName = "core.tilt.dev"
 
 const Version = "v1alpha1"
 
-// LabelTargetID is an internal Tilt target ID used for the build graph.
-const LabelTargetID = "tilt.dev/target-id"
+// AnnotationTargetID is an internal Tilt target ID used for the build graph.
+const AnnotationTargetID = "tilt.dev/target-id"
 
-// The label on any object that identifies which manifest
-// its logs should appear under.
-const LabelManifest = "tilt.dev/resource"
+// AnnotationManifest identifies which manifest an object's logs should appear under.
+const AnnotationManifest = "tilt.dev/resource"
 
 // An annotation on any object that identifies which span id
 // its logs should appear under.

--- a/pkg/apis/identifiers.go
+++ b/pkg/apis/identifiers.go
@@ -1,0 +1,44 @@
+package apis
+
+import (
+	"encoding/hex"
+	"hash/fnv"
+	"regexp"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/api/validation/path"
+	"k8s.io/apimachinery/pkg/util/validation"
+)
+
+const MaxNameLength = validation.DNS1123SubdomainMaxLength
+
+var invalidPathCharacters = regexp.MustCompile(`[` + strings.Join(path.NameMayNotContain, "") + `]`)
+
+// SanitizeName ensures a value is suitable for usage as an apiserver identifier.
+func SanitizeName(name string) string {
+	sanitized := name
+	if len(path.IsValidPathSegmentName(name)) != 0 {
+		for _, invalidName := range path.NameMayNotBe {
+			if name == invalidName {
+				// the only strictly invalid names are `.` and `..` so this is sufficient
+				return strings.ReplaceAll(name, ".", "_")
+			}
+		}
+		sanitized = invalidPathCharacters.ReplaceAllString(sanitized, "_")
+	}
+	if len(sanitized) > MaxNameLength {
+		var sb strings.Builder
+		sb.Grow(MaxNameLength)
+		sb.WriteString(sanitized[:MaxNameLength-9])
+		sb.WriteRune('-')
+		sb.WriteString(hashValue(name))
+		sanitized = sb.String()
+	}
+	return sanitized
+}
+
+func hashValue(v string) string {
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(v))
+	return hex.EncodeToString(h.Sum(nil))
+}

--- a/pkg/apis/identifiers_test.go
+++ b/pkg/apis/identifiers_test.go
@@ -1,0 +1,30 @@
+package apis_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/tilt-dev/tilt/pkg/apis"
+)
+
+func TestSanitizeName(t *testing.T) {
+	testCases := [][2]string{
+		{"abc123", "abc123"},
+		{"_def%456_", "_def_456_"},
+		{"$/./resource", "$_._resource"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc[0], func(t *testing.T) {
+			assert.Equal(t, tc[1], apis.SanitizeName(tc[0]))
+		})
+	}
+
+	t.Run("Max Length Exceeded", func(t *testing.T) {
+		tooLong := strings.Repeat("abc123", 50)
+		expected := tooLong[:apis.MaxNameLength-9] + "-3c8e47c5"
+		assert.Equal(t, expected, apis.SanitizeName(tooLong))
+	})
+}


### PR DESCRIPTION
  1) Use an annotation instead of label for manifest (labels have
     strict requirements, e.g. 63 char max + only alphanumeric and
     `-_.` allowed.

  2) Sanitize resource names that are for entities which cannot be
     made compliant, e.g. image refs