### PR TITLE
web: use starred resource bar on overview pane

### DIFF
--- a/web/src/OverviewItemView.tsx
+++ b/web/src/OverviewItemView.tsx
@@ -15,6 +15,7 @@ import { InstrumentedButton } from "./instrumentedComponents"
 import { displayURL } from "./links"
 import { usePathBuilder } from "./PathBuilder"
 import SidebarIcon from "./SidebarIcon"
+import SidebarPinButton, { PinButton } from "./SidebarPinButton"
 import SidebarTriggerButton from "./SidebarTriggerButton"
 import { buildStatus, runtimeStatus } from "./status"
 import {
@@ -198,6 +199,11 @@ let InnerRuntimeBox = styled.div`
   display: flex;
   align-items: center;
   flex-grow: 1;
+
+  ${PinButton} {
+    margin-left: ${SizeUnit(0.125)};
+    align-content: center;
+  }
 `
 let OverviewItemType = styled.div`
   display: flex;
@@ -369,6 +375,7 @@ function RuntimeBox(props: RuntimeBoxProps) {
       <RuntimeBoxStack>
         <InnerRuntimeBox>
           <OverviewItemType>{item.resourceTypeLabel}</OverviewItemType>
+          <SidebarPinButton resourceName={item.name} />
           <OverviewItemTimeAgo>
             {hasSuccessfullyDeployed ? timeAgo : "—"}
           </OverviewItemTimeAgo>

--- a/web/src/OverviewPane.test.tsx
+++ b/web/src/OverviewPane.test.tsx
@@ -3,13 +3,10 @@ import React from "react"
 import { MemoryRouter } from "react-router"
 import { accessorsForTesting, tiltfileKeyContext } from "./LocalStorage"
 import OverviewItemView from "./OverviewItemView"
-import OverviewPane, {
-  AllResources,
-  PinnedResources,
-  TestResources,
-} from "./OverviewPane"
+import OverviewPane, { AllResources, TestResources } from "./OverviewPane"
 import { TwoResources } from "./OverviewPane.stories"
 import { SidebarPinContextProvider } from "./SidebarPin"
+import { StarredResourceLabel } from "./StarredResourceBar"
 import { oneResourceTest, twoResourceView } from "./testdata"
 
 function assertContainerWithResources(
@@ -27,6 +24,13 @@ function assertContainerWithResources(
   }
 }
 
+function assertStarredResources(root: ReactWrapper, names: string[]) {
+  const renderedStarredResourceNames = root
+    .find(StarredResourceLabel)
+    .map((i) => i.text())
+  expect(renderedStarredResourceNames).toEqual(names)
+}
+
 const pinnedResourcesAccessor = accessorsForTesting<string[]>(
   "pinned-resources"
 )
@@ -36,12 +40,12 @@ it("renders all resources if no pinned and no tests", () => {
     <MemoryRouter initialEntries={["/"]}>{TwoResources()}</MemoryRouter>
   )
 
-  assertContainerWithResources(root, PinnedResources, [])
   assertContainerWithResources(root, AllResources, ["vigoda", "snack"])
   assertContainerWithResources(root, TestResources, [])
+  assertStarredResources(root, [])
 })
 
-it("renders pinned resources", () => {
+it("renders starred resources", () => {
   pinnedResourcesAccessor.set(["snack"])
 
   const root = mount(
@@ -52,9 +56,9 @@ it("renders pinned resources", () => {
     </MemoryRouter>
   )
 
-  assertContainerWithResources(root, PinnedResources, ["snack"])
   assertContainerWithResources(root, AllResources, ["vigoda", "snack"])
   assertContainerWithResources(root, TestResources, [])
+  assertStarredResources(root, ["snack"])
 })
 
 it("renders test resources separate from all resources", () => {
@@ -67,7 +71,7 @@ it("renders test resources separate from all resources", () => {
     </MemoryRouter>
   )
 
-  assertContainerWithResources(root, PinnedResources, [])
   assertContainerWithResources(root, AllResources, ["vigoda", "snack"])
   assertContainerWithResources(root, TestResources, ["boop"])
+  assertStarredResources(root, [])
 })

--- a/web/src/OverviewPane.tsx
+++ b/web/src/OverviewPane.tsx
@@ -7,6 +7,9 @@ import HeaderBar from "./HeaderBar"
 import OverviewGrid from "./OverviewGrid"
 import { OverviewItem } from "./OverviewItemView"
 import { useSidebarPin } from "./SidebarPin"
+import StarredResourceBar, {
+  starredResourcePropsFromView,
+} from "./StarredResourceBar"
 import { Color, Font } from "./style-helpers"
 
 type OverviewPaneProps = {
@@ -104,8 +107,8 @@ export default function OverviewPane(props: OverviewPaneProps) {
   return (
     <OverviewPaneRoot>
       <HeaderBar view={props.view} />
+      <StarredResourceBar {...starredResourcePropsFromView(props.view, "")} />
       <ServicesContainer>
-        <PinnedResources items={pinnedItems} />
         <AllResources items={allResources} />
         <TestResources items={testItems} />
       </ServicesContainer>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/7453991/114609228-8fece480-9c6c-11eb-856c-cb9ed0c1cee3.png)

(previously there was a "pinned items" section at top)