### PR TITLE
web: use starred resource bar instead of tabs and pinned section

### DIFF
--- a/web/src/HeaderBar.tsx
+++ b/web/src/HeaderBar.tsx
@@ -17,6 +17,7 @@ const HeaderBarRoot = styled.div`
   display: flex;
   align-items: center;
   padding-left: ${SizeUnit(1)};
+  background-color: ${Color.grayDarkest};
 
   ${ResourceStatusSummaryRoot} {
     justify-self: center;

--- a/web/src/OverviewItemView.tsx
+++ b/web/src/OverviewItemView.tsx
@@ -14,7 +14,6 @@ import { ReactComponent as MaximizeSvg } from "./assets/svg/maximize.svg"
 import { displayURL } from "./links"
 import { usePathBuilder } from "./PathBuilder"
 import SidebarIcon from "./SidebarIcon"
-import SidebarPinButton from "./SidebarPinButton"
 import SidebarTriggerButton from "./SidebarTriggerButton"
 import { buildStatus, runtimeStatus } from "./status"
 import {
@@ -373,7 +372,6 @@ function RuntimeBox(props: RuntimeBoxProps) {
       <RuntimeBoxStack>
         <InnerRuntimeBox>
           <OverviewItemType>{item.resourceTypeLabel}</OverviewItemType>
-          <SidebarPinButton resourceName={item.name} />
           <OverviewItemTimeAgo>
             {hasSuccessfullyDeployed ? timeAgo : "—"}
           </OverviewItemTimeAgo>

--- a/web/src/OverviewPane.tsx
+++ b/web/src/OverviewPane.tsx
@@ -3,10 +3,9 @@ import styled from "styled-components"
 import { ReactComponent as GridDividerAllSvg } from "./assets/svg/grid-divider-all.svg"
 import { ReactComponent as GridDividerPinSvg } from "./assets/svg/grid-divider-pin.svg"
 import { ReactComponent as GridDividerTestSvg } from "./assets/svg/grid-divider-test.svg"
+import HeaderBar from "./HeaderBar"
 import OverviewGrid from "./OverviewGrid"
 import { OverviewItem } from "./OverviewItemView"
-import OverviewResourceBar from "./OverviewResourceBar"
-import OverviewTabBar from "./OverviewTabBar"
 import { useSidebarPin } from "./SidebarPin"
 import { Color, Font } from "./style-helpers"
 
@@ -104,8 +103,7 @@ export default function OverviewPane(props: OverviewPaneProps) {
 
   return (
     <OverviewPaneRoot>
-      <OverviewTabBar selectedTab={""} />
-      <OverviewResourceBar view={props.view} />
+      <HeaderBar view={props.view} />
       <ServicesContainer>
         <PinnedResources items={pinnedItems} />
         <AllResources items={allResources} />

--- a/web/src/OverviewResourcePane.tsx
+++ b/web/src/OverviewResourcePane.tsx
@@ -1,11 +1,13 @@
 import React, { useEffect, useState } from "react"
 import styled from "styled-components"
 import { Alert, combinedAlerts } from "./alerts"
+import HeaderBar from "./HeaderBar"
 import { LogUpdateAction, LogUpdateEvent, useLogStore } from "./LogStore"
-import OverviewResourceBar from "./OverviewResourceBar"
 import OverviewResourceDetails from "./OverviewResourceDetails"
 import OverviewResourceSidebar from "./OverviewResourceSidebar"
-import OverviewTabBar from "./OverviewTabBar"
+import StarredResourceBar, {
+  starredResourcePropsFromView,
+} from "./StarredResourceBar"
 import { Color } from "./style-helpers"
 import { useTabNav } from "./TabNav"
 import { ResourceName } from "./types"
@@ -79,8 +81,10 @@ export default function OverviewResourcePane(props: OverviewResourcePaneProps) {
 
   return (
     <OverviewResourcePaneRoot>
-      <OverviewTabBar selectedTab={selectedTab} />
-      <OverviewResourceBar {...props} />
+      <HeaderBar view={props.view} />
+      <StarredResourceBar
+        {...starredResourcePropsFromView(props.view, selectedTab)}
+      />
       <Main>
         <OverviewResourceSidebar {...props} name={name} />
         <OverviewResourceDetails resource={r} name={name} alerts={alerts} />

--- a/web/src/OverviewSidebarOptions.test.tsx
+++ b/web/src/OverviewSidebarOptions.test.tsx
@@ -170,51 +170,6 @@ describe("overview sidebar options", () => {
     expect(filters).toHaveLength(1)
   })
 
-  it("still displays pinned tests when tests hidden", () => {
-    pinnedResourcesAccessor.set(["beep"])
-    const root = mount(
-      <MemoryRouter>
-        <tiltfileKeyContext.Provider value="test">
-          <SidebarPinContextProvider>
-            {TwoResourcesTwoTests()}
-          </SidebarPinContextProvider>
-        </tiltfileKeyContext.Provider>
-      </MemoryRouter>
-    )
-
-    assertSidebarItemsAndOptions(
-      root,
-      ["(Tiltfile)", "vigoda", "snack", "beep", "boop"],
-      false,
-      false,
-      false
-    )
-
-    let pinned = root
-      .find(SidebarListSection)
-      .find({ name: "Pinned" })
-      .find(SidebarItemView)
-    expect(pinned).toHaveLength(1)
-    expect(pinned.at(0).props().item.name).toEqual("beep")
-
-    clickTestsHiddenControl(root)
-    assertSidebarItemsAndOptions(
-      root,
-      ["(Tiltfile)", "vigoda", "snack"],
-      true,
-      false,
-      false
-    )
-
-    // "beep" should still be pinned, even though we're no longer showing tests in the main resource list
-    pinned = root
-      .find(SidebarListSection)
-      .find({ name: "Pinned" })
-      .find(SidebarItemView)
-    expect(pinned).toHaveLength(1)
-    expect(pinned.at(0).props().item.name).toEqual("beep")
-  })
-
   it("applies the name filter", () => {
     // 'B p' tests both case insensitivity and a multi-term query
     sidebarOptionsAccessor.set({ ...defaultOptions, resourceNameFilter: "B p" })

--- a/web/src/OverviewSidebarOptions.tsx
+++ b/web/src/OverviewSidebarOptions.tsx
@@ -250,7 +250,7 @@ export function OverviewSidebarOptions(
   props: OverviewSidebarOptionsProps
 ): JSX.Element {
   return (
-    <OverviewSidebarOptionsRoot style={{ marginTop: SizeUnit(0.75) }}>
+    <OverviewSidebarOptionsRoot>
       <OverviewSidebarOptionsButtonsRoot
         className={!props.showFilters ? "is-filterButtonsHidden" : ""}
       >

--- a/web/src/SidebarItemView.stories.tsx
+++ b/web/src/SidebarItemView.stories.tsx
@@ -2,10 +2,7 @@ import React from "react"
 import { MemoryRouter } from "react-router"
 import PathBuilder from "./PathBuilder"
 import SidebarItem from "./SidebarItem"
-import SidebarItemView, {
-  SidebarItemAll,
-  SidebarItemViewProps,
-} from "./SidebarItemView"
+import SidebarItemView, { SidebarItemViewProps } from "./SidebarItemView"
 import { LegacyNavProvider } from "./TabNav"
 import { oneResourceNoAlerts } from "./testdata"
 import {
@@ -159,19 +156,3 @@ export const Tiltfile = (args: Args) =>
     withName(ResourceName.tiltfile),
     withBuildStatusOnly(ResourceStatus.Healthy)
   )
-
-export const AllItemSelected = () => {
-  return (
-    <ItemWrapper>
-      <SidebarItemAll nothingSelected={true} totalAlerts={1} />
-    </ItemWrapper>
-  )
-}
-
-export const AllItemUnselected = () => {
-  return (
-    <ItemWrapper>
-      <SidebarItemAll nothingSelected={false} totalAlerts={1} />
-    </ItemWrapper>
-  )
-}

--- a/web/src/SidebarItemView.tsx
+++ b/web/src/SidebarItemView.tsx
@@ -5,7 +5,7 @@ import { incr } from "./analytics"
 import PathBuilder from "./PathBuilder"
 import SidebarIcon from "./SidebarIcon"
 import SidebarItem from "./SidebarItem"
-import SidebarPinButton from "./SidebarPinButton"
+import SidebarPinButton, { PinButton } from "./SidebarPinButton"
 import SidebarTriggerButton from "./SidebarTriggerButton"
 import {
   AnimDuration,
@@ -22,12 +22,7 @@ import { useTabNav } from "./TabNav"
 import { formatBuildDuration, isZeroTime } from "./time"
 import { timeAgoFormatter } from "./timeFormatters"
 import { TriggerModeToggle } from "./TriggerModeToggle"
-import {
-  ResourceName,
-  ResourceStatus,
-  ResourceView,
-  TriggerMode,
-} from "./types"
+import { ResourceStatus, ResourceView, TriggerMode } from "./types"
 
 export const SidebarItemRoot = styled.li`
   & + & {
@@ -37,6 +32,10 @@ export const SidebarItemRoot = styled.li`
   margin-left: ${SizeUnit(0.25)};
   margin-right: ${SizeUnit(0.5)};
   display: flex;
+
+  ${PinButton} {
+    margin-right: ${SizeUnit(1.0 / 12)};
+  }
 `
 
 const barberpole = keyframes`
@@ -127,46 +126,6 @@ let SidebarItemText = styled.div`
   padding-bottom: 4px;
   color: ${Color.grayLightest};
 `
-
-let SidebarItemAllRoot = styled(SidebarItemRoot)`
-  text-transform: uppercase;
-  // SidebarItemRoot's margin-left of 0.25 plus the pin icon's width of 0.75
-  margin-left: ${SizeUnit(1)};
-`
-let SidebarItemAllBox = styled(SidebarItemBox)`
-  flex-direction: row;
-  height: ${SizeUnit(1.25)};
-`
-
-type SidebarItemAllProps = {
-  nothingSelected: boolean
-  totalAlerts: number
-}
-
-export function SidebarItemAll(props: SidebarItemAllProps) {
-  let nav = useTabNav()
-  return (
-    <SidebarItemAllRoot>
-      <SidebarItemAllBox
-        className={props.nothingSelected ? "isSelected" : ""}
-        tabIndex={-1}
-        role="button"
-        onClick={(e) =>
-          nav.openResource(ResourceName.all, {
-            newTab: (e.ctrlKey || e.metaKey) && !e.shiftKey,
-          })
-        }
-      >
-        <SidebarIcon
-          status={ResourceStatus.None}
-          alertCount={props.totalAlerts}
-          tooltipText={""}
-        />
-        <SidebarItemNameRoot>All</SidebarItemNameRoot>
-      </SidebarItemAllBox>
-    </SidebarItemAllRoot>
-  )
-}
 
 let SidebarItemNameRoot = styled.div`
   display: flex;

--- a/web/src/SidebarPinButton.tsx
+++ b/web/src/SidebarPinButton.tsx
@@ -1,17 +1,25 @@
 import React from "react"
 import styled from "styled-components"
-import { ReactComponent as PinResourceFilledSvg } from "./assets/svg/pin.svg"
+import { ReactComponent as StarSvg } from "./assets/svg/star.svg"
 import { useSidebarPin } from "./SidebarPin"
-import { AnimDuration, Color, mixinResetButtonStyle } from "./style-helpers"
+import {
+  AnimDuration,
+  Color,
+  mixinResetButtonStyle,
+  SizeUnit,
+} from "./style-helpers"
 
-let PinButton = styled.button`
+export const PinButton = styled.button`
   ${mixinResetButtonStyle};
   padding: 0;
   background-color: transparent;
   align-items: center;
 `
-
-let PinnedPinIcon = styled(PinResourceFilledSvg)`
+let StarIcon = styled(StarSvg)`
+  width: ${SizeUnit(1.0 / 3)};
+  height: ${SizeUnit(1.0 / 3)};
+`
+let PinnedPinIcon = styled(StarIcon)`
   transition: transform ${AnimDuration.short} ease;
   fill: ${Color.grayLight};
 
@@ -20,7 +28,7 @@ let PinnedPinIcon = styled(PinResourceFilledSvg)`
   }
 `
 
-let UnpinnedPinIcon = styled(PinResourceFilledSvg)`
+let UnpinnedPinIcon = styled(StarIcon)`
   transition: fill ${AnimDuration.default} linear,
     opacity ${AnimDuration.short} linear;
   opacity: 0;
@@ -56,10 +64,10 @@ export default function SidebarPinButton(
 
   if (isPinned) {
     icon = <PinnedPinIcon />
-    title = "Remove Pin"
+    title = "Unstar"
   } else {
     icon = <UnpinnedPinIcon />
-    title = "Pin to Top"
+    title = "Star"
   }
 
   function onClick(e: any) {

--- a/web/src/SidebarResources.test.tsx
+++ b/web/src/SidebarResources.test.tsx
@@ -13,10 +13,9 @@ import {
 import { assertSidebarItemsAndOptions } from "./OverviewSidebarOptions.test"
 import PathBuilder from "./PathBuilder"
 import SidebarItem from "./SidebarItem"
-import { SidebarItemBox } from "./SidebarItemView"
 import { SidebarPinContextProvider } from "./SidebarPin"
 import SidebarPinButton from "./SidebarPinButton"
-import SidebarResources, { SidebarListSection } from "./SidebarResources"
+import SidebarResources from "./SidebarResources"
 import {
   oneResource,
   oneResourceTestWithName,
@@ -30,16 +29,6 @@ const sidebarOptionsAccessor = accessorsForTesting<SidebarOptions>(
   "sidebar_options"
 )
 const pinnedItemsAccessor = accessorsForTesting<string[]>("pinned-resources")
-
-function getPinnedItemNames(
-  root: ReactWrapper<any, React.Component["state"], React.Component>
-): Array<string> {
-  let pinnedItems = root
-    .find(SidebarListSection)
-    .find({ name: "Pinned" })
-    .find(SidebarItemBox)
-  return pinnedItems.map((i) => i.prop("data-name"))
-}
 
 function clickPin(
   root: ReactWrapper<any, React.Component["state"], React.Component>,
@@ -61,7 +50,7 @@ describe("SidebarResources", () => {
     localStorage.clear()
   })
 
-  it("adds items to the pinned group when items are pinned", () => {
+  it("adds items to the pinned list when items are pinned", () => {
     let items = twoResourceView().resources.map((r) => new SidebarItem(r))
     const root = mount(
       <MemoryRouter>
@@ -78,11 +67,7 @@ describe("SidebarResources", () => {
       </MemoryRouter>
     )
 
-    expect(getPinnedItemNames(root)).toEqual([])
-
     clickPin(root, "snack")
-
-    expect(getPinnedItemNames(root)).toEqual(["snack"])
 
     expectIncr(0, "ui.web.pin", { pinCount: "0", action: "load" })
     expectIncr(1, "ui.web.pin", { pinCount: "1", action: "pin" })
@@ -90,29 +75,7 @@ describe("SidebarResources", () => {
     expect(pinnedItemsAccessor.get()).toEqual(["snack"])
   })
 
-  it("reads pinned items from local storage", () => {
-    pinnedItemsAccessor.set(["vigoda", "snack"])
-
-    let items = twoResourceView().resources.map((r) => new SidebarItem(r))
-    const root = mount(
-      <MemoryRouter>
-        <tiltfileKeyContext.Provider value="test">
-          <SidebarPinContextProvider>
-            <SidebarResources
-              items={items}
-              selected={""}
-              resourceView={ResourceView.Log}
-              pathBuilder={pathBuilder}
-            />
-          </SidebarPinContextProvider>
-        </tiltfileKeyContext.Provider>
-      </MemoryRouter>
-    )
-
-    expect(getPinnedItemNames(root)).toEqual(["vigoda", "snack"])
-  })
-
-  it("removes items from the pinned group when items are pinned", () => {
+  it("removes items from the pinned list when items are unpinned", () => {
     let items = twoResourceView().resources.map((r) => new SidebarItem(r))
     pinnedItemsAccessor.set(items.map((i) => i.name))
 
@@ -131,11 +94,7 @@ describe("SidebarResources", () => {
       </MemoryRouter>
     )
 
-    expect(getPinnedItemNames(root)).toEqual(["vigoda", "snack"])
-
     clickPin(root, "snack")
-
-    expect(getPinnedItemNames(root)).toEqual(["vigoda"])
 
     expectIncr(0, "ui.web.pin", { pinCount: "2", action: "load" })
     expectIncr(1, "ui.web.pin", { pinCount: "1", action: "unpin" })

--- a/web/src/SidebarResources.tsx
+++ b/web/src/SidebarResources.tsx
@@ -4,10 +4,7 @@ import { PersistentStateProvider } from "./LocalStorage"
 import { OverviewSidebarOptions } from "./OverviewSidebarOptions"
 import PathBuilder from "./PathBuilder"
 import SidebarItem from "./SidebarItem"
-import SidebarItemView, {
-  SidebarItemAll,
-  triggerUpdate,
-} from "./SidebarItemView"
+import SidebarItemView, { triggerUpdate } from "./SidebarItemView"
 import SidebarKeyboardShortcuts from "./SidebarKeyboardShortcuts"
 import { useSidebarPin } from "./SidebarPin"
 import { Color, FontSize, SizeUnit } from "./style-helpers"
@@ -192,13 +189,6 @@ export class SidebarResources extends React.Component<SidebarProps> {
     return (
       <SidebarResourcesRoot className={`Sidebar-resources ${isOverviewClass}`}>
         <SidebarList>
-          <SidebarListSection name="">
-            <SidebarItemAll
-              nothingSelected={nothingSelected}
-              totalAlerts={totalAlerts}
-            />
-          </SidebarListSection>
-          <PinnedItems {...this.props} />
           <OverviewSidebarOptions
             showFilters={showFilters}
             options={options}

--- a/web/src/StarredResourceBar.tsx
+++ b/web/src/StarredResourceBar.tsx
@@ -4,6 +4,8 @@ import styled from "styled-components"
 import { ReactComponent as StarSvg } from "./assets/svg/star.svg"
 import { usePathBuilder } from "./PathBuilder"
 import { ClassNameFromResourceStatus } from "./ResourceStatus"
+import { useSidebarPin } from "./SidebarPin"
+import { combinedStatus } from "./status"
 import {
   AnimDuration,
   Color,
@@ -33,6 +35,7 @@ export const StarredResourceLabel = styled.div`
 const ResourceButton = styled.button`
   ${mixinResetButtonStyle};
   color: inherit;
+  display: flex;
 `
 const StarIcon = styled(StarSvg)`
   height: ${SizeUnit(0.5)};
@@ -57,6 +60,8 @@ const StarredResourceRoot = styled.div`
   display: inline-flex;
   align-items: center;
   background-color: ${Color.gray};
+  padding-top: ${SizeUnit(0.125)};
+  padding-bottom: ${SizeUnit(0.125)};
 
   &:hover {
     background-color: ${ColorRGBA(Color.gray, ColorAlpha.translucent)};
@@ -109,8 +114,12 @@ const StarredResourceRoot = styled.div`
   }
 `
 const StarredResourceBarRoot = styled.div`
-  margin-left: ${SizeUnit(0.5)};
-  margin-right: ${SizeUnit(0.5)};
+  padding-left: ${SizeUnit(0.5)};
+  padding-right: ${SizeUnit(0.5)};
+  padding-top: ${SizeUnit(0.25)};
+  padding-bottom: ${SizeUnit(0.25)};
+  margin-bottom: ${SizeUnit(0.25)};
+  background-color: ${Color.grayDarker};
 
   ${StarredResourceRoot} {
     margin-right: ${SizeUnit(0.25)};
@@ -177,4 +186,24 @@ export default function StarredResourceBar(props: StarredResourceBarProps) {
       ))}
     </StarredResourceBarRoot>
   )
+}
+
+// translates the view to a pared-down model so that `StarredResourceBar` can have a simple API for testing.
+export function starredResourcePropsFromView(
+  view: Proto.webviewView,
+  selectedResource: string
+): StarredResourceBarProps {
+  const pinCtx = useSidebarPin()
+  const namesAndStatuses = (view?.resources || []).flatMap((r) => {
+    if (r.name && pinCtx.pinnedResources.includes(r.name)) {
+      return [{ name: r.name, status: combinedStatus(r) }]
+    } else {
+      return []
+    }
+  })
+  return {
+    resources: namesAndStatuses,
+    unstar: pinCtx.unpinResource,
+    selectedResource: selectedResource,
+  }
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/7453991/114449160-6f585800-9ba2-11eb-99a3-d53bd023071e.png)

### Changes
* pins have been replaced by stars
* pins/stars and tabs were serving pretty similar purposes, so we've replaced both the "pinned items" section in the sidebar and the horizontal tab bar across the top with a single starred items bar across the top
* "all resources" is now in the header bar next to the tilt logo instead of showing up as a pseudo resource in the sidebar

### Notes
This PR is mostly just changing the UI to make use of recently merged components. If you want more context on those, here are their PRs:
* ResourceStatusSummary - https://github.com/tilt-dev/tilt/pull/4411
* StarredResourceBar - https://github.com/tilt-dev/tilt/pull/4398
* HeaderBar - https://github.com/tilt-dev/tilt/pull/4393

### Future PRs
* Actually change all the "pin" names in the code to "star"
* Delete the tabs code