### PR TITLE
local: fix assorted cmd bugs

### DIFF
--- a/integration/local_resource_test.go
+++ b/integration/local_resource_test.go
@@ -30,7 +30,7 @@ func TestLocalResource(t *testing.T) {
 
 	f.TiltUp()
 
-	const barServeLogMessage = "Running serve cmd: ./hello.sh bar"
+	const barServeLogMessage = "Running cmd: ./hello.sh bar"
 	const readinessProbeSuccessMessage = `[readiness probe: success] fake probe success message`
 
 	require.NoError(t, f.logs.WaitUntilContains("hello! foo #1", 5*time.Second))

--- a/internal/controllers/core/cmd/controller_test.go
+++ b/internal/controllers/core/cmd/controller_test.go
@@ -66,6 +66,38 @@ func TestUpdate(t *testing.T) {
 	f.assertCmdCount(1)
 }
 
+func TestUpdateWithCurrentBuild(t *testing.T) {
+	f := newFixture(t)
+	defer f.teardown()
+
+	t1 := time.Unix(1, 0)
+	f.resource("foo", "true", ".", t1)
+	f.step()
+	f.assertCmdMatches("foo-serve-1", func(cmd *Cmd) bool {
+		return cmd.Status.Running != nil
+	})
+
+	f.st.WithState(func(s *store.EngineState) {
+		c := model.ToHostCmd("false")
+		localTarget := model.NewLocalTarget(model.TargetName("foo"), c, c, nil)
+		s.ManifestTargets["foo"].Manifest.DeployTarget = localTarget
+		s.ManifestTargets["foo"].State.CurrentBuild = model.BuildRecord{StartTime: time.Now()}
+	})
+
+	f.step()
+
+	assert.Never(f.t, func() bool {
+		return f.st.Cmd("foo-serve-2") != nil
+	}, 20*time.Millisecond, 5*time.Millisecond)
+
+	f.st.WithState(func(s *store.EngineState) {
+		s.ManifestTargets["foo"].State.CurrentBuild = model.BuildRecord{}
+	})
+
+	f.step()
+	f.assertCmdDeleted("foo-serve-1")
+}
+
 func TestServe(t *testing.T) {
 	f := newFixture(t)
 	defer f.teardown()
@@ -261,7 +293,7 @@ func (s *testStore) CmdCount() int {
 	defer s.RUnlockState()
 	count := 0
 	for _, cmd := range st.Cmds {
-		if cmd.DeletionTimestamp != nil {
+		if cmd.DeletionTimestamp == nil {
 			count++
 		}
 	}
@@ -384,11 +416,17 @@ func (f *fixture) resourceFromTarget(name string, target model.TargetSpec, lastD
 
 	st := f.st.LockMutableStateForTesting()
 	defer f.st.UnlockMutableState()
+
+	state := &store.ManifestState{
+		LastSuccessfulDeployTime: lastDeploy,
+	}
+	state.AddCompletedBuild(model.BuildRecord{
+		StartTime:  lastDeploy,
+		FinishTime: lastDeploy,
+	})
 	st.UpsertManifestTarget(&store.ManifestTarget{
 		Manifest: m,
-		State: &store.ManifestState{
-			LastSuccessfulDeployTime: lastDeploy,
-		},
+		State:    state,
 	})
 }
 

--- a/internal/controllers/core/cmd/execer_test.go
+++ b/internal/controllers/core/cmd/execer_test.go
@@ -248,8 +248,7 @@ func (f *processExecFixture) start(cmd string) {
 }
 
 func (f *processExecFixture) assertCmdSucceeds() {
-	f.waitForStatus(Error)
-	f.assertLogContains("exited with exit code 0")
+	f.waitForStatus(Done)
 }
 
 func (f *processExecFixture) waitForStatus(expectedStatus status) {

--- a/internal/engine/local/reducers.go
+++ b/internal/engine/local/reducers.go
@@ -3,8 +3,6 @@ package local
 import (
 	"time"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"github.com/tilt-dev/tilt/internal/store"
 	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
 	"github.com/tilt-dev/tilt/pkg/model"
@@ -97,13 +95,5 @@ func HandleCmdCreateAction(state *store.EngineState, action CmdCreateAction) {
 
 // Mark the command for deletion.
 func HandleCmdDeleteAction(state *store.EngineState, action CmdDeleteAction) {
-	cmd, ok := state.Cmds[action.Name]
-	if !ok {
-		return
-	}
-
-	updated := cmd.DeepCopy()
-	now := metav1.Now()
-	updated.ObjectMeta.DeletionTimestamp = &now
-	state.Cmds[action.Name] = updated
+	delete(state.Cmds, action.Name)
 }

--- a/internal/hud/server/controller.go
+++ b/internal/hud/server/controller.go
@@ -102,6 +102,7 @@ func (s *HeadsUpServerController) setUpHelper(ctx context.Context, st store.RSto
 	r.PathPrefix("/readyz").Handler(apiserverHandler)
 	r.PathPrefix("/swagger").Handler(apiserverHandler)
 	r.PathPrefix("/version").Handler(apiserverHandler)
+	r.PathPrefix("/debug").Handler(http.DefaultServeMux) // for /debug/pprof
 	r.PathPrefix("/").Handler(s.hudServer.Router())
 
 	s.apiServer = &http.Server{


### PR DESCRIPTION
Hello @milas,

Please review the following commits I made in branch nicks/cmdprint:

b24b9076678a25745150c8cb61088096ff1cbe84 (2021-03-17 15:21:36 -0400)
local: fix assorted cmd bugs
- expose /debug/pprof (this broke during server refactor). Useful for debugging stuck goroutines
- ensure Cmd doesn't assume we're running a server
- ensure ServerCmd doesn't start Cmd while a build command is waiting

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics