### PR TITLE
session: clean up data model fields

### DIFF
--- a/pkg/apis/core/v1alpha1/session_types.go
+++ b/pkg/apis/core/v1alpha1/session_types.go
@@ -153,12 +153,14 @@ type SessionStatus struct {
 	//
 	// A resource from a Tiltfile might produce one or more targets. A target can also be shared across
 	// multiple resources (e.g. an image referenced by multiple K8s pods).
-	Targets []Target `json:"resources"`
+	Targets []Target `json:"targets"`
 
 	// Done indicates whether this Session has completed its work and is ready to exit.
 	Done bool `json:"done"`
 	// Error is a non-empty string when the Session is Done but encountered a failure as defined by the ExitCondition
 	// from the SessionSpec.
+	//
+	// +optional
 	Error string `json:"error,omitempty"`
 }
 
@@ -172,9 +174,9 @@ type Target struct {
 	// Server targets run indefinitely (e.g. an HTTP server).
 	Type TargetType `json:"type"`
 	// Resources are one or more Tiltfile resources that this target is associated with.
-	Resources []string `json:"resources,omitempty"`
+	Resources []string `json:"resources"`
 	// State provides information about the current status of the target.
-	State TargetState `json:"runtime,omitempty"`
+	State TargetState `json:"state"`
 }
 
 // TargetType describes a high-level categorization about the expected execution behavior for the target.
@@ -194,17 +196,25 @@ const (
 // be expected to execute.
 type TargetState struct {
 	// Waiting being non-nil indicates that the next execution of the target has been queued but not yet started.
-	Waiting *TargetStateWaiting `json:"pending,omitempty"`
+	//
+	// +optional
+	Waiting *TargetStateWaiting `json:"waiting,omitempty"`
 	// Active being non-nil indicates that the target is currently executing.
+	//
+	// +optional
 	Active *TargetStateActive `json:"active,omitempty"`
 	// Terminated being non-nil indicates that the target finished execution either normally or due to failure.
+	//
+	// +optional
 	Terminated *TargetStateTerminated `json:"terminated,omitempty"`
 }
 
 // TargetStateWaiting is a target that has been enqueued for execution but has not yet started.
 type TargetStateWaiting struct {
-	// Reason is a description for why the target is waiting and not yet active.
-	Reason string `json:"reason"`
+	// WaitReason is a description for why the target is waiting and not yet active.
+	//
+	// This is NOT the "cause" or "trigger" for the target being invoked.
+	WaitReason string `json:"waitReason"`
 }
 
 // TargetStateActive is a target that is currently running but has not yet finished.
@@ -213,8 +223,8 @@ type TargetStateActive struct {
 	StartTime metav1.MicroTime `json:"startTime"`
 	// Ready indicates that the target has passed readiness checks.
 	//
-	// If the target does not use readiness checks, this is always true.
-	Ready bool
+	// If the target does not use or support readiness checks, this is always true.
+	Ready bool `json:"ready"`
 }
 
 // TargetStateTerminated is a target that finished running, either because it completed successfully or
@@ -228,6 +238,8 @@ type TargetStateTerminated struct {
 	//
 	// For targets of type TargetTypeServer, this is always populated, as the target is expected to run indefinitely,
 	// and thus any termination is an error.
+	//
+	// +optional
 	Error string `json:"error,omitempty"`
 }
 

--- a/pkg/openapi/zz_generated.openapi.go
+++ b/pkg/openapi/zz_generated.openapi.go
@@ -1313,7 +1313,7 @@ func schema_pkg_apis_core_v1alpha1_SessionStatus(ref common.ReferenceCallback) c
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.MicroTime"),
 						},
 					},
-					"resources": {
+					"targets": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Targets are normalized representations of the servers/jobs managed by this Session.\n\nA resource from a Tiltfile might produce one or more targets. A target can also be shared across multiple resources (e.g. an image referenced by multiple K8s pods).",
 							Type:        []string{"array"},
@@ -1343,7 +1343,7 @@ func schema_pkg_apis_core_v1alpha1_SessionStatus(ref common.ReferenceCallback) c
 						},
 					},
 				},
-				Required: []string{"pid", "startTime", "resources", "done"},
+				Required: []string{"pid", "startTime", "targets", "done"},
 			},
 		},
 		Dependencies: []string{
@@ -1418,7 +1418,7 @@ func schema_pkg_apis_core_v1alpha1_Target(ref common.ReferenceCallback) common.O
 							},
 						},
 					},
-					"runtime": {
+					"state": {
 						SchemaProps: spec.SchemaProps{
 							Description: "State provides information about the current status of the target.",
 							Default:     map[string]interface{}{},
@@ -1426,7 +1426,7 @@ func schema_pkg_apis_core_v1alpha1_Target(ref common.ReferenceCallback) common.O
 						},
 					},
 				},
-				Required: []string{"name", "type"},
+				Required: []string{"name", "type", "resources", "state"},
 			},
 		},
 		Dependencies: []string{
@@ -1441,7 +1441,7 @@ func schema_pkg_apis_core_v1alpha1_TargetState(ref common.ReferenceCallback) com
 				Description: "TargetState describes the current execution status for a target.\n\nEither EXACTLY one of Waiting, Active, or Terminated will be populated or NONE of them will be. In the event that all states are null, the target is currently inactive or disabled and should not be expected to execute.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
-					"pending": {
+					"waiting": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Waiting being non-nil indicates that the next execution of the target has been queued but not yet started.",
 							Ref:         ref("github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1.TargetStateWaiting"),
@@ -1481,16 +1481,16 @@ func schema_pkg_apis_core_v1alpha1_TargetStateActive(ref common.ReferenceCallbac
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.MicroTime"),
 						},
 					},
-					"Ready": {
+					"ready": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Ready indicates that the target has passed readiness checks.\n\nIf the target does not use readiness checks, this is always true.",
+							Description: "Ready indicates that the target has passed readiness checks.\n\nIf the target does not use or support readiness checks, this is always true.",
 							Default:     false,
 							Type:        []string{"boolean"},
 							Format:      "",
 						},
 					},
 				},
-				Required: []string{"startTime", "Ready"},
+				Required: []string{"startTime", "ready"},
 			},
 		},
 		Dependencies: []string{
@@ -1542,16 +1542,16 @@ func schema_pkg_apis_core_v1alpha1_TargetStateWaiting(ref common.ReferenceCallba
 				Description: "TargetStateWaiting is a target that has been enqueued for execution but has not yet started.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
-					"reason": {
+					"waitReason": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Reason is a description for why the target is waiting and not yet active.",
+							Description: "WaitReason is a description for why the target is waiting and not yet active.\n\nThis is NOT the \"cause\" or \"trigger\" for the target being invoked.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 				},
-				Required: []string{"reason"},
+				Required: []string{"waitReason"},
 			},
 		},
 	}


### PR DESCRIPTION
Missed an desired rename here (`Reason` -> `WaitReason`) and a
few of these had mismatched/missing JSON field names from
continuous changes.

Also renamed a misnamed var in the conversion.