### PR TITLE
apis: simplify core.tilt.dev to tilt.dev

### DIFF
--- a/internal/hud/server/apiserver_test.go
+++ b/internal/hud/server/apiserver_test.go
@@ -107,7 +107,7 @@ func TestAPIServerTypedClient(t *testing.T) {
 		{
 			Name: "FileWatch",
 			Create: func(ctx context.Context, name string, annotations map[string]string) error {
-				_, err := clientset.CoreV1alpha1().FileWatches().Create(ctx, &v1alpha1.FileWatch{
+				_, err := clientset.TiltV1alpha1().FileWatches().Create(ctx, &v1alpha1.FileWatch{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:        name,
 						Annotations: annotations,
@@ -120,10 +120,10 @@ func TestAPIServerTypedClient(t *testing.T) {
 				return err
 			},
 			Get: func(ctx context.Context, name string) (resource.Object, error) {
-				return clientset.CoreV1alpha1().FileWatches().Get(ctx, name, metav1.GetOptions{})
+				return clientset.TiltV1alpha1().FileWatches().Get(ctx, name, metav1.GetOptions{})
 			},
 			Watch: func(ctx context.Context) (watch.Interface, error) {
-				return clientset.CoreV1alpha1().FileWatches().Watch(ctx, metav1.ListOptions{})
+				return clientset.TiltV1alpha1().FileWatches().Watch(ctx, metav1.ListOptions{})
 			},
 		},
 	}

--- a/pkg/apis/core/doc.go
+++ b/pkg/apis/core/doc.go
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 // +k8s:deepcopy-gen=package,register
-// +groupName=core.tilt.dev
+// +groupName=tilt.dev
 
 // Package api is the internal version of the API.
 package core

--- a/pkg/apis/core/v1alpha1/cmd_types.go
+++ b/pkg/apis/core/v1alpha1/cmd_types.go
@@ -108,7 +108,7 @@ func (in *Cmd) NewList() runtime.Object {
 
 func (in *Cmd) GetGroupVersionResource() schema.GroupVersionResource {
 	return schema.GroupVersionResource{
-		Group:    "core.tilt.dev",
+		Group:    "tilt.dev",
 		Version:  "v1alpha1",
 		Resource: "cmds",
 	}

--- a/pkg/apis/core/v1alpha1/doc.go
+++ b/pkg/apis/core/v1alpha1/doc.go
@@ -22,5 +22,5 @@ limitations under the License.
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=github.com/tilt-dev/tilt/pkg/apis/core
 // +k8s:defaulter-gen=TypeMeta
-// +groupName=core.tilt.dev
+// +groupName=tilt.dev
 package v1alpha1 // import "github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"

--- a/pkg/apis/core/v1alpha1/filewatch_types.go
+++ b/pkg/apis/core/v1alpha1/filewatch_types.go
@@ -91,7 +91,7 @@ func (in *FileWatch) NewList() runtime.Object {
 
 func (in *FileWatch) GetGroupVersionResource() schema.GroupVersionResource {
 	return schema.GroupVersionResource{
-		Group:    "core.tilt.dev",
+		Group:    "tilt.dev",
 		Version:  "v1alpha1",
 		Resource: "filewatches",
 	}

--- a/pkg/apis/core/v1alpha1/register.go
+++ b/pkg/apis/core/v1alpha1/register.go
@@ -26,7 +26,7 @@ import (
 )
 
 // GroupName is the group name used in this package
-const GroupName = "core.tilt.dev"
+const GroupName = "tilt.dev"
 
 const Version = "v1alpha1"
 

--- a/pkg/clientset/tiltapi/clientset.go
+++ b/pkg/clientset/tiltapi/clientset.go
@@ -25,24 +25,24 @@ import (
 	rest "k8s.io/client-go/rest"
 	flowcontrol "k8s.io/client-go/util/flowcontrol"
 
-	corev1alpha1 "github.com/tilt-dev/tilt/pkg/clientset/tiltapi/typed/core/v1alpha1"
+	tiltv1alpha1 "github.com/tilt-dev/tilt/pkg/clientset/tiltapi/typed/core/v1alpha1"
 )
 
 type Interface interface {
 	Discovery() discovery.DiscoveryInterface
-	CoreV1alpha1() corev1alpha1.CoreV1alpha1Interface
+	TiltV1alpha1() tiltv1alpha1.TiltV1alpha1Interface
 }
 
 // Clientset contains the clients for groups. Each group has exactly one
 // version included in a Clientset.
 type Clientset struct {
 	*discovery.DiscoveryClient
-	coreV1alpha1 *corev1alpha1.CoreV1alpha1Client
+	tiltV1alpha1 *tiltv1alpha1.TiltV1alpha1Client
 }
 
-// CoreV1alpha1 retrieves the CoreV1alpha1Client
-func (c *Clientset) CoreV1alpha1() corev1alpha1.CoreV1alpha1Interface {
-	return c.coreV1alpha1
+// TiltV1alpha1 retrieves the TiltV1alpha1Client
+func (c *Clientset) TiltV1alpha1() tiltv1alpha1.TiltV1alpha1Interface {
+	return c.tiltV1alpha1
 }
 
 // Discovery retrieves the DiscoveryClient
@@ -66,7 +66,7 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 	}
 	var cs Clientset
 	var err error
-	cs.coreV1alpha1, err = corev1alpha1.NewForConfig(&configShallowCopy)
+	cs.tiltV1alpha1, err = tiltv1alpha1.NewForConfig(&configShallowCopy)
 	if err != nil {
 		return nil, err
 	}
@@ -82,7 +82,7 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 // panics if there is an error in the config.
 func NewForConfigOrDie(c *rest.Config) *Clientset {
 	var cs Clientset
-	cs.coreV1alpha1 = corev1alpha1.NewForConfigOrDie(c)
+	cs.tiltV1alpha1 = tiltv1alpha1.NewForConfigOrDie(c)
 
 	cs.DiscoveryClient = discovery.NewDiscoveryClientForConfigOrDie(c)
 	return &cs
@@ -91,7 +91,7 @@ func NewForConfigOrDie(c *rest.Config) *Clientset {
 // New creates a new Clientset for the given RESTClient.
 func New(c rest.Interface) *Clientset {
 	var cs Clientset
-	cs.coreV1alpha1 = corev1alpha1.New(c)
+	cs.tiltV1alpha1 = tiltv1alpha1.New(c)
 
 	cs.DiscoveryClient = discovery.NewDiscoveryClient(c)
 	return &cs

--- a/pkg/clientset/tiltapi/fake/clientset_generated.go
+++ b/pkg/clientset/tiltapi/fake/clientset_generated.go
@@ -26,8 +26,8 @@ import (
 	"k8s.io/client-go/testing"
 
 	clientset "github.com/tilt-dev/tilt/pkg/clientset/tiltapi"
-	corev1alpha1 "github.com/tilt-dev/tilt/pkg/clientset/tiltapi/typed/core/v1alpha1"
-	fakecorev1alpha1 "github.com/tilt-dev/tilt/pkg/clientset/tiltapi/typed/core/v1alpha1/fake"
+	tiltv1alpha1 "github.com/tilt-dev/tilt/pkg/clientset/tiltapi/typed/core/v1alpha1"
+	faketiltv1alpha1 "github.com/tilt-dev/tilt/pkg/clientset/tiltapi/typed/core/v1alpha1/fake"
 )
 
 // NewSimpleClientset returns a clientset that will respond with the provided objects.
@@ -77,7 +77,7 @@ func (c *Clientset) Tracker() testing.ObjectTracker {
 
 var _ clientset.Interface = &Clientset{}
 
-// CoreV1alpha1 retrieves the CoreV1alpha1Client
-func (c *Clientset) CoreV1alpha1() corev1alpha1.CoreV1alpha1Interface {
-	return &fakecorev1alpha1.FakeCoreV1alpha1{Fake: &c.Fake}
+// TiltV1alpha1 retrieves the TiltV1alpha1Client
+func (c *Clientset) TiltV1alpha1() tiltv1alpha1.TiltV1alpha1Interface {
+	return &faketiltv1alpha1.FakeTiltV1alpha1{Fake: &c.Fake}
 }

--- a/pkg/clientset/tiltapi/fake/register.go
+++ b/pkg/clientset/tiltapi/fake/register.go
@@ -25,14 +25,14 @@ import (
 	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 
-	corev1alpha1 "github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
+	tiltv1alpha1 "github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
 )
 
 var scheme = runtime.NewScheme()
 var codecs = serializer.NewCodecFactory(scheme)
 
 var localSchemeBuilder = runtime.SchemeBuilder{
-	corev1alpha1.AddToScheme,
+	tiltv1alpha1.AddToScheme,
 }
 
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition

--- a/pkg/clientset/tiltapi/scheme/register.go
+++ b/pkg/clientset/tiltapi/scheme/register.go
@@ -25,14 +25,14 @@ import (
 	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 
-	corev1alpha1 "github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
+	tiltv1alpha1 "github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
 )
 
 var Scheme = runtime.NewScheme()
 var Codecs = serializer.NewCodecFactory(Scheme)
 var ParameterCodec = runtime.NewParameterCodec(Scheme)
 var localSchemeBuilder = runtime.SchemeBuilder{
-	corev1alpha1.AddToScheme,
+	tiltv1alpha1.AddToScheme,
 }
 
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition

--- a/pkg/clientset/tiltapi/typed/core/v1alpha1/cmd.go
+++ b/pkg/clientset/tiltapi/typed/core/v1alpha1/cmd.go
@@ -57,7 +57,7 @@ type cmds struct {
 }
 
 // newCmds returns a Cmds
-func newCmds(c *CoreV1alpha1Client) *cmds {
+func newCmds(c *TiltV1alpha1Client) *cmds {
 	return &cmds{
 		client: c.RESTClient(),
 	}

--- a/pkg/clientset/tiltapi/typed/core/v1alpha1/core_client.go
+++ b/pkg/clientset/tiltapi/typed/core/v1alpha1/core_client.go
@@ -25,27 +25,27 @@ import (
 	"github.com/tilt-dev/tilt/pkg/clientset/tiltapi/scheme"
 )
 
-type CoreV1alpha1Interface interface {
+type TiltV1alpha1Interface interface {
 	RESTClient() rest.Interface
 	CmdsGetter
 	FileWatchesGetter
 }
 
-// CoreV1alpha1Client is used to interact with features provided by the core.tilt.dev group.
-type CoreV1alpha1Client struct {
+// TiltV1alpha1Client is used to interact with features provided by the tilt.dev group.
+type TiltV1alpha1Client struct {
 	restClient rest.Interface
 }
 
-func (c *CoreV1alpha1Client) Cmds() CmdInterface {
+func (c *TiltV1alpha1Client) Cmds() CmdInterface {
 	return newCmds(c)
 }
 
-func (c *CoreV1alpha1Client) FileWatches() FileWatchInterface {
+func (c *TiltV1alpha1Client) FileWatches() FileWatchInterface {
 	return newFileWatches(c)
 }
 
-// NewForConfig creates a new CoreV1alpha1Client for the given config.
-func NewForConfig(c *rest.Config) (*CoreV1alpha1Client, error) {
+// NewForConfig creates a new TiltV1alpha1Client for the given config.
+func NewForConfig(c *rest.Config) (*TiltV1alpha1Client, error) {
 	config := *c
 	if err := setConfigDefaults(&config); err != nil {
 		return nil, err
@@ -54,12 +54,12 @@ func NewForConfig(c *rest.Config) (*CoreV1alpha1Client, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &CoreV1alpha1Client{client}, nil
+	return &TiltV1alpha1Client{client}, nil
 }
 
-// NewForConfigOrDie creates a new CoreV1alpha1Client for the given config and
+// NewForConfigOrDie creates a new TiltV1alpha1Client for the given config and
 // panics if there is an error in the config.
-func NewForConfigOrDie(c *rest.Config) *CoreV1alpha1Client {
+func NewForConfigOrDie(c *rest.Config) *TiltV1alpha1Client {
 	client, err := NewForConfig(c)
 	if err != nil {
 		panic(err)
@@ -67,9 +67,9 @@ func NewForConfigOrDie(c *rest.Config) *CoreV1alpha1Client {
 	return client
 }
 
-// New creates a new CoreV1alpha1Client for the given RESTClient.
-func New(c rest.Interface) *CoreV1alpha1Client {
-	return &CoreV1alpha1Client{c}
+// New creates a new TiltV1alpha1Client for the given RESTClient.
+func New(c rest.Interface) *TiltV1alpha1Client {
+	return &TiltV1alpha1Client{c}
 }
 
 func setConfigDefaults(config *rest.Config) error {
@@ -87,7 +87,7 @@ func setConfigDefaults(config *rest.Config) error {
 
 // RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
-func (c *CoreV1alpha1Client) RESTClient() rest.Interface {
+func (c *TiltV1alpha1Client) RESTClient() rest.Interface {
 	if c == nil {
 		return nil
 	}

--- a/pkg/clientset/tiltapi/typed/core/v1alpha1/fake/fake_cmd.go
+++ b/pkg/clientset/tiltapi/typed/core/v1alpha1/fake/fake_cmd.go
@@ -33,12 +33,12 @@ import (
 
 // FakeCmds implements CmdInterface
 type FakeCmds struct {
-	Fake *FakeCoreV1alpha1
+	Fake *FakeTiltV1alpha1
 }
 
-var cmdsResource = schema.GroupVersionResource{Group: "core.tilt.dev", Version: "v1alpha1", Resource: "cmds"}
+var cmdsResource = schema.GroupVersionResource{Group: "tilt.dev", Version: "v1alpha1", Resource: "cmds"}
 
-var cmdsKind = schema.GroupVersionKind{Group: "core.tilt.dev", Version: "v1alpha1", Kind: "Cmd"}
+var cmdsKind = schema.GroupVersionKind{Group: "tilt.dev", Version: "v1alpha1", Kind: "Cmd"}
 
 // Get takes name of the cmd, and returns the corresponding cmd object, and an error if there is any.
 func (c *FakeCmds) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1alpha1.Cmd, err error) {

--- a/pkg/clientset/tiltapi/typed/core/v1alpha1/fake/fake_core_client.go
+++ b/pkg/clientset/tiltapi/typed/core/v1alpha1/fake/fake_core_client.go
@@ -25,21 +25,21 @@ import (
 	v1alpha1 "github.com/tilt-dev/tilt/pkg/clientset/tiltapi/typed/core/v1alpha1"
 )
 
-type FakeCoreV1alpha1 struct {
+type FakeTiltV1alpha1 struct {
 	*testing.Fake
 }
 
-func (c *FakeCoreV1alpha1) Cmds() v1alpha1.CmdInterface {
+func (c *FakeTiltV1alpha1) Cmds() v1alpha1.CmdInterface {
 	return &FakeCmds{c}
 }
 
-func (c *FakeCoreV1alpha1) FileWatches() v1alpha1.FileWatchInterface {
+func (c *FakeTiltV1alpha1) FileWatches() v1alpha1.FileWatchInterface {
 	return &FakeFileWatches{c}
 }
 
 // RESTClient returns a RESTClient that is used to communicate
 // with API server by this client implementation.
-func (c *FakeCoreV1alpha1) RESTClient() rest.Interface {
+func (c *FakeTiltV1alpha1) RESTClient() rest.Interface {
 	var ret *rest.RESTClient
 	return ret
 }

--- a/pkg/clientset/tiltapi/typed/core/v1alpha1/fake/fake_filewatch.go
+++ b/pkg/clientset/tiltapi/typed/core/v1alpha1/fake/fake_filewatch.go
@@ -33,12 +33,12 @@ import (
 
 // FakeFileWatches implements FileWatchInterface
 type FakeFileWatches struct {
-	Fake *FakeCoreV1alpha1
+	Fake *FakeTiltV1alpha1
 }
 
-var filewatchesResource = schema.GroupVersionResource{Group: "core.tilt.dev", Version: "v1alpha1", Resource: "filewatches"}
+var filewatchesResource = schema.GroupVersionResource{Group: "tilt.dev", Version: "v1alpha1", Resource: "filewatches"}
 
-var filewatchesKind = schema.GroupVersionKind{Group: "core.tilt.dev", Version: "v1alpha1", Kind: "FileWatch"}
+var filewatchesKind = schema.GroupVersionKind{Group: "tilt.dev", Version: "v1alpha1", Kind: "FileWatch"}
 
 // Get takes name of the fileWatch, and returns the corresponding fileWatch object, and an error if there is any.
 func (c *FakeFileWatches) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1alpha1.FileWatch, err error) {

--- a/pkg/clientset/tiltapi/typed/core/v1alpha1/filewatch.go
+++ b/pkg/clientset/tiltapi/typed/core/v1alpha1/filewatch.go
@@ -57,7 +57,7 @@ type fileWatches struct {
 }
 
 // newFileWatches returns a FileWatches
-func newFileWatches(c *CoreV1alpha1Client) *fileWatches {
+func newFileWatches(c *TiltV1alpha1Client) *fileWatches {
 	return &fileWatches{
 		client: c.RESTClient(),
 	}

--- a/pkg/informers/externalversions/core/v1alpha1/cmd.go
+++ b/pkg/informers/externalversions/core/v1alpha1/cmd.go
@@ -62,13 +62,13 @@ func NewFilteredCmdInformer(client tiltapi.Interface, resyncPeriod time.Duration
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.CoreV1alpha1().Cmds().List(context.TODO(), options)
+				return client.TiltV1alpha1().Cmds().List(context.TODO(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.CoreV1alpha1().Cmds().Watch(context.TODO(), options)
+				return client.TiltV1alpha1().Cmds().Watch(context.TODO(), options)
 			},
 		},
 		&corev1alpha1.Cmd{},

--- a/pkg/informers/externalversions/core/v1alpha1/filewatch.go
+++ b/pkg/informers/externalversions/core/v1alpha1/filewatch.go
@@ -62,13 +62,13 @@ func NewFilteredFileWatchInformer(client tiltapi.Interface, resyncPeriod time.Du
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.CoreV1alpha1().FileWatches().List(context.TODO(), options)
+				return client.TiltV1alpha1().FileWatches().List(context.TODO(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.CoreV1alpha1().FileWatches().Watch(context.TODO(), options)
+				return client.TiltV1alpha1().FileWatches().Watch(context.TODO(), options)
 			},
 		},
 		&corev1alpha1.FileWatch{},

--- a/pkg/informers/externalversions/factory.go
+++ b/pkg/informers/externalversions/factory.go
@@ -173,9 +173,9 @@ type SharedInformerFactory interface {
 	ForResource(resource schema.GroupVersionResource) (GenericInformer, error)
 	WaitForCacheSync(stopCh <-chan struct{}) map[reflect.Type]bool
 
-	Core() core.Interface
+	Tilt() core.Interface
 }
 
-func (f *sharedInformerFactory) Core() core.Interface {
+func (f *sharedInformerFactory) Tilt() core.Interface {
 	return core.New(f, f.namespace, f.tweakListOptions)
 }

--- a/pkg/informers/externalversions/generic.go
+++ b/pkg/informers/externalversions/generic.go
@@ -53,11 +53,11 @@ func (f *genericInformer) Lister() cache.GenericLister {
 // TODO extend this to unknown resources with a client pool
 func (f *sharedInformerFactory) ForResource(resource schema.GroupVersionResource) (GenericInformer, error) {
 	switch resource {
-	// Group=core.tilt.dev, Version=v1alpha1
+	// Group=tilt.dev, Version=v1alpha1
 	case v1alpha1.SchemeGroupVersion.WithResource("cmds"):
-		return &genericInformer{resource: resource.GroupResource(), informer: f.Core().V1alpha1().Cmds().Informer()}, nil
+		return &genericInformer{resource: resource.GroupResource(), informer: f.Tilt().V1alpha1().Cmds().Informer()}, nil
 	case v1alpha1.SchemeGroupVersion.WithResource("filewatches"):
-		return &genericInformer{resource: resource.GroupResource(), informer: f.Core().V1alpha1().FileWatches().Informer()}, nil
+		return &genericInformer{resource: resource.GroupResource(), informer: f.Tilt().V1alpha1().FileWatches().Informer()}, nil
 
 	}
 

--- a/scripts/api-new-type-boilerplate.go.txt
+++ b/scripts/api-new-type-boilerplate.go.txt
@@ -76,7 +76,7 @@ func (in *Manifest) NewList() runtime.Object {
 
 func (in *Manifest) GetGroupVersionResource() schema.GroupVersionResource {
 	return schema.GroupVersionResource{
-		Group:    "core.tilt.dev",
+		Group:    "tilt.dev",
 		Version:  "v1alpha1",
 		Resource: "manifests",
 	}


### PR DESCRIPTION
Hello @milas,

Please review the following commits I made in branch nicks/core:

ea17be0fccfe83fe4df7784cc0d3d10b42747a1b (2021-03-17 16:08:45 -0400)
apis: simplify core.tilt.dev to tilt.dev

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics