### PR TITLE
store: fix a race condition where sometimes we would start a server twice

### DIFF
--- a/internal/store/manifest_target.go
+++ b/internal/store/manifest_target.go
@@ -34,6 +34,18 @@ func (mt *ManifestTarget) UpdateStatus() model.UpdateStatus {
 	}
 
 	if m.IsLocal() && m.LocalTarget().UpdateCmd.Empty() {
+		// NOTE(nick): We currently model a local_resource(serve_cmd) as a Manifest
+		// with a no-op Update. BuildController treats it like any other
+		// resource. When the build completes, the server controller starts the
+		// server.
+		//
+		// We want to make sure that the UpdateStatus is still "Pending" until we
+		// have a completed build record. Otherwise the server controller will try
+		// to start the server twice (once while the update is in-progress, and once
+		// when the update completes).
+		if us == model.UpdateStatusInProgress {
+			return model.UpdateStatusPending
+		}
 		return model.UpdateStatusNotApplicable
 	}
 

--- a/internal/store/manifest_target_test.go
+++ b/internal/store/manifest_target_test.go
@@ -15,6 +15,10 @@ func TestLocalTargetUpdateStatus(t *testing.T) {
 	mt := NewManifestTarget(m)
 	assert.Equal(t, model.UpdateStatusPending, mt.UpdateStatus())
 
+	mt.State.CurrentBuild = model.BuildRecord{StartTime: time.Now()}
+	assert.Equal(t, model.UpdateStatusPending, mt.UpdateStatus())
+
+	mt.State.CurrentBuild = model.BuildRecord{}
 	mt.State.AddCompletedBuild(model.BuildRecord{StartTime: time.Now(), FinishTime: time.Now()})
 	assert.Equal(t, model.UpdateStatusNotApplicable, mt.UpdateStatus())
 


### PR DESCRIPTION
Hello @landism, @milas,

Please review the following commits I made in branch nicks/dupecmds:

bc75d0ae2197c81cc48bc9306b12df90156c180a (2021-04-21 17:37:42 -0400)
store: fix a race condition where sometimes we would start a server twice

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics