### PR TITLE
engine: add a workaround for live-update race condition

### DIFF
--- a/internal/engine/fswatch/action.go
+++ b/internal/engine/fswatch/action.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -130,9 +131,28 @@ func processFileWatchStatus(ctx context.Context, state *store.EngineState, fw *f
 	} else if targetID.Empty() {
 		return
 	}
+
+	// NOTE(nick): BuildController uses these timestamps to determine which files
+	// to clear after a build. In particular, it:
+	//
+	// 1) Grabs the pending files
+	// 2) Runs a live update
+	// 3) Clears the pending files with timestamps before the live update started.
+	//
+	// Here's the race condition: suppose a file changes, but it doesn't get into
+	// the EngineState until after step (2). That means step (3) will clear the file
+	// even though it wasn't live-updated properly. Because as far as we can tell,
+	// the file must have been in the EngineState before the build started.
+	//
+	// Ideally, BuildController should be do more bookkeeping to keep track of
+	// which files it consumed from which FileWatches. But we're changing
+	// this architecture anyway. For now, we record the time it got into
+	// the EngineState, rather than the time it was originally changed.
+	now := time.Now()
+
 	if targetID.Type == model.TargetTypeConfigs {
 		for _, f := range latestEvent.SeenFiles {
-			state.PendingConfigFileChanges[f] = latestEvent.Time.Time
+			state.PendingConfigFileChanges[f] = now
 		}
 		return
 	}
@@ -146,7 +166,7 @@ func processFileWatchStatus(ctx context.Context, state *store.EngineState, fw *f
 
 		status := ms.MutableBuildStatus(targetID)
 		for _, f := range latestEvent.SeenFiles {
-			status.PendingFileChanges[f] = latestEvent.Time.Time
+			status.PendingFileChanges[f] = now
 		}
 	}
 }


### PR DESCRIPTION
Hello @milas,

Please review the following commits I made in branch nicks/race:

e9a97ceefd3c48d4d2e1a37e7b1f9388f33251ff (2021-03-18 09:30:23 -0400)
engine: add a workaround for live-update race condition
This isn't great, but i think will let us move forward with
a better architecture without too much grief.

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics