### PR TITLE
test: consistently truncate time when streaming logs

### DIFF
--- a/internal/k8s/fake_client.go
+++ b/internal/k8s/fake_client.go
@@ -355,9 +355,12 @@ func (c *FakeK8sClient) ContainerLogs(ctx context.Context, pID PodID, cName cont
 		return nil, c.ContainerLogsError
 	}
 
-	// If we have specific logs for this pod/container combo, return those
-	c.LastPodLogStartTime = startTime
+	// metav1.Time truncates to the nearest second when serializing across the
+	// wire, so truncate here to replicate that behavior.
+	c.LastPodLogStartTime = startTime.Truncate(time.Second)
 	c.LastPodLogContext = ctx
+
+	// If we have specific logs for this pod/container combo, return those
 	if buf, ok := c.PodLogsByPodAndContainer[PodAndCName{pID, cName}]; ok {
 		return buf, nil
 	}


### PR DESCRIPTION
Hello @milas,

Please review the following commits I made in branch nicks/truncate:

d2a475bc3004ab9a130492f53004fa26a83c2372 (2021-04-06 15:20:55 -0400)
test: consistently truncate time when streaming logs

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics