### PR TITLE
apis: send UIResource instead of Resource

### DIFF
--- a/internal/cloud/io_test.go
+++ b/internal/cloud/io_test.go
@@ -18,25 +18,6 @@ func TestWriteSnapshotTo(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, `{
   "view": {
-    "resources": [
-      {
-        "name": "(Tiltfile)",
-        "lastDeployTime": "0001-01-01T00:00:00Z",
-        "buildHistory": [
-          {
-            "startTime": "0001-01-01T00:00:00Z",
-            "finishTime": "0001-01-01T00:00:00Z"
-          }
-        ],
-        "currentBuild": {
-          "startTime": "0001-01-01T00:00:00Z",
-          "finishTime": "0001-01-01T00:00:00Z"
-        },
-        "runtimeStatus": "not_applicable",
-        "updateStatus": "pending",
-        "isTiltfile": true
-      }
-    ],
     "runningTiltBuild": {
 
     },
@@ -48,7 +29,23 @@ func TestWriteSnapshotTo(t *testing.T) {
       "fromCheckpoint": -1,
       "toCheckpoint": -1
     },
-    "tiltStartTime": "0001-01-01T00:00:00Z"
+    "tiltStartTime": "0001-01-01T00:00:00Z",
+    "uiResources": [
+      {
+        "metadata": {
+          "name": "(Tiltfile)"
+        },
+        "status": {
+          "buildHistory": [
+            {
+
+            }
+          ],
+          "runtimeStatus": "not_applicable",
+          "updateStatus": "pending"
+        }
+      }
+    ]
   }
 }
 `, buf.String())

--- a/pkg/apis/core/v1alpha1/uiresource_types.go
+++ b/pkg/apis/core/v1alpha1/uiresource_types.go
@@ -180,7 +180,7 @@ type UIResourceTargetType string
 
 const UIResourceTargetTypeUnspecified = UIResourceTargetType("unspecified")
 const UIResourceTargetTypeImage = UIResourceTargetType("image")
-const UIResourceTargetTypeK8s = UIResourceTargetType("k8s")
+const UIResourceTargetTypeKubernetes = UIResourceTargetType("k8s")
 const UIResourceTargetTypeDockerCompose = UIResourceTargetType("docker-compose")
 const UIResourceTargetTypeLocal = UIResourceTargetType("local")
 

--- a/web/src/AppController.test.ts
+++ b/web/src/AppController.test.ts
@@ -24,7 +24,7 @@ describe("AppController", () => {
   it("sets view from snapshot", async () => {
     fetchMock.mock(
       "/api/snapshot/aaaaaaa",
-      JSON.stringify({ view: { resources: [] } })
+      JSON.stringify({ view: { uiResources: [] } })
     )
 
     let pb = PathBuilder.forTesting("cloud.tilt.dev", "/snapshot/aaaaaaa")
@@ -39,7 +39,7 @@ describe("AppController", () => {
   it("sets view and path from snapshot", async () => {
     fetchMock.mock(
       "/api/snapshot/aaaaaa",
-      JSON.stringify({ view: { resources: [] }, path: "/foo" })
+      JSON.stringify({ view: { uiResources: [] }, path: "/foo" })
     )
 
     let pb = PathBuilder.forTesting("cloud.tilt.dev", "/snapshot/aaaaaa")
@@ -60,7 +60,7 @@ describe("AppController", () => {
     fetchMock.mock(
       "/api/snapshot/aaaaaa",
       JSON.stringify({
-        view: { resources: [] },
+        view: { uiResources: [] },
         snapshotHighlight: snapshotHighlight,
       })
     )

--- a/web/src/HUD.tsx
+++ b/web/src/HUD.tsx
@@ -68,7 +68,6 @@ export default class HUD extends Component<HudProps, HudState> {
 
     this.state = {
       view: {
-        resources: [],
         needsAnalyticsNudge: false,
         fatalError: undefined,
         runningTiltBuild: {
@@ -251,7 +250,7 @@ export default class HUD extends Component<HudProps, HudState> {
     let view = this.state.view
 
     let needsNudge = view?.needsAnalyticsNudge ?? false
-    let resources = view?.resources ?? []
+    let resources = view?.uiResources ?? []
     if (!resources?.length || !view?.tiltfileKey) {
       return <HeroScreen message={"Loading…"} />
     }
@@ -270,7 +269,7 @@ export default class HUD extends Component<HudProps, HudState> {
     }
 
     let validateResource = (name: string) =>
-      resources.some((res) => res.name === name)
+      resources.some((res) => res.metadata?.name === name)
     return (
       <tiltfileKeyContext.Provider value={view.tiltfileKey}>
         <StarredResourcesContextProvider>

--- a/web/src/HeaderBar.stories.tsx
+++ b/web/src/HeaderBar.stories.tsx
@@ -28,9 +28,9 @@ export const TenResources = () => <HeaderBar view={tenResourceView()} />
 
 export const TenResourcesErrorsAndWarnings = () => {
   let view = tenResourceView() as any
-  view.resources[0].updateStatus = UpdateStatus.Error
-  view.resources[1].buildHistory[0].warnings = ["warning time"]
-  view.resources[5].updateStatus = UpdateStatus.Error
+  view.uiResources[0].status.updateStatus = UpdateStatus.Error
+  view.uiResources[1].status.buildHistory[0].warnings = ["warning time"]
+  view.uiResources[5].status.updateStatus = UpdateStatus.Error
   return <HeaderBar view={view} />
 }
 
@@ -46,6 +46,6 @@ export const UpgradeAvailable = () => {
 
 export const WithTests = () => {
   let view = twoResourceView()
-  view.resources.push(oneResourceTest(), oneResourceTest())
+  view.uiResources.push(oneResourceTest(), oneResourceTest())
   return <HeaderBar view={view} />
 }

--- a/web/src/HeaderBar.tsx
+++ b/web/src/HeaderBar.tsx
@@ -62,9 +62,9 @@ export default function HeaderBar(props: HeaderBarProps) {
   let view = props.view
   let runningBuild = view?.runningTiltBuild
   let suggestedVersion = view?.suggestedTiltVersion
-  let resources = view?.resources || []
+  let resources = view?.uiResources || []
   let hasK8s = resources.some((r) => {
-    let specs = r.specs ?? []
+    let specs = r.status?.specs ?? []
     return specs.some((spec) => spec.type === TargetType.K8s)
   })
 

--- a/web/src/OverviewActionBar.stories.tsx
+++ b/web/src/OverviewActionBar.stories.tsx
@@ -6,7 +6,7 @@ import OverviewActionBar from "./OverviewActionBar"
 import { StarredResourceMemoryProvider } from "./StarredResourcesContext"
 import { oneResource } from "./testdata"
 
-type Resource = Proto.webviewResource
+type UIResource = Proto.v1alpha1UIResource
 
 export default {
   title: "New UI/Log View/OverviewActionBar",
@@ -48,29 +48,34 @@ let defaultFilter = { source: FilterSource.all, level: FilterLevel.all }
 export const OverflowTextBar = () => {
   let filterSet = useFilterSet()
   let res = oneResource()
-  res.endpointLinks = [
+  res.status = res.status || {}
+  res.status.endpointLinks = [
     { url: "http://my-pod-grafana-long-service-name-deadbeef:4001" },
     { url: "http://my-pod-grafana-long-service-name-deadbeef:4002" },
   ]
-  res.podID = "my-pod-grafana-long-service-name-deadbeef"
+  res.status.k8sResourceInfo = {
+    podName: "my-pod-grafana-long-service-name-deadbeef",
+  }
   return <OverviewActionBar resource={res} filterSet={filterSet} />
 }
 
 export const FullBar = () => {
   let filterSet = useFilterSet()
   let res = oneResource()
-  res.endpointLinks = [
+  res.status = res.status || {}
+  res.status.endpointLinks = [
     { url: "http://localhost:4001" },
     { url: "http://localhost:4002" },
   ]
-  res.podID = "my-pod-deadbeef"
+  res.status.k8sResourceInfo = { podName: "my-pod-deadbeef" }
   return <OverviewActionBar resource={res} filterSet={filterSet} />
 }
 
 export const EmptyBar = () => {
   let filterSet = useFilterSet()
   let res = oneResource()
-  res.endpointLinks = []
-  res.podID = ""
+  res.status = res.status || {}
+  res.status.endpointLinks = []
+  res.status.k8sResourceInfo = {}
   return <OverviewActionBar resource={res} filterSet={filterSet} />
 }

--- a/web/src/OverviewActionBar.tsx
+++ b/web/src/OverviewActionBar.tsx
@@ -21,9 +21,12 @@ import { usePathBuilder } from "./PathBuilder"
 import { AnimDuration, Color, Font, FontSize, SizeUnit } from "./style-helpers"
 import { ResourceName } from "./types"
 
+type UIResource = Proto.v1alpha1UIResource
+type Link = Proto.v1alpha1UIResourceLink
+
 type OverviewActionBarProps = {
   // The current resource. May be null if there is no resource.
-  resource?: Proto.webviewResource
+  resource?: UIResource
 
   // All the alerts for the current resource.
   alerts?: Alert[]
@@ -389,7 +392,7 @@ let ActionBarBottomRow = styled.div`
 `
 
 type ActionBarProps = {
-  endpoints: Proto.webviewLink[]
+  endpoints: Link[]
   podId: string
 }
 
@@ -425,9 +428,11 @@ function openEndpointUrl(url: string) {
 
 export default function OverviewActionBar(props: OverviewActionBarProps) {
   let { resource, filterSet, alerts } = props
-  let endpoints = resource?.endpointLinks || []
-  let podId = resource?.podID || ""
-  const resourceName = resource ? resource.name || "" : ResourceName.all
+  let endpoints = resource?.status?.endpointLinks || []
+  let podId = resource?.status?.k8sResourceInfo?.podName || ""
+  const resourceName = resource
+    ? resource.metadata?.name || ""
+    : ResourceName.all
   const isSnapshot = usePathBuilder().isSnapshot()
   const logStore = useLogStore()
 

--- a/web/src/OverviewActionBarKeyboardShortcuts.test.tsx
+++ b/web/src/OverviewActionBarKeyboardShortcuts.test.tsx
@@ -22,7 +22,7 @@ function numKeyCode(num: number): number {
   return num + 48
 }
 
-type Link = Proto.webviewLink
+type Link = Proto.v1alpha1UIResourceLink
 
 let logStore: LogStore | null
 let component: any

--- a/web/src/OverviewActionBarKeyboardShortcuts.tsx
+++ b/web/src/OverviewActionBarKeyboardShortcuts.tsx
@@ -5,7 +5,7 @@ import LogStore from "./LogStore"
 import { isTargetEditable } from "./shortcut"
 import { ResourceName } from "./types"
 
-type Link = Proto.webviewLink
+type Link = Proto.v1alpha1UIResourceLink
 
 type Props = {
   logStore: LogStore

--- a/web/src/OverviewGrid.stories.tsx
+++ b/web/src/OverviewGrid.stories.tsx
@@ -4,7 +4,7 @@ import OverviewGrid from "./OverviewGrid"
 import { OverviewItem } from "./OverviewItemView"
 import { nResourceView, tenResourceView, twoResourceView } from "./testdata"
 
-type Resource = Proto.webviewResource
+type UIResource = Proto.v1alpha1UIResource
 
 export default {
   title: "New UI/Overview/OverviewGrid",
@@ -20,7 +20,7 @@ export default {
 }
 
 function toItems(view: Proto.webviewView) {
-  return (view.resources || []).map((res) => new OverviewItem(res))
+  return (view.uiResources || []).map((res) => new OverviewItem(res))
 }
 
 export const TwoResources = () => (

--- a/web/src/OverviewItemView.stories.tsx
+++ b/web/src/OverviewItemView.stories.tsx
@@ -8,7 +8,7 @@ import OverviewItemView, {
 import { oneResourceNoAlerts } from "./testdata"
 import { ResourceStatus, TriggerMode } from "./types"
 
-type Resource = Proto.webviewResource
+type UIResource = Proto.v1alpha1UIResource
 
 type optionFn = (item: OverviewItemViewProps) => void
 

--- a/web/src/OverviewItemView.tsx
+++ b/web/src/OverviewItemView.tsx
@@ -35,7 +35,7 @@ import {
 import { formatBuildDuration, isZeroTime, timeDiff } from "./time"
 import { timeAgoFormatter } from "./timeFormatters"
 import { TriggerModeToggle } from "./TriggerModeToggle"
-import { ResourceStatus, TargetType, TriggerMode } from "./types"
+import { ResourceName, ResourceStatus, TargetType, TriggerMode } from "./types"
 
 export const OverviewItemRoot = styled.li`
   display: flex;
@@ -45,11 +45,15 @@ export const OverviewItemRoot = styled.li`
   margin: 0 0 ${SizeUnit(0.75)} ${SizeUnit(0.75)};
 `
 
-type Resource = Proto.webviewResource
-type Build = Proto.webviewBuildRecord
+type UIResource = Proto.v1alpha1UIResource
+type UIResourceStatus = Proto.v1alpha1UIResourceStatus
+type Build = Proto.v1alpha1UIBuildTerminated
+type UILink = Proto.v1alpha1UIResourceLink
 
-function resourceTypeLabel(res: Resource): string {
-  if (res.isTiltfile) {
+function resourceTypeLabel(r: UIResource): string {
+  let res = (r.status || {}) as UIResourceStatus
+  let name = r.metadata?.name
+  if (name == "(Tiltfile)") {
     return "Tiltfile"
   }
   let specs = res.specs ?? []
@@ -87,24 +91,25 @@ export class OverviewItem {
   hasPendingChanges: boolean
   queued: boolean
   lastBuild: Build | null = null
-  endpoints: Proto.webviewLink[]
+  endpoints: UILink[]
   podId: string
 
   /**
    * Create a pared down OverviewItem from a ResourceView
    */
-  constructor(res: Resource) {
+  constructor(r: UIResource) {
+    let res = (r.status || {}) as UIResourceStatus
     let buildHistory = res.buildHistory || []
     let lastBuild = buildHistory.length > 0 ? buildHistory[0] : null
 
-    this.name = res.name ?? ""
-    this.isTiltfile = !!res.isTiltfile
+    this.name = r.metadata?.name ?? ""
+    this.isTiltfile = this.name === ResourceName.tiltfile
     this.isTest =
       (res.localResourceInfo && !!res.localResourceInfo.isTest) || false
-    this.buildStatus = buildStatus(res)
-    this.buildAlertCount = buildAlerts(res, null).length
-    this.runtimeStatus = runtimeStatus(res)
-    this.runtimeAlertCount = runtimeAlerts(res, null).length
+    this.buildStatus = buildStatus(r)
+    this.buildAlertCount = buildAlerts(r, null).length
+    this.runtimeStatus = runtimeStatus(r)
+    this.runtimeAlertCount = runtimeAlerts(r, null).length
     this.hasEndpoints = (res.endpointLinks || []).length > 0
     this.lastBuildDur =
       lastBuild && lastBuild.startTime && lastBuild.finishTime
@@ -117,9 +122,9 @@ export class OverviewItem {
     this.hasPendingChanges = !!res.hasPendingChanges
     this.queued = !!res.queued
     this.lastBuild = lastBuild
-    this.resourceTypeLabel = resourceTypeLabel(res)
+    this.resourceTypeLabel = resourceTypeLabel(r)
     this.endpoints = res.endpointLinks ?? []
-    this.podId = res.podID ?? ""
+    this.podId = res.k8sResourceInfo?.podName ?? ""
   }
 }
 
@@ -360,7 +365,8 @@ function RuntimeBox(props: RuntimeBoxProps) {
   let { item } = props
 
   let formatter = timeAgoFormatter
-  let timeAgo = <TimeAgo date={item.lastDeployTime} formatter={formatter} />
+  let time = item.lastDeployTime || ""
+  let timeAgo = <TimeAgo date={time} formatter={formatter} />
 
   let building = !isZeroTime(item.currentBuildStartTime)
   let hasSuccessfullyDeployed = !isZeroTime(item.lastDeployTime)

--- a/web/src/OverviewPane.stories.tsx
+++ b/web/src/OverviewPane.stories.tsx
@@ -4,7 +4,7 @@ import OverviewPane from "./OverviewPane"
 import { StarredResourceMemoryProvider } from "./StarredResourcesContext"
 import { nResourceView, tenResourceView, twoResourceView } from "./testdata"
 
-type Resource = Proto.webviewResource
+type UIResource = Proto.v1alpha1UIResource
 
 export default {
   title: "New UI/OverviewPane",

--- a/web/src/OverviewPane.test.tsx
+++ b/web/src/OverviewPane.test.tsx
@@ -65,7 +65,7 @@ it("renders starred resources", () => {
 
 it("renders test resources separate from all resources", () => {
   let view = twoResourceView()
-  view.resources.push(oneResourceTest())
+  view.uiResources.push(oneResourceTest())
 
   const root = mount(
     <MemoryRouter initialEntries={["/"]}>

--- a/web/src/OverviewPane.tsx
+++ b/web/src/OverviewPane.tsx
@@ -71,7 +71,7 @@ export function TestResources(props: ResourceProps) {
 
 export default function OverviewPane(props: OverviewPaneProps) {
   let starContext = useStarredResources()
-  let resources = props.view.resources || []
+  let resources = props.view.uiResources || []
   let allItems = resources.map((res) => new OverviewItem(res))
   let allResources = allItems.filter(
     (item) =>

--- a/web/src/OverviewResourceBar.stories.tsx
+++ b/web/src/OverviewResourceBar.stories.tsx
@@ -9,7 +9,7 @@ import {
 } from "./testdata"
 import { UpdateStatus } from "./types"
 
-type Resource = Proto.webviewResource
+type UIResource = Proto.v1alpha1UIResource
 
 export default {
   title: "New UI/Shared/OverviewResourceBar",
@@ -34,9 +34,9 @@ export const TenResources = () => (
 
 export const TenResourcesErrorsAndWarnings = () => {
   let view = tenResourceView() as any
-  view.resources[0].updateStatus = UpdateStatus.Error
-  view.resources[1].buildHistory[0].warnings = ["warning time"]
-  view.resources[5].updateStatus = UpdateStatus.Error
+  view.uiResources[0].updateStatus = UpdateStatus.Error
+  view.uiResources[1].buildHistory[0].warnings = ["warning time"]
+  view.uiResources[5].updateStatus = UpdateStatus.Error
   return <OverviewResourceBar view={view} />
 }
 
@@ -54,6 +54,6 @@ export const UpgradeAvailable = () => {
 
 export const WithTests = () => {
   let view = twoResourceView()
-  view.resources.push(oneResourceTest(), oneResourceTest())
+  view.uiResources.push(oneResourceTest(), oneResourceTest())
   return <OverviewResourceBar view={view} />
 }

--- a/web/src/OverviewResourceBar.tsx
+++ b/web/src/OverviewResourceBar.tsx
@@ -30,9 +30,9 @@ export default function OverviewResourceBar(props: OverviewResourceBarProps) {
   let view = props.view
   let runningBuild = view?.runningTiltBuild
   let suggestedVersion = view?.suggestedTiltVersion
-  let resources = view?.resources || []
+  let resources = view?.uiResources || []
   let hasK8s = resources.some((r) => {
-    let specs = r.specs ?? []
+    let specs = r.status?.specs ?? []
     return specs.some((spec) => spec.type === TargetType.K8s)
   })
 

--- a/web/src/OverviewResourceDetails.tsx
+++ b/web/src/OverviewResourceDetails.tsx
@@ -7,8 +7,10 @@ import OverviewLogPane from "./OverviewLogPane"
 import { Color } from "./style-helpers"
 import { ResourceName } from "./types"
 
+type UIResource = Proto.v1alpha1UIResource
+
 type OverviewResourceDetailsProps = {
-  resource?: Proto.webviewResource
+  resource?: UIResource
   alerts?: Alert[]
   name: string
 }
@@ -33,7 +35,7 @@ export default function OverviewResourceDetails(
   props: OverviewResourceDetailsProps
 ) {
   let { name, resource, alerts } = props
-  let manifestName = resource?.name || ""
+  let manifestName = resource?.metadata?.name || ""
   let all = name === "" || name === ResourceName.all
   let notFound = !all && !manifestName
   let filterSet = useFilterSet()

--- a/web/src/OverviewResourcePane.stories.tsx
+++ b/web/src/OverviewResourcePane.stories.tsx
@@ -6,7 +6,7 @@ import { ResourceNavProvider } from "./ResourceNav"
 import { StarredResourceMemoryProvider } from "./StarredResourcesContext"
 import { nResourceView, tenResourceView, twoResourceView } from "./testdata"
 
-type Resource = Proto.webviewResource
+type UIResource = Proto.v1alpha1UIResource
 
 export default {
   title: "New UI/OverviewResourcePane",
@@ -29,9 +29,9 @@ function OverviewResourcePaneHarness(props: {
 }) {
   let { name, view } = props
   let entry = name ? `/r/${props.name}/overview` : `/overview`
-  let resources = view?.resources || []
+  let resources = view?.uiResources || []
   let validateResource = (name: string) =>
-    resources.some((res) => res.name == name)
+    resources.some((res) => res.metadata?.name == name)
   return (
     <MemoryRouter initialEntries={[entry]}>
       <ResourceNavProvider validateResource={validateResource}>
@@ -51,13 +51,14 @@ export const TenResources = () => (
 
 export const FullResourceBar = () => {
   let view = tenResourceView()
-  let res = view.resources[1]
-  res.endpointLinks = [
+  let res = view.uiResources[1]
+  res.status = res.status || {}
+  res.status.endpointLinks = [
     { url: "http://localhost:4001" },
     { url: "http://localhost:4002" },
     { url: "http://localhost:4003" },
   ]
-  res.podID = "my-pod-deadbeef"
+  res.status.k8sResourceInfo = { podName: "my-pod-deadbeef" }
   return <OverviewResourcePaneHarness name="vigoda_1" view={view} />
 }
 

--- a/web/src/OverviewResourcePane.tsx
+++ b/web/src/OverviewResourcePane.tsx
@@ -12,6 +12,7 @@ import StarredResourceBar, {
 import { Color } from "./style-helpers"
 import { ResourceName } from "./types"
 
+type UIResource = Proto.v1alpha1UIResource
 type OverviewResourcePaneProps = {
   view: Proto.webviewView
 }
@@ -36,18 +37,18 @@ let Main = styled.div`
 export default function OverviewResourcePane(props: OverviewResourcePaneProps) {
   let nav = useResourceNav()
   const logStore = useLogStore()
-  let resources = props.view?.resources || []
+  let resources = props.view?.uiResources || []
   let name = nav.invalidResource || nav.selectedResource || ""
-  let r: Proto.webviewResource | undefined
+  let r: UIResource | undefined
   let all = name === "" || name === ResourceName.all
   if (!all) {
-    r = resources.find((r) => r.name === name)
+    r = resources.find((r) => r.metadata?.name === name)
   }
   let selectedTab = ""
   if (all) {
     selectedTab = ResourceName.all
-  } else if (r?.name) {
-    selectedTab = r.name
+  } else if (r?.metadata?.name) {
+    selectedTab = r.metadata.name
   }
 
   const [truncateCount, setTruncateCount] = useState<number>(0)

--- a/web/src/OverviewResourceSidebar.stories.tsx
+++ b/web/src/OverviewResourceSidebar.stories.tsx
@@ -13,7 +13,7 @@ import {
 } from "./testdata"
 import { UpdateStatus } from "./types"
 
-type Resource = Proto.webviewResource
+type UIResource = Proto.v1alpha1UIResource
 let pathBuilder = PathBuilder.forTesting("localhost", "/")
 
 export default {
@@ -42,30 +42,30 @@ export const OneHundredResources = () => (
 )
 
 export function TwoResourcesTwoTests() {
-  let all: Resource[] = [
+  let all: UIResource[] = [
     tiltfileResource(),
     oneResource(),
     oneResourceNoAlerts(),
     oneResourceTest(),
     oneResourceTest(),
   ]
-  all[2].name = "snack"
-  all[3].name = "beep"
-  let view = { resources: all, tiltfileKey: "test" }
+  all[2].metadata = { name: "snack" }
+  all[3].metadata = { name: "beep" }
+  let view = { uiResources: all, tiltfileKey: "test" }
   return <OverviewResourceSidebar name={""} view={view} />
 }
 
 export function TestsWithErrors() {
-  let all: Resource[] = [tiltfileResource()]
+  let all: UIResource[] = [tiltfileResource()]
   for (let i = 0; i < 8; i++) {
     let test = oneResourceTest()
-    test.name = "test_" + i
+    test.metadata = { name: "test_" + i }
     if (i % 2 === 0) {
-      test.buildHistory![0].error = "egads!"
-      test.updateStatus = UpdateStatus.Error
+      test.status!.buildHistory![0].error = "egads!"
+      test.status!.updateStatus = UpdateStatus.Error
     }
     all.push(test)
   }
-  let view = { resources: all, tiltfileKey: "test" }
+  let view = { uiResources: all, tiltfileKey: "test" }
   return <OverviewResourceSidebar name={""} view={view} />
 }

--- a/web/src/OverviewResourceSidebar.tsx
+++ b/web/src/OverviewResourceSidebar.tsx
@@ -24,7 +24,7 @@ export default function OverviewResourceSidebar(
   props: OverviewResourceSidebarProps
 ) {
   let pathBuilder = usePathBuilder()
-  let resources = props.view.resources || []
+  let resources = props.view.uiResources || []
   let items = resources.map((res) => new SidebarItem(res))
   let selected = props.name
   if (props.name === ResourceName.all) {

--- a/web/src/ResourceStatusSummary.tsx
+++ b/web/src/ResourceStatusSummary.tsx
@@ -19,6 +19,8 @@ import {
 import Tooltip from "./Tooltip"
 import { ResourceName, ResourceStatus } from "./types"
 
+type UIResource = Proto.v1alpha1UIResource
+
 const ResourceGroupStatusRoot = styled.div`
   display: flex;
   font-family: ${Font.sansSerif};
@@ -212,7 +214,7 @@ export type StatusCounts = {
   warning: number
 }
 
-function statusCounts(resources: Proto.webviewResource[]): StatusCounts {
+function statusCounts(resources: UIResource[]): StatusCounts {
   let statuses = resources.map((res) => combinedStatus(res))
   let allStatusCount = 0
   let healthyStatusCount = 0
@@ -282,12 +284,12 @@ type ResourceStatusSummaryProps = {
 
 export function ResourceStatusSummary(props: ResourceStatusSummaryProps) {
   // Count the statuses.
-  let resources = props.view.resources || []
+  let resources = props.view.uiResources || []
 
-  let testResources = new Array<Proto.webviewResource>()
-  let otherResources = new Array<Proto.webviewResource>()
+  let testResources = new Array<UIResource>()
+  let otherResources = new Array<UIResource>()
   resources.forEach((r) => {
-    if (r.localResourceInfo && r.localResourceInfo.isTest) {
+    if (r.status?.localResourceInfo?.isTest) {
       testResources.push(r)
     } else {
       otherResources.push(r)

--- a/web/src/SidebarItemView.stories.tsx
+++ b/web/src/SidebarItemView.stories.tsx
@@ -12,7 +12,7 @@ import {
   TriggerMode,
 } from "./types"
 
-type Resource = Proto.webviewResource
+type UIResource = Proto.v1alpha1UIResource
 let pathBuilder = PathBuilder.forTesting("localhost", "/")
 
 function ItemWrapper(props: { children: React.ReactNode }) {

--- a/web/src/SidebarItemView.tsx
+++ b/web/src/SidebarItemView.tsx
@@ -258,7 +258,8 @@ export default function SidebarItemView(props: SidebarItemViewProps) {
   let hasSuccessfullyDeployed = !isZeroTime(item.lastDeployTime)
   let hasBuilt = item.lastBuild !== null
   let building = !isZeroTime(item.currentBuildStartTime)
-  let timeAgo = <TimeAgo date={item.lastDeployTime} formatter={formatter} />
+  let time = item.lastDeployTime || ""
+  let timeAgo = <TimeAgo date={time} formatter={formatter} />
   let isSelected = props.selected
 
   let isSelectedClass = isSelected ? "isSelected" : ""

--- a/web/src/SidebarKeyboardShortcuts.test.tsx
+++ b/web/src/SidebarKeyboardShortcuts.test.tsx
@@ -45,35 +45,35 @@ afterEach(() => {
 })
 
 it("navigates forwards", () => {
-  let items = twoResourceView().resources.map((res) => new SidebarItem(res))
+  let items = twoResourceView().uiResources.map((res) => new SidebarItem(res))
   shortcuts(items, "")
   fireEvent.keyDown(document.body, { key: "j" })
   expect(opened).toEqual("vigoda")
 })
 
 it("navigates forwards no wrap", () => {
-  let items = twoResourceView().resources.map((res) => new SidebarItem(res))
+  let items = twoResourceView().uiResources.map((res) => new SidebarItem(res))
   shortcuts(items, "snack")
   fireEvent.keyDown(document.body, { key: "j" })
   expect(opened).toEqual(null)
 })
 
 it("navigates backwards", () => {
-  let items = twoResourceView().resources.map((res) => new SidebarItem(res))
+  let items = twoResourceView().uiResources.map((res) => new SidebarItem(res))
   shortcuts(items, "snack")
   fireEvent.keyDown(document.body, { key: "k" })
   expect(opened).toEqual("vigoda")
 })
 
 it("navigates backwards no wrap", () => {
-  let items = twoResourceView().resources.map((res) => new SidebarItem(res))
+  let items = twoResourceView().uiResources.map((res) => new SidebarItem(res))
   let sks = shortcuts(items, "")
   fireEvent.keyDown(document.body, { key: "k" })
   expect(opened).toEqual(null)
 })
 
 it("triggers update", () => {
-  let items = twoResourceView().resources.map((res) => new SidebarItem(res))
+  let items = twoResourceView().uiResources.map((res) => new SidebarItem(res))
   let sks = shortcuts(items, "")
   expect(triggered).toEqual(false)
   fireEvent.keyDown(document.body, { key: "r" })

--- a/web/src/SidebarResources.test.tsx
+++ b/web/src/SidebarResources.test.tsx
@@ -53,7 +53,7 @@ describe("SidebarResources", () => {
   })
 
   it("adds items to the starred list when items are starred", () => {
-    let items = twoResourceView().resources.map((r) => new SidebarItem(r))
+    let items = twoResourceView().uiResources.map((r) => new SidebarItem(r))
     const root = mount(
       <MemoryRouter>
         <tiltfileKeyContext.Provider value="test">
@@ -84,7 +84,7 @@ describe("SidebarResources", () => {
   })
 
   it("removes items from the starred list when items are unstarred", () => {
-    let items = twoResourceView().resources.map((r) => new SidebarItem(r))
+    let items = twoResourceView().uiResources.map((r) => new SidebarItem(r))
     starredItemsAccessor.set(items.map((i) => i.name))
 
     const root = mount(

--- a/web/src/SidebarResources.tsx
+++ b/web/src/SidebarResources.tsx
@@ -48,8 +48,8 @@ export function SidebarListSection(
   )
 }
 
-type Resource = Proto.webviewResource
-type Build = Proto.webviewBuildRecord
+type UIResource = Proto.v1alpha1UIResource
+type Build = Proto.v1alpha1UIBuildTerminated
 
 type SidebarProps = {
   items: SidebarItem[]

--- a/web/src/SidebarTriggerButton.test.tsx
+++ b/web/src/SidebarTriggerButton.test.tsx
@@ -18,7 +18,7 @@ import SidebarTriggerButton, {
 import { oneResource, twoResourceView } from "./testdata"
 import { ResourceName, ResourceView, TriggerMode } from "./types"
 
-type Resource = Proto.webviewResource
+type UIResource = Proto.v1alpha1UIResource
 
 let pathBuilder = PathBuilder.forTesting("localhost", "/")
 
@@ -134,20 +134,23 @@ describe("SidebarTriggerButton", () => {
   })
 
   it("shows clickable + clickMe trigger button for manual resource with pending changes", () => {
-    let items = twoResourceView().resources.map((res: Resource, i: number) => {
-      res.triggerMode = TriggerMode.TriggerModeManualWithAutoInit // both manual
-      res.currentBuild = {} // not currently building
-      if (i == 0) {
-        // only first resource has pending changes -- only this one should have class `isDirty`
-        res.hasPendingChanges = true
-        res.pendingBuildSince = new Date(Date.now()).toISOString()
-      } else {
-        res.hasPendingChanges = false
-        res.pendingBuildSince = "0001-01-01T00:00:00Z"
-      }
+    let items = twoResourceView().uiResources.map(
+      (r: UIResource, i: number) => {
+        let res = r.status!
+        res.triggerMode = TriggerMode.TriggerModeManualWithAutoInit // both manual
+        res.currentBuild = {} // not currently building
+        if (i == 0) {
+          // only first resource has pending changes -- only this one should have class `isDirty`
+          res.hasPendingChanges = true
+          res.pendingBuildSince = new Date(Date.now()).toISOString()
+        } else {
+          res.hasPendingChanges = false
+          res.pendingBuildSince = "0001-01-01T00:00:00Z"
+        }
 
-      return new SidebarItem(res)
-    })
+        return new SidebarItem(r)
+      }
+    )
 
     const root = mount(
       <MemoryRouter initialEntries={["/"]}>
@@ -178,15 +181,18 @@ describe("SidebarTriggerButton", () => {
   })
 
   it("shows selected trigger button for selected resource", () => {
-    let items = twoResourceView().resources.map((res: Resource, i: number) => {
-      res.triggerMode = TriggerMode.TriggerModeManualWithAutoInit // both manual
-      res.currentBuild = {} // not currently building
-      if (i == 0) {
-        res.name = "selected resource"
-      }
+    let items = twoResourceView().uiResources.map(
+      (r: UIResource, i: number) => {
+        let res = r.status!
+        res.triggerMode = TriggerMode.TriggerModeManualWithAutoInit // both manual
+        res.currentBuild = {} // not currently building
+        if (i == 0) {
+          r.metadata = { name: "selected resource" }
+        }
 
-      return new SidebarItem(res)
-    })
+        return new SidebarItem(r)
+      }
+    )
 
     const root = mount(
       <MemoryRouter initialEntries={["/"]}>
@@ -207,20 +213,23 @@ describe("SidebarTriggerButton", () => {
   })
 
   it("never shows clickMe trigger button for automatic resources", () => {
-    let items = twoResourceView().resources.map((res: Resource, i: number) => {
-      res.currentBuild = {} // not currently building
+    let items = twoResourceView().uiResources.map(
+      (r: UIResource, i: number) => {
+        let res = r.status!
+        res.currentBuild = {} // not currently building
 
-      if (i == 0) {
-        // first resource has pending changes -- but is automatic, should NOT
-        // have a clickMe button (and button should be !clickable)
-        res.hasPendingChanges = true
-        res.pendingBuildSince = new Date(Date.now()).toISOString()
-      } else {
-        res.hasPendingChanges = false
-        res.pendingBuildSince = "0001-01-01T00:00:00Z"
+        if (i == 0) {
+          // first resource has pending changes -- but is automatic, should NOT
+          // have a clickMe button (and button should be !clickable)
+          res.hasPendingChanges = true
+          res.pendingBuildSince = new Date(Date.now()).toISOString()
+        } else {
+          res.hasPendingChanges = false
+          res.pendingBuildSince = "0001-01-01T00:00:00Z"
+        }
+        return new SidebarItem(r)
       }
-      return new SidebarItem(res)
-    })
+    )
 
     const root = mount(
       <MemoryRouter initialEntries={["/"]}>
@@ -274,13 +283,14 @@ describe("SidebarTriggerButton", () => {
   })
 
   it("trigger button not clickable if resource waiting for first build", () => {
-    let res = oneResource()
+    let r = oneResource()
+    let res = r.status!
     res.currentBuild = {}
     res.buildHistory = []
     res.lastDeployTime = ""
     res.hasPendingChanges = false
     res.pendingBuildSince = ""
-    let items = [new SidebarItem(res)]
+    let items = [new SidebarItem(r)]
 
     const root = mount(
       <MemoryRouter initialEntries={["/"]}>
@@ -304,8 +314,8 @@ describe("SidebarTriggerButton", () => {
 
   it("renders queued resource with class .isQueued and NOT .clickable", () => {
     let res = oneResource()
-    res.currentBuild = {}
-    res.queued = true
+    res.status!.currentBuild = {}
+    res.status!.queued = true
     let items = [new SidebarItem(res)]
 
     const root = mount(
@@ -330,10 +340,10 @@ describe("SidebarTriggerButton", () => {
 
   it("shows a trigger button for resource that failed its initial build", () => {
     let res = oneResource()
-    res.lastDeployTime = ""
-    res.currentBuild = {}
-    res.hasPendingChanges = false
-    res.pendingBuildSince = ""
+    res.status!.lastDeployTime = ""
+    res.status!.currentBuild = {}
+    res.status!.hasPendingChanges = false
+    res.status!.pendingBuildSince = ""
     let items = [new SidebarItem(res)]
 
     const root = mount(
@@ -358,11 +368,11 @@ describe("SidebarTriggerButton", () => {
 
   it("shows trigger button for Tiltfile", () => {
     let res = oneResource()
-    res.name = ResourceName.tiltfile
-    res.isTiltfile = true
-    res.currentBuild = {} // not currently building
-    res.hasPendingChanges = false
-    res.pendingBuildSince = "0001-01-01T00:00:00Z"
+    res.metadata = { name: ResourceName.tiltfile }
+    res.status = res.status || {}
+    res.status.currentBuild = {} // not currently building
+    res.status.hasPendingChanges = false
+    res.status.pendingBuildSince = "0001-01-01T00:00:00Z"
 
     let items = [new SidebarItem(res)]
 

--- a/web/src/StarredResourceBar.tsx
+++ b/web/src/StarredResourceBar.tsx
@@ -218,9 +218,10 @@ export function starredResourcePropsFromView(
   selectedResource: string
 ): StarredResourceBarProps {
   const starContext = useStarredResources()
-  const namesAndStatuses = (view?.resources || []).flatMap((r) => {
-    if (r.name && starContext.starredResources.includes(r.name)) {
-      return [{ name: r.name, status: combinedStatus(r) }]
+  const namesAndStatuses = (view?.uiResources || []).flatMap((r) => {
+    let name = r.metadata?.name
+    if (name && starContext.starredResources.includes(name)) {
+      return [{ name: name, status: combinedStatus(r) }]
     } else {
       return []
     }

--- a/web/src/TriggerModeToggle.test.tsx
+++ b/web/src/TriggerModeToggle.test.tsx
@@ -40,7 +40,7 @@ describe("SidebarTriggerButton", () => {
 
   it("shows toggle button only for test cards", () => {
     let view = twoResourceView()
-    view.resources.push(oneResourceTest())
+    view.uiResources.push(oneResourceTest())
 
     const root = mount(
       <MemoryRouter initialEntries={["/"]}>
@@ -59,12 +59,12 @@ describe("SidebarTriggerButton", () => {
       oneResourceTestWithName("manual_auto-init"),
       oneResourceTestWithName("manual_no-init"),
     ]
-    resources[0].triggerMode = TriggerMode.TriggerModeAuto
-    resources[1].triggerMode = TriggerMode.TriggerModeAutoWithManualInit
-    resources[2].triggerMode = TriggerMode.TriggerModeManualWithAutoInit
-    resources[3].triggerMode = TriggerMode.TriggerModeManual
+    resources[0].status!.triggerMode = TriggerMode.TriggerModeAuto
+    resources[1].status!.triggerMode = TriggerMode.TriggerModeAutoWithManualInit
+    resources[2].status!.triggerMode = TriggerMode.TriggerModeManualWithAutoInit
+    resources[3].status!.triggerMode = TriggerMode.TriggerModeManual
 
-    let view = { resources: resources }
+    let view = { uiResources: resources }
 
     const root = mount(
       <MemoryRouter initialEntries={["/"]}>

--- a/web/src/alerts.test.ts
+++ b/web/src/alerts.test.ts
@@ -4,8 +4,8 @@ import LogStore from "./LogStore"
 import { appendLinesForManifestAndSpan } from "./testlogs"
 import { TriggerMode } from "./types"
 
-type Resource = Proto.webviewResource
-type K8sResourceInfo = Proto.webviewK8sResourceInfo
+type UIResource = Proto.v1alpha1UIResource
+type K8sResourceInfo = Proto.v1alpha1UIResourceKubernetes
 
 let logStore = new LogStore()
 
@@ -15,8 +15,8 @@ beforeEach(() => {
 
 describe("combinedAlerts", () => {
   it("K8Resource: shows that a pod status of error is an alert", () => {
-    let r: Resource = k8sResource()
-    let rInfo = <K8sResourceInfo>r.k8sResourceInfo
+    let r: UIResource = k8sResource()
+    let rInfo = <K8sResourceInfo>r.status!.k8sResourceInfo
     rInfo.podStatus = "Error"
     rInfo.podStatusMessage = "I'm a pod in Error"
 
@@ -32,9 +32,9 @@ describe("combinedAlerts", () => {
     expect(actual).toEqual(expectedAlerts)
   })
 
-  it("K8s Resource: should show pod restart alert ", () => {
-    let r: Resource = k8sResource()
-    let rInfo = r.k8sResourceInfo
+  it("K8s UIResource: should show pod restart alert ", () => {
+    let r: UIResource = k8sResource()
+    let rInfo = r.status!.k8sResourceInfo
     if (!rInfo) throw new Error("missing k8s info")
     rInfo.podRestarts = 1
     let actual = combinedAlerts(r, logStore)
@@ -49,18 +49,18 @@ describe("combinedAlerts", () => {
     expect(actual).toEqual(expectedAlerts)
   })
 
-  it("K8s Resource should show the first build alert", () => {
-    let r: Resource = k8sResource()
-    r.buildHistory = [
+  it("K8s UIResource should show the first build alert", () => {
+    let r: UIResource = k8sResource()
+    r.status!.buildHistory = [
       {
         finishTime: "10:00AM",
         error: "build failed",
-        spanId: "build:1",
+        spanID: "build:1",
       },
       {},
     ]
     logStore.append({
-      spans: { "build:1": r.name },
+      spans: { "build:1": r.metadata!.name },
       segments: [{ text: "Build error log", spanId: "build:1" }],
     })
     let actual = combinedAlerts(r, logStore)
@@ -75,9 +75,9 @@ describe("combinedAlerts", () => {
     expect(actual).toEqual(expectedAlerts)
   })
 
-  it("K8s Resource: should show a crash rebuild alert  using the first build info", () => {
-    let r: Resource = k8sResource()
-    r.buildHistory = [
+  it("K8s UIResource: should show a crash rebuild alert  using the first build info", () => {
+    let r: UIResource = k8sResource()
+    r.status!.buildHistory = [
       {
         isCrashRebuild: true,
       },
@@ -85,7 +85,7 @@ describe("combinedAlerts", () => {
         isCrashRebuild: true,
       },
     ]
-    let rInfo = r.k8sResourceInfo
+    let rInfo = r.status!.k8sResourceInfo
     if (!rInfo) throw new Error("missing k8s info")
     rInfo.podCreationTime = "10:00AM"
 
@@ -101,22 +101,26 @@ describe("combinedAlerts", () => {
     expect(actual).toEqual(expectedAlerts)
   })
 
-  it("K8s Resource: should show a warning alert using the first build history ", () => {
-    let r: Resource = k8sResource()
-    r.buildHistory = [
+  it("K8s UIResource: should show a warning alert using the first build history ", () => {
+    let r: UIResource = k8sResource()
+    r.status!.buildHistory = [
       {
         warnings: ["Hi i'm a warning"],
         finishTime: "10:00am",
-        spanId: "build:2",
+        spanID: "build:2",
       },
       {
         warnings: ["This warning shouldn't show up", "Or this one"],
-        spanId: "build:1",
+        spanID: "build:1",
       },
     ]
 
-    appendLinesForManifestAndSpan(logStore, r.name!, "build:1", ["build 1"])
-    appendLinesForManifestAndSpan(logStore, r.name!, "build:2", ["build 2"])
+    appendLinesForManifestAndSpan(logStore, r.metadata!.name!, "build:1", [
+      "build 1",
+    ])
+    appendLinesForManifestAndSpan(logStore, r.metadata!.name!, "build:2", [
+      "build 2",
+    ])
 
     let actual = combinedAlerts(r, logStore)
     let expectedAlerts: Alert[] = [
@@ -130,24 +134,24 @@ describe("combinedAlerts", () => {
     expect(actual).toEqual(expectedAlerts)
   })
 
-  it("K8s Resource: should show a pod restart alert and a build failed alert", () => {
-    let r: Resource = k8sResource()
-    let rInfo = r.k8sResourceInfo
+  it("K8s UIResource: should show a pod restart alert and a build failed alert", () => {
+    let r: UIResource = k8sResource()
+    let rInfo = r.status!.k8sResourceInfo
     if (!rInfo) throw new Error("missing k8s info")
     rInfo.podRestarts = 1 // triggers pod restart alert
     rInfo.podCreationTime = "10:00AM"
 
-    r.buildHistory = [
+    r.status!.buildHistory = [
       // triggers build failed alert
       {
         finishTime: "10:00AM",
         error: "build failed",
-        spanId: "build:1",
+        spanID: "build:1",
       },
       {},
     ]
     logStore.append({
-      spans: { "build:1": r.name },
+      spans: { "build:1": r.metadata!.name },
       segments: [{ text: "Build error log", spanId: "build:1" }],
     })
 
@@ -169,19 +173,18 @@ describe("combinedAlerts", () => {
     expect(actual).toEqual(expectedAlerts)
   })
 
-  it("K8s Resource: should show 3 alerts: 1 crash rebuild alert, 1 build failed alert, 1 warning alert ", () => {
-    let r: Resource = k8sResource()
-    r.buildHistory = [
+  it("K8s UIResource: should show 3 alerts: 1 crash rebuild alert, 1 build failed alert, 1 warning alert ", () => {
+    let r: UIResource = k8sResource()
+    r.status!.buildHistory = [
       {
         isCrashRebuild: true,
         warnings: ["Hi I am a warning"],
-        finishTime: "10:00am",
         error: "build failed",
-        spanId: "build:1",
+        spanID: "build:1",
       },
     ]
     logStore.append({
-      spans: { "build:1": r.name },
+      spans: { "build:1": r.metadata!.name },
       segments: [{ text: "Build failed log", spanId: "build:1" }],
     })
     let actual = combinedAlerts(r, logStore)
@@ -208,9 +211,9 @@ describe("combinedAlerts", () => {
     expect(actual).toEqual(expectedAlerts)
   })
 
-  it("K8s Resource: should show number of alerts a resource has", () => {
-    let r: Resource = k8sResource()
-    let rInfo = r.k8sResourceInfo
+  it("K8s UIResource: should show number of alerts a resource has", () => {
+    let r: UIResource = k8sResource()
+    let rInfo = r.status!.k8sResourceInfo
     if (!rInfo) throw new Error("missing k8s info")
     rInfo.podRestarts = 1
     let actualNum = combinedAlerts(r, null).length
@@ -220,23 +223,27 @@ describe("combinedAlerts", () => {
   })
 })
 
-//DC Resource Tests
-it("DC Resource: should show a warning alert using the first build history", () => {
-  let r: Resource = dcResource()
-  r.buildHistory = [
+//DC UIResource Tests
+it("DC UIResource: should show a warning alert using the first build history", () => {
+  let r: UIResource = dcResource()
+  r.status!.buildHistory = [
     {
       warnings: ["Hi i'm a warning"],
       finishTime: "10:00am",
-      spanId: "build:2",
+      spanID: "build:2",
     },
     {
       warnings: ["This warning shouldn't show up", "Or this one"],
-      spanId: "build:1",
+      spanID: "build:1",
     },
   ]
 
-  appendLinesForManifestAndSpan(logStore, r.name!, "build:1", ["build 1"])
-  appendLinesForManifestAndSpan(logStore, r.name!, "build:2", ["build 2"])
+  appendLinesForManifestAndSpan(logStore, r.metadata!.name!, "build:1", [
+    "build 1",
+  ])
+  appendLinesForManifestAndSpan(logStore, r.metadata!.name!, "build:2", [
+    "build 2",
+  ])
 
   let actual = combinedAlerts(r, logStore)
   let expectedAlerts: Alert[] = [
@@ -250,11 +257,11 @@ it("DC Resource: should show a warning alert using the first build history", () 
   expect(actual).toEqual(expectedAlerts)
 })
 
-it("DC Resource has build failed alert using first build history info ", () => {
-  let r: Resource = dcResource()
-  r.buildHistory = [
+it("DC UIResource has build failed alert using first build history info ", () => {
+  let r: UIResource = dcResource()
+  r.status!.buildHistory = [
     {
-      spanId: "build:1",
+      spanID: "build:1",
       error: "theres an error !!!!",
       finishTime: "10:00am",
     },
@@ -263,7 +270,7 @@ it("DC Resource has build failed alert using first build history info ", () => {
     },
   ]
   logStore.append({
-    spans: { "build:1": r.name },
+    spans: { "build:1": r.metadata!.name },
     segments: [{ text: "Hi you're build failed :'(", spanId: "build:1" }],
   })
   let actual = combinedAlerts(r, logStore)
@@ -279,23 +286,23 @@ it("DC Resource has build failed alert using first build history info ", () => {
 })
 
 it("renders a build error for both a K8s resource and DC resource ", () => {
-  let dcresource: Resource = dcResource()
-  dcresource.buildHistory = [
+  let dcresource: UIResource = dcResource()
+  dcresource.status!.buildHistory = [
     {
       error: "theres an error !!!!",
       finishTime: "10:00am",
-      spanId: "build:1",
+      spanID: "build:1",
     },
     {
       warnings: ["This warning shouldn't show up", "Or this one"],
     },
   ]
-  let k8sresource: Resource = k8sResource()
-  k8sresource.buildHistory = [
+  let k8sresource: UIResource = k8sResource()
+  k8sresource.status!.buildHistory = [
     {
       error: "theres an error !!!!",
       finishTime: "10:00am",
-      spanId: "build:2",
+      spanID: "build:2",
     },
     {
       warnings: ["This warning shouldn't show up", "Or this one"],
@@ -303,8 +310,8 @@ it("renders a build error for both a K8s resource and DC resource ", () => {
   ]
   logStore.append({
     spans: {
-      "build:1": { manifestName: dcresource.name },
-      "build:2": { manifestName: k8sresource.name },
+      "build:1": { manifestName: dcresource.metadata!.name },
+      "build:2": { manifestName: k8sresource.metadata!.name },
     },
     segments: [
       { text: "Hi your build failed :'(", spanId: "build:1" },
@@ -333,53 +340,55 @@ it("renders a build error for both a K8s resource and DC resource ", () => {
   expect(actual).toEqual(expectedAlerts)
 })
 
-function k8sResource(): Resource {
+function k8sResource(): UIResource {
   return {
-    name: "snack",
-    buildHistory: [],
-    endpointLinks: [],
-    podID: "podID",
-    isTiltfile: false,
-    lastDeployTime: "",
-    pendingBuildSince: "",
-    k8sResourceInfo: {
-      podName: "testPod",
-      podCreationTime: "",
-      podUpdateStartTime: "",
-      podStatus: "",
-      podStatusMessage: "",
-      podRestarts: 0,
+    metadata: {
+      name: "snack",
     },
-    runtimeStatus: "",
-    triggerMode: TriggerMode.TriggerModeAuto,
-    hasPendingChanges: true,
-    queued: false,
+    status: {
+      buildHistory: [],
+      endpointLinks: [],
+      lastDeployTime: "",
+      pendingBuildSince: "",
+      k8sResourceInfo: {
+        podName: "testPod",
+        podCreationTime: "",
+        podUpdateStartTime: "",
+        podStatus: "",
+        podStatusMessage: "",
+        podRestarts: 0,
+      },
+      runtimeStatus: "",
+      triggerMode: TriggerMode.TriggerModeAuto,
+      hasPendingChanges: true,
+      queued: false,
+    },
   }
 }
 
-function dcResource(): Resource {
+function dcResource(): UIResource {
   return {
-    name: "vigoda",
-    lastDeployTime: "2019-08-07T11:43:37.568629-04:00",
-    triggerMode: 0,
-    buildHistory: [
-      {
-        startTime: "2019-08-07T11:43:32.422237-04:00",
-        finishTime: "2019-08-07T11:43:37.568626-04:00",
-        isCrashRebuild: false,
-      },
-    ],
-    currentBuild: {
-      startTime: "0001-01-01T00:00:00Z",
-      finishTime: "0001-01-01T00:00:00Z",
-      isCrashRebuild: false,
+    metadata: {
+      name: "vigoda",
     },
-    pendingBuildSince: "0001-01-01T00:00:00Z",
-    hasPendingChanges: false,
-    endpointLinks: [{ url: "http://localhost:9007/" }],
-    podID: "",
-    runtimeStatus: "ok",
-    isTiltfile: false,
-    queued: false,
+    status: {
+      lastDeployTime: "2019-08-07T11:43:37.568629-04:00",
+      triggerMode: 0,
+      buildHistory: [
+        {
+          startTime: "2019-08-07T11:43:32.422237-04:00",
+          finishTime: "2019-08-07T11:43:37.568626-04:00",
+          isCrashRebuild: false,
+        },
+      ],
+      currentBuild: {
+        startTime: "0001-01-01T00:00:00Z",
+      },
+      pendingBuildSince: "0001-01-01T00:00:00Z",
+      hasPendingChanges: false,
+      endpointLinks: [{ url: "http://localhost:9007/" }],
+      runtimeStatus: "ok",
+      queued: false,
+    },
   }
 }

--- a/web/src/links.ts
+++ b/web/src/links.ts
@@ -1,6 +1,8 @@
 // Helper functions for displaying links
 
-export function displayURL(li: Proto.webviewLink): string {
+type Link = Proto.v1alpha1UIResourceLink
+
+export function displayURL(li: Link): string {
   let url = li.url?.replace(/^(http:\/\/)/, "")
   url = url?.replace(/^(https:\/\/)/, "")
   url = url?.replace(/^(www\.)/, "")

--- a/web/src/status.test.tsx
+++ b/web/src/status.test.tsx
@@ -5,11 +5,11 @@ import { ResourceStatus, RuntimeStatus, UpdateStatus } from "./types"
 
 function emptyResource() {
   let res = oneResource()
-  res.currentBuild = { startTime: zeroTime }
-  res.buildHistory = []
-  res.pendingBuildSince = zeroTime
-  res.runtimeStatus = "pending"
-  res.updateStatus = "none"
+  res.status!.currentBuild = { startTime: zeroTime }
+  res.status!.buildHistory = []
+  res.status!.pendingBuildSince = zeroTime
+  res.status!.runtimeStatus = "pending"
+  res.status!.updateStatus = "none"
   return res
 }
 
@@ -22,82 +22,82 @@ describe("combinedStatus", () => {
   it("building when current build", () => {
     const ts = Date.now().toLocaleString()
     let res = emptyResource()
-    res.updateStatus = UpdateStatus.InProgress
-    res.runtimeStatus = RuntimeStatus.Ok
+    res.status!.updateStatus = UpdateStatus.InProgress
+    res.status!.runtimeStatus = RuntimeStatus.Ok
     expect(combinedStatus(res)).toBe(ResourceStatus.Building)
   })
 
   it("healthy when runtime ok", () => {
     const ts = Date.now().toLocaleString()
     let res = emptyResource()
-    res.updateStatus = UpdateStatus.Ok
-    res.runtimeStatus = RuntimeStatus.Ok
+    res.status!.updateStatus = UpdateStatus.Ok
+    res.status!.runtimeStatus = RuntimeStatus.Ok
     expect(combinedStatus(res)).toBe(ResourceStatus.Healthy)
   })
 
   it("unhealthy when runtime error", () => {
     const ts = Date.now().toLocaleString()
     let res = emptyResource()
-    res.updateStatus = UpdateStatus.Ok
-    res.runtimeStatus = RuntimeStatus.Error
+    res.status!.updateStatus = UpdateStatus.Ok
+    res.status!.runtimeStatus = RuntimeStatus.Error
     expect(combinedStatus(res)).toBe(ResourceStatus.Unhealthy)
   })
 
   it("unhealthy when last build error", () => {
     const ts = Date.now().toLocaleString()
     let res = emptyResource()
-    res.updateStatus = UpdateStatus.Error
-    res.runtimeStatus = RuntimeStatus.Ok
+    res.status!.updateStatus = UpdateStatus.Error
+    res.status!.runtimeStatus = RuntimeStatus.Ok
     expect(combinedStatus(res)).toBe(ResourceStatus.Unhealthy)
   })
 
   it("building when runtime status error, but also building", () => {
     const ts = Date.now().toLocaleString()
     let res = emptyResource()
-    res.updateStatus = UpdateStatus.InProgress
-    res.runtimeStatus = RuntimeStatus.Error
+    res.status!.updateStatus = UpdateStatus.InProgress
+    res.status!.runtimeStatus = RuntimeStatus.Error
     expect(combinedStatus(res)).toBe(ResourceStatus.Building)
   })
 
   it("unhealthy when warning and runtime error", () => {
     let res = emptyResource()
-    res.runtimeStatus = RuntimeStatus.Error
-    if (!res.k8sResourceInfo) throw new Error("missing k8s info")
-    res.k8sResourceInfo.podRestarts = 1
+    res.status!.runtimeStatus = RuntimeStatus.Error
+    if (!res.status!.k8sResourceInfo) throw new Error("missing k8s info")
+    res.status!.k8sResourceInfo.podRestarts = 1
     expect(combinedStatus(res)).toBe(ResourceStatus.Unhealthy)
   })
 
   it("warning when container restarts", () => {
     const ts = Date.now().toLocaleString()
     let res = emptyResource()
-    res.updateStatus = UpdateStatus.Ok
-    res.runtimeStatus = RuntimeStatus.Ok
-    if (!res.k8sResourceInfo) throw new Error("missing k8s info")
-    res.k8sResourceInfo.podRestarts = 1
+    res.status!.updateStatus = UpdateStatus.Ok
+    res.status!.runtimeStatus = RuntimeStatus.Ok
+    if (!res.status!.k8sResourceInfo) throw new Error("missing k8s info")
+    res.status!.k8sResourceInfo.podRestarts = 1
     expect(combinedStatus(res)).toBe(ResourceStatus.Warning)
     expect(warnings(res)).toEqual(["Container restarted"])
   })
 
   it("none when n/a runtime status and no builds", () => {
     let res = emptyResource()
-    res.updateStatus = UpdateStatus.None
-    res.runtimeStatus = RuntimeStatus.NotApplicable
+    res.status!.updateStatus = UpdateStatus.None
+    res.status!.runtimeStatus = RuntimeStatus.NotApplicable
     expect(combinedStatus(res)).toBe(ResourceStatus.None)
   })
 
   it("healthy when n/a runtime status and last build succeeded", () => {
     const ts = Date.now().toLocaleString()
     let res = emptyResource()
-    res.runtimeStatus = RuntimeStatus.NotApplicable
-    res.updateStatus = UpdateStatus.Ok
+    res.status!.runtimeStatus = RuntimeStatus.NotApplicable
+    res.status!.updateStatus = UpdateStatus.Ok
     expect(combinedStatus(res)).toBe(ResourceStatus.Healthy)
   })
 
   it("unhealthy when n/a runtime status and last build failed", () => {
     const ts = Date.now().toLocaleString()
     let res = emptyResource()
-    res.runtimeStatus = RuntimeStatus.NotApplicable
-    res.updateStatus = UpdateStatus.Error
+    res.status!.runtimeStatus = RuntimeStatus.NotApplicable
+    res.status!.updateStatus = UpdateStatus.Error
     expect(combinedStatus(res)).toBe(ResourceStatus.Unhealthy)
   })
 })

--- a/web/src/testdata.tsx
+++ b/web/src/testdata.tsx
@@ -2,14 +2,14 @@ import { Href, UnregisterCallback } from "history"
 import { RouteComponentProps } from "react-router-dom"
 import { TriggerMode } from "./types"
 
-type Resource = Proto.webviewResource
-type Link = Proto.webviewLink
+type UIResource = Proto.v1alpha1UIResource
+type Link = Proto.v1alpha1UIResourceLink
 
 const unnamedEndpointLink: Link = { url: "1.2.3.4:8080" }
 const namedEndpointLink: Link = { url: "1.2.3.4:9090", name: "debugger" }
 
 type view = {
-  resources: Array<Resource>
+  uiResources: Array<UIResource>
   logList?: Proto.webviewLogList
   featureFlags?: { [featureFlag: string]: boolean }
   tiltfileKey?: string
@@ -87,210 +87,234 @@ function vigodaSpecs(): any {
   ]
 }
 
-export function tiltfileResource(): Resource {
+export function tiltfileResource(): UIResource {
   const ts = new Date(Date.now()).toISOString()
   const tsPast = new Date(Date.now() - 12300).toISOString()
-  const resource: Resource = {
-    name: "(Tiltfile)",
-    lastDeployTime: ts,
-    buildHistory: [
-      {
-        finishTime: ts,
-        startTime: tsPast,
-      },
-    ],
-    updateStatus: "ok",
-    runtimeStatus: "not_applicable",
-    triggerMode: TriggerMode.TriggerModeAuto,
-    hasPendingChanges: false,
-    endpointLinks: [],
-    podID: "",
-    isTiltfile: true,
-    queued: false,
+  const resource: UIResource = {
+    metadata: {
+      name: "(Tiltfile)",
+    },
+    status: {
+      lastDeployTime: ts,
+      buildHistory: [
+        {
+          finishTime: ts,
+          startTime: tsPast,
+        },
+      ],
+      updateStatus: "ok",
+      runtimeStatus: "not_applicable",
+      triggerMode: TriggerMode.TriggerModeAuto,
+      hasPendingChanges: false,
+      endpointLinks: [],
+      queued: false,
+    },
   }
   return resource
 }
 
-function oneResource(): Resource {
+function oneResource(): UIResource {
   const ts = new Date(Date.now()).toISOString()
   const tsPast = new Date(Date.now() - 12300).toISOString()
-  const resource: Resource = {
-    name: "vigoda",
-    lastDeployTime: ts,
-    buildHistory: [
-      {
-        error: "the build failed!",
-        finishTime: ts,
-        startTime: tsPast,
-      },
-    ],
-    pendingBuildSince: ts,
-    currentBuild: {
-      startTime: ts,
+  const resource: UIResource = {
+    metadata: {
+      name: "vigoda",
     },
-    k8sResourceInfo: {
-      podName: "vigoda-pod",
-      podCreationTime: ts,
-      podStatus: "Running",
-      podStatusMessage: "",
-      podRestarts: 0,
-      podUpdateStartTime: ts,
-    },
-    updateStatus: "in_progress",
-    runtimeStatus: "ok",
-    triggerMode: TriggerMode.TriggerModeAuto,
-    hasPendingChanges: false,
-    endpointLinks: [],
-    podID: "",
-    isTiltfile: false,
-    queued: false,
-    specs: vigodaSpecs(),
-  }
-  return resource
-}
-
-function oneResourceNoAlerts(): Resource {
-  const ts = new Date(Date.now()).toISOString()
-  const resource = {
-    name: "vigoda",
-    lastDeployTime: ts,
-    buildHistory: [
-      {
-        finishTime: ts,
+    status: {
+      lastDeployTime: ts,
+      buildHistory: [
+        {
+          error: "the build failed!",
+          finishTime: ts,
+          startTime: tsPast,
+        },
+      ],
+      pendingBuildSince: ts,
+      currentBuild: {
         startTime: ts,
       },
-    ],
-    pendingBuildSince: ts,
-    currentBuild: {},
-    k8sResourceInfo: {
-      podName: "vigoda-pod",
-      podCreationTime: ts,
-      podStatus: "Running",
-      podRestarts: 0,
+      k8sResourceInfo: {
+        podName: "vigoda-pod",
+        podCreationTime: ts,
+        podStatus: "Running",
+        podStatusMessage: "",
+        podRestarts: 0,
+        podUpdateStartTime: ts,
+      },
+      updateStatus: "in_progress",
+      runtimeStatus: "ok",
+      triggerMode: TriggerMode.TriggerModeAuto,
+      hasPendingChanges: false,
+      endpointLinks: [],
+      queued: false,
+      specs: vigodaSpecs(),
     },
-    updateStatus: "ok",
-    endpointLinks: [unnamedEndpointLink],
-    runtimeStatus: "ok",
-    specs: vigodaSpecs(),
   }
   return resource
 }
 
-function oneResourceImagePullBackOff(): Resource {
+function oneResourceNoAlerts(): UIResource {
   const ts = new Date(Date.now()).toISOString()
   const resource = {
-    name: "vigoda",
-    lastDeployTime: ts,
-    buildHistory: [
-      {
-        finishTime: ts,
-        startTime: ts,
-      },
-    ],
-    pendingBuildSince: ts,
-    currentBuild: {},
-    k8sResourceInfo: {
-      podName: "vigoda-pod",
-      podCreationTime: ts,
-      podStatus: "ImagePullBackOff",
-      podRestarts: 0,
+    metadata: {
+      name: "vigoda",
     },
-    endpointLinks: [unnamedEndpointLink],
-    updateStatus: "ok",
-    runtimeStatus: "ok",
-    specs: vigodaSpecs(),
+    status: {
+      lastDeployTime: ts,
+      buildHistory: [
+        {
+          finishTime: ts,
+          startTime: ts,
+        },
+      ],
+      pendingBuildSince: ts,
+      currentBuild: {},
+      k8sResourceInfo: {
+        podName: "vigoda-pod",
+        podCreationTime: ts,
+        podStatus: "Running",
+        podRestarts: 0,
+      },
+      updateStatus: "ok",
+      endpointLinks: [unnamedEndpointLink],
+      runtimeStatus: "ok",
+      specs: vigodaSpecs(),
+    },
   }
   return resource
 }
 
-function oneResourceErrImgPull(): Resource {
+function oneResourceImagePullBackOff(): UIResource {
   const ts = new Date(Date.now()).toISOString()
   const resource = {
-    name: "vigoda",
-    lastDeployTime: ts,
-    buildHistory: [
-      {
-        finishTime: ts,
-        startTime: ts,
-      },
-    ],
-    pendingBuildSince: ts,
-    currentBuild: {},
-    k8sResourceInfo: {
-      podName: "vigoda-pod",
-      podCreationTime: ts,
-      podStatus: "ErrImagePull",
-      podRestarts: 0,
+    metadata: {
+      name: "vigoda",
     },
-    endpointLinks: [unnamedEndpointLink],
-    updateStatus: "ok",
-    runtimeStatus: "ok",
-    specs: vigodaSpecs(),
+    status: {
+      lastDeployTime: ts,
+      buildHistory: [
+        {
+          finishTime: ts,
+          startTime: ts,
+        },
+      ],
+      pendingBuildSince: ts,
+      currentBuild: {},
+      k8sResourceInfo: {
+        podName: "vigoda-pod",
+        podCreationTime: ts,
+        podStatus: "ImagePullBackOff",
+        podRestarts: 0,
+      },
+      endpointLinks: [unnamedEndpointLink],
+      updateStatus: "ok",
+      runtimeStatus: "ok",
+      specs: vigodaSpecs(),
+    },
   }
   return resource
 }
 
-function oneResourceUnrecognizedError(): Resource {
+function oneResourceErrImgPull(): UIResource {
   const ts = new Date(Date.now()).toISOString()
   const resource = {
-    name: "vigoda",
-    lastDeployTime: ts,
-    buildHistory: [
-      {
-        finishTime: ts,
-        startTime: ts,
-      },
-    ],
-    pendingBuildSince: ts,
-    currentBuild: {},
-    k8sResourceInfo: {
-      podName: "vigoda-pod",
-      podCreationTime: ts,
-      podStatus: "GarbleError",
-      podStatusMessage: "Detailed message on GarbleError",
+    metadata: {
+      name: "vigoda",
     },
-    updateStatus: "ok",
-    runtimeStatus: "ok",
-    specs: vigodaSpecs(),
+    status: {
+      lastDeployTime: ts,
+      buildHistory: [
+        {
+          finishTime: ts,
+          startTime: ts,
+        },
+      ],
+      pendingBuildSince: ts,
+      currentBuild: {},
+      k8sResourceInfo: {
+        podName: "vigoda-pod",
+        podCreationTime: ts,
+        podStatus: "ErrImagePull",
+        podRestarts: 0,
+      },
+      endpointLinks: [unnamedEndpointLink],
+      updateStatus: "ok",
+      runtimeStatus: "ok",
+      specs: vigodaSpecs(),
+    },
   }
   return resource
 }
 
-function oneResourceTestWithName(name: string): Resource {
+function oneResourceUnrecognizedError(): UIResource {
   const ts = new Date(Date.now()).toISOString()
   const resource = {
-    name: name,
-    lastDeployTime: ts,
-    buildHistory: [
-      {
-        startTime: ts,
-        finishTime: ts,
-        spanId: "build:1",
-      },
-    ],
-    localResourceInfo: {
-      pid: "0",
-      isTest: true,
+    metadata: {
+      name: "vigoda",
     },
-    runtimeStatus: "not_applicable",
-    updateStatus: "ok",
-    specs: [
-      {
-        id: "local:boop",
-        type: "TARGET_TYPE_LOCAL",
-        hasLiveUpdate: false,
+    status: {
+      lastDeployTime: ts,
+      buildHistory: [
+        {
+          finishTime: ts,
+          startTime: ts,
+        },
+      ],
+      pendingBuildSince: ts,
+      currentBuild: {},
+      k8sResourceInfo: {
+        podName: "vigoda-pod",
+        podCreationTime: ts,
+        podStatus: "GarbleError",
+        podStatusMessage: "Detailed message on GarbleError",
       },
-    ],
+      updateStatus: "ok",
+      runtimeStatus: "ok",
+      specs: vigodaSpecs(),
+    },
   }
   return resource
 }
 
-function oneResourceTest(): Resource {
+function oneResourceTestWithName(name: string): UIResource {
+  const ts = new Date(Date.now()).toISOString()
+  const resource = {
+    metadata: {
+      name: name,
+    },
+    status: {
+      lastDeployTime: ts,
+      buildHistory: [
+        {
+          startTime: ts,
+          finishTime: ts,
+          spanId: "build:1",
+        },
+      ],
+      localResourceInfo: {
+        pid: "0",
+        isTest: true,
+      },
+      runtimeStatus: "not_applicable",
+      updateStatus: "ok",
+      specs: [
+        {
+          id: "local:boop",
+          type: "TARGET_TYPE_LOCAL",
+          hasLiveUpdate: false,
+        },
+      ],
+    },
+  }
+  return resource
+}
+
+function oneResourceTest(): UIResource {
   return oneResourceTestWithName("boop")
 }
 
 function oneResourceView(): view {
-  return { resources: [oneResource()], tiltfileKey: "test", runningTiltBuild }
+  return { uiResources: [oneResource()], tiltfileKey: "test", runningTiltBuild }
 }
 
 function twoResourceView(): view {
@@ -298,39 +322,41 @@ function twoResourceView(): view {
   const ts = new Date(time).toISOString()
   const vigoda = oneResource()
 
-  const snack: Resource = {
-    name: "snack",
-    lastDeployTime: new Date(time - 10000).toISOString(),
-    buildHistory: [
-      {
-        error: "the build failed!",
-        finishTime: new Date(time - 10000).toISOString(),
+  const snack: UIResource = {
+    metadata: {
+      name: "snack",
+    },
+    status: {
+      lastDeployTime: new Date(time - 10000).toISOString(),
+      buildHistory: [
+        {
+          error: "the build failed!",
+          finishTime: new Date(time - 10000).toISOString(),
+          startTime: ts,
+        },
+      ],
+      pendingBuildSince: ts,
+      currentBuild: {
         startTime: ts,
       },
-    ],
-    pendingBuildSince: ts,
-    currentBuild: {
-      startTime: ts,
+      endpointLinks: [unnamedEndpointLink],
+      updateStatus: "in_progress",
+      runtimeStatus: "ok",
+      triggerMode: TriggerMode.TriggerModeAuto,
+      k8sResourceInfo: {
+        podStatus: "Running",
+        podStatusMessage: "",
+        podRestarts: 0,
+        podCreationTime: "",
+        podName: "snack",
+        podUpdateStartTime: "",
+      },
+      hasPendingChanges: false,
+      queued: false,
+      specs: vigodaSpecs(),
     },
-    endpointLinks: [unnamedEndpointLink],
-    updateStatus: "in_progress",
-    runtimeStatus: "ok",
-    triggerMode: TriggerMode.TriggerModeAuto,
-    isTiltfile: false,
-    podID: "",
-    k8sResourceInfo: {
-      podStatus: "Running",
-      podStatusMessage: "",
-      podRestarts: 0,
-      podCreationTime: "",
-      podName: "snack",
-      podUpdateStartTime: "",
-    },
-    hasPendingChanges: false,
-    queued: false,
-    specs: vigodaSpecs(),
   }
-  return { resources: [vigoda, snack], tiltfileKey: "test", runningTiltBuild }
+  return { uiResources: [vigoda, snack], tiltfileKey: "test", runningTiltBuild }
 }
 
 export function tenResourceView(): view {
@@ -338,193 +364,205 @@ export function tenResourceView(): view {
 }
 
 export function nResourceView(n: number): view {
-  let resources: Resource[] = []
+  let resources: UIResource[] = []
   for (let i = 0; i < n; i++) {
     if (i === 0) {
       let res = tiltfileResource()
       resources.push(res)
     } else {
       let res = oneResourceNoAlerts()
-      res.name += "_" + i
+      res.metadata = { name: "_" + i }
       resources.push(res)
     }
   }
-  return { resources: resources, tiltfileKey: "test", runningTiltBuild }
+  return { uiResources: resources, tiltfileKey: "test", runningTiltBuild }
 }
 
-function oneResourceFailedToBuild(): Resource[] {
+function oneResourceFailedToBuild(): UIResource[] {
   return [
     {
-      name: "snack",
-      lastDeployTime: "2019-04-22T11:00:04.242586-04:00",
-      buildHistory: [
-        {
-          error: "oh no",
-          startTime: "2019-04-22T11:05:07.250689-04:00",
-          finishTime: "2019-04-22T11:05:17.689819-04:00",
-        },
-        {
-          startTime: "2019-04-22T11:00:02.810268-04:00",
-          finishTime: "2019-04-22T11:00:04.242583-04:00",
-        },
-      ],
-      currentBuild: {
-        startTime: "0001-01-01T00:00:00Z",
-        finishTime: "0001-01-01T00:00:00Z",
+      metadata: {
+        name: "snack",
       },
-      pendingBuildSince: "0001-01-01T00:00:00Z",
-      endpointLinks: [{ url: "http://localhost:9002/" }],
-      k8sResourceInfo: {
-        podName: "dan-snack-f885fb46f-d5z2t",
-        podCreationTime: "2019-04-22T11:00:04-04:00",
-        podUpdateStartTime: "2019-04-22T11:05:07.250689-04:00",
-        podStatus: "Running",
-        podRestarts: 0,
+      status: {
+        lastDeployTime: "2019-04-22T11:00:04.242586-04:00",
+        buildHistory: [
+          {
+            error: "oh no",
+            startTime: "2019-04-22T11:05:07.250689-04:00",
+            finishTime: "2019-04-22T11:05:17.689819-04:00",
+          },
+          {
+            startTime: "2019-04-22T11:00:02.810268-04:00",
+            finishTime: "2019-04-22T11:00:04.242583-04:00",
+          },
+        ],
+        currentBuild: {
+          startTime: "0001-01-01T00:00:00Z",
+        },
+        pendingBuildSince: "0001-01-01T00:00:00Z",
+        endpointLinks: [{ url: "http://localhost:9002/" }],
+        k8sResourceInfo: {
+          podName: "dan-snack-f885fb46f-d5z2t",
+          podCreationTime: "2019-04-22T11:00:04-04:00",
+          podUpdateStartTime: "2019-04-22T11:05:07.250689-04:00",
+          podStatus: "Running",
+          podRestarts: 0,
+        },
+        updateStatus: "pending",
+        runtimeStatus: "ok",
       },
-      updateStatus: "pending",
-      runtimeStatus: "ok",
-      isTiltfile: false,
     },
   ]
 }
 
-function oneResourceBuilding(): Resource[] {
+function oneResourceBuilding(): UIResource[] {
   return [
     {
-      name: "(Tiltfile)",
-      lastDeployTime: "2019-04-22T10:59:53.903047-04:00",
-      buildHistory: [
-        {
-          startTime: "2019-04-22T10:59:53.574652-04:00",
-          finishTime: "2019-04-22T10:59:53.903047-04:00",
-        },
-      ],
-      currentBuild: {
-        startTime: "0001-01-01T00:00:00Z",
-        finishTime: "0001-01-01T00:00:00Z",
+      metadata: {
+        name: "(Tiltfile)",
       },
-      pendingBuildSince: "0001-01-01T00:00:00Z",
-      updateStatus: "ok",
-      runtimeStatus: "ok",
-      isTiltfile: true,
+      status: {
+        lastDeployTime: "2019-04-22T10:59:53.903047-04:00",
+        buildHistory: [
+          {
+            startTime: "2019-04-22T10:59:53.574652-04:00",
+            finishTime: "2019-04-22T10:59:53.903047-04:00",
+          },
+        ],
+        currentBuild: {
+          startTime: "0001-01-01T00:00:00Z",
+        },
+        pendingBuildSince: "0001-01-01T00:00:00Z",
+        updateStatus: "ok",
+        runtimeStatus: "ok",
+      },
     },
     {
-      name: "fe",
-      lastDeployTime: "2019-04-22T11:00:01.337285-04:00",
-      buildHistory: [
-        {
-          startTime: "2019-04-22T10:59:56.489417-04:00",
-          finishTime: "2019-04-22T11:00:01.337284-04:00",
+      metadata: {
+        name: "fe",
+      },
+      status: {
+        lastDeployTime: "2019-04-22T11:00:01.337285-04:00",
+        buildHistory: [
+          {
+            startTime: "2019-04-22T10:59:56.489417-04:00",
+            finishTime: "2019-04-22T11:00:01.337284-04:00",
+          },
+        ],
+        currentBuild: {
+          startTime: "0001-01-01T00:00:00Z",
         },
-      ],
-      currentBuild: {
-        startTime: "0001-01-01T00:00:00Z",
-        finishTime: "0001-01-01T00:00:00Z",
+        pendingBuildSince: "0001-01-01T00:00:00Z",
+        endpointLinks: [{ url: "http://localhost:9000/" }],
+        k8sResourceInfo: {
+          podName: "dan-fe-7cdc8f978f-vp94d",
+          podCreationTime: "2019-04-22T11:00:01-04:00",
+          podUpdateStartTime: "0001-01-01T00:00:00Z",
+          podStatus: "Running",
+          podRestarts: 0,
+        },
+        updateStatus: "ok",
+        runtimeStatus: "ok",
       },
-      pendingBuildSince: "0001-01-01T00:00:00Z",
-      endpointLinks: [{ url: "http://localhost:9000/" }],
-      k8sResourceInfo: {
-        podName: "dan-fe-7cdc8f978f-vp94d",
-        podCreationTime: "2019-04-22T11:00:01-04:00",
-        podUpdateStartTime: "0001-01-01T00:00:00Z",
-        podStatus: "Running",
-        podRestarts: 0,
-      },
-      updateStatus: "ok",
-      runtimeStatus: "ok",
-      isTiltfile: false,
     },
     {
-      name: "vigoda",
-      lastDeployTime: "2019-04-22T11:00:02.810113-04:00",
-      buildHistory: [
-        {
-          startTime: "2019-04-22T11:00:01.337359-04:00",
-          finishTime: "2019-04-22T11:00:02.810112-04:00",
+      metadata: {
+        name: "vigoda",
+      },
+      status: {
+        lastDeployTime: "2019-04-22T11:00:02.810113-04:00",
+        buildHistory: [
+          {
+            startTime: "2019-04-22T11:00:01.337359-04:00",
+            finishTime: "2019-04-22T11:00:02.810112-04:00",
+          },
+        ],
+        currentBuild: {
+          startTime: "0001-01-01T00:00:00Z",
         },
-      ],
-      currentBuild: {
-        startTime: "0001-01-01T00:00:00Z",
-        finishTime: "0001-01-01T00:00:00Z",
+        pendingBuildSince: "0001-01-01T00:00:00Z",
+        endpointLinks: [{ url: "http://localhost:9001/" }],
+        k8sResourceInfo: {
+          podName: "dan-vigoda-67d79bd8d5-w77q4",
+          podCreationTime: "2019-04-22T11:00:02-04:00",
+          podUpdateStartTime: "0001-01-01T00:00:00Z",
+          podStatus: "Running",
+          podRestarts: 0,
+        },
+        updateStatus: "ok",
+        runtimeStatus: "ok",
       },
-      pendingBuildSince: "0001-01-01T00:00:00Z",
-      endpointLinks: [{ url: "http://localhost:9001/" }],
-      k8sResourceInfo: {
-        podName: "dan-vigoda-67d79bd8d5-w77q4",
-        podCreationTime: "2019-04-22T11:00:02-04:00",
-        podUpdateStartTime: "0001-01-01T00:00:00Z",
-        podStatus: "Running",
-        podRestarts: 0,
-      },
-      updateStatus: "ok",
-      runtimeStatus: "ok",
-      isTiltfile: false,
     },
     {
-      name: "snack",
-      lastDeployTime: "2019-04-22T11:05:58.928369-04:00",
-      buildHistory: [
-        {
-          startTime: "2019-04-22T11:05:53.676776-04:00",
-          finishTime: "2019-04-22T11:05:58.928367-04:00",
-        },
-        {
-          error: "eek",
-          startTime: "2019-04-22T11:05:07.250689-04:00",
-          finishTime: "2019-04-22T11:05:17.689819-04:00",
-        },
-      ],
-      currentBuild: {
-        startTime: "2019-04-22T11:20:44.674248-04:00",
-        finishTime: "0001-01-01T00:00:00Z",
+      metadata: {
+        name: "snack",
       },
-      pendingBuildSince: "2019-04-22T11:20:44.672903-04:00",
-      endpointLinks: [{ url: "http://localhost:9002/" }],
-      k8sResourceInfo: {
-        podName: "dan-snack-65f9775f49-gcc8d",
-        podCreationTime: "2019-04-22T11:05:58-04:00",
-        podUpdateStartTime: "2019-04-22T11:20:44.674248-04:00",
-        podStatus: "CrashLoopBackOff",
-        podRestarts: 7,
+      status: {
+        lastDeployTime: "2019-04-22T11:05:58.928369-04:00",
+        buildHistory: [
+          {
+            startTime: "2019-04-22T11:05:53.676776-04:00",
+            finishTime: "2019-04-22T11:05:58.928367-04:00",
+          },
+          {
+            error: "eek",
+            startTime: "2019-04-22T11:05:07.250689-04:00",
+            finishTime: "2019-04-22T11:05:17.689819-04:00",
+          },
+        ],
+        currentBuild: {
+          startTime: "2019-04-22T11:20:44.674248-04:00",
+        },
+        pendingBuildSince: "2019-04-22T11:20:44.672903-04:00",
+        endpointLinks: [{ url: "http://localhost:9002/" }],
+        k8sResourceInfo: {
+          podName: "dan-snack-65f9775f49-gcc8d",
+          podCreationTime: "2019-04-22T11:05:58-04:00",
+          podUpdateStartTime: "2019-04-22T11:20:44.674248-04:00",
+          podStatus: "CrashLoopBackOff",
+          podRestarts: 7,
+        },
+        updateStatus: "error",
+        runtimeStatus: "error",
       },
-      updateStatus: "error",
-      runtimeStatus: "error",
-      isTiltfile: false,
     },
   ]
 }
 
-function oneResourceCrashedOnStart(): Resource[] {
+function oneResourceCrashedOnStart(): UIResource[] {
   return [
     {
-      name: "snack",
-      lastDeployTime: "2019-04-22T13:34:59.442147-04:00",
-      buildHistory: [
-        {
-          startTime: "2019-04-22T13:34:57.084919-04:00",
-          finishTime: "2019-04-22T13:34:59.442139-04:00",
-        },
-        {
-          startTime: "2019-04-22T13:34:05.844691-04:00",
-          finishTime: "2019-04-22T13:34:07.352812-04:00",
-        },
-      ],
-      currentBuild: {
-        startTime: "0001-01-01T00:00:00Z",
-        finishTime: "0001-01-01T00:00:00Z",
+      metadata: {
+        name: "snack",
       },
-      pendingBuildSince: "0001-01-01T00:00:00Z",
-      endpointLinks: [{ url: "http://localhost:9002/" }],
-      k8sResourceInfo: {
-        podName: "dan-snack-cd4d74d7b-lg8sh",
-        podCreationTime: "2019-04-22T13:34:59-04:00",
-        podUpdateStartTime: "0001-01-01T00:00:00Z",
-        podStatus: "CrashLoopBackOff",
-        podRestarts: 1,
+      status: {
+        lastDeployTime: "2019-04-22T13:34:59.442147-04:00",
+        buildHistory: [
+          {
+            startTime: "2019-04-22T13:34:57.084919-04:00",
+            finishTime: "2019-04-22T13:34:59.442139-04:00",
+          },
+          {
+            startTime: "2019-04-22T13:34:05.844691-04:00",
+            finishTime: "2019-04-22T13:34:07.352812-04:00",
+          },
+        ],
+        currentBuild: {
+          startTime: "0001-01-01T00:00:00Z",
+        },
+        pendingBuildSince: "0001-01-01T00:00:00Z",
+        endpointLinks: [{ url: "http://localhost:9002/" }],
+        k8sResourceInfo: {
+          podName: "dan-snack-cd4d74d7b-lg8sh",
+          podCreationTime: "2019-04-22T13:34:59-04:00",
+          podUpdateStartTime: "0001-01-01T00:00:00Z",
+          podStatus: "CrashLoopBackOff",
+          podRestarts: 1,
+        },
+        updateStatus: "ok",
+        runtimeStatus: "error",
       },
-      updateStatus: "ok",
-      runtimeStatus: "error",
-      isTiltfile: false,
     },
   ]
 }
@@ -2076,7 +2114,7 @@ const logPaneDOM = `<section class="LogPane"><span data-lineid="0" class="logLin
 </span><span data-lineid="772" class="logLine "><code><span>fortune     ┊   ENTRYPOINT /go/bin/fortune</span></code>
 <br>
 </span><span data-lineid="773" class="logLine "><code><span>fortune     ┊ </span></code>
-<br>
+c<br>
 </span><span data-lineid="774" class="logLine "><code><span>fortune     ┊ </span></code>
 <br>
 </span><span data-lineid="775" class="logLine "><code><span>fortune     ┊ </span><span class="ansi-blue">  │ </span><span>Tarring context…</span></code>

--- a/web/src/time.tsx
+++ b/web/src/time.tsx
@@ -2,7 +2,7 @@ import moment from "moment"
 
 export const zeroTime = "0001-01-01T00:00:00Z"
 
-export function isZeroTime(time: string | undefined) {
+export function isZeroTime(time: string) {
   return !time || time === zeroTime
 }
 
@@ -27,7 +27,7 @@ export function formatBuildDuration(d: moment.Duration): string {
 }
 
 export function timeDiff(start: string, end: string): moment.Duration {
-  let t1 = moment(start)
-  let t2 = moment(end)
+  let t1 = moment(start || zeroTime)
+  let t2 = moment(end || zeroTime)
   return moment.duration(t2.diff(t1))
 }


### PR DESCRIPTION
Hello @milas, @landism,

Please review the following commits I made in branch nicks/uisession3:

42e651196944fee3b9d0e07fd5506d113a5e6fac (2021-05-04 16:14:20 -0400)
apis: send UIResource instead of Resource

9dbf8d09ad0dc86a1eea9614f9e876ee26613c97 (2021-05-04 14:21:11 -0400)
apis: define fields for UIResourceStatus
This is a pretty straight-up port of what's currently
in the UI protobuf, but with some slight tweaks to better match
conventions for Kubernetes APIs.

See also:
https://github.com/tilt-dev/tilt/blob/8d9c1033b3bc308b51af865682dd1c6be6a81040/pkg/webview/view.proto

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics