### PR TITLE
engine: add multi-manifest support for Pods

### DIFF
--- a/internal/engine/pod.go
+++ b/internal/engine/pod.go
@@ -36,7 +36,7 @@ func handlePodChangeAction(ctx context.Context, state *store.EngineState, action
 
 	pod := action.Pod
 	podID := k8s.PodID(pod.Name)
-	spanID := k8sconv.SpanIDForPod(podID)
+	spanID := k8sconv.SpanIDForPod(mt.Manifest.Name, podID)
 	ms := mt.State
 	krs := ms.K8sRuntimeState()
 	manifest := mt.Manifest

--- a/internal/engine/portforward/subscriber.go
+++ b/internal/engine/portforward/subscriber.go
@@ -221,6 +221,6 @@ type PodLogActionWriter struct {
 }
 
 func (w PodLogActionWriter) Write(level logger.Level, fields logger.Fields, p []byte) error {
-	w.Store.Dispatch(store.NewLogAction(w.ManifestName, k8sconv.SpanIDForPod(w.PodID), level, fields, p))
+	w.Store.Dispatch(store.NewLogAction(w.ManifestName, k8sconv.SpanIDForPod(w.ManifestName, w.PodID), level, fields, p))
 	return nil
 }

--- a/internal/engine/runtimelog/podlogmanager.go
+++ b/internal/engine/runtimelog/podlogmanager.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/tilt-dev/tilt/internal/k8s"
+	"github.com/tilt-dev/tilt/internal/store/k8sconv"
+
 	"github.com/tilt-dev/tilt/pkg/apis"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -11,9 +14,7 @@ import (
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/tilt-dev/tilt/internal/container"
-	"github.com/tilt-dev/tilt/internal/k8s"
 	"github.com/tilt-dev/tilt/internal/store"
-	"github.com/tilt-dev/tilt/internal/store/k8sconv"
 	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
 	"github.com/tilt-dev/tilt/pkg/model"
 )
@@ -75,7 +76,7 @@ func (m *PodLogManager) diff(ctx context.Context, st store.RStore) (setup []*Pod
 					Name: fmt.Sprintf("%s-%s", pod.Namespace, pod.Name),
 					Annotations: map[string]string{
 						v1alpha1.AnnotationManifest: string(man.Name),
-						v1alpha1.AnnotationSpanID:   string(k8sconv.SpanIDForPod(k8s.PodID(pod.Name))),
+						v1alpha1.AnnotationSpanID:   string(k8sconv.SpanIDForPod(man.Name, k8s.PodID(pod.Name))),
 					},
 				},
 				Spec: spec,

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -1452,11 +1452,11 @@ func TestPodEventOrdering(t *testing.T) {
 			}
 
 			f.upper.store.Dispatch(
-				store.NewLogAction("fe", k8sconv.SpanIDForPod(podBNow.PodID()), logger.InfoLvl, nil, []byte("pod b log\n")))
+				store.NewLogAction("fe", k8sconv.SpanIDForPod(manifest.Name, podBNow.PodID()), logger.InfoLvl, nil, []byte("pod b log\n")))
 
 			f.WaitUntil("pod log seen", func(state store.EngineState) bool {
-				ms, _ := state.ManifestState("fe")
-				spanID := k8sconv.SpanIDForPod(k8s.PodID(ms.MostRecentPod().Name))
+				ms, _ := state.ManifestState(manifest.Name)
+				spanID := k8sconv.SpanIDForPod(manifest.Name, k8s.PodID(ms.MostRecentPod().Name))
 				return spanID != "" && strings.Contains(state.LogStore.SpanLog(spanID), "pod b log")
 			})
 
@@ -2113,7 +2113,7 @@ func TestUpper_ShowErrorPodLog(t *testing.T) {
 
 	f.withState(func(state store.EngineState) {
 		ms, _ := state.ManifestState(name)
-		spanID := k8sconv.SpanIDForPod(k8s.PodID(ms.MostRecentPod().Name))
+		spanID := k8sconv.SpanIDForPod(name, k8s.PodID(ms.MostRecentPod().Name))
 		assert.Equal(t, "first string\nsecond string\n", state.LogStore.SpanLog(spanID))
 	})
 
@@ -2142,7 +2142,7 @@ func TestUpperPodLogInCrashLoopThirdInstanceStillUp(t *testing.T) {
 	// the third instance is still up, so we want to show the log from the last crashed pod plus the log from the current pod
 	f.withState(func(es store.EngineState) {
 		ms, _ := es.ManifestState(name)
-		spanID := k8sconv.SpanIDForPod(k8s.PodID(ms.MostRecentPod().Name))
+		spanID := k8sconv.SpanIDForPod(name, k8s.PodID(ms.MostRecentPod().Name))
 		assert.Contains(t, es.LogStore.SpanLog(spanID), "third string\n")
 		assert.Contains(t, es.LogStore.ManifestLog(name), "second string\n")
 		assert.Contains(t, es.LogStore.ManifestLog(name), "third string\n")
@@ -2179,7 +2179,7 @@ func TestUpperPodLogInCrashLoopPodCurrentlyDown(t *testing.T) {
 
 	f.withState(func(state store.EngineState) {
 		ms, _ := state.ManifestState(name)
-		spanID := k8sconv.SpanIDForPod(k8s.PodID(ms.MostRecentPod().Name))
+		spanID := k8sconv.SpanIDForPod(name, k8s.PodID(ms.MostRecentPod().Name))
 		assert.Equal(t, "first string\nWARNING: Detected container restart. Pod: fakePodID. Container: sancho.\nsecond string\n",
 			state.LogStore.SpanLog(spanID))
 	})
@@ -4262,11 +4262,11 @@ func (f *testFixture) startPod(pod *v1.Pod, manifestName model.ManifestName) {
 
 func (f *testFixture) podLog(pod *v1.Pod, manifestName model.ManifestName, s string) {
 	podID := k8s.PodID(pod.Name)
-	f.upper.store.Dispatch(store.NewLogAction(manifestName, k8sconv.SpanIDForPod(podID), logger.InfoLvl, nil, []byte(s+"\n")))
+	f.upper.store.Dispatch(store.NewLogAction(manifestName, k8sconv.SpanIDForPod(manifestName, podID), logger.InfoLvl, nil, []byte(s+"\n")))
 
 	f.WaitUntil("pod log seen", func(es store.EngineState) bool {
 		ms, _ := es.ManifestState(manifestName)
-		spanID := k8sconv.SpanIDForPod(k8s.PodID(ms.MostRecentPod().Name))
+		spanID := k8sconv.SpanIDForPod(manifestName, k8s.PodID(ms.MostRecentPod().Name))
 		return strings.Contains(es.LogStore.SpanLog(spanID), s)
 	})
 }

--- a/internal/store/engine_state.go
+++ b/internal/store/engine_state.go
@@ -915,7 +915,7 @@ func resourceInfoView(mt *ManifestTarget) view.ResourceInfoView {
 			PodUpdateStartTime: pod.UpdateStartedAt.Time,
 			PodStatus:          pod.Status,
 			PodRestarts:        int(VisiblePodContainerRestarts(pod)),
-			SpanID:             k8sconv.SpanIDForPod(k8s.PodID(pod.Name)),
+			SpanID:             k8sconv.SpanIDForPod(mt.Manifest.Name, k8s.PodID(pod.Name)),
 			RunStatus:          runStatus,
 			DisplayNames:       mt.Manifest.K8sTarget().DisplayNames,
 		}

--- a/internal/store/k8sconv/pod.go
+++ b/internal/store/k8sconv/pod.go
@@ -142,8 +142,8 @@ var ErrorWaitingReasons = map[string]bool{
 	"Error":             true,
 }
 
-func SpanIDForPod(podID k8s.PodID) logstore.SpanID {
-	return logstore.SpanID(fmt.Sprintf("pod:%s", podID))
+func SpanIDForPod(mn model.ManifestName, podID k8s.PodID) logstore.SpanID {
+	return logstore.SpanID(fmt.Sprintf("%s:pod:%s", mn.String(), podID))
 }
 
 // copied from https://github.com/kubernetes/kubernetes/blob/aedeccda9562b9effe026bb02c8d3c539fc7bb77/pkg/kubectl/resource_printer.go#L692-L764

--- a/internal/store/k8sconv/pod.go
+++ b/internal/store/k8sconv/pod.go
@@ -142,8 +142,13 @@ var ErrorWaitingReasons = map[string]bool{
 	"Error":             true,
 }
 
+// SpanIDForPod creates a span ID for a given pod associated with a manifest.
+//
+// Generally, a given Pod is only referenced by a single manifest, but there are
+// rare occasions where it can be referenced by multiple. If the span ID is not
+// unique between them, things will behave erratically.
 func SpanIDForPod(mn model.ManifestName, podID k8s.PodID) logstore.SpanID {
-	return logstore.SpanID(fmt.Sprintf("%s:pod:%s", mn.String(), podID))
+	return logstore.SpanID(fmt.Sprintf("pod:%s:%s", mn.String(), podID))
 }
 
 // copied from https://github.com/kubernetes/kubernetes/blob/aedeccda9562b9effe026bb02c8d3c539fc7bb77/pkg/kubectl/resource_printer.go#L692-L764


### PR DESCRIPTION
99.9% of the time, a Pod will only be associated with one manifest,
both because that's the general usage pattern aside from some Helm
charts that cause the same Pod to get referenced across mulitple
manifests, and because the `k8swatch.ManifestSubscriber` that is
responsible for creating `KubernetesDiscovery` objects from the
resources in the `Tiltfile` only allows one manifest to "claim" a
given UID so that even if it's referenced in another, it will be
invisible to it.

However, there is a remaining scenario, which is trickier, and that
is extra pod label selectors. The manifest subscriber can't
practically play the same games with uniqueness here (at least not
in any sane, predictable fashion). The `PodWatcher` now behaves
more like a reconciler (and will be one soon), so tries to evaluate
things on a per-entity basis rather than a global basis, which is
to say that without a lot of extra tracking to provide a similar
"claim" system on labels, it soon won't be able to guarantee that
only ONE `KubernetesDiscovery` object sees a particular Pod based
on a label match (and even then if and only if no other object had
a transitive UID match for that Pod!)

As a result, the path of least resistance is to ensure that Tilt
generally behaves in the event that the same pod occurs in multiple
resources. The manifest subscriber that generates the specs will
still try to avoid this by claiming UIDs, but in the case that extra
label selectors are being used and overlap with known UIDs, the pod
will show up in both resources without causing things to get wonky.