### PR TITLE
tests: fix engine dump on test failure

### DIFF
--- a/integration/crash_test.go
+++ b/integration/crash_test.go
@@ -4,12 +4,10 @@ package integration
 
 import (
 	"bytes"
-	"fmt"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 // Make sure that Tilt crashes if there are two tilts running on the same port.
@@ -18,13 +16,12 @@ func TestCrash(t *testing.T) {
 	defer f.TearDown()
 
 	f.TiltUp()
-	require.NotZero(t, f.activeTiltUp.port)
 	time.Sleep(500 * time.Millisecond)
 
 	out := bytes.NewBuffer(nil)
-	// explicitly pass a port argument or the integration tests will pick a random unused one, thus defeating
-	// the point of the test
-	res, err := f.tilt.Up(out, fmt.Sprintf("--port=%d", f.activeTiltUp.port))
+	// fixture assigns a random unused port when created, which is used for all Tilt commands, so this
+	// will collide with the previous invocation
+	res, err := f.tilt.Up(out)
 	assert.NoError(t, err)
 	<-res.Done()
 	assert.Contains(t, out.String(), "Tilt cannot start")

--- a/integration/fixture_test.go
+++ b/integration/fixture_test.go
@@ -52,7 +52,7 @@ func newFixture(t *testing.T, dir string) *fixture {
 		t.Fatal(err)
 	}
 
-	client := NewTiltDriver()
+	client := NewTiltDriver(t)
 	client.Environ["TILT_DISABLE_ANALYTICS"] = "true"
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/integration/fixture_test.go
+++ b/integration/fixture_test.go
@@ -52,7 +52,7 @@ func newFixture(t *testing.T, dir string) *fixture {
 		t.Fatal(err)
 	}
 
-	client := NewTiltDriver(t)
+	client := NewTiltDriver(t, TiltDriverUseRandomFreePort)
 	client.Environ["TILT_DISABLE_ANALYTICS"] = "true"
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/integration/tilt_args_test.go
+++ b/integration/tilt_args_test.go
@@ -15,15 +15,13 @@ func TestTiltArgs(t *testing.T) {
 	defer f.TearDown()
 
 	f.TiltUp("foo")
-	require.NotZero(t, f.activeTiltUp.port)
 
 	err := f.logs.WaitUntilContains("foo run", 5*time.Second)
 	require.NoError(t, err)
 
 	f.logs.Reset()
 
-	// need to explicitly pass the port number to connect to the instance launched by this test
-	err = f.tilt.Args([]string{"bar", fmt.Sprintf("--port=%d", f.activeTiltUp.port)}, f.LogWriter())
+	err = f.tilt.Args([]string{"bar"}, f.LogWriter())
 	if err != nil {
 		// Currently, Tilt starts printing logs before the webserver has bound to a port.
 		// If this happens, just sleep for a second and try again.


### PR DESCRIPTION
Randomized port assignment wasn't playing nice with this. I
simplified the port assignment so that it's part of the main Tilt
driver fixture so that all calls will use it consistently. In the
event that a test does pass `--port` as an arg, it won't include
`TILT_PORT` on the env for that call to avoid precedence issues.

Now, when `tilt dump engine` is called, it'll have the right port
via `TILT_PORT` in env, so that the engine state can be dumped.

This also (minimally) simplifies a couple tests that needed to capture
the port and explicitly pass it back for subsequent calls, either to
intentionally simulate a port conflict or to interact with the running
engine.