### PR TITLE
web: add headerbar to storybook

### DIFF
--- a/web/src/GlobalNav.tsx
+++ b/web/src/GlobalNav.tsx
@@ -21,10 +21,8 @@ import {
 import UpdateDialog from "./UpdateDialog"
 
 const GlobalNavRoot = styled.div`
-  flex-grow: 1;
   display: flex;
   align-items: stretch;
-  justify-content: flex-end;
 `
 export const MenuButton = styled.button`
   ${mixinResetButtonStyle};

--- a/web/src/GlobalNav.tsx
+++ b/web/src/GlobalNav.tsx
@@ -20,7 +20,7 @@ import {
 } from "./style-helpers"
 import UpdateDialog from "./UpdateDialog"
 
-const GlobalNavRoot = styled.div`
+export const GlobalNavRoot = styled.div`
   display: flex;
   align-items: stretch;
 `

--- a/web/src/HeaderBar.stories.tsx
+++ b/web/src/HeaderBar.stories.tsx
@@ -1,0 +1,51 @@
+import React from "react"
+import { MemoryRouter } from "react-router"
+import HeaderBar from "./HeaderBar"
+import {
+  nResourceView,
+  oneResourceTest,
+  tenResourceView,
+  twoResourceView,
+} from "./testdata"
+import { UpdateStatus } from "./types"
+
+export default {
+  title: "New UI/Shared/HeaderBar",
+  decorators: [
+    (Story: any) => (
+      <MemoryRouter initialEntries={["/"]}>
+        <div style={{ margin: "-1rem" }}>
+          <Story />
+        </div>
+      </MemoryRouter>
+    ),
+  ],
+}
+
+export const TwoResources = () => <HeaderBar view={twoResourceView()} />
+
+export const TenResources = () => <HeaderBar view={tenResourceView()} />
+
+export const TenResourcesErrorsAndWarnings = () => {
+  let view = tenResourceView() as any
+  view.resources[0].updateStatus = UpdateStatus.Error
+  view.resources[1].buildHistory[0].warnings = ["warning time"]
+  view.resources[5].updateStatus = UpdateStatus.Error
+  return <HeaderBar view={view} />
+}
+
+export const OneHundredResources = () => <HeaderBar view={nResourceView(100)} />
+
+export const UpgradeAvailable = () => {
+  let view = twoResourceView()
+  view.suggestedTiltVersion = "0.18.1"
+  view.runningTiltBuild = { version: "0.18.0", dev: false }
+  view.versionSettings = { checkUpdates: true }
+  return <HeaderBar view={view} />
+}
+
+export const WithTests = () => {
+  let view = twoResourceView()
+  view.resources.push(oneResourceTest(), oneResourceTest())
+  return <HeaderBar view={view} />
+}

--- a/web/src/HeaderBar.test.tsx
+++ b/web/src/HeaderBar.test.tsx
@@ -1,0 +1,63 @@
+import { fireEvent } from "@testing-library/dom"
+import { mount } from "enzyme"
+import React from "react"
+import { act } from "react-dom/test-utils"
+import { MemoryRouter } from "react-router-dom"
+import { MenuButton } from "./GlobalNav"
+import { TwoResources } from "./HeaderBar.stories"
+import MetricsDialog from "./MetricsDialog"
+import ShortcutsDialog from "./ShortcutsDialog"
+import { SnapshotActionProvider } from "./snapshot"
+
+it("renders shortcuts dialog on ?", () => {
+  const root = mount(
+    <MemoryRouter initialEntries={["/"]}>{TwoResources()}</MemoryRouter>
+  )
+
+  expect(root.find(ShortcutsDialog).props().open).toEqual(false)
+  act(() => void fireEvent.keyDown(document.body, { key: "?" }))
+  root.update()
+  expect(root.find(ShortcutsDialog).props().open).toEqual(true)
+  root.unmount()
+})
+
+it("opens snapshot modal on s", () => {
+  let opened = 0
+  let snapshot = {
+    enabled: true,
+    openModal: () => {
+      opened++
+    },
+  }
+  const root = mount(
+    <MemoryRouter initialEntries={["/"]}>
+      <SnapshotActionProvider value={snapshot}>
+        {TwoResources()}
+      </SnapshotActionProvider>
+    </MemoryRouter>
+  )
+
+  expect(opened).toEqual(0)
+  act(() => void fireEvent.keyDown(document.body, { key: "s" }))
+  root.update()
+  expect(opened).toEqual(1)
+  root.unmount()
+})
+
+it("opens metrics dialog", () => {
+  const root = mount(
+    <MemoryRouter initialEntries={["/"]}>{TwoResources()}</MemoryRouter>
+  )
+
+  let buttons = root.find(MenuButton)
+  expect(buttons).toHaveLength(5)
+
+  let metricButton = buttons.at(2)
+  expect(metricButton.getDOMNode().innerHTML).toEqual(
+    expect.stringContaining("Metrics")
+  )
+
+  expect(root.find(MetricsDialog).props().open).toEqual(false)
+  metricButton.simulate("click")
+  expect(root.find(MetricsDialog).props().open).toEqual(true)
+})

--- a/web/src/HeaderBar.tsx
+++ b/web/src/HeaderBar.tsx
@@ -1,14 +1,14 @@
 import React from "react"
+import { Link } from "react-router-dom"
 import styled from "styled-components"
 import { ReactComponent as LogoWordmarkSvg } from "./assets/svg/logo-wordmark.svg"
 import { GlobalNav } from "./GlobalNav"
 import { usePathBuilder } from "./PathBuilder"
 import { ResourceStatusSummary } from "./ResourceStatusSummary"
 import { useSnapshotAction } from "./snapshot"
-import {AnimDuration, Color, Font, FontSize, SizeUnit} from "./style-helpers"
+import { AnimDuration, Color, Font, FontSize, SizeUnit } from "./style-helpers"
 import { TargetType } from "./types"
 import { showUpdate } from "./UpdateDialog"
-import { Link } from "react-router-dom"
 
 const HeaderBarRoot = styled.div`
   display: flex;
@@ -84,11 +84,13 @@ export default function HeaderBar(props: HeaderBarProps) {
 
   return (
     <HeaderBarRoot>
-      <Link to='/overview'>
+      <Link to="/overview">
         <Logo width="57px" />
       </Link>
       <HeaderDivider />
-      <AllResourcesLink to={pb.encpath`/r/(all)/overview`} >All Resources</AllResourcesLink>
+      <AllResourcesLink to={pb.encpath`/r/(all)/overview`}>
+        All Resources
+      </AllResourcesLink>
       <ResourceStatusSummaryContainer>
         <ResourceStatusSummary view={props.view} showStatusLabels={false} />
       </ResourceStatusSummaryContainer>

--- a/web/src/HeaderBar.tsx
+++ b/web/src/HeaderBar.tsx
@@ -4,7 +4,10 @@ import styled from "styled-components"
 import { ReactComponent as LogoWordmarkSvg } from "./assets/svg/logo-wordmark.svg"
 import { GlobalNav } from "./GlobalNav"
 import { usePathBuilder } from "./PathBuilder"
-import { ResourceStatusSummary } from "./ResourceStatusSummary"
+import {
+  ResourceStatusSummary,
+  ResourceStatusSummaryRoot,
+} from "./ResourceStatusSummary"
 import { useSnapshotAction } from "./snapshot"
 import { AnimDuration, Color, Font, FontSize, SizeUnit } from "./style-helpers"
 import { TargetType } from "./types"
@@ -14,6 +17,12 @@ const HeaderBarRoot = styled.div`
   display: flex;
   align-items: center;
   padding-left: ${SizeUnit(1)};
+
+  ${ResourceStatusSummaryRoot} {
+    justify-self: center;
+    flex-grow: 1;
+    justify-content: center;
+  }
 `
 
 const Logo = styled(LogoWordmarkSvg)`
@@ -29,12 +38,6 @@ const Logo = styled(LogoWordmarkSvg)`
   display: block;
 `
 
-const ResourceStatusSummaryContainer = styled.div`
-  justify-self: center;
-  flex-grow: 1;
-  display: flex;
-  justify-content: center;
-`
 const HeaderDivider = styled.div`
   border-left: 1px solid ${Color.grayLighter};
   height: ${SizeUnit(1)};
@@ -91,9 +94,7 @@ export default function HeaderBar(props: HeaderBarProps) {
       <AllResourcesLink to={pb.encpath`/r/(all)/overview`}>
         All Resources
       </AllResourcesLink>
-      <ResourceStatusSummaryContainer>
-        <ResourceStatusSummary view={props.view} showStatusLabels={false} />
-      </ResourceStatusSummaryContainer>
+      <ResourceStatusSummary view={props.view} showStatusLabels={false} />
       <GlobalNav {...globalNavProps} />
     </HeaderBarRoot>
   )

--- a/web/src/HeaderBar.tsx
+++ b/web/src/HeaderBar.tsx
@@ -1,0 +1,98 @@
+import React from "react"
+import styled from "styled-components"
+import { ReactComponent as LogoWordmarkSvg } from "./assets/svg/logo-wordmark.svg"
+import { GlobalNav } from "./GlobalNav"
+import { usePathBuilder } from "./PathBuilder"
+import { ResourceStatusSummary } from "./ResourceStatusSummary"
+import { useSnapshotAction } from "./snapshot"
+import {AnimDuration, Color, Font, FontSize, SizeUnit} from "./style-helpers"
+import { TargetType } from "./types"
+import { showUpdate } from "./UpdateDialog"
+import { Link } from "react-router-dom"
+
+const HeaderBarRoot = styled.div`
+  display: flex;
+  align-items: center;
+  padding-left: ${SizeUnit(1)};
+`
+
+const Logo = styled(LogoWordmarkSvg)`
+  justify-self: flex-start;
+  & .fillStd {
+    transition: fill ${AnimDuration.short} ease;
+    fill: ${Color.grayLightest};
+  }
+  &:hover .fillStd,
+  &.isSelected .fillStd {
+    fill: ${Color.gray7};
+  }
+  display: block;
+`
+
+const ResourceStatusSummaryContainer = styled.div`
+  justify-self: center;
+  flex-grow: 1;
+  display: flex;
+  justify-content: center;
+`
+const HeaderDivider = styled.div`
+  border-left: 1px solid ${Color.grayLighter};
+  height: ${SizeUnit(1)};
+  margin: ${SizeUnit(0.5)};
+`
+
+const AllResourcesLink = styled(Link)`
+  font-family: ${Font.monospace};
+  color: ${Color.gray7};
+  font-size: ${FontSize.small};
+  text-decoration: none;
+`
+
+type HeaderBarProps = {
+  view: Proto.webviewView
+}
+
+export default function HeaderBar(props: HeaderBarProps) {
+  let isSnapshot = usePathBuilder().isSnapshot()
+  let snapshot = useSnapshotAction()
+  let view = props.view
+  let runningBuild = view?.runningTiltBuild
+  let suggestedVersion = view?.suggestedTiltVersion
+  let resources = view?.resources || []
+  let hasK8s = resources.some((r) => {
+    let specs = r.specs ?? []
+    return specs.some((spec) => spec.type === TargetType.K8s)
+  })
+  let showMetricsButton = !!(hasK8s || view?.metricsServing?.mode)
+  let metricsServing = view?.metricsServing
+
+  let globalNavProps = {
+    isSnapshot,
+    snapshot,
+    showUpdate: showUpdate(view),
+    suggestedVersion,
+    runningBuild,
+    showMetricsButton,
+    metricsServing,
+    tiltCloudUsername: view.tiltCloudUsername ?? "",
+    tiltCloudSchemeHost: view.tiltCloudSchemeHost ?? "",
+    tiltCloudTeamID: view.tiltCloudTeamID ?? "",
+    tiltCloudTeamName: view.tiltCloudTeamName ?? "",
+  }
+
+  const pb = usePathBuilder()
+
+  return (
+    <HeaderBarRoot>
+      <Link to='/overview'>
+        <Logo width="57px" />
+      </Link>
+      <HeaderDivider />
+      <AllResourcesLink to={pb.encpath`/r/(all)/overview`} >All Resources</AllResourcesLink>
+      <ResourceStatusSummaryContainer>
+        <ResourceStatusSummary view={props.view} showStatusLabels={false} />
+      </ResourceStatusSummaryContainer>
+      <GlobalNav {...globalNavProps} />
+    </HeaderBarRoot>
+  )
+}

--- a/web/src/OverviewResourceBar.tsx
+++ b/web/src/OverviewResourceBar.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 import styled from "styled-components"
-import { GlobalNav } from "./GlobalNav"
+import { GlobalNav, GlobalNavRoot } from "./GlobalNav"
 import { usePathBuilder } from "./PathBuilder"
 import { ResourceStatusSummary } from "./ResourceStatusSummary"
 import { useSnapshotAction } from "./snapshot"
@@ -16,12 +16,12 @@ const OverviewResourceBarRoot = styled.div`
   display: flex;
   align-items: stretch;
   padding-left: ${SizeUnit(1)};
-`
 
-const GlobalNavContainer = styled.div`
-  justify-content: flex-end;
-  flex-grow: 1;
-  display: flex;
+  ${GlobalNavRoot} {
+    justify-content: flex-end;
+    flex-grow: 1;
+    display: flex;
+  }
 `
 
 export default function OverviewResourceBar(props: OverviewResourceBarProps) {
@@ -55,9 +55,7 @@ export default function OverviewResourceBar(props: OverviewResourceBarProps) {
   return (
     <OverviewResourceBarRoot>
       <ResourceStatusSummary view={props.view} showStatusLabels={true} />
-      <GlobalNavContainer>
-        <GlobalNav {...globalNavProps} />
-      </GlobalNavContainer>
+      <GlobalNav {...globalNavProps} />
     </OverviewResourceBarRoot>
   )
 }

--- a/web/src/OverviewResourceBar.tsx
+++ b/web/src/OverviewResourceBar.tsx
@@ -12,10 +12,16 @@ type OverviewResourceBarProps = {
   view: Proto.webviewView
 }
 
-let OverviewResourceBarRoot = styled.div`
+const OverviewResourceBarRoot = styled.div`
   display: flex;
   align-items: stretch;
   padding-left: ${SizeUnit(1)};
+`
+
+const GlobalNavContainer = styled.div`
+  justify-content: flex-end;
+  flex-grow: 1;
+  display: flex;
 `
 
 export default function OverviewResourceBar(props: OverviewResourceBarProps) {
@@ -32,7 +38,7 @@ export default function OverviewResourceBar(props: OverviewResourceBarProps) {
   let showMetricsButton = !!(hasK8s || view?.metricsServing?.mode)
   let metricsServing = view?.metricsServing
 
-  let tiltMenuProps = {
+  let globalNavProps = {
     isSnapshot,
     snapshot,
     showUpdate: showUpdate(view),
@@ -48,8 +54,10 @@ export default function OverviewResourceBar(props: OverviewResourceBarProps) {
 
   return (
     <OverviewResourceBarRoot>
-      <ResourceStatusSummary view={props.view} />
-      <GlobalNav {...tiltMenuProps} />
+      <ResourceStatusSummary view={props.view} showStatusLabels={true} />
+      <GlobalNavContainer>
+        <GlobalNav {...globalNavProps} />
+      </GlobalNavContainer>
     </OverviewResourceBarRoot>
   )
 }

--- a/web/src/ResourceStatusSummary.tsx
+++ b/web/src/ResourceStatusSummary.tsx
@@ -77,6 +77,8 @@ const ResourceGroupStatusSummaryItemCount = styled.span`
 type ResourceGroupStatusProps = {
   counts: StatusCounts
   label: string
+  // TODO(matt) once we've removed OverviewResourceBar, remove this prop
+  showStatusLabels: boolean
   healthyLabel: string
   unhealthyLabel: string
   warningLabel: string
@@ -102,23 +104,23 @@ function ResourceGroupStatus(props: ResourceGroupStatusProps) {
         <ResourceGroupStatusSummaryItem
           className={props.counts.unhealthy >= 1 ? "is-highlightError" : ""}
         >
-          <CloseSvg width="11" />
+          <CloseSvg width="11" title={props.unhealthyLabel}/>
           <Link to={errorLink}>
             <ResourceGroupStatusSummaryItemCount>
               {props.counts.unhealthy}
             </ResourceGroupStatusSummaryItemCount>{" "}
-            {props.unhealthyLabel}
+            {props.showStatusLabels ? props.unhealthyLabel : null}
           </Link>
         </ResourceGroupStatusSummaryItem>
         <ResourceGroupStatusSummaryItem
           className={props.counts.warning >= 1 ? "is-highlightWarning" : ""}
         >
-          <WarningSvg width="7" />
+          <WarningSvg width="7" title={props.warningLabel}/>
           <Link to={warnLink}>
             <ResourceGroupStatusSummaryItemCount>
               {props.counts.warning}
             </ResourceGroupStatusSummaryItemCount>{" "}
-            {props.warningLabel}
+            {props.showStatusLabels ? props.warningLabel : null}
           </Link>
         </ResourceGroupStatusSummaryItem>
         <ResourceGroupStatusSummaryItem
@@ -128,7 +130,7 @@ function ResourceGroupStatus(props: ResourceGroupStatusProps) {
               : ""
           }
         >
-          <CheckmarkSmallSvg />
+          <CheckmarkSmallSvg title={props.healthyLabel}/>
           <ResourceGroupStatusSummaryItemCount>
             {props.counts.healthy}
           </ResourceGroupStatusSummaryItemCount>
@@ -136,7 +138,7 @@ function ResourceGroupStatus(props: ResourceGroupStatusProps) {
           <ResourceGroupStatusSummaryItemCount>
             {props.counts.total}
           </ResourceGroupStatusSummaryItemCount>{" "}
-          {props.healthyLabel}
+          {props.showStatusLabels ? props.healthyLabel : null}
         </ResourceGroupStatusSummaryItem>
       </ResourceGroupStatusSummaryList>
     </ResourceGroupStatusRoot>
@@ -217,6 +219,7 @@ function ResourceMetadata(props: { counts: StatusCounts }) {
 
 type ResourceStatusSummaryProps = {
   view: Proto.webviewView
+  showStatusLabels: boolean
 }
 
 export function ResourceStatusSummary(props: ResourceStatusSummaryProps) {
@@ -239,6 +242,7 @@ export function ResourceStatusSummary(props: ResourceStatusSummaryProps) {
       <ResourceGroupStatus
         counts={statusCounts(otherResources)}
         label={"Resources"}
+        showStatusLabels={props.showStatusLabels}
         healthyLabel={"healthy"}
         unhealthyLabel={"err"}
         warningLabel={"warn"}
@@ -246,6 +250,7 @@ export function ResourceStatusSummary(props: ResourceStatusSummaryProps) {
       <ResourceGroupStatus
         counts={statusCounts(testResources)}
         label={"Tests"}
+        showStatusLabels={props.showStatusLabels}
         healthyLabel={"pass"}
         unhealthyLabel={"fail"}
         warningLabel={"warn"}

--- a/web/src/ResourceStatusSummary.tsx
+++ b/web/src/ResourceStatusSummary.tsx
@@ -104,7 +104,7 @@ function ResourceGroupStatus(props: ResourceGroupStatusProps) {
         <ResourceGroupStatusSummaryItem
           className={props.counts.unhealthy >= 1 ? "is-highlightError" : ""}
         >
-          <CloseSvg width="11" title={props.unhealthyLabel}/>
+          <CloseSvg width="11" title={props.unhealthyLabel} />
           <Link to={errorLink}>
             <ResourceGroupStatusSummaryItemCount>
               {props.counts.unhealthy}
@@ -115,7 +115,7 @@ function ResourceGroupStatus(props: ResourceGroupStatusProps) {
         <ResourceGroupStatusSummaryItem
           className={props.counts.warning >= 1 ? "is-highlightWarning" : ""}
         >
-          <WarningSvg width="7" title={props.warningLabel}/>
+          <WarningSvg width="7" title={props.warningLabel} />
           <Link to={warnLink}>
             <ResourceGroupStatusSummaryItemCount>
               {props.counts.warning}
@@ -130,7 +130,7 @@ function ResourceGroupStatus(props: ResourceGroupStatusProps) {
               : ""
           }
         >
-          <CheckmarkSmallSvg title={props.healthyLabel}/>
+          <CheckmarkSmallSvg title={props.healthyLabel} />
           <ResourceGroupStatusSummaryItemCount>
             {props.counts.healthy}
           </ResourceGroupStatusSummaryItemCount>

--- a/web/src/ResourceStatusSummary.tsx
+++ b/web/src/ResourceStatusSummary.tsx
@@ -73,6 +73,9 @@ const ResourceGroupStatusSummaryItemCount = styled.span`
   padding-left: 4px;
   padding-right: 4px;
 `
+export const ResourceStatusSummaryRoot = styled.div`
+  display: flex;
+`
 
 type ResourceGroupStatusProps = {
   counts: StatusCounts
@@ -237,7 +240,7 @@ export function ResourceStatusSummary(props: ResourceStatusSummaryProps) {
   })
 
   return (
-    <>
+    <ResourceStatusSummaryRoot>
       <ResourceMetadata counts={statusCounts(resources)} />
       <ResourceGroupStatus
         counts={statusCounts(otherResources)}
@@ -255,6 +258,6 @@ export function ResourceStatusSummary(props: ResourceStatusSummaryProps) {
         unhealthyLabel={"fail"}
         warningLabel={"warn"}
       />
-    </>
+    </ResourceStatusSummaryRoot>
   )
 }


### PR DESCRIPTION
As part of merging tabs + pins, we're pulling resource status + nav menu up to the top bar, where the tabs currently are.

This PR adds a new HeaderBar component that matches this design, but only in the storybook. It won't be included in the actual UI until the new starred resources component is ready.

Screenshots:

![image](https://user-images.githubusercontent.com/7453991/113214041-ead31480-9246-11eb-9dbe-2427d1c948be.png)

![image](https://user-images.githubusercontent.com/7453991/113214010-e149ac80-9246-11eb-823f-18d43446b92b.png)

NB: there are some differences in the resource status summary between this and the design in figma:
* no vertical dividing line between resources and tests
* no "pending"
* status counts are only colored if they meet their highlight criteria (for err/warn: # => 1, for healthy: # = 100%)

I figure sorting out the resource status summary is a separate change.
I did take out the explicit status labels (the existing tilt UI says, e.g., "10/10 healthy", and the new heaer bar doesn't show "healthy", since they took up a lot of horizontal space and the header bar felt cramped.