### PR TITLE
k8sconv: a new package for code the converts Kuberentes apis to internal/storage apis

### DIFF
--- a/internal/engine/k8swatch/pod_watch.go
+++ b/internal/engine/k8swatch/pod_watch.go
@@ -12,20 +12,12 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/tilt-dev/tilt/internal/store"
+	"github.com/tilt-dev/tilt/internal/store/k8sconv"
 	"github.com/tilt-dev/tilt/pkg/logger"
 	"github.com/tilt-dev/tilt/pkg/model"
 
 	"github.com/tilt-dev/tilt/internal/k8s"
 )
-
-var errorWaitingReasons = map[string]bool{
-	"CrashLoopBackOff":  true,
-	"ErrImagePull":      true,
-	"ImagePullBackOff":  true,
-	"RunContainerError": true,
-	"StartError":        true,
-	"Error":             true,
-}
 
 type PodWatcher struct {
 	kCli         k8s.Client
@@ -318,30 +310,6 @@ func PodStatusToString(pod v1.Pod) string {
 	return reason
 }
 
-func ContainerStatusToRuntimeState(status v1.ContainerStatus) model.RuntimeStatus {
-	state := status.State
-	if state.Terminated != nil {
-		if state.Terminated.ExitCode == 0 {
-			return model.RuntimeStatusOK
-		} else {
-			return model.RuntimeStatusError
-		}
-	}
-
-	if state.Waiting != nil {
-		if errorWaitingReasons[state.Waiting.Reason] {
-			return model.RuntimeStatusError
-		}
-		return model.RuntimeStatusPending
-	}
-
-	if state.Running != nil {
-		return model.RuntimeStatusOK
-	}
-
-	return model.RuntimeStatusUnknown
-}
-
 // Pull out interesting error messages from the pod status
 func PodStatusErrorMessages(pod v1.Pod) []string {
 	result := []string{}
@@ -371,7 +339,7 @@ func containerStatusErrorMessages(container v1.ContainerStatus) []string {
 		// If we're in an error mode, also include the error message.
 		// Many error modes put important information in the error message,
 		// like when the pod will get rescheduled.
-		if state.Waiting.Message != "" && errorWaitingReasons[state.Waiting.Reason] {
+		if state.Waiting.Message != "" && k8sconv.ErrorWaitingReasons[state.Waiting.Reason] {
 			result = append(result, state.Waiting.Message)
 		}
 	} else if state.Terminated != nil &&

--- a/internal/engine/k8swatch/pod_watch_test.go
+++ b/internal/engine/k8swatch/pod_watch_test.go
@@ -25,46 +25,6 @@ import (
 	"github.com/tilt-dev/tilt/pkg/model"
 )
 
-func TestContainerStatusToRuntimeState(t *testing.T) {
-	cases := []struct {
-		Name   string
-		Status v1.ContainerStatus
-		Result model.RuntimeStatus
-	}{
-		{
-			"ok-running", v1.ContainerStatus{
-				State: v1.ContainerState{Running: &v1.ContainerStateRunning{}},
-			}, model.RuntimeStatusOK,
-		},
-		{
-			"ok-terminated", v1.ContainerStatus{
-				State: v1.ContainerState{Terminated: &v1.ContainerStateTerminated{}},
-			}, model.RuntimeStatusOK,
-		},
-		{
-			"error-terminated", v1.ContainerStatus{
-				State: v1.ContainerState{Terminated: &v1.ContainerStateTerminated{ExitCode: 1}},
-			}, model.RuntimeStatusError,
-		},
-		{
-			"error-waiting", v1.ContainerStatus{
-				State: v1.ContainerState{Waiting: &v1.ContainerStateWaiting{Reason: "CrashLoopBackOff"}},
-			}, model.RuntimeStatusError,
-		},
-		{
-			"pending-waiting", v1.ContainerStatus{
-				State: v1.ContainerState{Waiting: &v1.ContainerStateWaiting{Reason: "Initializing"}},
-			}, model.RuntimeStatusPending,
-		},
-	}
-
-	for _, c := range cases {
-		t.Run(c.Name, func(t *testing.T) {
-			assert.Equal(t, c.Result, ContainerStatusToRuntimeState(c.Status))
-		})
-	}
-}
-
 func TestPodWatch(t *testing.T) {
 	f := newPWFixture(t)
 	defer f.TearDown()

--- a/internal/store/k8sconv/doc.go
+++ b/internal/store/k8sconv/doc.go
@@ -1,0 +1,4 @@
+// Converts Kubernetes data models into our own internal data models.
+//
+// (package name loosely inspired by strconv)
+package k8sconv

--- a/internal/store/k8sconv/pod.go
+++ b/internal/store/k8sconv/pod.go
@@ -1,0 +1,108 @@
+package k8sconv
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	v1 "k8s.io/api/core/v1"
+
+	"github.com/tilt-dev/tilt/internal/container"
+	"github.com/tilt-dev/tilt/internal/k8s"
+	"github.com/tilt-dev/tilt/internal/store"
+	"github.com/tilt-dev/tilt/pkg/logger"
+	"github.com/tilt-dev/tilt/pkg/model"
+)
+
+// Convert a Kubernetes Pod into a list if simpler Container models to store in the engine state.
+func PodContainers(ctx context.Context, pod *v1.Pod, containerStatuses []v1.ContainerStatus) []store.Container {
+	result := make([]store.Container, 0, len(containerStatuses))
+	for _, cStatus := range containerStatuses {
+		c, err := ContainerForStatus(ctx, pod, cStatus)
+		if err != nil {
+			logger.Get(ctx).Debugf("%s", err.Error())
+			continue
+		}
+
+		if !c.Empty() {
+			result = append(result, c)
+		}
+	}
+	return result
+}
+
+// Convert a Kubernetes Pod and ContainerStatus into a simpler Container model to store in the engine state.
+func ContainerForStatus(ctx context.Context, pod *v1.Pod, cStatus v1.ContainerStatus) (store.Container, error) {
+	cName := k8s.ContainerNameFromContainerStatus(cStatus)
+
+	cID, err := k8s.ContainerIDFromContainerStatus(cStatus)
+	if err != nil {
+		return store.Container{}, errors.Wrap(err, "Error parsing container ID")
+	}
+
+	cRef, err := container.ParseNamed(cStatus.Image)
+	if err != nil {
+		return store.Container{}, errors.Wrap(err, "Error parsing container image ID")
+
+	}
+
+	ports := make([]int32, 0)
+	cSpec := k8s.ContainerSpecOf(pod, cStatus)
+	for _, cPort := range cSpec.Ports {
+		ports = append(ports, cPort.ContainerPort)
+	}
+
+	isRunning := false
+	if cStatus.State.Running != nil && !cStatus.State.Running.StartedAt.IsZero() {
+		isRunning = true
+	}
+
+	isTerminated := false
+	if cStatus.State.Terminated != nil && !cStatus.State.Terminated.StartedAt.IsZero() {
+		isTerminated = true
+	}
+
+	return store.Container{
+		Name:       cName,
+		ID:         cID,
+		Ports:      ports,
+		Ready:      cStatus.Ready,
+		Running:    isRunning,
+		Terminated: isTerminated,
+		ImageRef:   cRef,
+		Restarts:   int(cStatus.RestartCount),
+		Status:     ContainerStatusToRuntimeState(cStatus),
+	}, nil
+}
+
+func ContainerStatusToRuntimeState(status v1.ContainerStatus) model.RuntimeStatus {
+	state := status.State
+	if state.Terminated != nil {
+		if state.Terminated.ExitCode == 0 {
+			return model.RuntimeStatusOK
+		} else {
+			return model.RuntimeStatusError
+		}
+	}
+
+	if state.Waiting != nil {
+		if ErrorWaitingReasons[state.Waiting.Reason] {
+			return model.RuntimeStatusError
+		}
+		return model.RuntimeStatusPending
+	}
+
+	if state.Running != nil {
+		return model.RuntimeStatusOK
+	}
+
+	return model.RuntimeStatusUnknown
+}
+
+var ErrorWaitingReasons = map[string]bool{
+	"CrashLoopBackOff":  true,
+	"ErrImagePull":      true,
+	"ImagePullBackOff":  true,
+	"RunContainerError": true,
+	"StartError":        true,
+	"Error":             true,
+}

--- a/internal/store/k8sconv/pod_test.go
+++ b/internal/store/k8sconv/pod_test.go
@@ -1,0 +1,50 @@
+package k8sconv
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+
+	"github.com/tilt-dev/tilt/pkg/model"
+)
+
+func TestContainerStatusToRuntimeState(t *testing.T) {
+	cases := []struct {
+		Name   string
+		Status v1.ContainerStatus
+		Result model.RuntimeStatus
+	}{
+		{
+			"ok-running", v1.ContainerStatus{
+				State: v1.ContainerState{Running: &v1.ContainerStateRunning{}},
+			}, model.RuntimeStatusOK,
+		},
+		{
+			"ok-terminated", v1.ContainerStatus{
+				State: v1.ContainerState{Terminated: &v1.ContainerStateTerminated{}},
+			}, model.RuntimeStatusOK,
+		},
+		{
+			"error-terminated", v1.ContainerStatus{
+				State: v1.ContainerState{Terminated: &v1.ContainerStateTerminated{ExitCode: 1}},
+			}, model.RuntimeStatusError,
+		},
+		{
+			"error-waiting", v1.ContainerStatus{
+				State: v1.ContainerState{Waiting: &v1.ContainerStateWaiting{Reason: "CrashLoopBackOff"}},
+			}, model.RuntimeStatusError,
+		},
+		{
+			"pending-waiting", v1.ContainerStatus{
+				State: v1.ContainerState{Waiting: &v1.ContainerStateWaiting{Reason: "Initializing"}},
+			}, model.RuntimeStatusPending,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.Name, func(t *testing.T) {
+			assert.Equal(t, c.Result, ContainerStatusToRuntimeState(c.Status))
+		})
+	}
+}


### PR DESCRIPTION
Hello @landism, @milas,

Please review the following commits I made in branch nicks/k8sconv:

49aee7b24277064760dd95a35aa8c4cd046233dc (2021-03-30 16:12:00 -0400)
k8sconv: a new package for code the converts Kuberentes apis to internal/storage apis

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics