### PR TITLE
portforwards: PortForwardSubscriber uses new api objects, stores current PortForwards on state

### DIFF
--- a/internal/engine/portforward/actions.go
+++ b/internal/engine/portforward/actions.go
@@ -26,6 +26,10 @@ type PortForwardDeleteAction struct {
 	Name string
 }
 
+func NewPortForwardDeleteAction(pfName string) PortForwardDeleteAction {
+	return PortForwardDeleteAction{Name: pfName}
+}
+
 func (PortForwardDeleteAction) Action() {}
 
 func (a PortForwardDeleteAction) Summarize(s *store.ChangeSummary) {

--- a/internal/engine/portforward/subscriber.go
+++ b/internal/engine/portforward/subscriber.go
@@ -2,6 +2,7 @@ package portforward
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -81,8 +82,9 @@ func (s *Subscriber) diff(ctx context.Context, st store.RStore) (toStart []portF
 					continue
 				}
 
-				// The port forward has changed, so remove the old version and re-add the new one
-				toShutdown = append(toShutdown, oldEntry)
+				// Every possible PortForward ought to have a unique name--it
+				// should be impossible to get two unequal PFs with the same name
+				panic(fmt.Sprintf("found two different PortForwards with same name %s (this should be impossible)", apiPf.Name))
 			}
 
 			toStart = append(toStart, entry)

--- a/internal/engine/portforward/subscriber.go
+++ b/internal/engine/portforward/subscriber.go
@@ -42,7 +42,7 @@ func (s *Subscriber) diff(ctx context.Context, st store.RStore) (toStart []portF
 	state := st.RLockState()
 	defer st.RUnlockState()
 
-	currentPFs := make(map[string]bool) // 😱 do we want a type for PF Name?
+	currentPFs := make(map[string]bool)
 
 	// Find all the port-forwards that need to be created.
 	for _, mt := range state.Targets() {
@@ -77,8 +77,8 @@ func (s *Subscriber) diff(ctx context.Context, st store.RStore) (toStart []portF
 
 			oldEntry, isActive := s.activeForwards[apiPf.Name]
 			if isActive {
-				// We're already running this port forward, nothing to do
 				if equality.Semantic.DeepEqual(oldEntry.Spec, apiPf.Spec) {
+					// We're already running this port forward, nothing to do
 					continue
 				}
 

--- a/internal/engine/portforward/subscriber.go
+++ b/internal/engine/portforward/subscriber.go
@@ -88,7 +88,6 @@ func (s *Subscriber) diff(ctx context.Context, st store.RStore) (toStart []portF
 			}
 
 			toStart = append(toStart, entry)
-			state.PortForwards[apiPf.Name] = apiPf
 			s.activeForwards[apiPf.Name] = entry
 		}
 	}
@@ -113,7 +112,7 @@ func (s *Subscriber) OnChange(ctx context.Context, st store.RStore, _ store.Chan
 	for _, entry := range toShutdown {
 		entry.cancel()
 
-		// ◽️ dispatch deletion event for PF set on state
+		st.Dispatch(NewPortForwardDeleteAction(entry.Name))
 		// TODO(maia): delete PF object in API
 	}
 
@@ -127,7 +126,8 @@ func (s *Subscriber) OnChange(ctx context.Context, st store.RStore, _ store.Chan
 
 		go s.startPortForwardLoop(ctx, entry)
 
-		// ◽️ dispatch creation event for PF set on state
+		st.Dispatch(NewPortForwardCreateAction(entry.PortForward))
+
 		// TODO(maia): create PF object in API
 	}
 }

--- a/internal/engine/portforward/subscriber.go
+++ b/internal/engine/portforward/subscriber.go
@@ -24,7 +24,7 @@ type Subscriber struct {
 	kClient k8s.Client
 
 	// Temporary map of PortForward name --> PortForwardEntry, so that we have
-	// a way of cancelling running forwards (soon this will be the responsibility
+	// a way of canceling running forwards (soon this will be the responsibility
 	// of the PortForwardReconciler)
 	activeForwards map[string]portForwardEntry
 }
@@ -187,7 +187,7 @@ func (s *Subscriber) onePortForward(ctx context.Context, entry portForwardEntry)
 var _ store.Subscriber = &Subscriber{}
 
 // NOTE(maia): this struct is temporary, soon this subscriber won't maintain the state of PF's
-//   or be responsible for cancelling them, and so will no longer need the context/cancel func.
+//   or be responsible for canceling them, and so will no longer need the context/cancel func.
 type portForwardEntry struct {
 	*v1alpha1.PortForward
 	ctx    context.Context

--- a/internal/engine/portforward/subscriber_test.go
+++ b/internal/engine/portforward/subscriber_test.go
@@ -76,61 +76,61 @@ func TestPortForward(t *testing.T) {
 		"Expected first port-forward to be canceled")
 }
 
-func TestMultiplePortForwards(t *testing.T) {
-	f := newPLCFixture(t)
-	defer f.TearDown()
-
-	state := f.st.LockMutableStateForTesting()
-	m := model.Manifest{
-		Name: "fe",
-	}
-	m = m.WithDeployTarget(model.K8sTarget{
-		PortForwards: []model.PortForward{
-			{
-				LocalPort:     8000,
-				ContainerPort: 8080,
-			},
-			{
-				LocalPort:     8001,
-				ContainerPort: 8081,
-			},
-		},
-	})
-	state.UpsertManifestTarget(store.NewManifestTarget(m))
-	f.st.UnlockMutableState()
-
-	f.onChange()
-	assert.Equal(t, 0, len(f.plc.activeForwards))
-
-	state = f.st.LockMutableStateForTesting()
-	mt := state.ManifestTargets["fe"]
-	mt.State.RuntimeState = store.NewK8sRuntimeStateWithPods(mt.Manifest,
-		v1alpha1.Pod{Name: "pod-id", Phase: string(v1.PodRunning)})
-	f.st.UnlockMutableState()
-
-	f.onChange()
-	assert.Equal(t, 2, len(f.plc.activeForwards))
-	assert.Equal(t, 8080, f.kCli.PortForwardCalls[0].RemotePort)
-	assert.Equal(t, 8081, f.kCli.PortForwardCalls[1].RemotePort)
-	assert.Equal(t, "pod-id", f.kCli.PortForwardCalls[0].PodID.String())
-	assert.Equal(t, "pod-id", f.kCli.PortForwardCalls[1].PodID.String())
-	pfCtx1 := f.kCli.PortForwardCalls[0].Context
-	pfCtx2 := f.kCli.PortForwardCalls[1].Context
-
-	state = f.st.LockMutableStateForTesting()
-	mt = state.ManifestTargets["fe"]
-	mt.State.RuntimeState = store.NewK8sRuntimeStateWithPods(mt.Manifest,
-		v1alpha1.Pod{Name: "pod-id", Phase: string(v1.PodPending)})
-	f.st.UnlockMutableState()
-
-	f.onChange()
-	assert.Equal(t, 0, len(f.plc.activeForwards))
-
-	assert.Equal(t, context.Canceled, pfCtx1.Err(),
-		"Expected first port-forward to be canceled")
-	assert.Equal(t, context.Canceled, pfCtx2.Err(),
-		"Expected second port-forward to be canceled")
-}
+// func TestMultiplePortForwards(t *testing.T) {
+// 	f := newPLCFixture(t)
+// 	defer f.TearDown()
+//
+// 	state := f.st.LockMutableStateForTesting()
+// 	m := model.Manifest{
+// 		Name: "fe",
+// 	}
+// 	m = m.WithDeployTarget(model.K8sTarget{
+// 		PortForwards: []model.PortForward{
+// 			{
+// 				LocalPort:     8000,
+// 				ContainerPort: 8080,
+// 			},
+// 			{
+// 				LocalPort:     8001,
+// 				ContainerPort: 8081,
+// 			},
+// 		},
+// 	})
+// 	state.UpsertManifestTarget(store.NewManifestTarget(m))
+// 	f.st.UnlockMutableState()
+//
+// 	f.onChange()
+// 	assert.Equal(t, 0, len(f.plc.activeForwards))
+//
+// 	state = f.st.LockMutableStateForTesting()
+// 	mt := state.ManifestTargets["fe"]
+// 	mt.State.RuntimeState = store.NewK8sRuntimeStateWithPods(mt.Manifest,
+// 		v1alpha1.Pod{Name: "pod-id", Phase: string(v1.PodRunning)})
+// 	f.st.UnlockMutableState()
+//
+// 	f.onChange()
+// 	assert.Equal(t, 2, len(f.plc.activeForwards))
+// 	assert.Equal(t, 8080, f.kCli.PortForwardCalls[0].RemotePort)
+// 	assert.Equal(t, 8081, f.kCli.PortForwardCalls[1].RemotePort)
+// 	assert.Equal(t, "pod-id", f.kCli.PortForwardCalls[0].PodID.String())
+// 	assert.Equal(t, "pod-id", f.kCli.PortForwardCalls[1].PodID.String())
+// 	pfCtx1 := f.kCli.PortForwardCalls[0].Context
+// 	pfCtx2 := f.kCli.PortForwardCalls[1].Context
+//
+// 	state = f.st.LockMutableStateForTesting()
+// 	mt = state.ManifestTargets["fe"]
+// 	mt.State.RuntimeState = store.NewK8sRuntimeStateWithPods(mt.Manifest,
+// 		v1alpha1.Pod{Name: "pod-id", Phase: string(v1.PodPending)})
+// 	f.st.UnlockMutableState()
+//
+// 	f.onChange()
+// 	assert.Equal(t, 0, len(f.plc.activeForwards))
+//
+// 	assert.Equal(t, context.Canceled, pfCtx1.Err(),
+// 		"Expected first port-forward to be canceled")
+// 	assert.Equal(t, context.Canceled, pfCtx2.Err(),
+// 		"Expected second port-forward to be canceled")
+// }
 
 func TestPortForwardAutoDiscovery(t *testing.T) {
 	f := newPLCFixture(t)

--- a/internal/engine/portforward/subscriber_test.go
+++ b/internal/engine/portforward/subscriber_test.go
@@ -50,8 +50,8 @@ func TestPortForward(t *testing.T) {
 
 	f.onChange()
 	assert.Equal(t, 1, len(f.plc.activeForwards))
-	assert.Equal(t, "pod-id", f.kCli.LastForwardPortPodID.String())
-	firstPodForwardCtx := f.kCli.LastForwardContext
+	assert.Equal(t, "pod-id", f.kCli.LastForwardPortPodID().String())
+	firstPodForwardCtx := f.kCli.LastForwardContext()
 
 	state = f.st.LockMutableStateForTesting()
 	mt = state.ManifestTargets["fe"]
@@ -61,7 +61,7 @@ func TestPortForward(t *testing.T) {
 
 	f.onChange()
 	assert.Equal(t, 1, len(f.plc.activeForwards))
-	assert.Equal(t, "pod-id2", f.kCli.LastForwardPortPodID.String())
+	assert.Equal(t, "pod-id2", f.kCli.LastForwardPortPodID().String())
 
 	state = f.st.LockMutableStateForTesting()
 	mt = state.ManifestTargets["fe"]
@@ -74,6 +74,62 @@ func TestPortForward(t *testing.T) {
 
 	assert.Equal(t, context.Canceled, firstPodForwardCtx.Err(),
 		"Expected first port-forward to be canceled")
+}
+
+func TestMultiplePortForwards(t *testing.T) {
+	f := newPLCFixture(t)
+	defer f.TearDown()
+
+	state := f.st.LockMutableStateForTesting()
+	m := model.Manifest{
+		Name: "fe",
+	}
+	m = m.WithDeployTarget(model.K8sTarget{
+		PortForwards: []model.PortForward{
+			{
+				LocalPort:     8000,
+				ContainerPort: 8080,
+			},
+			{
+				LocalPort:     8001,
+				ContainerPort: 8081,
+			},
+		},
+	})
+	state.UpsertManifestTarget(store.NewManifestTarget(m))
+	f.st.UnlockMutableState()
+
+	f.onChange()
+	assert.Equal(t, 0, len(f.plc.activeForwards))
+
+	state = f.st.LockMutableStateForTesting()
+	mt := state.ManifestTargets["fe"]
+	mt.State.RuntimeState = store.NewK8sRuntimeStateWithPods(mt.Manifest,
+		v1alpha1.Pod{Name: "pod-id", Phase: string(v1.PodRunning)})
+	f.st.UnlockMutableState()
+
+	f.onChange()
+	assert.Equal(t, 2, len(f.plc.activeForwards))
+	assert.Equal(t, 8080, f.kCli.PortForwardCalls[0].RemotePort)
+	assert.Equal(t, 8081, f.kCli.PortForwardCalls[1].RemotePort)
+	assert.Equal(t, "pod-id", f.kCli.PortForwardCalls[0].PodID.String())
+	assert.Equal(t, "pod-id", f.kCli.PortForwardCalls[1].PodID.String())
+	pfCtx1 := f.kCli.PortForwardCalls[0].Context
+	pfCtx2 := f.kCli.PortForwardCalls[1].Context
+
+	state = f.st.LockMutableStateForTesting()
+	mt = state.ManifestTargets["fe"]
+	mt.State.RuntimeState = store.NewK8sRuntimeStateWithPods(mt.Manifest,
+		v1alpha1.Pod{Name: "pod-id", Phase: string(v1.PodPending)})
+	f.st.UnlockMutableState()
+
+	f.onChange()
+	assert.Equal(t, 0, len(f.plc.activeForwards))
+
+	assert.Equal(t, context.Canceled, pfCtx1.Err(),
+		"Expected first port-forward to be canceled")
+	assert.Equal(t, context.Canceled, pfCtx2.Err(),
+		"Expected second port-forward to be canceled")
 }
 
 func TestPortForwardAutoDiscovery(t *testing.T) {
@@ -108,7 +164,7 @@ func TestPortForwardAutoDiscovery(t *testing.T) {
 
 	f.onChange()
 	assert.Equal(t, 1, len(f.plc.activeForwards))
-	assert.Equal(t, 8000, f.kCli.LastForwardPortRemotePort)
+	assert.Equal(t, 8000, f.kCli.LastForwardPortRemotePort())
 }
 
 func TestPortForwardAutoDiscovery2(t *testing.T) {
@@ -140,7 +196,7 @@ func TestPortForwardAutoDiscovery2(t *testing.T) {
 
 	f.onChange()
 	assert.Equal(t, 1, len(f.plc.activeForwards))
-	assert.Equal(t, 8080, f.kCli.LastForwardPortRemotePort)
+	assert.Equal(t, 8080, f.kCli.LastForwardPortRemotePort())
 }
 
 func TestPortForwardChangePort(t *testing.T) {
@@ -164,7 +220,7 @@ func TestPortForwardChangePort(t *testing.T) {
 
 	f.onChange()
 	assert.Equal(t, 1, len(f.plc.activeForwards))
-	assert.Equal(t, 8081, f.kCli.LastForwardPortRemotePort)
+	assert.Equal(t, 8081, f.kCli.LastForwardPortRemotePort())
 
 	state = f.st.LockMutableStateForTesting()
 	kTarget := state.ManifestTargets["fe"].Manifest.K8sTarget()
@@ -173,7 +229,7 @@ func TestPortForwardChangePort(t *testing.T) {
 
 	f.onChange()
 	assert.Equal(t, 1, len(f.plc.activeForwards))
-	assert.Equal(t, 8082, f.kCli.LastForwardPortRemotePort)
+	assert.Equal(t, 8082, f.kCli.LastForwardPortRemotePort())
 }
 
 func TestPortForwardRestart(t *testing.T) {
@@ -200,16 +256,16 @@ func TestPortForwardRestart(t *testing.T) {
 
 	f.onChange()
 	assert.Equal(t, 1, len(f.plc.activeForwards))
-	assert.Equal(t, 1, f.kCli.CreatePortForwardCallCount)
+	assert.Equal(t, 1, f.kCli.CreatePortForwardCallCount())
 
 	err := fmt.Errorf("unique-error")
-	f.kCli.LastForwarder.Done <- err
+	f.kCli.LastForwarder().Done <- err
 
 	assert.Contains(t, "unique-error", f.out.String())
 	time.Sleep(100 * time.Millisecond)
 
 	assert.Equal(t, 1, len(f.plc.activeForwards))
-	assert.Equal(t, 2, f.kCli.CreatePortForwardCallCount)
+	assert.Equal(t, 2, f.kCli.CreatePortForwardCallCount())
 }
 
 type portForwardTestCase struct {

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -3736,7 +3736,7 @@ func TestPortForwardActions(t *testing.T) {
 
 	pfA := &portforward.PortForward{
 		ObjectMeta: metav1.ObjectMeta{Name: pfAName},
-		Spec:       portforward.PortForwardSpec{Pod: "pod-A"},
+		Spec:       portforward.PortForwardSpec{PodName: "pod-A"},
 	}
 
 	f.Start([]model.Manifest{})

--- a/internal/k8s/client_test.go
+++ b/internal/k8s/client_test.go
@@ -242,7 +242,7 @@ func newClientTestFixture(t *testing.T) *clientTestFixture {
 	ret.client = K8sClient{
 		env:               EnvUnknown,
 		core:              core,
-		portForwardClient: &FakePortForwardClient{},
+		portForwardClient: NewFakePortfowardClient(),
 		runtimeAsync:      runtimeAsync,
 		registryAsync:     registryAsync,
 		helmKubeClient:    helmKube,

--- a/internal/k8s/fake_client.go
+++ b/internal/k8s/fake_client.go
@@ -491,26 +491,56 @@ func (pf FakePortForwarder) ForwardPorts() error {
 }
 
 type FakePortForwardClient struct {
-	CreatePortForwardCallCount int
-	LastForwardPortPodID       PodID
-	LastForwardPortRemotePort  int
-	LastForwardPortHost        string
-	LastForwarder              FakePortForwarder
-	LastForwardContext         context.Context
+	PortForwardCalls []PortForwardCall
+}
+
+func NewFakePortfowardClient() *FakePortForwardClient {
+	return &FakePortForwardClient{
+		PortForwardCalls: []PortForwardCall{},
+	}
+}
+
+type PortForwardCall struct {
+	PodID      PodID
+	RemotePort int
+	Host       string
+	Forwarder  FakePortForwarder
+	Context    context.Context
 }
 
 func (c *FakePortForwardClient) CreatePortForwarder(ctx context.Context, namespace Namespace, podID PodID, optionalLocalPort, remotePort int, host string) (PortForwarder, error) {
-	c.CreatePortForwardCallCount++
-	c.LastForwardContext = ctx
-	c.LastForwardPortPodID = podID
-	c.LastForwardPortRemotePort = remotePort
-	c.LastForwardPortHost = host
-
 	result := FakePortForwarder{
 		localPort: optionalLocalPort,
 		ctx:       ctx,
 		Done:      make(chan error),
 	}
-	c.LastForwarder = result
+
+	c.PortForwardCalls = append(c.PortForwardCalls, PortForwardCall{
+		PodID:      podID,
+		RemotePort: remotePort,
+		Host:       host,
+		Forwarder:  result,
+		Context:    ctx,
+	})
+
 	return result, nil
+}
+
+func (c *FakePortForwardClient) CreatePortForwardCallCount() int {
+	return len(c.PortForwardCalls)
+}
+func (c *FakePortForwardClient) LastForwardPortPodID() PodID {
+	return c.PortForwardCalls[len(c.PortForwardCalls)-1].PodID
+}
+func (c *FakePortForwardClient) LastForwardPortRemotePort() int {
+	return c.PortForwardCalls[len(c.PortForwardCalls)-1].RemotePort
+}
+func (c *FakePortForwardClient) LastForwardPortHost() string {
+	return c.PortForwardCalls[len(c.PortForwardCalls)-1].Host
+}
+func (c *FakePortForwardClient) LastForwarder() FakePortForwarder {
+	return c.PortForwardCalls[len(c.PortForwardCalls)-1].Forwarder
+}
+func (c *FakePortForwardClient) LastForwardContext() context.Context {
+	return c.PortForwardCalls[len(c.PortForwardCalls)-1].Context
 }

--- a/internal/k8s/fake_client.go
+++ b/internal/k8s/fake_client.go
@@ -491,6 +491,7 @@ func (pf FakePortForwarder) ForwardPorts() error {
 }
 
 type FakePortForwardClient struct {
+	mu               sync.Mutex
 	PortForwardCalls []PortForwardCall
 }
 
@@ -509,6 +510,9 @@ type PortForwardCall struct {
 }
 
 func (c *FakePortForwardClient) CreatePortForwarder(ctx context.Context, namespace Namespace, podID PodID, optionalLocalPort, remotePort int, host string) (PortForwarder, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	result := FakePortForwarder{
 		localPort: optionalLocalPort,
 		ctx:       ctx,

--- a/pkg/openapi/zz_generated.openapi.go
+++ b/pkg/openapi/zz_generated.openapi.go
@@ -1579,7 +1579,7 @@ func schema_pkg_apis_core_v1alpha1_PortForwardSpec(ref common.ReferenceCallback)
 				Description: "PortForwardSpec defines the desired state of PortForward",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
-					"pod": {
+					"pod_name": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The name of the pod to port forward to/from. Required.",
 							Default:     "",
@@ -1594,17 +1594,17 @@ func schema_pkg_apis_core_v1alpha1_PortForwardSpec(ref common.ReferenceCallback)
 							Format:      "",
 						},
 					},
-					"container_port": {
+					"local_port": {
 						SchemaProps: spec.SchemaProps{
-							Description: "The port on the Kubernetes pod to connect to. Required.",
+							Description: "The port to expose on the current machine. Required.",
 							Default:     0,
 							Type:        []string{"integer"},
 							Format:      "int32",
 						},
 					},
-					"local_port": {
+					"container_port": {
 						SchemaProps: spec.SchemaProps{
-							Description: "The port to expose on the current machine. Required.",
+							Description: "The port on the Kubernetes pod to connect to. Required.",
 							Default:     0,
 							Type:        []string{"integer"},
 							Format:      "int32",
@@ -1619,7 +1619,7 @@ func schema_pkg_apis_core_v1alpha1_PortForwardSpec(ref common.ReferenceCallback)
 						},
 					},
 				},
-				Required: []string{"pod", "container_port", "local_port"},
+				Required: []string{"pod_name", "local_port", "container_port"},
 			},
 		},
 	}


### PR DESCRIPTION
this PR updates the `PortForwardSubscriber` to think about what PFs to start/stop in terms of `v1alpha1.PortForward` objects

the Subscriber also updates the list of current PortForwards on the engine state.

In a future, PR, we'll have the Subscriber create/delete PortForward objects in the API as well, and move all the logic for actually running a PortForward to the to-be-created `PortForwardReconciler`