### PR TITLE
logstore: raise the log limit, and truncate by both recency and length

### DIFF
--- a/web/src/LogStore.test.ts
+++ b/web/src/LogStore.test.ts
@@ -506,6 +506,30 @@ describe("LogStore", () => {
     expect(logLinesToString(logs.manifestLog("be"), false)).toEqual("")
   })
 
+  it("weights on recenty and length", () => {
+    let logs = new LogStore()
+    expect(
+      logs.heaviestManifestName({
+        a: { name: "a", byteCount: 100, start: "2020-04" },
+        b: { name: "b", byteCount: 100, start: "2021-04" },
+      })
+    ).toEqual("a")
+
+    expect(
+      logs.heaviestManifestName({
+        a: { name: "a", byteCount: 100, start: "2020-04" },
+        b: { name: "b", byteCount: 1000, start: "2021-04" },
+      })
+    ).toEqual("b")
+
+    expect(
+      logs.heaviestManifestName({
+        a: { name: "a", byteCount: 100, start: "2020-04" },
+        b: { name: "b", byteCount: 150, start: "2021-04" },
+      })
+    ).toEqual("a")
+  })
+
   it("truncates output for snapshots", () => {
     let logs = new LogStore()
     logs.maxLogLength = 40


### PR DESCRIPTION
Hello @landism, @milas,

Please review the following commits I made in branch nicks/logstore:

cfb1e8b4ceab8491cc8fae42c9060d47766e5cd4 (2021-04-28 14:40:37 -0400)
logstore: raise the log limit, and truncate by both recency and length
fixes https://github.com/tilt-dev/tilt/issues/4476

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics