### PR TITLE
web: fix css of selected+building+starred resource

### DIFF
--- a/web/src/SidebarItemView.tsx
+++ b/web/src/SidebarItemView.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 import TimeAgo from "react-timeago"
-import styled, { keyframes } from "styled-components"
+import styled from "styled-components"
 import PathBuilder from "./PathBuilder"
 import SidebarIcon from "./SidebarIcon"
 import SidebarItem from "./SidebarItem"
@@ -8,6 +8,7 @@ import SidebarPinButton, { PinButton } from "./SidebarPinButton"
 import SidebarTriggerButton from "./SidebarTriggerButton"
 import {
   AnimDuration,
+  barberpole,
   Color,
   ColorAlpha,
   ColorRGBA,
@@ -34,12 +35,6 @@ export const SidebarItemRoot = styled.li`
 
   ${PinButton} {
     margin-right: ${SizeUnit(1.0 / 12)};
-  }
-`
-
-const barberpole = keyframes`
-  100% {
-    background-position: 100% 100%;
   }
 `
 

--- a/web/src/StarredResourceBar.stories.tsx
+++ b/web/src/StarredResourceBar.stories.tsx
@@ -1,3 +1,4 @@
+import { Story } from "@storybook/react"
 import React from "react"
 import StarredResourceBar, { ResourceNameAndStatus } from "./StarredResourceBar"
 import { Color } from "./style-helpers"
@@ -15,47 +16,69 @@ export default {
   ],
 }
 
-function story(resources: ResourceNameAndStatus[], selectedResource?: string) {
-  return (
-    <StarredResourceBar
-      resources={resources}
-      unstar={(n) => {}}
-      selectedResource={selectedResource}
-    />
-  )
+type StoryProps = {
+  resources: ResourceNameAndStatus[]
+  selectedResource?: string
+}
+const Template: Story<StoryProps> = (args) => (
+  <StarredResourceBar
+    resources={args.resources}
+    unstar={(n) => {}}
+    selectedResource={args.selectedResource}
+  />
+)
+
+export const OneItem = Template.bind({})
+OneItem.args = {
+  resources: [{ name: "foo", status: ResourceStatus.Healthy }],
 }
 
-export const OneItem = () =>
-  story([{ name: "foo", status: ResourceStatus.Healthy }])
+export const ThreeItems = Template.bind({})
+ThreeItems.args = {
+  resources: Array(3).fill({ name: "foo", status: ResourceStatus.Healthy }),
+}
 
-export const ThreeItems = () =>
-  story(Array(3).fill({ name: "foo", status: ResourceStatus.Healthy }))
+export const TwentyItems = Template.bind({})
+TwentyItems.args = {
+  resources: Array(20).fill({ name: "foobar", status: ResourceStatus.Healthy }),
+}
 
-export const TwentyItems = () =>
-  story(Array(20).fill({ name: "foobar", status: ResourceStatus.Healthy }))
-
-export const LongName = () =>
-  story([
+export const LongName = Template.bind({})
+LongName.args = {
+  resources: [
     {
       name: "supercalifragilisticexpialidocious",
       status: ResourceStatus.Unhealthy,
     },
-  ])
+  ],
+}
 
-export const MixedNames = () =>
-  story(
-    [
-      { name: "max-object-detected-name", status: ResourceStatus.Healthy },
-      { name: "muxer", status: ResourceStatus.Unhealthy },
-      { name: "benchmark-muxer", status: ResourceStatus.Healthy },
-      { name: "benchmark-all", status: ResourceStatus.Healthy },
-      { name: "recompile-storage", status: ResourceStatus.Unhealthy },
-      { name: "benchamrk-rectangle-test", status: ResourceStatus.Healthy },
-      { name: "benchmark-storage", status: ResourceStatus.Healthy },
-      { name: "(Tiltfile)", status: ResourceStatus.Pending },
-      { name: "recompile-rectangle-test", status: ResourceStatus.Unhealthy },
-      { name: "SillyOne test", status: ResourceStatus.Unhealthy },
-      { name: "AttackOfTheSilly test", status: ResourceStatus.Unhealthy },
-    ],
-    "benchmark-muxer"
-  )
+export const MixedNames = Template.bind({})
+MixedNames.args = {
+  resources: [
+    { name: "max-object-detected-name", status: ResourceStatus.Healthy },
+    { name: "muxer", status: ResourceStatus.Unhealthy },
+    { name: "benchmark-muxer", status: ResourceStatus.Healthy },
+    { name: "benchmark-all", status: ResourceStatus.Healthy },
+    { name: "recompile-storage", status: ResourceStatus.Unhealthy },
+    { name: "benchamrk-rectangle-test", status: ResourceStatus.Healthy },
+    { name: "benchmark-storage", status: ResourceStatus.Healthy },
+    { name: "(Tiltfile)", status: ResourceStatus.Pending },
+    { name: "recompile-rectangle-test", status: ResourceStatus.Unhealthy },
+    { name: "SillyOne test", status: ResourceStatus.Unhealthy },
+    { name: "AttackOfTheSilly test", status: ResourceStatus.Unhealthy },
+  ],
+  selectedResource: "benchmark-muxer",
+}
+
+export const PendingActive = Template.bind({})
+PendingActive.args = {
+  resources: [{ name: "foo", status: ResourceStatus.Pending }],
+  selectedResource: "foo",
+}
+
+export const BuildingActive = Template.bind({})
+BuildingActive.args = {
+  resources: [{ name: "foo", status: ResourceStatus.Building }],
+  selectedResource: "foo",
+}

--- a/web/src/StarredResourceBar.tsx
+++ b/web/src/StarredResourceBar.tsx
@@ -9,6 +9,7 @@ import { useSidebarPin } from "./SidebarPin"
 import { combinedStatus } from "./status"
 import {
   AnimDuration,
+  barberpole,
   Color,
   ColorAlpha,
   ColorRGBA,
@@ -63,14 +64,10 @@ const StarredResourceRoot = styled.div`
   background-color: ${Color.gray};
   padding-top: ${SizeUnit(0.125)};
   padding-bottom: ${SizeUnit(0.125)};
+  position: relative; // Anchor the .isBuilding::after psuedo-element
 
   &:hover {
     background-color: ${ColorRGBA(Color.gray, ColorAlpha.translucent)};
-  }
-
-  &.isSelected {
-    background-color: ${Color.white};
-    color: ${Color.gray};
   }
 
   &.isWarning {
@@ -102,6 +99,28 @@ const StarredResourceRoot = styled.div`
   &.isNone {
     color: ${Color.grayLighter};
     transition: border-color ${AnimDuration.default} linear;
+  }
+  &.isSelected {
+    background-color: ${Color.white};
+    color: ${Color.gray};
+  }
+
+  &.isBuilding::after {
+    content: "";
+    position: absolute;
+    pointer-events: none;
+    width: 100%;
+    top: 0;
+    bottom: 0;
+    background: repeating-linear-gradient(
+      225deg,
+      ${ColorRGBA(Color.grayLight, ColorAlpha.translucent)},
+      ${ColorRGBA(Color.grayLight, ColorAlpha.translucent)} 1px,
+      ${ColorRGBA(Color.black, 0)} 1px,
+      ${ColorRGBA(Color.black, 0)} 6px
+    );
+    background-size: 200% 200%;
+    animation: ${barberpole} 8s linear infinite;
   }
 
   // implement margins as padding on child buttons, to ensure the buttons consume the

--- a/web/src/style-helpers.ts
+++ b/web/src/style-helpers.ts
@@ -155,3 +155,9 @@ export const spin = keyframes`
     transform: rotate(360deg);
   }
 `
+
+export const barberpole = keyframes`
+100% {
+  background-position: 100% 100%;
+}
+`


### PR DESCRIPTION
### Problem

If a resource is selected, building, and starred, it shows up in the starred resource bar as white on white:
![image](https://user-images.githubusercontent.com/7453991/114735823-8b2f3b80-9d13-11eb-8339-5961852a6837.png)

### Solution

1. Copy the rest of the sidebaritemview css that adds the barberpole animation to building resources
2. move the .isSelected selector lower down so that the gray foreground takes precedence so that things are actually readable

![image](https://user-images.githubusercontent.com/7453991/114735965-adc15480-9d13-11eb-8888-ee4e5038e435.png)
(but animated)