### PR TITLE
engine: remove type alias for Container

### DIFF
--- a/internal/engine/buildcontrol/build_control_test.go
+++ b/internal/engine/buildcontrol/build_control_test.go
@@ -285,7 +285,7 @@ func readyPod(podID k8s.PodID, ref reference.Named) *store.Pod {
 		PodID:  podID,
 		Phase:  v1.PodRunning,
 		Status: "Running",
-		Containers: []store.Container{
+		Containers: []v1alpha1.Container{
 			{
 				ID:    string(podID + "-container"),
 				Name:  "c",
@@ -304,7 +304,7 @@ func crashingPod(podID k8s.PodID, ref reference.Named) *store.Pod {
 		PodID:  podID,
 		Phase:  v1.PodRunning,
 		Status: "CrashLoopBackOff",
-		Containers: []store.Container{
+		Containers: []v1alpha1.Container{
 			{
 				ID:       string(podID + "-container"),
 				Name:     "c",
@@ -328,7 +328,7 @@ func crashedInThePastPod(podID k8s.PodID, ref reference.Named) *store.Pod {
 		PodID:  podID,
 		Phase:  v1.PodRunning,
 		Status: "Ready",
-		Containers: []store.Container{
+		Containers: []v1alpha1.Container{
 			{
 				ID:       string(podID + "-container"),
 				Name:     "c",
@@ -348,7 +348,7 @@ func sidecarCrashedPod(podID k8s.PodID, ref reference.Named) *store.Pod {
 		PodID:  podID,
 		Phase:  v1.PodRunning,
 		Status: "Ready",
-		Containers: []store.Container{
+		Containers: []v1alpha1.Container{
 			{
 				ID:       string(podID + "-container"),
 				Name:     "c",

--- a/internal/engine/pod.go
+++ b/internal/engine/pod.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
+
 	v1 "k8s.io/api/core/v1"
 
 	"github.com/tilt-dev/tilt/internal/container"
@@ -104,7 +106,7 @@ func handlePodChangeAction(ctx context.Context, state *store.EngineState, action
 	checkForContainerCrash(ctx, state, mt)
 }
 
-func restartedContainerNames(existingContainers []store.Container, newContainers []store.Container) []container.Name {
+func restartedContainerNames(existingContainers []v1alpha1.Container, newContainers []v1alpha1.Container) []container.Name {
 	result := []container.Name{}
 	for i, c := range newContainers {
 		if i >= len(existingContainers) {

--- a/internal/engine/portforward/controller_test.go
+++ b/internal/engine/portforward/controller_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
+
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 
@@ -98,8 +100,8 @@ func TestPortForwardAutoDiscovery(t *testing.T) {
 	f.onChange()
 	assert.Equal(t, 0, len(f.plc.activeForwards))
 	state = f.st.LockMutableStateForTesting()
-	state.ManifestTargets["fe"].State.K8sRuntimeState().Pods["pod-id"].Containers = []store.Container{
-		store.Container{Ports: []int32{8000}},
+	state.ManifestTargets["fe"].State.K8sRuntimeState().Pods["pod-id"].Containers = []v1alpha1.Container{
+		v1alpha1.Container{Ports: []int32{8000}},
 	}
 	f.st.UnlockMutableState()
 
@@ -129,8 +131,8 @@ func TestPortForwardAutoDiscovery2(t *testing.T) {
 	mt.State.RuntimeState = store.NewK8sRuntimeStateWithPods(mt.Manifest, store.Pod{
 		PodID: "pod-id",
 		Phase: v1.PodRunning,
-		Containers: []store.Container{
-			store.Container{Ports: []int32{8000, 8080}},
+		Containers: []v1alpha1.Container{
+			v1alpha1.Container{Ports: []int32{8000, 8080}},
 		},
 	})
 	f.st.UnlockMutableState()
@@ -247,8 +249,8 @@ func TestPopulatePortForward(t *testing.T) {
 				PortForwards: c.spec,
 			})
 			pod := store.Pod{
-				Containers: []store.Container{
-					store.Container{Ports: c.containerPorts},
+				Containers: []v1alpha1.Container{
+					v1alpha1.Container{Ports: c.containerPorts},
 				},
 			}
 

--- a/internal/engine/session/controller_test.go
+++ b/internal/engine/session/controller_test.go
@@ -112,7 +112,7 @@ func TestExitControlCI_FirstRuntimeFailure(t *testing.T) {
 		mt.State.RuntimeState = store.NewK8sRuntimeStateWithPods(mt.Manifest, store.Pod{
 			PodID:  "pod-a",
 			Status: "ErrImagePull",
-			Containers: []store.Container{
+			Containers: []v1alpha1.Container{
 				{
 					Name: "c1",
 					State: v1alpha1.ContainerState{
@@ -154,7 +154,7 @@ func TestExitControlCI_PodRunningContainerError(t *testing.T) {
 		mt.State.RuntimeState = store.NewK8sRuntimeStateWithPods(mt.Manifest, store.Pod{
 			PodID: "pod-a",
 			Phase: v1.PodRunning,
-			Containers: []store.Container{
+			Containers: []v1alpha1.Container{
 				{
 					Name:     "c1",
 					Ready:    false,
@@ -557,7 +557,7 @@ func pod(podID k8s.PodID, ready bool) store.Pod {
 	return store.Pod{
 		PodID: podID,
 		Phase: v1.PodRunning,
-		Containers: []store.Container{
+		Containers: []v1alpha1.Container{
 			{
 				ID:    string(podID + "-container"),
 				Ready: ready,
@@ -574,7 +574,7 @@ func successPod(podID k8s.PodID) store.Pod {
 		PodID:  podID,
 		Phase:  v1.PodSucceeded,
 		Status: "Completed",
-		Containers: []store.Container{
+		Containers: []v1alpha1.Container{
 			{
 				ID: string(podID + "-container"),
 				State: v1alpha1.ContainerState{

--- a/internal/hud/webview/convert_test.go
+++ b/internal/hud/webview/convert_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
+
 	"github.com/golang/protobuf/ptypes/timestamp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -251,7 +253,7 @@ func TestReadinessCheckFailing(t *testing.T) {
 			"pod id": {
 				Status: "Running",
 				Phase:  "Running",
-				Containers: []store.Container{
+				Containers: []v1alpha1.Container{
 					{
 						Ready: false,
 					},

--- a/internal/store/runtime_state.go
+++ b/internal/store/runtime_state.go
@@ -224,8 +224,8 @@ type Pod struct {
 
 	HasSynclet bool
 
-	Containers     []Container
-	InitContainers []Container
+	Containers     []v1alpha1.Container
+	InitContainers []v1alpha1.Container
 
 	// We want to show the user # of restarts since some baseline time
 	// i.e. Total Restarts - BaselineRestarts
@@ -236,14 +236,12 @@ type Pod struct {
 	SpanID model.LogSpanID
 }
 
-func (p Pod) AllContainers() []Container {
-	result := []Container{}
+func (p Pod) AllContainers() []v1alpha1.Container {
+	result := []v1alpha1.Container{}
 	result = append(result, p.InitContainers...)
 	result = append(result, p.Containers...)
 	return result
 }
-
-type Container = v1alpha1.Container
 
 func (p Pod) Empty() bool {
 	return p.PodID == ""


### PR DESCRIPTION
Purely mechanical - removed the type alias in `store` package.

(This was way fewer changes than I thought it was going to be, which is why I'd planned to do it as its own PR 🤷)