### PR TITLE
engine: remove apply mode (--watch=false remnants)

### DIFF
--- a/internal/engine/dcwatch/event_watcher.go
+++ b/internal/engine/dcwatch/event_watcher.go
@@ -26,14 +26,8 @@ func NewEventWatcher(dcc dockercompose.DockerComposeClient, docker docker.LocalC
 	}
 }
 
-func (w *EventWatcher) needsWatch(st store.RStore) bool {
-	state := st.RLockState()
-	defer st.RUnlockState()
-	return state.EngineMode.WatchesRuntime() && !w.watching
-}
-
 func (w *EventWatcher) OnChange(ctx context.Context, st store.RStore, _ store.ChangeSummary) {
-	if !w.needsWatch(st) {
+	if !w.watching {
 		return
 	}
 

--- a/internal/engine/k8swatch/watcher.go
+++ b/internal/engine/k8swatch/watcher.go
@@ -51,17 +51,15 @@ func (ks *watcherKnownState) createTaskList(state store.EngineState) watcherTask
 
 		name := mt.Manifest.Name
 
-		if state.EngineMode.WatchesRuntime() {
-			for _, obj := range mt.Manifest.K8sTarget().ObjectRefs {
-				namespace := k8s.Namespace(obj.Namespace)
-				if namespace == "" {
-					namespace = ks.cfgNS
-				}
-				if namespace == "" {
-					namespace = k8s.DefaultNamespace
-				}
-				namespaces[namespace] = true
+		for _, obj := range mt.Manifest.K8sTarget().ObjectRefs {
+			namespace := k8s.Namespace(obj.Namespace)
+			if namespace == "" {
+				namespace = ks.cfgNS
 			}
+			if namespace == "" {
+				namespace = k8s.DefaultNamespace
+			}
+			namespaces[namespace] = true
 		}
 
 		// Collect all the new UIDs

--- a/internal/engine/runtimelog/docker_compose_log_manager.go
+++ b/internal/engine/runtimelog/docker_compose_log_manager.go
@@ -33,10 +33,6 @@ func (m *DockerComposeLogManager) diff(ctx context.Context, st store.RStore) (se
 	state := st.RLockState()
 	defer st.RUnlockState()
 
-	if !state.EngineMode.WatchesRuntime() {
-		return nil, nil
-	}
-
 	for _, mt := range state.ManifestTargets {
 		manifest := mt.Manifest
 		if !manifest.IsDC() {

--- a/internal/engine/runtimelog/podlogmanager.go
+++ b/internal/engine/runtimelog/podlogmanager.go
@@ -77,10 +77,6 @@ func (m *PodLogManager) diff(ctx context.Context, st store.RStore) (setup []PodL
 	state := st.RLockState()
 	defer st.RUnlockState()
 
-	if !state.EngineMode.WatchesRuntime() {
-		return nil, nil
-	}
-
 	stateWatches := make(map[podLogKey]bool)
 	for _, mt := range state.Targets() {
 		man := mt.Manifest

--- a/internal/store/mode.go
+++ b/internal/store/mode.go
@@ -7,14 +7,10 @@ type EngineMode struct {
 }
 
 var (
-	// "up" is an interactive dev mode that watches files and resources.
+	// EngineModeUp is an interactive dev mode that watches files and resources.
 	EngineModeUp = EngineMode{}
 
-	// "apply" is a dev mode that builds and applies all resources,
-	// but doesn't wait to see if they come up.
-	EngineModeApply = EngineMode{Name: "apply"}
-
-	// "CI" is a mode that builds and applies all resources,
+	// EngineModeCI is a mode that builds and applies all resources,
 	// waits until they come up, then exits.
 	EngineModeCI = EngineMode{Name: "ci"}
 )
@@ -25,10 +21,6 @@ func (m EngineMode) WatchesFiles() bool {
 
 func (m EngineMode) WatchesRuntime() bool {
 	return m == EngineModeUp || m == EngineModeCI
-}
-
-func (m EngineMode) IsApplyMode() bool {
-	return m == EngineModeApply
 }
 
 func (m EngineMode) IsCIMode() bool {


### PR DESCRIPTION
Looking towards revamping exit controller for API server world and
don't want to carry this along since it's no longer used.

There was one test removed that was specifically testing this so
was removed, and a couple others that were relying on it for Upper
to run to completion without a successful deploy that were tweaked
slightly (in one case: test was actually meant to be around `Up`
behavior, so it actually does that; in the other, a fake pod event
is emmitted and we ensure that Upper in CI mode returns cleanly.)