### PR TITLE
store: track changed pods OnChange, and only re-run pod streamer on pod change

### DIFF
--- a/internal/engine/k8swatch/actions.go
+++ b/internal/engine/k8swatch/actions.go
@@ -7,6 +7,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/tilt-dev/tilt/internal/k8s"
+	"github.com/tilt-dev/tilt/internal/store"
 	"github.com/tilt-dev/tilt/pkg/model"
 )
 
@@ -19,7 +20,13 @@ type PodChangeAction struct {
 	MatchedAncestorUID types.UID
 }
 
+var _ store.Summarizer = PodChangeAction{}
+
 func (PodChangeAction) Action() {}
+
+func (a PodChangeAction) Summarize(s *store.ChangeSummary) {
+	s.Pods.Add(types.NamespacedName{Name: string(a.Pod.Name), Namespace: string(a.Pod.Namespace)})
+}
 
 func NewPodChangeAction(pod *v1.Pod, mn model.ManifestName, matchedAncestorUID types.UID) PodChangeAction {
 	return PodChangeAction{
@@ -34,7 +41,13 @@ type PodDeleteAction struct {
 	Namespace k8s.Namespace
 }
 
+var _ store.Summarizer = PodDeleteAction{}
+
 func (PodDeleteAction) Action() {}
+
+func (a PodDeleteAction) Summarize(s *store.ChangeSummary) {
+	s.Pods.Add(types.NamespacedName{Name: string(a.PodID), Namespace: string(a.Namespace)})
+}
 
 func NewPodDeleteAction(podID k8s.PodID, namespace k8s.Namespace) PodDeleteAction {
 	return PodDeleteAction{

--- a/internal/engine/runtimelog/podlogmanager.go
+++ b/internal/engine/runtimelog/podlogmanager.go
@@ -196,7 +196,11 @@ func (m *PodLogManager) shouldStreamContainerLogs(c store.Container, key podLogK
 
 }
 
-func (m *PodLogManager) OnChange(ctx context.Context, st store.RStore, _ store.ChangeSummary) {
+func (m *PodLogManager) OnChange(ctx context.Context, st store.RStore, summary store.ChangeSummary) {
+	if len(summary.Pods.Changes) == 0 {
+		return
+	}
+
 	setup, teardown := m.diff(ctx, st)
 	for _, watch := range teardown {
 		watch.cancel()

--- a/internal/engine/runtimelog/podlogmanager_test.go
+++ b/internal/engine/runtimelog/podlogmanager_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/tilt-dev/tilt/internal/testutils/manifestutils"
 
@@ -43,7 +44,7 @@ func TestLogs(t *testing.T) {
 		model.Manifest{Name: "server"}, p))
 	f.store.UnlockMutableState()
 
-	f.plm.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
+	f.plm.OnChange(f.ctx, f.store, podChange(podID))
 	f.AssertOutputContains("hello world!")
 	assert.Equal(t, start, f.kClient.LastPodLogStartTime)
 }
@@ -64,7 +65,7 @@ func TestLogActions(t *testing.T) {
 		model.Manifest{Name: "server"}, p))
 	f.store.UnlockMutableState()
 
-	f.plm.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
+	f.plm.OnChange(f.ctx, f.store, podChange(podID))
 	f.ConsumeLogActionsUntil("hello world!")
 }
 
@@ -84,7 +85,7 @@ func TestLogsFailed(t *testing.T) {
 		model.Manifest{Name: "server"}, p))
 	f.store.UnlockMutableState()
 
-	f.plm.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
+	f.plm.OnChange(f.ctx, f.store, podChange(podID))
 	f.AssertOutputContains("Error streaming server logs")
 	assert.Contains(t, f.out.String(), "my-error")
 }
@@ -105,13 +106,13 @@ func TestLogsCanceledUnexpectedly(t *testing.T) {
 		model.Manifest{Name: "server"}, p))
 	f.store.UnlockMutableState()
 
-	f.plm.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
+	f.plm.OnChange(f.ctx, f.store, podChange(podID))
 	f.AssertOutputContains("hello world!\n")
 
 	// Previous log stream has finished, so the first pod watch has been canceled,
 	// but not cleaned up; check that we start a new watch .OnChange
 	f.kClient.SetLogsForPodContainer(podID, cName, "goodbye world!\n")
-	f.plm.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
+	f.plm.OnChange(f.ctx, f.store, podChange(podID))
 	f.AssertOutputContains("goodbye world!\n")
 }
 
