### PR TITLE
ci: add some more exclude patterns for changelog

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -49,8 +49,11 @@ changelog:
   sort: asc
   filters:
     exclude:
-    - '^docs:'
-    - '^test:'
+    - '^docs?:'
+    - '^tests?:'
+    - '^cleanup:'
+    - '^circleci:'
+    - '^ci:'
 brews:
 - tap:
     owner: tilt-dev


### PR DESCRIPTION
Not exhaustive by any means but took a quick look at some common
prefixes that aren't useful for the changelog and added them.

```
git log --pretty=format:%s | cut -d':' -f1 | sort | uniq -c | sort -r
```

FWIW the releaser bot itself doesn't use a prefix for version bumps, now that `ci:` is in the list, might be a good candidate?