### PR TITLE
integration: use --format dots

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,10 +57,10 @@ shorttest:
 
 shorttestsum:
 ifneq ($(CIRCLECI),true)
-	gotestsum --format dots -- -mod vendor -p $(GO_PARALLEL_JOBS) -tags skipcontainertests,skiplargetiltfiletests -timeout 60s ./...
+	gotestsum -- -mod vendor -p $(GO_PARALLEL_JOBS) -tags skipcontainertests,skiplargetiltfiletests -timeout 60s ./...
 else
 	mkdir -p test-results
-	gotestsum --format dots --junitfile test-results/unit-tests.xml -- ./... -mod vendor -count 1 -p $(GO_PARALLEL_JOBS) -tags skipcontainertests,skiplargetiltfiletests -timeout 60s
+	gotestsum --format standard-quiet --junitfile test-results/unit-tests.xml -- ./... -mod vendor -count 1 -p $(GO_PARALLEL_JOBS) -tags skipcontainertests,skiplargetiltfiletests -timeout 60s
 endif
 
 integration:

--- a/Makefile
+++ b/Makefile
@@ -57,10 +57,10 @@ shorttest:
 
 shorttestsum:
 ifneq ($(CIRCLECI),true)
-	gotestsum -- -mod vendor -p $(GO_PARALLEL_JOBS) -tags skipcontainertests,skiplargetiltfiletests -timeout 60s ./...
+	gotestsum --format dots -- -mod vendor -p $(GO_PARALLEL_JOBS) -tags skipcontainertests,skiplargetiltfiletests -timeout 60s ./...
 else
 	mkdir -p test-results
-	gotestsum --format standard-quiet --junitfile test-results/unit-tests.xml -- ./... -mod vendor -count 1 -p $(GO_PARALLEL_JOBS) -tags skipcontainertests,skiplargetiltfiletests -timeout 60s
+	gotestsum --format dots --junitfile test-results/unit-tests.xml -- ./... -mod vendor -count 1 -p $(GO_PARALLEL_JOBS) -tags skipcontainertests,skiplargetiltfiletests -timeout 60s
 endif
 
 integration:
@@ -68,7 +68,7 @@ ifneq ($(CIRCLECI),true)
 		go test -mod vendor -v -count 1 -p $(GO_PARALLEL_JOBS) -tags 'integration' -timeout 700s ./integration
 else
 		mkdir -p test-results
-		gotestsum --format standard-quiet --junitfile test-results/unit-tests.xml -- ./integration -mod vendor -count 1 -p $(GO_PARALLEL_JOBS) -tags 'integration' -timeout 700s
+		gotestsum --format dots --junitfile test-results/unit-tests.xml -- ./integration -mod vendor -count 1 -p $(GO_PARALLEL_JOBS) -tags 'integration' -timeout 700s
 endif
 
 # Run the integration tests on kind

--- a/internal/analytics/tilt_analytics_test.go
+++ b/internal/analytics/tilt_analytics_test.go
@@ -76,7 +76,7 @@ func TestIncr(t *testing.T) {
 					N:    1,
 				})
 			}
-			assert.Equal(t, expectedCounts, ma.Counts)
+			assert.Equal(t, nil, ma.Counts)
 		})
 	}
 }

--- a/internal/analytics/tilt_analytics_test.go
+++ b/internal/analytics/tilt_analytics_test.go
@@ -76,7 +76,7 @@ func TestIncr(t *testing.T) {
 					N:    1,
 				})
 			}
-			assert.Equal(t, nil, ma.Counts)
+			assert.Equal(t, expectedCounts, ma.Counts)
 		})
 	}
 }


### PR DESCRIPTION
### Problem

The integration CI job is failing with `Too long with no output (exceeded 10m0s): context deadline exceeded`
(circle ci page for this error is [here](https://support.circleci.com/hc/en-us/articles/360045268074-Build-Fails-with-Too-long-with-no-output-exceeded-10m0s-context-deadline-exceeded-))

### Solution

Run `gotestsum` with `--format dots`, which prints a dot every time it runs a test, and also prints stdout from failed tests at the end.