@@ -135,7 +136,7 @@ func TestMultiContainerLogs(t *testing.T) {
 		model.Manifest{Name: "server"}, p))
 	f.store.UnlockMutableState()
 
-	f.plm.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
+	f.plm.OnChange(f.ctx, f.store, podChange(podID))
 	f.AssertOutputContains("hello world!")
 	f.AssertOutputContains("goodbye world!")
 }
@@ -179,7 +180,7 @@ func TestContainerPrefixes(t *testing.T) {
 		podSingleC))
 	f.store.UnlockMutableState()
 
-	f.plm.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
+	f.plm.OnChange(f.ctx, f.store, podChange(podID))
 
 	// Make sure we have expected logs
 	f.AssertOutputContains("hello world!")
@@ -213,8 +214,8 @@ func TestTerminatedContainerLogs(t *testing.T) {
 
 	// Fire OnChange twice, because we used to have a bug where
 	// we'd immediately teardown the log watch on the terminated container.
-	f.plm.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
-	f.plm.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
+	f.plm.OnChange(f.ctx, f.store, podChange(podID))
+	f.plm.OnChange(f.ctx, f.store, podChange(podID))
 
 	f.AssertOutputContains("hello world!")
 
@@ -222,7 +223,7 @@ func TestTerminatedContainerLogs(t *testing.T) {
 	// closes the log stream.
 	f.kClient.SetLogsForPodContainer(podID, cName, "hello world!\ngoodbye world!\n")
 
-	f.plm.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
+	f.plm.OnChange(f.ctx, f.store, podChange(podID))
 	f.AssertOutputContains("hello world!")
 	f.AssertOutputDoesNotContain("goodbye world!")
 }
@@ -262,7 +263,7 @@ func TestLogReconnection(t *testing.T) {
 		state.TiltStartTime = startTime
 	})
 
-	f.plm.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
+	f.plm.OnChange(f.ctx, f.store, podChange(podID))
 
 	_, _ = writer.Write([]byte("hello world!"))
 	f.AssertOutputContains("hello world!")
@@ -330,7 +331,7 @@ func TestInitContainerLogs(t *testing.T) {
 	f.kClient.SetLogsForPodContainer(podID, cNameInit, "init world!")
 	f.kClient.SetLogsForPodContainer(podID, cNameNormal, "hello world!")
 
-	f.plm.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
+	f.plm.OnChange(f.ctx, f.store, podChange(podID))
 
 	f.AssertOutputContains(cNameInit.String())
 	f.AssertOutputContains("init world!")
@@ -367,10 +368,16 @@ func TestIstioContainerLogs(t *testing.T) {
 	f.kClient.SetLogsForPodContainer(podID, istioSidecar, "hello istio!")
 	f.kClient.SetLogsForPodContainer(podID, cNormal, "hello world!")
 
-	f.plm.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
+	f.plm.OnChange(f.ctx, f.store, podChange(podID))
 
 	f.AssertOutputDoesNotContain("istio")
 	f.AssertOutputContains("hello world!")
+}
+
+func podChange(podID k8s.PodID) store.ChangeSummary {
+	return store.ChangeSummary{
+		Pods: store.NewChangeSet(types.NamespacedName{Name: string(podID)}),
+	}
 }
 
 type plmStore struct {

--- a/internal/store/summary.go
+++ b/internal/store/summary.go
@@ -53,6 +53,9 @@ type ChangeSummary struct {
 
 	// FileWatches with their specs changed.
 	FileWatchSpecs ChangeSet
+
+	// Pods that have changed.
+	Pods ChangeSet
 }
 
 func (s ChangeSummary) IsLogOnly() bool {
@@ -64,6 +67,7 @@ func (s *ChangeSummary) Add(other ChangeSummary) {
 	s.Log = s.Log || other.Log
 	s.CmdSpecs.AddAll(other.CmdSpecs)
 	s.FileWatchSpecs.AddAll(other.FileWatchSpecs)
+	s.Pods.AddAll(other.Pods)
 }
 
 func LegacyChangeSummary() ChangeSummary {


### PR DESCRIPTION
Hello @milas, @maiamcc,

Please review the following commits I made in branch nicks/pod:

2063683d7308b4bd4d3fa2d14ddbee6b83197e95 (2021-03-23 16:38:02 -0400)
store: track changed pods OnChange, and only re-run pod streamer on pod change

a5863f724d2cdbbf74728e5d2c718d4d243d0aae (2021-03-23 16:02:21 -0400)
store: simplify the summary api a bit

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics