### PR TITLE
engine: truncate list of files in live_update display

### DIFF
--- a/internal/engine/buildcontrol/live_update_build_and_deployer.go
+++ b/internal/engine/buildcontrol/live_update_build_and_deployer.go
@@ -3,7 +3,6 @@ package buildcontrol
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/docker/distribution/reference"
@@ -207,9 +206,9 @@ func liveUpdateInfoForStateTree(stateTree liveUpdateStateTree) (liveUpdInfo, err
 			return liveUpdInfo{}, err
 		}
 		if len(pathsMatchingNoSync) > 0 {
-			prettyPaths := ospath.FileListDisplayNames(iTarget.LocalPaths(), pathsMatchingNoSync)
 			return liveUpdInfo{}, RedirectToNextBuilderInfof(
-				"Found file(s) not matching any sync for %s (files: %s)", iTarget.ID(), strings.Join(prettyPaths, ", "))
+				"Found file(s) not matching any sync for %s (files: %s)", iTarget.ID(),
+				ospath.FormatFileChangeList(pathsMatchingNoSync))
 		}
 
 		// If any changed files match a FallBackOn file, fall back to next BuildAndDeployer
@@ -218,7 +217,7 @@ func liveUpdateInfoForStateTree(stateTree liveUpdateStateTree) (liveUpdInfo, err
 			return liveUpdInfo{}, err
 		}
 		if anyMatch {
-			prettyFile := ospath.FileListDisplayNames(iTarget.LocalPaths(), []string{file})[0]
+			prettyFile := ospath.FileDisplayName(iTarget.LocalPaths(), file)
 			return liveUpdInfo{}, RedirectToNextBuilderInfof(
 				"Detected change to fall_back_on file %q", prettyFile)
 		}


### PR DESCRIPTION
Hello @landism, @maiamcc,

Please review the following commits I made in branch nicks/display:

2607e702dd6ee907e9afe608cc9c02d73e7d8ae1 (2021-04-20 10:34:50 -0400)
engine: truncate list of files in live_update display

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics