### PR TITLE
cli: fix panic following logs for non-existent resources

### DIFF
--- a/pkg/model/logstore/logstore.go
+++ b/pkg/model/logstore/logstore.go
@@ -199,7 +199,7 @@ func (s *LogStore) prevIndexMatchingManifests(index int, mns model.ManifestNameS
 		return index - 1
 	}
 
-	for i := index - 1; index >= 0; i-- {
+	for i := index - 1; i >= 0; i-- {
 		span, ok := s.spans[s.segments[i].SpanID]
 		if !ok {
 			continue


### PR DESCRIPTION
When searching for a matching manifest, if we never found it, we
could go negative on the index because the loop was using the wrong
variable.

In a normal `tilt up`, this would never be hit, since we would not
be looking for logs for a non-existent manifest.

When running `tilt logs`, it's possible to pass a resource name,
so an easy way to hit this would be with a typo. But also due to
the way logs are streamed combined with truncation, if you tried
to follow `bar` but only got logs for `foo`, the client would not
know about `foo` at all so would trigger this case even though it
is actually a legitimate manifest.

Now it'll fail to find it and fall-through to the `-1` case as it
should.

Fixes #4453.