### PR TITLE
engine: update podlogstreamcontroller to read pods from the cache

### DIFF
--- a/internal/k8s/exploding_client.go
+++ b/internal/k8s/exploding_client.go
@@ -9,6 +9,7 @@ import (
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/tilt-dev/tilt/internal/container"
 	"github.com/tilt-dev/tilt/pkg/model"
@@ -56,7 +57,7 @@ func (ec *explodingClient) WatchPods(ctx context.Context, ns Namespace) (<-chan 
 	return nil, errors.Wrap(ec.err, "could not set up k8s client")
 }
 
-func (ec *explodingClient) PodFromInformerCache(ctx context.Context, podID PodID, ns Namespace) (*v1.Pod, error) {
+func (ec *explodingClient) PodFromInformerCache(ctx context.Context, nn types.NamespacedName) (*v1.Pod, error) {
 	return nil, errors.Wrap(ec.err, "could not set up k8s client")
 }
 

--- a/internal/k8s/watch_test.go
+++ b/internal/k8s/watch_test.go
@@ -18,6 +18,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/version"
 	"k8s.io/apimachinery/pkg/watch"
 	difake "k8s.io/client-go/discovery/fake"
@@ -51,11 +52,11 @@ func TestPodFromInformerCacheAfterWatch(t *testing.T) {
 	tf.addObjects(pods...)
 	tf.assertPods(pods, ch)
 
-	pod1Cache, err := tf.kCli.PodFromInformerCache(tf.ctx, PodID("abcd"), "default")
+	pod1Cache, err := tf.kCli.PodFromInformerCache(tf.ctx, types.NamespacedName{Name: "abcd", Namespace: "default"})
 	require.NoError(t, err)
 	assert.Equal(t, "abcd", pod1Cache.Name)
 
-	_, err = tf.kCli.PodFromInformerCache(tf.ctx, PodID("missing"), "default")
+	_, err = tf.kCli.PodFromInformerCache(tf.ctx, types.NamespacedName{Name: "missing", Namespace: "default"})
 	if assert.Error(t, err) {
 		assert.True(t, apierrors.IsNotFound(err))
 	}
@@ -69,12 +70,13 @@ func TestPodFromInformerCacheBeforeWatch(t *testing.T) {
 	pods := []runtime.Object{pod1}
 	tf.addObjects(pods...)
 
+	nn := types.NamespacedName{Name: "abcd", Namespace: "default"}
 	assert.Eventually(t, func() bool {
-		_, err := tf.kCli.PodFromInformerCache(tf.ctx, PodID("abcd"), "default")
+		_, err := tf.kCli.PodFromInformerCache(tf.ctx, nn)
 		return err == nil
 	}, time.Second, 5*time.Millisecond)
 
-	pod1Cache, err := tf.kCli.PodFromInformerCache(tf.ctx, PodID("abcd"), "default")
+	pod1Cache, err := tf.kCli.PodFromInformerCache(tf.ctx, nn)
 	require.NoError(t, err)
 	assert.Equal(t, "abcd", pod1Cache.Name)
 


### PR DESCRIPTION
Hello @milas, @maiamcc,

Please review the following commits I made in branch nicks/podfrominformer2:

f26fdfee368c8b4bc5d1aeae161fb18bb0f8b380 (2021-03-31 11:26:45 -0400)
engine: update podlogstreamcontroller to read pods from the cache
This is part of a general trend of having all our controllers read
from the cache directly instead of through EngineState.

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics