### PR TITLE
test: make the integration tests more verbose

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,7 +90,10 @@ jobs:
       - run: echo 'export PATH=/go/bin:$PATH' >> $BASH_ENV
       - setup_remote_docker:
           version: 19.03.12
-      - run: ctlptl create cluster kind --registry=ctlptl-registry && make integration
+      - run: |
+          set -ex
+          ctlptl create cluster kind --registry=ctlptl-registry
+          exec make integration
       - store_test_results:
           path: test-results
       - slack/notify-on-failure:

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ ifneq ($(CIRCLECI),true)
 		go test -mod vendor -v -count 1 -p $(GO_PARALLEL_JOBS) -tags 'integration' -timeout 700s ./integration
 else
 		mkdir -p test-results
-		gotestsum --format standard-quiet --junitfile test-results/unit-tests.xml -- ./integration -mod vendor -count 1 -p $(GO_PARALLEL_JOBS) -tags 'integration' -timeout 700s
+		gotestsum --format standard-verbose --junitfile test-results/unit-tests.xml -- ./integration -mod vendor -count 1 -p $(GO_PARALLEL_JOBS) -tags 'integration' -timeout 700s
 endif
 
 # Run the integration tests on kind


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/verbose:

5480a49b0e1fdc19a698e068652b105fd5fbad98 (2021-03-17 16:38:59 -0400)
test: make the integration tests more verbose
circleci is killing them because they run a long time without printing anything

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics