### PR TITLE
portforward: port forward actions for writing API portforward's back to engine state [ch11906]

### DIFF
--- a/internal/engine/portforward/actions.go
+++ b/internal/engine/portforward/actions.go
@@ -1,0 +1,33 @@
+package portforward
+
+import (
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/tilt-dev/tilt/internal/store"
+)
+
+type PortForwardCreateAction struct {
+	PortForward *PortForward
+}
+
+func NewPortForwardCreateAction(pf *PortForward) PortForwardCreateAction {
+	return PortForwardCreateAction{PortForward: pf.DeepCopy()}
+}
+
+var _ store.Summarizer = PortForwardCreateAction{}
+
+func (PortForwardCreateAction) Action() {}
+
+func (a PortForwardCreateAction) Summarize(s *store.ChangeSummary) {
+	s.PortForwards.Add(types.NamespacedName{Name: a.PortForward.Name})
+}
+
+type PortForwardDeleteAction struct {
+	Name string
+}
+
+func (PortForwardDeleteAction) Action() {}
+
+func (a PortForwardDeleteAction) Summarize(s *store.ChangeSummary) {
+	s.PodLogStreams.Add(types.NamespacedName{Name: a.Name})
+}

--- a/internal/engine/portforward/reducers.go
+++ b/internal/engine/portforward/reducers.go
@@ -1,0 +1,17 @@
+package portforward
+
+import (
+	"github.com/tilt-dev/tilt/internal/store"
+)
+
+func HandlePortForwardCreateAction(state *store.EngineState, action PortForwardCreateAction) {
+	pf := action.PortForward
+	_, exists := state.PortForwards[pf.Name]
+	if !exists {
+		state.PortForwards[pf.Name] = pf
+	}
+}
+
+func HandlePortForwardDeleteAction(state *store.EngineState, action PortForwardDeleteAction) {
+	delete(state.PortForwards, action.Name)
+}

--- a/internal/engine/portforward/types.go
+++ b/internal/engine/portforward/types.go
@@ -1,0 +1,12 @@
+package portforward
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
+)
+
+type PortForward = v1alpha1.PortForward
+type PortForwardSpec = v1alpha1.PortForwardSpec
+type PortForwardStatus = v1alpha1.PortForwardStatus
+type ObjectMeta = metav1.ObjectMeta

--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -9,6 +9,8 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/tilt-dev/tilt/internal/engine/portforward"
+
 	"github.com/davecgh/go-spew/spew"
 	"github.com/tilt-dev/wmclient/pkg/analytics"
 
@@ -196,6 +198,10 @@ func upperReducerFn(ctx context.Context, state *store.EngineState, action store.
 		runtimelog.HandlePodLogStreamCreateAction(state, action)
 	case runtimelog.PodLogStreamDeleteAction:
 		runtimelog.HandlePodLogStreamDeleteAction(state, action)
+	case portforward.PortForwardCreateAction:
+		portforward.HandlePortForwardCreateAction(state, action)
+	case portforward.PortForwardDeleteAction:
+		portforward.HandlePortForwardDeleteAction(state, action)
 	default:
 		state.FatalError = fmt.Errorf("unrecognized action: %T", action)
 	}

--- a/internal/store/engine_state.go
+++ b/internal/store/engine_state.go
@@ -126,6 +126,7 @@ type EngineState struct {
 	Cmds          map[string]*Cmd                                 `json:"-"`
 	FileWatches   map[types.NamespacedName]*filewatches.FileWatch `json:"-"`
 	PodLogStreams map[string]*PodLogStream                        `json:"-"`
+	PortForwards  map[string]*PortForward                         `json:"-"`
 }
 
 type CloudStatus struct {
@@ -486,6 +487,7 @@ func NewState() *EngineState {
 	ret.Cmds = make(map[string]*Cmd)
 	ret.FileWatches = make(map[types.NamespacedName]*filewatches.FileWatch)
 	ret.PodLogStreams = make(map[string]*PodLogStream)
+	ret.PortForwards = make(map[string]*PortForward)
 
 	return ret
 }

--- a/internal/store/summary.go
+++ b/internal/store/summary.go
@@ -62,6 +62,9 @@ type ChangeSummary struct {
 
 	// Sessions that have changed.
 	Sessions ChangeSet
+
+	// PortForwards that have changed.
+	PortForwards ChangeSet
 }
 
 func (s ChangeSummary) IsLogOnly() bool {
@@ -76,6 +79,7 @@ func (s *ChangeSummary) Add(other ChangeSummary) {
 	s.Pods.AddAll(other.Pods)
 	s.PodLogStreams.AddAll(other.PodLogStreams)
 	s.Sessions.AddAll(other.Sessions)
+	s.PortForwards.AddAll(other.PortForwards)
 }
 
 func LegacyChangeSummary() ChangeSummary {

--- a/internal/store/types.go
+++ b/internal/store/types.go
@@ -4,3 +4,4 @@ import "github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
 
 type Cmd = v1alpha1.Cmd
 type PodLogStream = v1alpha1.PodLogStream
+type PortForward = v1alpha1.PortForward


### PR DESCRIPTION
trying to keep PRs smallish -- will use these actions in a future PR to
store API PortForward objects on state whenever we create/delete them
via the API