### PR TITLE
engine: consider Unschedulable pods as being in error state

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,7 +90,12 @@ jobs:
       - run: echo 'export PATH=/go/bin:$PATH' >> $BASH_ENV
       - setup_remote_docker:
           version: 19.03.12
-      - run: ctlptl create cluster kind --registry=ctlptl-registry && make integration
+      - run:
+          name: Execute integration tests
+          command: |
+            ctlptl create cluster kind --registry=ctlptl-registry
+            kubectl wait --for=condition=ready node --all --timeout=60s
+            make integration
       - store_test_results:
           path: test-results
       - slack/notify-on-failure:
@@ -104,7 +109,12 @@ jobs:
       - run: echo 'export PATH=/go/bin:$PATH' >> $BASH_ENV
       - setup_remote_docker:
           version: 19.03.12
-      - run: ctlptl create cluster kind --registry=ctlptl-registry && make install test-extensions
+      - run:
+          name: Execute extension tests
+          command: |
+            ctlptl create cluster kind --registry=ctlptl-registry
+            kubectl wait --for=condition=ready node --all --timeout=60s
+            make install test-extensions
       - slack/notify-on-failure:
           only_for_branches: master
 

--- a/integration/event/Dockerfile
+++ b/integration/event/Dockerfile
@@ -1,4 +1,4 @@
 FROM busybox
 
 ADD . .
-ENTRYPOINT busybox httpd -f -p 8000
+ENTRYPOINT echo "Starting HTTP server..." && busybox httpd -f -p 8000

--- a/integration/event_test.go
+++ b/integration/event_test.go
@@ -41,7 +41,11 @@ func markNodeSchedulable(f *k8sFixture, name string) {
 		"markNodeSchedulable")
 }
 
-func TestEvent(t *testing.T) {
+// TestUnschedulableEvent is testing two things:
+//	1) Important K8s events (such as unschedulable pods) are propagated to logs (at least until #3532 is done)
+//	2) Unschedulable pods are continued to be monitored by Tilt after the situation is resolved
+//		(see comments on assertions - this is hacky right now!)
+func TestUnschedulableEvent(t *testing.T) {
 	f := newK8sFixture(t, "event")
 	defer f.TearDown()
 
@@ -70,4 +74,10 @@ func TestEvent(t *testing.T) {
 	ctx, cancel = context.WithTimeout(f.ctx, time.Minute)
 	defer cancel()
 	f.CurlUntil(ctx, "http://localhost:31234", "Hello world")
+
+	// TODO(milas): once Tilt API is more fully-fledged, assert on the status of resource (from Tilt's perspective)
+	// 	to verify that it's failing while the node is unschedulable and replace this log hack with a corresponding
+	// 	status check to show it's passing as well (the log inspection is being used as a way to check that Tilt is
+	// 	still correctly watching the pod even though it was temporarily in an error state)
+	assert.NoError(t, f.logs.WaitUntilContains("Starting HTTP server", 2*time.Second))
 }

--- a/integration/event_test.go
+++ b/integration/event_test.go
@@ -43,7 +43,7 @@ func markNodeSchedulable(f *k8sFixture, name string) {
 
 // TestUnschedulableEvent is testing two things:
 //	1) Important K8s events (such as unschedulable pods) are propagated to logs (at least until #3532 is done)
-//	2) Unschedulable pods are continued to be monitored by Tilt after the situation is resolved
+//	2) Unschedulable pods continue to be monitored by Tilt after the situation is resolved
 //		(see comments on assertions - this is hacky right now!)
 func TestUnschedulableEvent(t *testing.T) {
 	f := newK8sFixture(t, "event")

--- a/internal/store/runtime_state.go
+++ b/internal/store/runtime_state.go
@@ -140,6 +140,12 @@ func (s K8sRuntimeState) RuntimeStatus() model.RuntimeStatus {
 		return model.RuntimeStatusError
 	}
 
+	for _, condition := range pod.Conditions {
+		if condition.Type == v1.PodScheduled && condition.Reason == v1.PodReasonUnschedulable {
+			return model.RuntimeStatusError
+		}
+	}
+
 	for _, container := range pod.AllContainers() {
 		if container.Status == model.RuntimeStatusError {
 			return model.RuntimeStatusError

--- a/internal/store/runtime_state.go
+++ b/internal/store/runtime_state.go
@@ -14,6 +14,10 @@ import (
 	"github.com/tilt-dev/tilt/pkg/model"
 )
 
+// UnschedulablePodGracePeriod is the maximum amount of time a pod can be in the Unschedulable state
+// before we consider it to be an error rather than just pending.
+const UnschedulablePodGracePeriod = 15 * time.Second
+
 type RuntimeState interface {
 	RuntimeState()
 
@@ -142,7 +146,13 @@ func (s K8sRuntimeState) RuntimeStatus() model.RuntimeStatus {
 
 	for _, condition := range pod.Conditions {
 		if condition.Type == v1.PodScheduled && condition.Reason == v1.PodReasonUnschedulable {
-			return model.RuntimeStatusError
+			// some wiggle room is provided to reduce the likelihood that in a CI workflow where
+			// a local K8s cluster is created just before `tilt ci` that things immediately error
+			// out due to the node not being ready just yet
+			unschedulableDeadline := condition.LastTransitionTime.Add(UnschedulablePodGracePeriod)
+			if time.Now().After(unschedulableDeadline) {
+				return model.RuntimeStatusError
+			}
 		}
 	}
 

--- a/internal/store/runtime_state_k8s_test.go
+++ b/internal/store/runtime_state_k8s_test.go
@@ -1,0 +1,91 @@
+package store_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+
+	"github.com/tilt-dev/tilt/internal/k8s"
+	"github.com/tilt-dev/tilt/internal/store"
+	"github.com/tilt-dev/tilt/pkg/model"
+)
+
+func TestK8sRuntimeState_RuntimeStatus_NeverDeployed(t *testing.T) {
+	s := store.K8sRuntimeState{
+		HasEverDeployedSuccessfully: false,
+		PodReadinessMode:            model.PodReadinessIgnore,
+	}
+	assert.Equal(t, model.RuntimeStatusPending, s.RuntimeStatus())
+}
+
+func TestK8sRuntimeState_RuntimeStatus_PodReadinessIgnore(t *testing.T) {
+	s := store.K8sRuntimeState{
+		HasEverDeployedSuccessfully: true,
+		PodReadinessMode:            model.PodReadinessIgnore,
+	}
+	assert.Equal(t, model.RuntimeStatusOK, s.RuntimeStatus())
+}
+
+func TestK8sRuntimeState_RuntimeStatus(t *testing.T) {
+	type tc struct {
+		name           string
+		expectedStatus model.RuntimeStatus
+		pod            store.Pod
+	}
+
+	tcs := []tc{
+		{
+			name:           "Phase_PodRunning_AllContainersReady",
+			expectedStatus: model.RuntimeStatusOK,
+			pod: store.Pod{
+				Phase:      v1.PodRunning,
+				Containers: []store.Container{{Ready: true}},
+			},
+		},
+		{
+			name:           "Phase_PodRunning_SomeContainersNotReady",
+			expectedStatus: model.RuntimeStatusPending,
+			pod: store.Pod{
+				Phase:      v1.PodRunning,
+				Containers: []store.Container{{Ready: true}, {Ready: false}},
+			},
+		},
+		{
+			name:           "Phase_PodSucceeded",
+			expectedStatus: model.RuntimeStatusOK,
+			pod:            store.Pod{Phase: v1.PodSucceeded},
+		},
+		{
+			name:           "Phase_PodFailed",
+			expectedStatus: model.RuntimeStatusError,
+			pod:            store.Pod{Phase: v1.PodFailed},
+		},
+		{
+			name:           "Conditions_Unschedulable",
+			expectedStatus: model.RuntimeStatusError,
+			pod: store.Pod{
+				Phase:      v1.PodPending,
+				Conditions: []v1.PodCondition{{Type: v1.PodScheduled, Reason: v1.PodReasonUnschedulable}},
+			},
+		},
+		{
+			name:           "ContainerStatus_Error",
+			expectedStatus: model.RuntimeStatusError,
+			pod: store.Pod{
+				Containers: []store.Container{{Status: model.RuntimeStatusOK}, {Status: model.RuntimeStatusError}},
+			},
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			s := store.K8sRuntimeState{
+				HasEverDeployedSuccessfully: true,
+				PodReadinessMode:            model.PodReadinessWait,
+				Pods:                        map[k8s.PodID]*store.Pod{"test": &tc.pod},
+			}
+			assert.Equal(t, tc.expectedStatus, s.RuntimeStatus())
+		})
+	}
+}


### PR DESCRIPTION
If a pod is unschedulable for some reason (e.g. resource limits),
mark its status as an error instead of letting it sit in pending
indefinitely.

If the scheduling issue is resolved, the resource (i.e. the pod
from Tilt's perspective) should then transition to OK as usual.

See also #437 which originally introduced a check for this;
while the code was deleted in #4365, it was **dead code** at that
point, so this regressed at some indeterminate point in the past
when we stopped relying on watching individual containers.
(I'm assuming TBH - I don't actually know _how_ that container
watch code was used originally! 😬)

Closes #4385.