### PR TITLE
scripts: codegen helper portability tweaks

### DIFF
--- a/scripts/api-new-type.sh
+++ b/scripts/api-new-type.sh
@@ -19,7 +19,7 @@ fi
 # where the first is used in YAML and the second is used in HTTP endpoints
 #
 # shellcheck disable=SC2001
-TYPE_NAME_LOWER=$(echo "$TYPE_NAME" | sed -e 's/^\(.*\)$/\L\1/g')
+TYPE_NAME_LOWER=$(echo "$TYPE_NAME" | awk '{print tolower($0)}')
 if [[ "$TYPE_NAME" == "$TYPE_NAME_LOWER" ]]; then
     echo "Error: type name must be uppercase"
     exit 1

--- a/scripts/update-codegen-helper.sh
+++ b/scripts/update-codegen-helper.sh
@@ -18,7 +18,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-if [[ "$CODEGEN_USER" != "" ]]; then
+if [[ -n "${CODEGEN_USER-}" ]]; then
     useradd "$CODEGEN_USER"
 fi
 
@@ -50,7 +50,7 @@ bash "${CODEGEN_PKG}/generate-internal-groups.sh" "deepcopy,defaulter,openapi" \
   --output-base "$(dirname "${BASH_SOURCE[0]}")/../../../.." \
   --go-header-file "${SCRIPT_ROOT}/hack/boilerplate.go.txt"
 
-if [[ "$CODEGEN_USER" != "" ]]; then
+if [[ -n "${CODEGEN_USER-}" ]]; then
     chown "$CODEGEN_USER" -R pkg/clientset
     chown "$CODEGEN_USER" -R pkg/informers
     chown "$CODEGEN_USER" -R pkg/listers


### PR DESCRIPTION
1) BSD sed (by default on macOS) doesn't support `\L` so just use
   `awk` which should work on anything remotely POSIX-y

2) Codegen script has `nounset` so need to check if variables are
   defined in a very particular way to make Bash happy


(I have been using the `update-codegen-helper.sh` script directly after installing recent Bash via Homebrew because the Dockerized version takes 10+ mins - I found an issue at some point about its slowness which is apparently due to running `go list` an excessive number of times.)