### PR TITLE
tests: add explicit dump engine call to an integration test

### DIFF
--- a/integration/oneup_test.go
+++ b/integration/oneup_test.go
@@ -3,9 +3,12 @@
 package integration
 
 import (
+	"bytes"
 	"context"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestOneUp(t *testing.T) {
@@ -28,4 +31,9 @@ func TestOneUp(t *testing.T) {
 	ctx, cancel = context.WithTimeout(f.ctx, time.Minute)
 	defer cancel()
 	f.CurlUntil(ctx, "http://localhost:31234", "🍄 One-Up! 🍄")
+
+	// minimal sanity check that the engine dump works - this really just ensures that there's no egregious
+	// serialization issues
+	var b bytes.Buffer
+	assert.NoErrorf(t, f.tilt.DumpEngine(&b), "Failed to dump engine state, command output:\n%s", b.String())
 }


### PR DESCRIPTION
Currently, the integration tests (try to) invoke an engine dump
on failure to give state for debugging purposes.

We had a regression recently (#4318), however, where the engine dump
command was completely non-functional due to a serialization
issue. This adds an explicit call to dump the engine in one of
the tests which will catch any total breakage like this. It's
not a comprehensive test of the actual output of the engine
dump (though the CLI command ensures it's valid JSON), but
that's okay because the API of it is not stable and we're
moving away from it towards a stable interface for this type
of introspection via apiserver.