### PR TITLE
engine: track deployed object refs

### DIFF
--- a/internal/engine/buildcontrol/image_build_and_deployer.go
+++ b/internal/engine/buildcontrol/image_build_and_deployer.go
@@ -11,7 +11,6 @@ import (
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/tilt-dev/tilt/internal/analytics"
 	"github.com/tilt-dev/tilt/internal/build"
@@ -274,15 +273,11 @@ func (ibd *ImageBuildAndDeployer) deploy(ctx context.Context, st store.RStore, p
 		return nil, err
 	}
 
-	// TODO(nick): Do something with this result
-	uids := []types.UID{}
 	podTemplateSpecHashes := []k8s.PodTemplateSpecHash{}
 	for _, entity := range deployed {
-		uid := entity.UID()
-		if uid == "" {
+		if entity.UID() == "" {
 			return nil, fmt.Errorf("Entity not deployed correctly: %v", entity)
 		}
-		uids = append(uids, entity.UID())
 		hs, err := k8s.ReadPodTemplateSpecHashes(entity)
 		if err != nil {
 			return nil, errors.Wrap(err, "reading pod template spec hashes")
@@ -290,7 +285,7 @@ func (ibd *ImageBuildAndDeployer) deploy(ctx context.Context, st store.RStore, p
 		podTemplateSpecHashes = append(podTemplateSpecHashes, hs...)
 	}
 
-	return store.NewK8sDeployResult(kTarget.ID(), uids, podTemplateSpecHashes, deployed), nil
+	return store.NewK8sDeployResult(kTarget.ID(), podTemplateSpecHashes, deployed), nil
 }
 
 func (ibd *ImageBuildAndDeployer) indentLogger(ctx context.Context) context.Context {

--- a/internal/engine/buildcontrol/image_build_and_deployer_test.go
+++ b/internal/engine/buildcontrol/image_build_and_deployer_test.go
@@ -864,8 +864,9 @@ func TestIBDDeployUIDs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	assert.Equal(t, 1, len(result.DeployedUIDSet()))
-	assert.True(t, result.DeployedUIDSet().Contains(f.k8s.LastUpsertResult[0].UID()))
+	deployed := result.DeployedEntities()
+	assert.Equal(t, 1, len(deployed))
+	assert.True(t, deployed.ContainsUID(f.k8s.LastUpsertResult[0].UID()))
 }
 
 func TestDockerBuildTargetStage(t *testing.T) {

--- a/internal/engine/k8swatch/event_watch_manager.go
+++ b/internal/engine/k8swatch/event_watch_manager.go
@@ -34,7 +34,7 @@ type EventWatchManager struct {
 	// all events that they own (transitively).
 	//
 	// For example, a Deployment UID might contain a set of N event UIDs.
-	knownDescendentEventUIDs map[types.UID]store.UIDSet
+	knownDescendentEventUIDs map[types.UID]k8s.UIDSet
 
 	// An index of all the known events, by UID
 	knownEvents map[types.UID]*v1.Event
@@ -45,7 +45,7 @@ func NewEventWatchManager(kClient k8s.Client, ownerFetcher k8s.OwnerFetcher, cfg
 		kClient:                  kClient,
 		ownerFetcher:             ownerFetcher,
 		watcherKnownState:        newWatcherKnownState(cfgNS),
-		knownDescendentEventUIDs: make(map[types.UID]store.UIDSet),
+		knownDescendentEventUIDs: make(map[types.UID]k8s.UIDSet),
 		knownEvents:              make(map[types.UID]*v1.Event),
 	}
 }
@@ -143,7 +143,7 @@ func (m *EventWatchManager) triageEventUpdate(event *v1.Event, objTree k8s.Objec
 	for _, ownerUID := range objTree.UIDs() {
 		set, ok := m.knownDescendentEventUIDs[ownerUID]
 		if !ok {
-			set = store.NewUIDSet()
+			set = k8s.NewUIDSet()
 			m.knownDescendentEventUIDs[ownerUID] = set
 		}
 		set.Add(uid)

--- a/internal/engine/k8swatch/watcher.go
+++ b/internal/engine/k8swatch/watcher.go
@@ -63,7 +63,7 @@ func (ks *watcherKnownState) createTaskList(state store.EngineState) watcherTask
 		}
 
 		// Collect all the new UIDs
-		for id := range mt.State.K8sRuntimeState().DeployedUIDSet {
+		for _, ref := range mt.State.K8sRuntimeState().DeployedEntities {
 			// Our data model allows people to have the same resource defined in
 			// multiple manifests, and so we can have the same deployed UID in
 			// multiple manifests.
@@ -72,6 +72,7 @@ func (ks *watcherKnownState) createTaskList(state store.EngineState) watcherTask
 			// between the two manifests.
 			//
 			// Ideally, our data model would prevent this from happening entirely.
+			id := ref.UID
 			if seenUIDs[id] {
 				continue
 			}

--- a/internal/engine/pod.go
+++ b/internal/engine/pod.go
@@ -142,7 +142,7 @@ func matchPodChangeToManifest(state *store.EngineState, action k8swatch.PodChang
 	// If the event has an ancestor UID attached, but that ancestor isn't in the
 	// deployed UID set anymore, we can ignore it.
 	isAncestorMatched := matchedAncestorUID != ""
-	if isAncestorMatched && !runtime.DeployedUIDSet.Contains(matchedAncestorUID) {
+	if isAncestorMatched && !runtime.DeployedEntities.ContainsUID(matchedAncestorUID) {
 		return nil
 	}
 	return mt

--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -427,9 +427,9 @@ func handleBuildCompleted(ctx context.Context, engineState *store.EngineState, c
 	manifest := mt.Manifest
 	if manifest.IsK8s() {
 		state := ms.K8sRuntimeState()
-		deployedUIDSet := cb.Result.DeployedUIDSet()
-		if len(deployedUIDSet) > 0 {
-			state.DeployedUIDSet = deployedUIDSet
+		deployedEntities := cb.Result.DeployedEntities()
+		if len(deployedEntities) > 0 {
+			state.DeployedEntities = deployedEntities
 		}
 
 		deployedPodTemplateSpecHashSet := cb.Result.DeployedPodTemplateSpecHashes()

--- a/internal/k8s/ref.go
+++ b/internal/k8s/ref.go
@@ -1,0 +1,30 @@
+package k8s
+
+import (
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+type ObjRefList []v1.ObjectReference
+
+func (o ObjRefList) ContainsUID(uid types.UID) bool {
+	_, ok := o.GetByUID(uid)
+	return ok
+}
+
+func (o ObjRefList) GetByUID(uid types.UID) (v1.ObjectReference, bool) {
+	for _, ref := range o {
+		if ref.UID == uid {
+			return ref, true
+		}
+	}
+	return v1.ObjectReference{}, false
+}
+
+func (o ObjRefList) UIDSet() UIDSet {
+	out := NewUIDSet()
+	for _, ref := range o {
+		out.Add(ref.UID)
+	}
+	return out
+}

--- a/internal/k8s/ref_test.go
+++ b/internal/k8s/ref_test.go
@@ -1,0 +1,29 @@
+package k8s
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+)
+
+func TestObjRefList(t *testing.T) {
+	var orl ObjRefList
+	require.False(t, orl.ContainsUID("abc123"))
+	require.Empty(t, orl.UIDSet())
+	ref, ok := orl.GetByUID("abc123")
+	require.False(t, ok)
+	require.Empty(t, ref)
+
+	ref = v1.ObjectReference{UID: "abc123", Namespace: "namespace", Name: "name"}
+	orl = append(orl, ref)
+	require.True(t, orl.ContainsUID("abc123"))
+	require.False(t, orl.ContainsUID("def456"))
+	expectedUIDs := NewUIDSet()
+	expectedUIDs.Add("abc123")
+	require.Equal(t, expectedUIDs, orl.UIDSet())
+
+	r, ok := orl.GetByUID("abc123")
+	require.True(t, ok)
+	require.Equal(t, ref, r)
+}

--- a/internal/k8s/uid.go
+++ b/internal/k8s/uid.go
@@ -1,0 +1,19 @@
+package k8s
+
+import "k8s.io/apimachinery/pkg/types"
+
+type UIDSet map[types.UID]bool
+
+func NewUIDSet() UIDSet {
+	return make(map[types.UID]bool)
+}
+
+func (s UIDSet) Add(uids ...types.UID) {
+	for _, uid := range uids {
+		s[uid] = true
+	}
+}
+
+func (s UIDSet) Contains(uid types.UID) bool {
+	return s[uid]
+}

--- a/internal/k8s/uid_test.go
+++ b/internal/k8s/uid_test.go
@@ -1,0 +1,26 @@
+package k8s
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func TestUIDSet(t *testing.T) {
+	uids := NewUIDSet()
+	require.NotNil(t, uids)
+	require.Equal(t, 0, len(uids))
+
+	values := []types.UID{types.UID("uid-0"), types.UID("uid-1"), types.UID("uid-2"), types.UID("uid-3")}
+	for _, v := range values {
+		require.False(t, uids.Contains(v))
+	}
+	uids.Add(values[0])
+	require.True(t, uids.Contains("uid-0"))
+	uids.Add(values[1], values[2])
+	for _, v := range values[:3] {
+		require.True(t, uids.Contains(v))
+	}
+	require.False(t, uids.Contains(values[3]))
+}

--- a/internal/store/json_test.go
+++ b/internal/store/json_test.go
@@ -23,7 +23,7 @@ func TestToJSON(t *testing.T) {
 	state := newState([]model.Manifest{m})
 
 	mState, _ := state.ManifestState("fe")
-	mState.MutableBuildStatus(m.K8sTarget().ID()).LastResult = NewK8sDeployResult(m.K8sTarget().ID(), nil, nil, nil)
+	mState.MutableBuildStatus(m.K8sTarget().ID()).LastResult = NewK8sDeployResult(m.K8sTarget().ID(), nil, nil)
 
 	buf := bytes.NewBuffer(nil)
 	encoder := CreateEngineStateEncoder(buf)

--- a/internal/testutils/podbuilder/podbuilder.go
+++ b/internal/testutils/podbuilder/podbuilder.go
@@ -355,12 +355,26 @@ func (b PodBuilder) validateContainerIDs(numContainers int) {
 	}
 }
 
+type PodObjectTree []k8s.K8sEntity
+
+func (p PodObjectTree) Pod() k8s.K8sEntity {
+	return p[0]
+}
+
+func (p PodObjectTree) ReplicaSet() k8s.K8sEntity {
+	return p[1]
+}
+
+func (p PodObjectTree) Deployment() k8s.K8sEntity {
+	return p[2]
+}
+
 // Simulates a Pod -> ReplicaSet -> Deployment ref tree
-func (b PodBuilder) ObjectTreeEntities() []k8s.K8sEntity {
+func (b PodBuilder) ObjectTreeEntities() PodObjectTree {
 	pod := b.Build()
 	rs := b.buildReplicaSet()
 	dep := b.buildDeployment()
-	return []k8s.K8sEntity{
+	return PodObjectTree{
 		k8s.NewK8sEntity(pod),
 		k8s.NewK8sEntity(rs),
 		k8s.NewK8sEntity(dep),


### PR DESCRIPTION
This is in preparation for `PodDiscovery` API work.

The motivation here is that currently, the engine extracts some
details about the objects it's managing from the specs, i.e. what
it "expects" to deploy. These are gathered across all manifests to
determine which namespaces to watch in the cluster.

Indepedently, the deployer stores the UIDs, but that loses the
mapping back to namespace. Currently, it's not an issue because of
the aforementioned logic determining which namespaces to watch.

With the move to apiserver, the semantics will be slightly different;
each manifest will define the ancestor UID + namespaces it cares
about. The reconciler will handle ensuring only 1x watch per namespace
is created for efficiency, but the key is that the spec needs to
include the UID + namespace together.

By holding the deployed object refs, we now have this information, so
a targeted spec can be created.

(This will also enable resolving a long-standing bug/unexpected
behavior that the extra label selectors will be across _any_ namespace
that's being watched, even if the respective manifest doesn't deploy
anything there. It's a very minor issue, but will be nice to clean up
in the process for free.)