### PR TITLE
cmd: Cmd Terminated should rely on Process Wait() semantics instead of Go Cmd Wait() semantics

### DIFF
--- a/internal/controllers/core/cmd/execer_unix_test.go
+++ b/internal/controllers/core/cmd/execer_unix_test.go
@@ -1,0 +1,44 @@
+// +build !windows
+
+package cmd
+
+import (
+	"os"
+	"runtime"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStopsBackgroundGrandchildren(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("no bash on windows")
+	}
+	f := newProcessExecFixture(t)
+	defer f.tearDown()
+
+	f.start(`bash -c 'sleep 100 &
+echo BACKGROUND $!
+'`)
+	f.waitForStatus(Done)
+
+	lines := strings.Split(f.testWriter.String(), "\n")
+	assert.Contains(t, lines[1], "BACKGROUND")
+	grandkidPid, err := strconv.Atoi(strings.TrimSpace(strings.TrimPrefix(lines[1], "BACKGROUND")))
+	require.NoError(t, err)
+
+	grandkid, err := os.FindProcess(grandkidPid)
+	require.NoError(t, err)
+
+	// Old unix trick - signal to check if the process is still alive.
+	time.Sleep(10 * time.Millisecond)
+	err = grandkid.Signal(syscall.SIGCONT)
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "process already finished")
+	}
+}

--- a/pkg/apis/core/v1alpha1/cmd_types.go
+++ b/pkg/apis/core/v1alpha1/cmd_types.go
@@ -32,7 +32,11 @@ import (
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
-// Cmd
+// Cmd represents a process on the host machine.
+//
+// When the process exits, we will make a best-effort attempt
+// (within OS limitations) to kill any spawned descendant processes.
+//
 // +k8s:openapi-gen=true
 type Cmd struct {
 	metav1.TypeMeta   `json:",inline"`
@@ -51,7 +55,7 @@ type CmdList struct {
 	Items []Cmd `json:"items" protobuf:"bytes,2,rep,name=items"`
 }
 
-// CmdSpec defines the desired state of Cmd
+// CmdSpec defines how to run a local command.
 type CmdSpec struct {
 	// Command-line arguments. Must have length at least 1.
 	Args []string `json:"args,omitempty" protobuf:"bytes,1,rep,name=args"`
@@ -81,9 +85,14 @@ type CmdSpec struct {
 
 	// Indicates objects that can trigger a restart of this command.
 	//
+	// When a restart is triggered, Tilt will try to gracefully shutdown any
+	// currently running process, waiting for it to exit before starting a new
+	// process. If the process doesn't shutdown within the allotted time, Tilt
+	// will kill the process abruptly.
+	//
 	// Restarts can happen even if the command is already done.
 	//
-	// Logs of the currently process after the restart are discarded.
+	// Logs of the current process after the restart are discarded.
 	RestartOn *RestartOnSpec `json:"restartOn,omitempty" protobuf:"bytes,5,opt,name=restartOn"`
 }
 

--- a/pkg/apis/core/v1alpha1/generated.proto
+++ b/pkg/apis/core/v1alpha1/generated.proto
@@ -26,7 +26,11 @@ import "k8s.io/apimachinery/pkg/runtime/schema/generated.proto";
 // Package-wide variables from generator "generated".
 option go_package = "v1alpha1";
 
-// Cmd
+// Cmd represents a process on the host machine.
+//
+// When the process exits, we will make a best-effort attempt
+// (within OS limitations) to kill any spawned descendant processes.
+//
 // +k8s:openapi-gen=true
 message Cmd {
   optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
@@ -44,7 +48,7 @@ message CmdList {
   repeated Cmd items = 2;
 }
 
-// CmdSpec defines the desired state of Cmd
+// CmdSpec defines how to run a local command.
 message CmdSpec {
   // Command-line arguments. Must have length at least 1.
   repeated string args = 1;
@@ -74,9 +78,14 @@ message CmdSpec {
 
   // Indicates objects that can trigger a restart of this command.
   //
+  // When a restart is triggered, Tilt will try to gracefully shutdown any
+  // currently running process, waiting for it to exit before starting a new
+  // process. If the process doesn't shutdown within the allotted time, Tilt
+  // will kill the process abruptly.
+  //
   // Restarts can happen even if the command is already done.
   //
-  // Logs of the currently process after the restart are discarded.
+  // Logs of the current process after the restart are discarded.
   optional RestartOnSpec restartOn = 5;
 }
 

--- a/pkg/openapi/zz_generated.openapi.go
+++ b/pkg/openapi/zz_generated.openapi.go
@@ -139,7 +139,7 @@ func schema_pkg_apis_core_v1alpha1_Cmd(ref common.ReferenceCallback) common.Open
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "Cmd",
+				Description: "Cmd represents a process on the host machine.\n\nWhen the process exits, we will make a best-effort attempt (within OS limitations) to kill any spawned descendant processes.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"kind": {
@@ -235,7 +235,7 @@ func schema_pkg_apis_core_v1alpha1_CmdSpec(ref common.ReferenceCallback) common.
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "CmdSpec defines the desired state of Cmd",
+				Description: "CmdSpec defines how to run a local command.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"args": {
@@ -283,7 +283,7 @@ func schema_pkg_apis_core_v1alpha1_CmdSpec(ref common.ReferenceCallback) common.
 					},
 					"restartOn": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Indicates objects that can trigger a restart of this command.\n\nRestarts can happen even if the command is already done.\n\nLogs of the currently process after the restart are discarded.",
+							Description: "Indicates objects that can trigger a restart of this command.\n\nWhen a restart is triggered, Tilt will try to gracefully shutdown any currently running process, waiting for it to exit before starting a new process. If the process doesn't shutdown within the allotted time, Tilt will kill the process abruptly.\n\nRestarts can happen even if the command is already done.\n\nLogs of the current process after the restart are discarded.",
 							Ref:         ref("github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1.RestartOnSpec"),
 						},
 					},


### PR DESCRIPTION
Hello @landism,

Please review the following commits I made in branch nicks/ch11952:

bee2771ebd947779b1986fc02bf1d811eba48ceb (2021-04-29 20:49:50 -0400)
cmd: Cmd Terminated should rely on Process Wait() semantics instead of Go Cmd Wait() semantics
The Go semantics are not what most people expect, and even Go team is considering changing them.

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics