### PR TITLE
test: add a check to ensure codegen is in sync as part of CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,8 @@ jobs:
     resource_class: medium+
     docker:
       - image: gcr.io/windmill-public-containers/tilt-ci@sha256:6cff318d4e9ac8904b97945c6fb73eae8330004a3782ce1c9406863f64f71eab
+    # apiserver code generation scripts require being in GOPATH
+    working_directory: /go/src/github.com/tilt-dev/tilt
 
     steps:
       - checkout
@@ -21,6 +23,7 @@ jobs:
       - run: make lint
       - run: make test_install_version_check
       - run: make wire-check
+      - run: ./scripts/check-codegen.sh
       - run: make test-go
       - store_test_results:
           path: test-results

--- a/scripts/check-codegen.sh
+++ b/scripts/check-codegen.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+# This script ensures that codegen files are up-to-date based on changes to HEAD as
+# compared to origin/master.
+#
+# Because the codegen script is pretty slow, it bails early if no files in pkg/apis
+# (or pkg/openapi) were modified.
+#
+# If there were changed files, the codegen script is run and if there are any uncommitted
+# files as a result, it fails with an error.
+
+set -e
+
+dir=$(dirname "$0")
+cd "${dir}/.."
+
+codegen_regex="pkg/apis|pkg/openapi"
+
+function print_file_list() {
+    while IFS= read -r line
+    do
+      if [[ $line =~ $codegen_regex ]]; then
+        printf "  - %s\n" "${line}"
+      fi
+    done < <(printf '%s\n' "${*}")
+}
+
+master_sha=$(git rev-parse origin/master)
+changes=$(git diff-tree --no-commit-id --no-renames --name-only -r "$(git merge-base "${master_sha}" HEAD)" HEAD)
+if [[ $changes =~ $codegen_regex ]]; then
+  echo "Found changed API files (compared to origin/master):"
+  print_file_list "${changes}"
+  printf "\nRunning codegen to ensure up-to-date...\n\n"
+  # use the helper script directly - this is primarily run on CircleCI Linux
+  # and the wrapper script uses local volume mounts that won't work with remote Docker
+  # stdout is also suppressed because it's emits a ton of bogus warnings
+  # that aren't relevant and might cause confusion when looking at CI output
+  ( "${dir}/update-codegen-helper.sh" ) >/dev/null
+  goimports -w -local github.com/tilt-dev/tilt pkg >/dev/null
+else
+  echo "No API files modified (skipping up-to-date check)"
+  exit 0
+fi
+
+# find any uncommitted changes: getting a list of modified (staged + unstaged) as well as
+# untracked is really only doable with git status; the porcelain format is stable and has
+# a fixed length prefix for each line that can be chopped off to just get the filenames
+modified=$(git status --porcelain --no-renames | cut -c 4-)
+if [[ $modified =~ $codegen_regex ]]; then
+  >&2 echo "Found out of sync codegen files:"
+  >&2 print_file_list "${modified}"
+  if [[ -n "${CIRCLECI}" ]]; then
+    >&2 printf "\nRun make update-codegen locally and push the changes.\n"
+  else
+    >&2 printf "\nThe modified files should be committed before pushing.\n"
+  fi
+  exit 1
+fi
+
+echo "All codegen files up to date!"

--- a/scripts/update-codegen-helper.sh
+++ b/scripts/update-codegen-helper.sh
@@ -18,6 +18,11 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+if [ "${BASH_VERSINFO:-0}" -lt 5 ]; then
+  >&2 printf "This script requires Bash 5.0+.\n\nOn macOS, run brew install bash and relaunch your terminal.\n"
+  exit 2
+fi
+
 if [[ -n "${CODEGEN_USER-}" ]]; then
     useradd "$CODEGEN_USER"
 fi
@@ -29,7 +34,7 @@ SCRIPT_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 CODEGEN_PKG=${CODEGEN_PKG:-$(cd "${SCRIPT_ROOT}"; ls -d -1 ./vendor/k8s.io/code-generator 2>/dev/null || echo ../code-generator)}
 
 if [[ "$(pwd)" != "${GOPATH}"* ]]; then
-    echo "ERROR: update-codegen.sh does not work correctly outside of GOPATH: $GOPATH $(pwd)"
+    >&2 echo "ERROR: update-codegen.sh does not work correctly outside of GOPATH: $GOPATH $(pwd)"
     exit 1
 fi
 


### PR DESCRIPTION
This script tries to be smart and only run if the commit changed something under `pkg/apis` or `pkg/openapi` so it won't slow down CI in most cases.

If there was a modified file, it runs the codegen script and ensures there's no modified files in the repo afterwards.