### PR TITLE
k8s: remove ability to watch all namespaces

### DIFF
--- a/internal/engine/k8swatch/pod_watch.go
+++ b/internal/engine/k8swatch/pod_watch.go
@@ -118,7 +118,7 @@ func (w *PodWatcher) OnChange(ctx context.Context, st store.RStore, _ store.Chan
 }
 
 func (w *PodWatcher) setupWatch(ctx context.Context, st store.RStore, ns k8s.Namespace) {
-	ch, err := w.kCli.WatchPods(ctx, ns, labels.Everything())
+	ch, err := w.kCli.WatchPods(ctx, ns)
 	if err != nil {
 		err = errors.Wrapf(err, "Error watching pods. Are you connected to kubernetes?\nTry running `kubectl get pods -n %q`", ns)
 		st.Dispatch(store.NewErrorAction(err))

--- a/internal/engine/k8swatch/service_watch.go
+++ b/internal/engine/k8swatch/service_watch.go
@@ -66,7 +66,7 @@ func (w *ServiceWatcher) OnChange(ctx context.Context, st store.RStore, _ store.
 }
 
 func (w *ServiceWatcher) setupWatch(ctx context.Context, st store.RStore, ns k8s.Namespace) {
-	ch, err := w.kCli.WatchServices(ctx, ns, k8s.ManagedByTiltSelector())
+	ch, err := w.kCli.WatchServices(ctx, ns)
 	if err != nil {
 		err = errors.Wrapf(err, "Error watching services. Are you connected to kubernetes?\nTry running `kubectl get services -n %q`", ns)
 		st.Dispatch(store.NewErrorAction(err))

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -17,7 +17,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/validation"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/version"
 	"k8s.io/apimachinery/pkg/watch"
@@ -104,9 +103,9 @@ type Client interface {
 	//
 	// Over time, we want to remove the ability to watch all namespaces
 	// https://github.com/tilt-dev/tilt/issues/3792
-	WatchPods(ctx context.Context, ns Namespace, lps labels.Selector) (<-chan ObjectUpdate, error)
+	WatchPods(ctx context.Context, ns Namespace) (<-chan ObjectUpdate, error)
 
-	WatchServices(ctx context.Context, ns Namespace, lps labels.Selector) (<-chan *v1.Service, error)
+	WatchServices(ctx context.Context, ns Namespace) (<-chan *v1.Service, error)
 
 	WatchEvents(ctx context.Context, ns Namespace) (<-chan *v1.Event, error)
 

--- a/internal/k8s/exploding_client.go
+++ b/internal/k8s/exploding_client.go
@@ -8,7 +8,6 @@ import (
 	"github.com/docker/distribution/reference"
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/watch"
 
@@ -62,11 +61,11 @@ func (ec *explodingClient) CreatePortForwarder(ctx context.Context, namespace Na
 	return nil, errors.Wrap(ec.err, "could not set up k8s client")
 }
 
-func (ec *explodingClient) WatchPods(ctx context.Context, ns Namespace, lps labels.Selector) (<-chan ObjectUpdate, error) {
+func (ec *explodingClient) WatchPods(ctx context.Context, ns Namespace) (<-chan ObjectUpdate, error) {
 	return nil, errors.Wrap(ec.err, "could not set up k8s client")
 }
 
-func (ec *explodingClient) WatchServices(ctx context.Context, ns Namespace, lps labels.Selector) (<-chan *v1.Service, error) {
+func (ec *explodingClient) WatchServices(ctx context.Context, ns Namespace) (<-chan *v1.Service, error) {
 	return nil, errors.Wrap(ec.err, "could not set up k8s client")
 }
 


### PR DESCRIPTION
Hello @landism, @maiamcc,

Please review the following commits I made in branch nicks/namespace:

6ed82b7cbea44d6b648804a7ed7b2196d049cdc8 (2021-03-24 18:16:01 -0400)
k8s: remove ability to watch all namespaces

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics