### PR TITLE
cli: updog accepts configs as input

### DIFF
--- a/internal/cli/updog-examples/hello-world.yaml
+++ b/internal/cli/updog-examples/hello-world.yaml
@@ -1,0 +1,7 @@
+apiVersion: tilt.dev/v1alpha1
+kind: Cmd
+metadata:
+  name: hello-world
+spec:
+  args: ["echo", "hello world"]
+

--- a/internal/cli/visitor/decode.go
+++ b/internal/cli/visitor/decode.go
@@ -1,0 +1,74 @@
+package visitor
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+
+	"github.com/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/yaml"
+)
+
+// Given a set of YAML inputs, decode them into real API objects.
+//
+// The scheme is used to lookup the objects by group/version/kind.
+func DecodeAll(scheme *runtime.Scheme, vs []Interface) ([]runtime.Object, error) {
+	result := []runtime.Object{}
+	for _, v := range vs {
+		objs, err := Decode(scheme, v)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, objs...)
+	}
+	return result, nil
+}
+
+func Decode(scheme *runtime.Scheme, v Interface) ([]runtime.Object, error) {
+	r, err := v.Open()
+	if err != nil {
+		return nil, err
+	}
+	defer r.Close()
+
+	result, err := ParseStream(scheme, r)
+	if err != nil {
+		return nil, errors.Wrapf(err, "visiting %s", v.Name())
+	}
+	return result, nil
+}
+
+func ParseStream(scheme *runtime.Scheme, r io.Reader) ([]runtime.Object, error) {
+	var current bytes.Buffer
+	reader := io.TeeReader(bufio.NewReader(r), &current)
+
+	objDecoder := yaml.NewYAMLOrJSONDecoder(&current, 4096)
+	typeDecoder := yaml.NewYAMLOrJSONDecoder(reader, 4096)
+	result := []runtime.Object{}
+	for {
+		tm := metav1.TypeMeta{}
+		if err := typeDecoder.Decode(&tm); err != nil {
+			if err == io.EOF {
+				break
+			}
+			return nil, err
+		}
+
+		obj, err := scheme.New(tm.GroupVersionKind())
+		if err != nil {
+			return nil, err
+		}
+
+		if err := objDecoder.Decode(obj); err != nil {
+			if err == io.EOF {
+				break
+			}
+			return nil, errors.Wrapf(err, "decoding %s", tm)
+		}
+
+		result = append(result, obj)
+	}
+	return result, nil
+}

--- a/internal/cli/visitor/strings.go
+++ b/internal/cli/visitor/strings.go
@@ -1,0 +1,34 @@
+package visitor
+
+import (
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+// Convert a list of filenames into YAML inputs.
+func FromStrings(filenames []string, stdin io.Reader) ([]Interface, error) {
+	result := []Interface{}
+	for _, f := range filenames {
+
+		switch {
+		case f == "-":
+			result = append(result, Stdin(stdin))
+
+		case strings.Index(f, "http://") == 0 || strings.Index(f, "https://") == 0:
+			url, err := url.Parse(f)
+			if err != nil {
+				return nil, errors.Wrapf(err, "invalid URL %s", url)
+			}
+			result = append(result, URL(http.DefaultClient, f))
+
+		default:
+			result = append(result, File(f))
+
+		}
+	}
+	return result, nil
+}

--- a/internal/cli/visitor/visitor.go
+++ b/internal/cli/visitor/visitor.go
@@ -1,0 +1,87 @@
+package visitor
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+)
+
+// A simplified version of cli-runtime/pkg/resource Visitor
+// for objects that don't query the cluster.
+type Interface interface {
+	Name() string
+	Open() (io.ReadCloser, error)
+}
+
+func Stdin(stdin io.Reader) stdinVisitor {
+	return stdinVisitor{reader: stdin}
+}
+
+type noOpCloseReader struct {
+	io.Reader
+}
+
+func (noOpCloseReader) Close() error { return nil }
+
+type stdinVisitor struct {
+	reader io.Reader
+}
+
+func (v stdinVisitor) Name() string {
+	return "stdin"
+}
+
+func (v stdinVisitor) Open() (io.ReadCloser, error) {
+	return noOpCloseReader{Reader: v.reader}, nil
+}
+
+var _ Interface = stdinVisitor{}
+
+func File(path string) fileVisitor {
+	return fileVisitor{path: path}
+}
+
+type fileVisitor struct {
+	path string
+}
+
+func (v fileVisitor) Name() string {
+	return v.path
+}
+
+func (v fileVisitor) Open() (io.ReadCloser, error) {
+	return os.Open(v.path)
+}
+
+var _ Interface = urlVisitor{}
+
+type HTTPClient interface {
+	Get(url string) (*http.Response, error)
+}
+
+func URL(client HTTPClient, url string) urlVisitor {
+	return urlVisitor{client: client, url: url}
+}
+
+type urlVisitor struct {
+	client HTTPClient
+	url    string
+}
+
+func (v urlVisitor) Name() string {
+	return v.url
+}
+
+func (v urlVisitor) Open() (io.ReadCloser, error) {
+	resp, err := v.client.Get(v.url)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("fetch(%q) failed with status code %d", v.url, resp.StatusCode)
+	}
+	return resp.Body, nil
+}
+
+var _ Interface = urlVisitor{}


### PR DESCRIPTION
Hello @milas, @maiamcc,

Please review the following commits I made in branch nicks/ch11531:

8ebac2d998e128c63f5d596e682676639fd89771 (2021-03-17 17:32:21 -0400)
cli: updog accepts configs as input
Most of the input-decoding code here is loosely adapted from ctlptl and
not super great. We should probably clean it up at some point and move
it into a common package.

kubectl's input parsing code is much more complicated because it needs to
discover types from the server before parsing anything

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics