### PR TITLE
filewatch: refactor the ignore api a bit

### DIFF
--- a/internal/engine/fswatch/manifest_subscriber.go
+++ b/internal/engine/fswatch/manifest_subscriber.go
@@ -121,27 +121,7 @@ func specForTarget(t WatchableTarget, globalIgnores []model.Dockerignore) *filew
 
 	spec := &filewatches.FileWatchSpec{
 		WatchedPaths: watchedPaths,
-	}
-
-	for _, r := range t.LocalRepos() {
-		spec.Ignores = append(spec.Ignores, filewatches.IgnoreDef{
-			BasePath: filepath.Join(r.LocalPath, ".git"),
-		})
-	}
-
-	for _, di := range t.Dockerignores() {
-		if di.Empty() {
-			continue
-		}
-		spec.Ignores = append(spec.Ignores, filewatches.IgnoreDef{
-			BasePath: di.LocalPath,
-			Patterns: append([]string(nil), di.Patterns...),
-		})
-	}
-	for _, ild := range t.IgnoredLocalDirectories() {
-		spec.Ignores = append(spec.Ignores, filewatches.IgnoreDef{
-			BasePath: ild,
-		})
+		Ignores:      ignore.TargetToFileWatchIgnores(t),
 	}
 
 	// process global ignores last


### PR DESCRIPTION
Hello @landism,

Please review the following commits I made in branch nicks/ignore2:

b28dab088739c35ce39331f148b0fd34f3a273bb (2021-03-26 15:16:24 -0400)
filewatch: refactor the ignore api a bit

0eac967e3fdd7e969ce6f5e8bf6dd674d848839d (2021-03-26 12:11:49 -0400)
filewatch: fix a missing ignore. Fixes https://github.com/tilt-dev/tilt/issues/4370

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics