### PR TITLE
tiltfile: add sys.executable

### DIFF
--- a/internal/tiltfile/sys/sys.go
+++ b/internal/tiltfile/sys/sys.go
@@ -1,0 +1,53 @@
+package sys
+
+import (
+	"os"
+
+	"go.starlark.net/starlark"
+
+	"github.com/tilt-dev/tilt/internal/tiltfile/starkit"
+)
+
+// The starlark sys module.
+// Contains a subset of Python's sys module.
+// https://docs.python.org/3/library/sys.html
+type Extension struct {
+}
+
+func NewExtension() Extension {
+	return Extension{}
+}
+
+func (e Extension) OnStart(env *starkit.Environment) error {
+	err := env.AddValue("sys.argv", argv())
+	if err != nil {
+		return err
+	}
+
+	err = env.AddValue("sys.executable", executable())
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// List of commandline arguments that Tilt started with.
+func argv() starlark.Value {
+	values := []starlark.Value{}
+	for _, arg := range os.Args {
+		values = append(values, starlark.String(arg))
+	}
+
+	list := starlark.NewList(values)
+	list.Freeze()
+	return list
+}
+
+// Full path to the Tilt executable.
+func executable() starlark.Value {
+	e, err := os.Executable()
+	if err != nil {
+		return starlark.None
+	}
+	return starlark.String(e)
+}

--- a/internal/tiltfile/sys/sys_test.go
+++ b/internal/tiltfile/sys/sys_test.go
@@ -1,0 +1,45 @@
+package sys
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/tilt-dev/tilt/internal/tiltfile/starkit"
+)
+
+func TestArgv(t *testing.T) {
+	f := NewFixture(t)
+	f.File("Tiltfile", `
+print(sys.argv)
+`)
+
+	quoted := []string{}
+	for _, arg := range os.Args {
+		quoted = append(quoted, fmt.Sprintf("%q", arg))
+	}
+	expected := fmt.Sprintf("[%s]\n", strings.Join(quoted, ", "))
+
+	_, err := f.ExecFile("Tiltfile")
+	assert.NoError(t, err)
+	assert.Equal(t, expected, f.PrintOutput())
+}
+
+func TestExecutable(t *testing.T) {
+	f := NewFixture(t)
+	f.File("Tiltfile", `
+print(sys.executable)
+`)
+
+	expected, _ := os.Executable()
+	_, err := f.ExecFile("Tiltfile")
+	assert.NoError(t, err)
+	assert.Equal(t, fmt.Sprintf("%v\n", expected), f.PrintOutput())
+}
+
+func NewFixture(tb testing.TB) *starkit.Fixture {
+	return starkit.NewFixture(tb, NewExtension())
+}

--- a/internal/tiltfile/tiltfile_state.go
+++ b/internal/tiltfile/tiltfile_state.go
@@ -15,6 +15,7 @@ import (
 	links "github.com/tilt-dev/tilt/internal/tiltfile/links"
 	"github.com/tilt-dev/tilt/internal/tiltfile/print"
 	"github.com/tilt-dev/tilt/internal/tiltfile/probe"
+	"github.com/tilt-dev/tilt/internal/tiltfile/sys"
 
 	"github.com/tilt-dev/tilt/internal/container"
 	"github.com/tilt-dev/tilt/internal/dockercompose"
@@ -190,6 +191,7 @@ func (s *tiltfileState) loadManifests(absFilename string, userConfigState model.
 		include.IncludeFn{},
 		git.NewExtension(),
 		os.NewExtension(),
+		sys.NewExtension(),
 		io.NewExtension(),
 		s.k8sContextExt,
 		dockerprune.NewExtension(),


### PR DESCRIPTION
Hello @landism,

Please review the following commits I made in branch nicks/ch11874:

3fcb25f3d0b61e866c9338f6d9138287bcfc6ece (2021-04-14 17:02:23 -0400)
tiltfile: add sys.executable
We want to write tilt extensions that use tilt get, tilt apply,
etc to mutate things on the fly, so we need a way for extensions
to reliably find the tilt binary.

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics