### PR TITLE
 engine: use v1alpha.Pod for pod change events

### DIFF
--- a/internal/engine/buildcontroller_test.go
+++ b/internal/engine/buildcontroller_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/tilt-dev/tilt/internal/store/k8sconv"
 	"github.com/tilt-dev/tilt/pkg/apis"
 
 	"github.com/stretchr/testify/assert"
@@ -692,7 +693,7 @@ func TestFullBuildTriggerClearsLiveUpdate(t *testing.T) {
 	})
 
 	deleteEvent := k8swatch.NewPodChangeAction(
-		podbuilder.New(f.T(), manifest).WithDeletionTime(time.Now()).Build(),
+		k8sconv.Pod(f.ctx, podbuilder.New(f.T(), manifest).WithDeletionTime(time.Now()).Build()),
 		manifest.Name, f.lastDeployedUID(manifest.Name))
 
 	f.b.completeBuildsManually = true

--- a/internal/engine/k8swatch/actions.go
+++ b/internal/engine/k8swatch/actions.go
@@ -3,6 +3,8 @@ package k8swatch
 import (
 	"net/url"
 
+	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
+
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -12,7 +14,7 @@ import (
 )
 
 type PodChangeAction struct {
-	Pod          *v1.Pod
+	Pod          *v1alpha1.Pod
 	ManifestName model.ManifestName
 
 	// The UID that we matched against to associate this pod with Tilt.
@@ -25,10 +27,10 @@ var _ store.Summarizer = PodChangeAction{}
 func (PodChangeAction) Action() {}
 
 func (a PodChangeAction) Summarize(s *store.ChangeSummary) {
-	s.Pods.Add(types.NamespacedName{Name: string(a.Pod.Name), Namespace: string(a.Pod.Namespace)})
+	s.Pods.Add(types.NamespacedName{Name: a.Pod.Name, Namespace: a.Pod.Namespace})
 }
 
-func NewPodChangeAction(pod *v1.Pod, mn model.ManifestName, matchedAncestorUID types.UID) PodChangeAction {
+func NewPodChangeAction(pod *v1alpha1.Pod, mn model.ManifestName, matchedAncestorUID types.UID) PodChangeAction {
 	return PodChangeAction{
 		Pod:                pod,
 		ManifestName:       mn,

--- a/internal/engine/pod.go
+++ b/internal/engine/pod.go
@@ -18,7 +18,7 @@ import (
 	"github.com/tilt-dev/tilt/pkg/logger"
 )
 
-func handlePodDeleteAction(ctx context.Context, state *store.EngineState, action k8swatch.PodDeleteAction) {
+func handlePodDeleteAction(_ context.Context, state *store.EngineState, action k8swatch.PodDeleteAction) {
 	// PodDeleteActions only have the pod id. We don't have a good way to tie them back to their ancestors.
 	// So just brute-force it.
 	for _, target := range state.ManifestTargets {
@@ -34,49 +34,49 @@ func handlePodChangeAction(ctx context.Context, state *store.EngineState, action
 		return
 	}
 
-	pod := action.Pod
+	podInfo := action.Pod
+	podID := k8s.PodID(podInfo.Name)
+	spanID := k8sconv.SpanIDForPod(podID)
 	ms := mt.State
+	krs := ms.K8sRuntimeState()
 	manifest := mt.Manifest
-	podInfo, isNew := maybeTrackPod(ms, action)
-	if podInfo == nil {
-		// This is an event from an old pod that has never been tracked.
-		return
+
+	var existing *v1alpha1.Pod
+	isCurrentDeploy := krs.HasOKPodTemplateSpecHash(podInfo)
+	if isCurrentDeploy {
+		// Only attach a new pod to the runtime state if it's from the current deploy;
+		// if it's from an old deploy/an old Tilt run, we don't want to be checking it
+		// for status etc.
+		existing = trackPod(ms, action)
+	} else {
+		// If this is from an outdated deploy but the pod is still being tracked, we
+		// will still update it; if it's outdated and untracked, just ignore
+		existing = krs.Pods[podID]
+		if existing == nil {
+			return
+		}
+		krs.Pods[podID] = podInfo
 	}
-
-	spanID := k8sconv.SpanIDForPod(k8s.PodID(podInfo.Name))
-
-	// Update the status
-	podInfo.CreatedAt = *pod.CreationTimestamp.DeepCopy()
-	podInfo.Status = k8swatch.PodStatusToString(*pod)
-	podInfo.Namespace = pod.Namespace
-	podInfo.Deleting = pod.DeletionTimestamp != nil && !pod.DeletionTimestamp.IsZero()
-	podInfo.Phase = string(pod.Status.Phase)
-	podInfo.Errors = k8swatch.PodStatusErrorMessages(*pod)
-	podInfo.Conditions = k8sconv.PodConditions(pod.Status.Conditions)
 
 	prunePods(ms)
 
-	initContainers := k8sconv.PodContainers(ctx, pod, pod.Status.InitContainerStatuses)
-	if !isNew {
-		names := restartedContainerNames(podInfo.InitContainers, initContainers)
+	if existing != nil {
+		names := restartedContainerNames(existing.InitContainers, podInfo.InitContainers)
 		for _, name := range names {
-			s := fmt.Sprintf("Detected container restart. Pod: %s. Container: %s.", podInfo.Name, name)
+			s := fmt.Sprintf("Detected container restart. Pod: %s. Container: %s.", existing.Name, name)
 			handleLogAction(state, store.NewLogAction(manifest.Name, spanID, logger.WarnLvl, nil, []byte(s)))
 		}
 	}
-	podInfo.InitContainers = initContainers
 
-	containers := k8sconv.PodContainers(ctx, pod, pod.Status.ContainerStatuses)
-	if !isNew {
-		names := restartedContainerNames(podInfo.Containers, containers)
+	if existing != nil {
+		names := restartedContainerNames(existing.Containers, podInfo.Containers)
 		for _, name := range names {
-			s := fmt.Sprintf("Detected container restart. Pod: %s. Container: %s.", podInfo.Name, name)
+			s := fmt.Sprintf("Detected container restart. Pod: %s. Container: %s.", existing.Name, name)
 			handleLogAction(state, store.NewLogAction(manifest.Name, spanID, logger.WarnLvl, nil, []byte(s)))
 		}
 	}
-	podInfo.Containers = containers
 
-	if isNew {
+	if existing == nil {
 		// This is the first time we've seen this pod.
 		// Ignore any restarts that happened before Tilt saw it.
 		//
@@ -103,7 +103,7 @@ func handlePodChangeAction(ctx context.Context, state *store.EngineState, action
 			"Resource %s is using port forwards, but no container ports on pod %s",
 			manifest.Name, podInfo.Name)
 	}
-	checkForContainerCrash(ctx, state, mt)
+	checkForContainerCrash(state, mt)
 }
 
 func restartedContainerNames(existingContainers []v1alpha1.Container, newContainers []v1alpha1.Container) []container.Name {
@@ -148,24 +148,21 @@ func matchPodChangeToManifest(state *store.EngineState, action k8swatch.PodChang
 	return mt
 }
 
-// Checks the runtime state if we're already tracking this pod.
-// If not, AND if the pod matches the current deploy, create a new tracking object.
-// Returns a store.Pod that the caller can mutate, and true
-// if this is the first time we've seen this pod.
-func maybeTrackPod(ms *store.ManifestState, action k8swatch.PodChangeAction) (*v1alpha1.Pod, bool) {
+// trackPod adds a Pod to the RuntimeState for a resource.
+//
+// If there are currently tracked Pods and the new Pod's ancestor UID differs from theirs,
+// the tracked Pods will be cleared and the ancestor UID updated. Otherwise, the Pod will
+// be upserted and the prior version returned.
+//
+// A mutable reference to the Pod to be tracked is stored so that further changes to it
+// can be made based on the diff from the returned prior version. The caller should *not*
+// hold their reference beyond the action handler.
+func trackPod(ms *store.ManifestState, action k8swatch.PodChangeAction) *v1alpha1.Pod {
 	pod := action.Pod
-	podID := k8s.PodIDFromPod(pod)
+	podID := k8s.PodID(pod.Name)
 	runtime := ms.K8sRuntimeState()
-	isCurrentDeploy := runtime.HasOKPodTemplateSpecHash(pod) // is pod from the most recent Tilt deploy?
 
-	// Only attach a new pod to the runtime state if it's from the current deploy;
-	// if it's from an old deploy/an old Tilt run, we don't want to be checking it
-	// for status etc.
-	if !isCurrentDeploy {
-		return runtime.Pods[podID], false
-	}
-
-	// Case 1: We haven't seen pods for this ancestor yet.
+	// (Re-)initialize state if we haven't seen pods for this ancestor yet
 	matchedAncestorUID := action.MatchedAncestorUID
 	isAncestorMatch := matchedAncestorUID != ""
 	if runtime.PodAncestorUID == "" ||
@@ -175,28 +172,15 @@ func maybeTrackPod(ms *store.ManifestState, action k8swatch.PodChangeAction) (*v
 		runtime.Pods = make(map[k8s.PodID]*v1alpha1.Pod)
 		runtime.PodAncestorUID = matchedAncestorUID
 		ms.RuntimeState = runtime
-
-		// Fall through to the case below to create a new tracked pod.
 	}
 
-	podInfo, ok := runtime.Pods[podID]
-	if !ok {
-		// CASE 2: We have a set of pods for this ancestor UID, but not this
-		// particular pod -- record it
-		podInfo = &v1alpha1.Pod{
-			Name: podID.String(),
-		}
-
-		runtime.Pods[podID] = podInfo
-
-		return podInfo, true
-	}
-
-	// CASE 3: This pod is already in the PodSet, nothing to do.
-	return podInfo, false
+	// Return the existing (if any) and track the new version
+	existing := runtime.Pods[podID]
+	runtime.Pods[podID] = pod
+	return existing
 }
 
-func checkForContainerCrash(ctx context.Context, state *store.EngineState, mt *store.ManifestTarget) {
+func checkForContainerCrash(state *store.EngineState, mt *store.ManifestTarget) {
 	ms := mt.State
 	if ms.NeedsRebuildFromCrash {
 		// We're already aware the pod is crashing.

--- a/internal/engine/pod_test.go
+++ b/internal/engine/pod_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"testing"
 
+	"github.com/tilt-dev/tilt/internal/store/k8sconv"
+
 	"github.com/stretchr/testify/assert"
 
 	"github.com/tilt-dev/tilt/internal/engine/k8swatch"
@@ -29,10 +31,7 @@ func TestPodDeleteAction(t *testing.T) {
 
 	assert.Equal(t, 0, len(ms.K8sRuntimeState().Pods))
 
-	handlePodChangeAction(f.ctx, f.state, k8swatch.PodChangeAction{
-		Pod:          pod,
-		ManifestName: m.Name,
-	})
+	handlePodChangeAction(f.ctx, f.state, k8swatch.NewPodChangeAction(k8sconv.Pod(f.ctx, pod), m.Name, ""))
 
 	assert.Equal(t, 1, len(ms.K8sRuntimeState().Pods))
 

--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -421,7 +421,7 @@ func handleBuildCompleted(ctx context.Context, engineState *store.EngineState, c
 		bestPod := ms.MostRecentPod()
 		if timecmp.AfterOrEqual(bestPod.CreatedAt, bs.StartTime) ||
 			timecmp.Equal(bestPod.UpdateStartedAt, bs.StartTime) {
-			checkForContainerCrash(ctx, engineState, mt)
+			checkForContainerCrash(engineState, mt)
 		}
 	}
 

--- a/internal/store/k8sconv/pod.go
+++ b/internal/store/k8sconv/pod.go
@@ -15,6 +15,24 @@ import (
 	"github.com/tilt-dev/tilt/pkg/model"
 )
 
+func Pod(ctx context.Context, pod *v1.Pod) *v1alpha1.Pod {
+	podInfo := &v1alpha1.Pod{
+		Name:           pod.Name,
+		Namespace:      pod.Namespace,
+		CreatedAt:      *pod.CreationTimestamp.DeepCopy(),
+		Phase:          string(pod.Status.Phase),
+		Deleting:       pod.DeletionTimestamp != nil && !pod.DeletionTimestamp.IsZero(),
+		Conditions:     PodConditions(pod.Status.Conditions),
+		InitContainers: PodContainers(ctx, pod, pod.Status.InitContainerStatuses),
+		Containers:     PodContainers(ctx, pod, pod.Status.ContainerStatuses),
+
+		PodTemplateSpecHash: pod.Labels[k8s.TiltPodTemplateHashLabel],
+		Status:              PodStatusToString(*pod),
+		Errors:              PodStatusErrorMessages(*pod),
+	}
+	return podInfo
+}
+
 func PodConditions(conditions []v1.PodCondition) []v1alpha1.PodCondition {
 	result := make([]v1alpha1.PodCondition, 0, len(conditions))
 	for _, c := range conditions {
@@ -126,4 +144,113 @@ var ErrorWaitingReasons = map[string]bool{
 
 func SpanIDForPod(podID k8s.PodID) logstore.SpanID {
 	return logstore.SpanID(fmt.Sprintf("pod:%s", podID))
+}
+
+// copied from https://github.com/kubernetes/kubernetes/blob/aedeccda9562b9effe026bb02c8d3c539fc7bb77/pkg/kubectl/resource_printer.go#L692-L764
+// to match the status column of `kubectl get pods`
+func PodStatusToString(pod v1.Pod) string {
+	reason := string(pod.Status.Phase)
+	if pod.Status.Reason != "" {
+		reason = pod.Status.Reason
+	}
+
+	for i, container := range pod.Status.InitContainerStatuses {
+		state := container.State
+
+		switch {
+		case state.Terminated != nil && state.Terminated.ExitCode == 0:
+			continue
+		case state.Terminated != nil:
+			// initialization is failed
+			if len(state.Terminated.Reason) == 0 {
+				if state.Terminated.Signal != 0 {
+					reason = fmt.Sprintf("Init:Signal:%d", state.Terminated.Signal)
+				} else {
+					reason = fmt.Sprintf("Init:ExitCode:%d", state.Terminated.ExitCode)
+				}
+			} else {
+				reason = "Init:" + state.Terminated.Reason
+			}
+		case state.Waiting != nil && len(state.Waiting.Reason) > 0 && state.Waiting.Reason != "PodInitializing":
+			reason = "Init:" + state.Waiting.Reason
+		default:
+			reason = fmt.Sprintf("Init:%d/%d", i, len(pod.Spec.InitContainers))
+		}
+		break
+	}
+
+	if isPodStillInitializing(pod) {
+		return reason
+	}
+
+	for i := len(pod.Status.ContainerStatuses) - 1; i >= 0; i-- {
+		container := pod.Status.ContainerStatuses[i]
+		state := container.State
+
+		if state.Waiting != nil && state.Waiting.Reason != "" {
+			reason = state.Waiting.Reason
+		} else if state.Terminated != nil && state.Terminated.Reason != "" {
+			reason = state.Terminated.Reason
+		} else if state.Terminated != nil && state.Terminated.Reason == "" {
+			if state.Terminated.Signal != 0 {
+				reason = fmt.Sprintf("Signal:%d", state.Terminated.Signal)
+			} else {
+				reason = fmt.Sprintf("ExitCode:%d", state.Terminated.ExitCode)
+			}
+		}
+	}
+
+	return reason
+}
+
+// Pull out interesting error messages from the pod status
+func PodStatusErrorMessages(pod v1.Pod) []string {
+	result := []string{}
+	if isPodStillInitializing(pod) {
+		for _, container := range pod.Status.InitContainerStatuses {
+			result = append(result, containerStatusErrorMessages(container)...)
+		}
+	}
+	for i := len(pod.Status.ContainerStatuses) - 1; i >= 0; i-- {
+		container := pod.Status.ContainerStatuses[i]
+		result = append(result, containerStatusErrorMessages(container)...)
+	}
+	return result
+}
+
+func containerStatusErrorMessages(container v1.ContainerStatus) []string {
+	result := []string{}
+	state := container.State
+	if state.Waiting != nil {
+		lastState := container.LastTerminationState
+		if lastState.Terminated != nil &&
+			lastState.Terminated.ExitCode != 0 &&
+			lastState.Terminated.Message != "" {
+			result = append(result, lastState.Terminated.Message)
+		}
+
+		// If we're in an error mode, also include the error message.
+		// Many error modes put important information in the error message,
+		// like when the pod will get rescheduled.
+		if state.Waiting.Message != "" && ErrorWaitingReasons[state.Waiting.Reason] {
+			result = append(result, state.Waiting.Message)
+		}
+	} else if state.Terminated != nil &&
+		state.Terminated.ExitCode != 0 &&
+		state.Terminated.Message != "" {
+		result = append(result, state.Terminated.Message)
+	}
+
+	return result
+}
+
+func isPodStillInitializing(pod v1.Pod) bool {
+	for _, container := range pod.Status.InitContainerStatuses {
+		state := container.State
+		isFinished := state.Terminated != nil && state.Terminated.ExitCode == 0
+		if !isFinished {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/store/runtime_state.go
+++ b/internal/store/runtime_state.go
@@ -194,14 +194,14 @@ func (s K8sRuntimeState) MostRecentPod() v1alpha1.Pod {
 	return bestPod
 }
 
-func (s K8sRuntimeState) HasOKPodTemplateSpecHash(pod *v1.Pod) bool {
+func (s K8sRuntimeState) HasOKPodTemplateSpecHash(pod *v1alpha1.Pod) bool {
 	// if it doesn't have a label, just let it through - maybe it's from a CRD w/ no pod template spec
-	hash, ok := pod.Labels[k8s.TiltPodTemplateHashLabel]
-	if !ok {
+	hash := k8s.PodTemplateSpecHash(pod.PodTemplateSpecHash)
+	if hash == "" {
 		return true
 	}
 
-	return s.DeployedPodTemplateSpecHashSet.Contains(k8s.PodTemplateSpecHash(hash))
+	return s.DeployedPodTemplateSpecHashSet.Contains(hash)
 }
 
 func (s K8sRuntimeState) DeployedUIDSet() k8s.UIDSet {


### PR DESCRIPTION
This is another incremental change; it _mostly_ shifts the conversion
logic out of the action handler. The other biggest change is that it
now completely replaces the tracked Pod objects instead of getting a
reference and mutating it - this shifts some of the logic about
whether to track up a level. This gets the logic closer to its
eventual state as part of a reconciler based on the patterns we've
been following.

The actual action is still a change for a single Pod rather than a
`PodDiscoveryStatus` update, but the changes are large enough for
this chunk that it made since to use this as an increment.

~~(⚠️ This needs the changes from #4458, so I'll rebase once that's merged; diff might be chaotic in the interim)~~