### PR TITLE
store: remove Pod alias and use canonical API type

### DIFF
--- a/internal/controllers/core/podlogstream/podlogstreamcontroller_test.go
+++ b/internal/controllers/core/podlogstream/podlogstreamcontroller_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
@@ -625,9 +627,9 @@ func (pb *podBuilder) toPod() *v1.Pod {
 	return (*v1.Pod)(pb)
 }
 
-func (pb *podBuilder) toStorePod(ctx context.Context) store.Pod {
+func (pb *podBuilder) toStorePod(ctx context.Context) v1alpha1.Pod {
 	pod := (*v1.Pod)(pb)
-	return store.Pod{
+	return v1alpha1.Pod{
 		Name:           pb.Name,
 		Namespace:      pb.Namespace,
 		InitContainers: k8sconv.PodContainers(ctx, pod, pod.Status.InitContainerStatuses),

--- a/internal/engine/buildcontrol/build_control_test.go
+++ b/internal/engine/buildcontrol/build_control_test.go
@@ -280,8 +280,8 @@ func TestHoldForDeploy(t *testing.T) {
 	f.assertNextTargetToBuild("sancho")
 }
 
-func readyPod(podID k8s.PodID, ref reference.Named) *store.Pod {
-	return &store.Pod{
+func readyPod(podID k8s.PodID, ref reference.Named) *v1alpha1.Pod {
+	return &v1alpha1.Pod{
 		Name:   podID.String(),
 		Phase:  string(v1.PodRunning),
 		Status: "Running",
@@ -299,8 +299,8 @@ func readyPod(podID k8s.PodID, ref reference.Named) *store.Pod {
 	}
 }
 
-func crashingPod(podID k8s.PodID, ref reference.Named) *store.Pod {
-	return &store.Pod{
+func crashingPod(podID k8s.PodID, ref reference.Named) *v1alpha1.Pod {
+	return &v1alpha1.Pod{
 		Name:   podID.String(),
 		Phase:  string(v1.PodRunning),
 		Status: "CrashLoopBackOff",
@@ -323,8 +323,8 @@ func crashingPod(podID k8s.PodID, ref reference.Named) *store.Pod {
 	}
 }
 
-func crashedInThePastPod(podID k8s.PodID, ref reference.Named) *store.Pod {
-	return &store.Pod{
+func crashedInThePastPod(podID k8s.PodID, ref reference.Named) *v1alpha1.Pod {
+	return &v1alpha1.Pod{
 		Name:   podID.String(),
 		Phase:  string(v1.PodRunning),
 		Status: "Ready",
@@ -343,8 +343,8 @@ func crashedInThePastPod(podID k8s.PodID, ref reference.Named) *store.Pod {
 	}
 }
 
-func sidecarCrashedPod(podID k8s.PodID, ref reference.Named) *store.Pod {
-	return &store.Pod{
+func sidecarCrashedPod(podID k8s.PodID, ref reference.Named) *v1alpha1.Pod {
+	return &v1alpha1.Pod{
 		Name:   podID.String(),
 		Phase:  string(v1.PodRunning),
 		Status: "Ready",

--- a/internal/engine/k8srollout/podmonitor.go
+++ b/internal/engine/k8srollout/podmonitor.go
@@ -135,7 +135,7 @@ type podStatus struct {
 	ready        v1alpha1.PodCondition
 }
 
-func newPodStatus(pod store.Pod, manifestName model.ManifestName) podStatus {
+func newPodStatus(pod v1alpha1.Pod, manifestName model.ManifestName) podStatus {
 	s := podStatus{podID: k8s.PodID(pod.Name), manifestName: manifestName, startTime: pod.CreatedAt.Time}
 	for _, condition := range pod.Conditions {
 		switch v1.PodConditionType(condition.Type) {

--- a/internal/engine/k8srollout/podmonitor_test.go
+++ b/internal/engine/k8srollout/podmonitor_test.go
@@ -32,7 +32,7 @@ func TestMonitorReady(t *testing.T) {
 	defer f.TearDown()
 
 	start := time.Now()
-	p := store.Pod{
+	p := v1alpha1.Pod{
 		Name:      "pod-id",
 		CreatedAt: metav1.NewTime(start),
 		Conditions: []v1alpha1.PodCondition{

--- a/internal/engine/pod.go
+++ b/internal/engine/pod.go
@@ -152,7 +152,7 @@ func matchPodChangeToManifest(state *store.EngineState, action k8swatch.PodChang
 // If not, AND if the pod matches the current deploy, create a new tracking object.
 // Returns a store.Pod that the caller can mutate, and true
 // if this is the first time we've seen this pod.
-func maybeTrackPod(ms *store.ManifestState, action k8swatch.PodChangeAction) (*store.Pod, bool) {
+func maybeTrackPod(ms *store.ManifestState, action k8swatch.PodChangeAction) (*v1alpha1.Pod, bool) {
 	pod := action.Pod
 	podID := k8s.PodIDFromPod(pod)
 	runtime := ms.K8sRuntimeState()
@@ -172,7 +172,7 @@ func maybeTrackPod(ms *store.ManifestState, action k8swatch.PodChangeAction) (*s
 		(isAncestorMatch && runtime.PodAncestorUID != matchedAncestorUID) {
 
 		// Track a new ancestor ID, and delete all existing tracked pods.
-		runtime.Pods = make(map[k8s.PodID]*store.Pod)
+		runtime.Pods = make(map[k8s.PodID]*v1alpha1.Pod)
 		runtime.PodAncestorUID = matchedAncestorUID
 		ms.RuntimeState = runtime
 
@@ -183,7 +183,7 @@ func maybeTrackPod(ms *store.ManifestState, action k8swatch.PodChangeAction) (*s
 	if !ok {
 		// CASE 2: We have a set of pods for this ancestor UID, but not this
 		// particular pod -- record it
-		podInfo = &store.Pod{
+		podInfo = &v1alpha1.Pod{
 			Name: podID.String(),
 		}
 

--- a/internal/engine/portforward/controller.go
+++ b/internal/engine/portforward/controller.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"time"
 
+	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
+
 	"github.com/tilt-dev/tilt/internal/store/k8sconv"
 
 	v1 "k8s.io/api/core/v1"
@@ -183,7 +185,7 @@ type portForwardEntry struct {
 // Extract the port-forward specs from the manifest. If any of them
 // have ContainerPort = 0, populate them with the default port for the pod.
 // Quietly drop forwards that we can't populate.
-func populatePortForwards(m model.Manifest, pod store.Pod) []model.PortForward {
+func populatePortForwards(m model.Manifest, pod v1alpha1.Pod) []model.PortForward {
 	cPorts := store.AllPodContainerPorts(pod)
 	fwds := m.K8sTarget().PortForwards
 	forwards := make([]model.PortForward, 0, len(fwds))
@@ -206,7 +208,7 @@ func populatePortForwards(m model.Manifest, pod store.Pod) []model.PortForward {
 	return forwards
 }
 
-func PortForwardsAreValid(m model.Manifest, pod store.Pod) bool {
+func PortForwardsAreValid(m model.Manifest, pod v1alpha1.Pod) bool {
 	expectedFwds := m.K8sTarget().PortForwards
 	actualFwds := populatePortForwards(m, pod)
 	return len(actualFwds) == len(expectedFwds)

--- a/internal/engine/portforward/controller_test.go
+++ b/internal/engine/portforward/controller_test.go
@@ -45,7 +45,7 @@ func TestPortForward(t *testing.T) {
 	state = f.st.LockMutableStateForTesting()
 	mt := state.ManifestTargets["fe"]
 	mt.State.RuntimeState = store.NewK8sRuntimeStateWithPods(mt.Manifest,
-		store.Pod{Name: "pod-id", Phase: string(v1.PodRunning)})
+		v1alpha1.Pod{Name: "pod-id", Phase: string(v1.PodRunning)})
 	f.st.UnlockMutableState()
 
 	f.onChange()
@@ -56,7 +56,7 @@ func TestPortForward(t *testing.T) {
 	state = f.st.LockMutableStateForTesting()
 	mt = state.ManifestTargets["fe"]
 	mt.State.RuntimeState = store.NewK8sRuntimeStateWithPods(mt.Manifest,
-		store.Pod{Name: "pod-id2", Phase: string(v1.PodRunning)})
+		v1alpha1.Pod{Name: "pod-id2", Phase: string(v1.PodRunning)})
 	f.st.UnlockMutableState()
 
 	f.onChange()
@@ -66,7 +66,7 @@ func TestPortForward(t *testing.T) {
 	state = f.st.LockMutableStateForTesting()
 	mt = state.ManifestTargets["fe"]
 	mt.State.RuntimeState = store.NewK8sRuntimeStateWithPods(mt.Manifest,
-		store.Pod{Name: "pod-id2", Phase: string(v1.PodPending)})
+		v1alpha1.Pod{Name: "pod-id2", Phase: string(v1.PodPending)})
 	f.st.UnlockMutableState()
 
 	f.onChange()
@@ -95,7 +95,7 @@ func TestPortForwardAutoDiscovery(t *testing.T) {
 
 	mt := state.ManifestTargets["fe"]
 	mt.State.RuntimeState = store.NewK8sRuntimeStateWithPods(mt.Manifest,
-		store.Pod{Name: "pod-id", Phase: string(v1.PodRunning)})
+		v1alpha1.Pod{Name: "pod-id", Phase: string(v1.PodRunning)})
 	f.st.UnlockMutableState()
 
 	f.onChange()
@@ -129,7 +129,7 @@ func TestPortForwardAutoDiscovery2(t *testing.T) {
 	state.UpsertManifestTarget(store.NewManifestTarget(m))
 
 	mt := state.ManifestTargets["fe"]
-	mt.State.RuntimeState = store.NewK8sRuntimeStateWithPods(mt.Manifest, store.Pod{
+	mt.State.RuntimeState = store.NewK8sRuntimeStateWithPods(mt.Manifest, v1alpha1.Pod{
 		Name:  "pod-id",
 		Phase: string(v1.PodRunning),
 		Containers: []v1alpha1.Container{
@@ -159,7 +159,7 @@ func TestPortForwardChangePort(t *testing.T) {
 	state.UpsertManifestTarget(store.NewManifestTarget(m))
 	mt := state.ManifestTargets["fe"]
 	mt.State.RuntimeState = store.NewK8sRuntimeStateWithPods(mt.Manifest,
-		store.Pod{Name: "pod-id", Phase: string(v1.PodRunning)})
+		v1alpha1.Pod{Name: "pod-id", Phase: string(v1.PodRunning)})
 	f.st.UnlockMutableState()
 
 	f.onChange()
@@ -195,7 +195,7 @@ func TestPortForwardRestart(t *testing.T) {
 	state.UpsertManifestTarget(store.NewManifestTarget(m))
 	mt := state.ManifestTargets["fe"]
 	mt.State.RuntimeState = store.NewK8sRuntimeStateWithPods(mt.Manifest,
-		store.Pod{Name: "pod-id", Phase: string(v1.PodRunning)})
+		v1alpha1.Pod{Name: "pod-id", Phase: string(v1.PodRunning)})
 	f.st.UnlockMutableState()
 
 	f.onChange()
@@ -250,7 +250,7 @@ func TestPopulatePortForward(t *testing.T) {
 			m := model.Manifest{Name: "fe"}.WithDeployTarget(model.K8sTarget{
 				PortForwards: c.spec,
 			})
-			pod := store.Pod{
+			pod := v1alpha1.Pod{
 				Containers: []v1alpha1.Container{
 					v1alpha1.Container{Ports: c.containerPorts},
 				},

--- a/internal/engine/session/controller_test.go
+++ b/internal/engine/session/controller_test.go
@@ -109,7 +109,7 @@ func TestExitControlCI_FirstRuntimeFailure(t *testing.T) {
 
 	f.store.WithState(func(state *store.EngineState) {
 		mt := state.ManifestTargets["fe"]
-		mt.State.RuntimeState = store.NewK8sRuntimeStateWithPods(mt.Manifest, store.Pod{
+		mt.State.RuntimeState = store.NewK8sRuntimeStateWithPods(mt.Manifest, v1alpha1.Pod{
 			Name:   "pod-a",
 			Status: "ErrImagePull",
 			Containers: []v1alpha1.Container{
@@ -151,7 +151,7 @@ func TestExitControlCI_PodRunningContainerError(t *testing.T) {
 
 	f.store.WithState(func(state *store.EngineState) {
 		mt := state.ManifestTargets["fe"]
-		mt.State.RuntimeState = store.NewK8sRuntimeStateWithPods(mt.Manifest, store.Pod{
+		mt.State.RuntimeState = store.NewK8sRuntimeStateWithPods(mt.Manifest, v1alpha1.Pod{
 			Name:  "pod-a",
 			Phase: string(v1.PodRunning),
 			Containers: []v1alpha1.Container{
@@ -553,8 +553,8 @@ func (s *testStore) requireExitSignalWithNoError() {
 	require.NoError(s.t, state.ExitError)
 }
 
-func pod(podID k8s.PodID, ready bool) store.Pod {
-	return store.Pod{
+func pod(podID k8s.PodID, ready bool) v1alpha1.Pod {
+	return v1alpha1.Pod{
 		Name:  podID.String(),
 		Phase: string(v1.PodRunning),
 		Containers: []v1alpha1.Container{
@@ -569,8 +569,8 @@ func pod(podID k8s.PodID, ready bool) store.Pod {
 	}
 }
 
-func successPod(podID k8s.PodID) store.Pod {
-	return store.Pod{
+func successPod(podID k8s.PodID) v1alpha1.Pod {
+	return v1alpha1.Pod{
 		Name:   podID.String(),
 		Phase:  string(v1.PodSucceeded),
 		Status: "Completed",

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -1483,7 +1483,7 @@ func TestPodEventContainerStatus(t *testing.T) {
 	pod.Spec = k8s.FakePodSpec(ref)
 	f.podEvent(pod, manifest.Name)
 
-	podState := store.Pod{}
+	podState := v1alpha1.Pod{}
 	f.WaitUntilManifestState("container status", "foobar", func(ms store.ManifestState) bool {
 		podState = ms.MostRecentPod()
 		return podState.Name == pod.Name && len(podState.Containers) > 0
@@ -1537,7 +1537,7 @@ func TestPodEventContainerStatusWithoutImage(t *testing.T) {
 
 	f.podEvent(pod, manifest.Name)
 
-	podState := store.Pod{}
+	podState := v1alpha1.Pod{}
 	f.WaitUntilManifestState("container status", "foobar", func(ms store.ManifestState) bool {
 		podState = ms.MostRecentPod()
 		return podState.Name == pod.Name && len(podState.Containers) > 0
@@ -1993,19 +1993,19 @@ func TestPodAddedToStateOrNotByTemplateHash(t *testing.T) {
 			require.True(t, ok, "couldn't find manifest state for %s", mName)
 
 			runtime := ms.K8sRuntimeState()
-			runtime.Pods = make(map[k8s.PodID]*store.Pod)
+			runtime.Pods = make(map[k8s.PodID]*v1alpha1.Pod)
 			if test.ancestorSeen {
 				runtime.PodAncestorUID = ancestorUID
 			}
 
 			if test.podSeen {
-				runtime.Pods[podID] = &store.Pod{
+				runtime.Pods[podID] = &v1alpha1.Pod{
 					Name:   podID.String(),
 					Status: "Running",
 				}
 			}
 			if test.haveAdditionalPod {
-				runtime.Pods[otherPodID] = &store.Pod{
+				runtime.Pods[otherPodID] = &v1alpha1.Pod{
 					Name:   otherPodID.String(),
 					Status: "Running",
 				}
@@ -2163,7 +2163,7 @@ func TestUpperPodLogInCrashLoopPodCurrentlyDown(t *testing.T) {
 
 	pod := pb.Build()
 	pod.Status.ContainerStatuses[0].Ready = false
-	f.notifyAndWaitForPodStatus(pod, name, func(pod store.Pod) bool {
+	f.notifyAndWaitForPodStatus(pod, name, func(pod v1alpha1.Pod) bool {
 		return !store.AllPodContainersReady(pod)
 	})
 
@@ -2278,7 +2278,7 @@ func TestUpperRecordPodWithMultipleContainers(t *testing.T) {
 	})
 
 	f.startPod(pod, manifest.Name)
-	f.notifyAndWaitForPodStatus(pod, manifest.Name, func(pod store.Pod) bool {
+	f.notifyAndWaitForPodStatus(pod, manifest.Name, func(pod v1alpha1.Pod) bool {
 		if len(pod.Containers) != 2 {
 			return false
 		}
@@ -2326,7 +2326,7 @@ func TestUpperProcessOtherContainersIfOneErrors(t *testing.T) {
 	})
 
 	f.startPod(pod, manifest.Name)
-	f.notifyAndWaitForPodStatus(pod, manifest.Name, func(pod store.Pod) bool {
+	f.notifyAndWaitForPodStatus(pod, manifest.Name, func(pod v1alpha1.Pod) bool {
 		if len(pod.Containers) != 2 {
 			return false
 		}
@@ -4263,7 +4263,7 @@ func (f *testFixture) restartPod(pb podbuilder.PodBuilder) podbuilder.PodBuilder
 	return pb
 }
 
-func (f *testFixture) notifyAndWaitForPodStatus(pod *v1.Pod, mn model.ManifestName, pred func(pod store.Pod) bool) {
+func (f *testFixture) notifyAndWaitForPodStatus(pod *v1.Pod, mn model.ManifestName, pred func(pod v1alpha1.Pod) bool) {
 	f.upper.store.Dispatch(k8swatch.NewPodChangeAction(pod, mn, f.lastDeployedUID(mn)))
 
 	f.WaitUntilManifestState("pod status change seen", mn, func(state store.ManifestState) bool {

--- a/internal/hud/webview/convert_test.go
+++ b/internal/hud/webview/convert_test.go
@@ -249,7 +249,7 @@ func TestReadinessCheckFailing(t *testing.T) {
 	}.WithDeployTarget(model.K8sTarget{})
 	state := newState([]model.Manifest{m})
 	state.ManifestTargets[m.Name].State.RuntimeState = store.K8sRuntimeState{
-		Pods: map[k8s.PodID]*store.Pod{
+		Pods: map[k8s.PodID]*v1alpha1.Pod{
 			"pod id": {
 				Status: "Running",
 				Phase:  "Running",

--- a/internal/store/engine_state.go
+++ b/internal/store/engine_state.go
@@ -14,7 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/tilt-dev/tilt/internal/k8s"
-	filewatches "github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
+	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
 
 	tiltanalytics "github.com/tilt-dev/tilt/internal/analytics"
 	"github.com/tilt-dev/tilt/internal/container"
@@ -123,9 +123,9 @@ type EngineState struct {
 
 	// API-server-based data models. Stored in EngineState
 	// to assist in migration.
-	Cmds          map[string]*Cmd                                 `json:"-"`
-	FileWatches   map[types.NamespacedName]*filewatches.FileWatch `json:"-"`
-	PodLogStreams map[string]*PodLogStream                        `json:"-"`
+	Cmds          map[string]*Cmd                              `json:"-"`
+	FileWatches   map[types.NamespacedName]*v1alpha1.FileWatch `json:"-"`
+	PodLogStreams map[string]*PodLogStream                     `json:"-"`
 }
 
 type CloudStatus struct {
@@ -484,7 +484,7 @@ func NewState() *EngineState {
 	}
 
 	ret.Cmds = make(map[string]*Cmd)
-	ret.FileWatches = make(map[types.NamespacedName]*filewatches.FileWatch)
+	ret.FileWatches = make(map[types.NamespacedName]*v1alpha1.FileWatch)
 	ret.PodLogStreams = make(map[string]*PodLogStream)
 
 	return ret
@@ -584,11 +584,11 @@ func (ms *ManifestState) StartedFirstBuild() bool {
 	return !ms.CurrentBuild.Empty() || len(ms.BuildHistory) > 0
 }
 
-func (ms *ManifestState) MostRecentPod() filewatches.Pod {
+func (ms *ManifestState) MostRecentPod() v1alpha1.Pod {
 	return ms.K8sRuntimeState().MostRecentPod()
 }
 
-func (ms *ManifestState) PodWithID(pid k8s.PodID) (*filewatches.Pod, bool) {
+func (ms *ManifestState) PodWithID(pid k8s.PodID) (*v1alpha1.Pod, bool) {
 	for id, pod := range ms.K8sRuntimeState().Pods {
 		if id == pid {
 			return pod, true

--- a/internal/store/engine_state.go
+++ b/internal/store/engine_state.go
@@ -584,11 +584,11 @@ func (ms *ManifestState) StartedFirstBuild() bool {
 	return !ms.CurrentBuild.Empty() || len(ms.BuildHistory) > 0
 }
 
-func (ms *ManifestState) MostRecentPod() Pod {
+func (ms *ManifestState) MostRecentPod() filewatches.Pod {
 	return ms.K8sRuntimeState().MostRecentPod()
 }
 
-func (ms *ManifestState) PodWithID(pid k8s.PodID) (*Pod, bool) {
+func (ms *ManifestState) PodWithID(pid k8s.PodID) (*filewatches.Pod, bool) {
 	for id, pod := range ms.K8sRuntimeState().Pods {
 		if id == pid {
 			return pod, true

--- a/internal/store/engine_state_test.go
+++ b/internal/store/engine_state_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/stretchr/testify/assert"
@@ -193,9 +195,9 @@ func TestStateToViewNonWorkloadYAMLManifest(t *testing.T) {
 }
 
 func TestMostRecentPod(t *testing.T) {
-	podA := Pod{Name: "pod-a", CreatedAt: metav1.Now()}
-	podB := Pod{Name: "pod-b", CreatedAt: metav1.NewTime(time.Now().Add(time.Minute))}
-	podC := Pod{Name: "pod-c", CreatedAt: metav1.NewTime(time.Now().Add(-time.Minute))}
+	podA := v1alpha1.Pod{Name: "pod-a", CreatedAt: metav1.Now()}
+	podB := v1alpha1.Pod{Name: "pod-b", CreatedAt: metav1.NewTime(time.Now().Add(time.Minute))}
+	podC := v1alpha1.Pod{Name: "pod-c", CreatedAt: metav1.NewTime(time.Now().Add(-time.Minute))}
 	m := model.Manifest{Name: "fe"}
 	podSet := NewK8sRuntimeStateWithPods(m, podA, podB, podC)
 	assert.Equal(t, "pod-b", podSet.MostRecentPod().Name)

--- a/internal/testutils/manifestutils/manifest.go
+++ b/internal/testutils/manifestutils/manifest.go
@@ -2,10 +2,11 @@ package manifestutils
 
 import (
 	"github.com/tilt-dev/tilt/internal/store"
+	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
 	"github.com/tilt-dev/tilt/pkg/model"
 )
 
-func NewManifestTargetWithPod(m model.Manifest, pod store.Pod) *store.ManifestTarget {
+func NewManifestTargetWithPod(m model.Manifest, pod v1alpha1.Pod) *store.ManifestTarget {
 	mt := store.NewManifestTarget(m)
 	mt.State.RuntimeState = store.NewK8sRuntimeStateWithPods(m, pod)
 	return mt


### PR DESCRIPTION
Purely mechanical change to get rid of the transitional type alias.

See #4448 for the introduction of the type alias and migration of
logic to use the API type rather than the old `store.Pod` type.

Note that there are still some helper methods in `store` that _really_
shouldn't be there, but with the current package dependency tree,
there isn't any easy/obvious place to move them.

As part of broader Pod discovery API server refactoring, they'll find
a better home and get moved around; most of these should probably be
unexported functions that live alongside the logic that depends on
them.