### PR TITLE
test: emit Pod events instead of manually dispatching actions

### DIFF
--- a/internal/engine/buildcontroller_test.go
+++ b/internal/engine/buildcontroller_test.go
@@ -33,14 +33,16 @@ func TestBuildControllerOnePod(t *testing.T) {
 	defer f.TearDown()
 
 	manifest := f.newManifest("fe")
+	pb := f.registerForDeployer(manifest)
+
 	f.Start([]model.Manifest{manifest})
 
 	call := f.nextCall()
 	assert.Equal(t, manifest.ImageTargetAt(0), call.firstImgTarg())
 	assert.Equal(t, []string{}, call.oneImageState().FilesChanged())
 
-	pod := podbuilder.New(f.T(), manifest).Build()
-	f.podEvent(pod, manifest.Name)
+	pod := pb.Build()
+	f.podEvent(pod)
 	f.fsWatcher.Events <- watch.NewFileEvent(f.JoinPath("main.go"))
 
 	call = f.nextCall()
@@ -56,6 +58,9 @@ func TestBuildControllerTooManyPodsForLiveUpdateErrorMessage(t *testing.T) {
 	defer f.TearDown()
 
 	manifest := NewSanchoLiveUpdateManifest(f)
+	// basePB is used for all pods so that they share the same deployment
+	basePB := f.registerForDeployer(manifest)
+
 	f.Start([]model.Manifest{manifest})
 
 	// initial build
@@ -63,11 +68,10 @@ func TestBuildControllerTooManyPodsForLiveUpdateErrorMessage(t *testing.T) {
 	assert.Equal(t, manifest.ImageTargetAt(0), call.firstImgTarg())
 	assert.Equal(t, []string{}, call.oneImageState().FilesChanged())
 
-	p1 := podbuilder.New(t, manifest).WithPodID("pod1").Build()
-	p2 := podbuilder.New(t, manifest).WithPodID("pod2").Build()
-
-	f.podEvent(p1, manifest.Name)
-	f.podEvent(p2, manifest.Name)
+	pb1 := basePB.WithPodID("pod1")
+	pb2 := basePB.WithPodID("pod2")
+	f.podEvent(pb1.Build())
+	f.podEvent(pb2.Build())
 	f.fsWatcher.Events <- watch.NewFileEvent(f.JoinPath("main.go"))
 
 	call = f.nextCall()
@@ -90,6 +94,9 @@ func TestBuildControllerTooManyPodsForDockerBuildNoErrorMessage(t *testing.T) {
 	defer f.TearDown()
 
 	manifest := NewSanchoDockerBuildManifest(f)
+	// basePB is used for all pods so that they share the same deployment
+	basePB := f.registerForDeployer(manifest)
+
 	f.Start([]model.Manifest{manifest})
 
 	// initial build
@@ -97,11 +104,11 @@ func TestBuildControllerTooManyPodsForDockerBuildNoErrorMessage(t *testing.T) {
 	assert.Equal(t, manifest.ImageTargetAt(0), call.firstImgTarg())
 	assert.Equal(t, []string{}, call.oneImageState().FilesChanged())
 
-	p1 := podbuilder.New(t, manifest).WithPodID("pod1").Build()
-	p2 := podbuilder.New(t, manifest).WithPodID("pod2").Build()
+	p1 := basePB.WithPodID("pod1").Build()
+	p2 := basePB.WithPodID("pod2").Build()
 
-	f.podEvent(p1, manifest.Name)
-	f.podEvent(p2, manifest.Name)
+	f.podEvent(p1)
+	f.podEvent(p2)
 	f.fsWatcher.Events <- watch.NewFileEvent(f.JoinPath("main.go"))
 
 	call = f.nextCall()
@@ -123,17 +130,18 @@ func TestBuildControllerIgnoresImageTags(t *testing.T) {
 
 	ref := container.MustParseNamed("image-foo:tagged")
 	manifest := f.newManifestWithRef("fe", ref)
+	basePB := f.registerForDeployer(manifest)
 	f.Start([]model.Manifest{manifest})
 
 	call := f.nextCall()
 	assert.Equal(t, manifest.ImageTargetAt(0), call.firstImgTarg())
 	assert.Equal(t, []string{}, call.oneImageState().FilesChanged())
 
-	pod := podbuilder.New(t, manifest).
+	pod := basePB.
 		WithPodID("pod-id").
 		WithImage("image-foo:othertag").
 		Build()
-	f.podEvent(pod, manifest.Name)
+	f.podEvent(pod)
 	f.fsWatcher.Events <- watch.NewFileEvent(f.JoinPath("main.go"))
 
 	call = f.nextCall()
@@ -199,6 +207,7 @@ func TestBuildControllerWontContainerBuildWithTwoPods(t *testing.T) {
 	defer f.TearDown()
 
 	manifest := f.newManifest("fe")
+	basePB := f.registerForDeployer(manifest)
 	f.Start([]model.Manifest{manifest})
 
 	call := f.nextCall()
@@ -206,10 +215,10 @@ func TestBuildControllerWontContainerBuildWithTwoPods(t *testing.T) {
 	assert.Equal(t, []string{}, call.oneImageState().FilesChanged())
 
 	// Associate the pods with the manifest state
-	podA := podbuilder.New(f.T(), manifest).WithPodID("pod-a").Build()
-	podB := podbuilder.New(f.T(), manifest).WithPodID("pod-b").Build()
-	f.podEvent(podA, manifest.Name)
-	f.podEvent(podB, manifest.Name)
+	podA := basePB.WithPodID("pod1").Build()
+	podB := basePB.WithPodID("pod2").Build()
+	f.podEvent(podA)
+	f.podEvent(podB)
 
 	f.fsWatcher.Events <- watch.NewFileEvent(f.JoinPath("main.go"))
 
@@ -229,6 +238,7 @@ func TestBuildControllerTwoContainers(t *testing.T) {
 	defer f.TearDown()
 
 	manifest := f.newManifest("fe")
+	basePB := f.registerForDeployer(manifest)
 	f.Start([]model.Manifest{manifest})
 
 	call := f.nextCall()
@@ -236,7 +246,7 @@ func TestBuildControllerTwoContainers(t *testing.T) {
 	assert.Equal(t, []string{}, call.oneImageState().FilesChanged())
 
 	// container already on this pod matches the image built by this manifest
-	pod := podbuilder.New(f.T(), manifest).Build()
+	pod := basePB.Build()
 	imgName := pod.Status.ContainerStatuses[0].Image
 	runningState := v1.ContainerState{
 		Running: &v1.ContainerStateRunning{
@@ -256,7 +266,7 @@ func TestBuildControllerTwoContainers(t *testing.T) {
 		State:       runningState,
 		ContainerID: "docker://cID-different-image",
 	})
-	f.podEvent(pod, manifest.Name)
+	f.podEvent(pod)
 	f.fsWatcher.Events <- watch.NewFileEvent(f.JoinPath("main.go"))
 
 	call = f.nextCall()
@@ -287,6 +297,7 @@ func TestBuildControllerWontContainerBuildWithSomeButNotAllReadyContainers(t *te
 	defer f.TearDown()
 
 	manifest := f.newManifest("fe")
+	basePB := f.registerForDeployer(manifest)
 	f.Start([]model.Manifest{manifest})
 
 	call := f.nextCall()
@@ -294,7 +305,7 @@ func TestBuildControllerWontContainerBuildWithSomeButNotAllReadyContainers(t *te
 	assert.Equal(t, []string{}, call.oneImageState().FilesChanged())
 
 	// container already on this pod matches the image built by this manifest
-	pod := podbuilder.New(f.T(), manifest).Build()
+	pod := basePB.Build()
 	imgName := pod.Status.ContainerStatuses[0].Image
 	pod.Status.ContainerStatuses = append(pod.Status.ContainerStatuses, v1.ContainerStatus{
 		Name:        "same image",
@@ -302,7 +313,7 @@ func TestBuildControllerWontContainerBuildWithSomeButNotAllReadyContainers(t *te
 		Ready:       false,
 		ContainerID: "docker://cID-same-image",
 	})
-	f.podEvent(pod, manifest.Name)
+	f.podEvent(pod)
 	f.fsWatcher.Events <- watch.NewFileEvent(f.JoinPath("main.go"))
 
 	// If even one of the containers matching this image is !ready, we have to do a
@@ -324,6 +335,7 @@ func TestBuildControllerCrashRebuild(t *testing.T) {
 	defer f.TearDown()
 
 	manifest := f.newManifest("fe")
+	basePB := f.registerForDeployer(manifest)
 	f.Start([]model.Manifest{manifest})
 
 	call := f.nextCall()
@@ -332,9 +344,8 @@ func TestBuildControllerCrashRebuild(t *testing.T) {
 	f.waitForCompletedBuildCount(1)
 
 	f.b.nextLiveUpdateContainerIDs = []container.ID{podbuilder.FakeContainerID()}
-	pb := podbuilder.New(f.T(), manifest)
-	pod := pb.Build()
-	f.podEvent(pod, manifest.Name)
+	pod := basePB.Build()
+	f.podEvent(pod)
 	f.fsWatcher.Events <- watch.NewFileEvent(f.JoinPath("main.go"))
 
 	call = f.nextCall()
@@ -346,7 +357,7 @@ func TestBuildControllerCrashRebuild(t *testing.T) {
 	})
 
 	// Restart the pod with a new container id, to simulate a container restart.
-	f.podEvent(pb.WithContainerID("funnyContainerID").Build(), manifest.Name)
+	f.podEvent(basePB.WithContainerID("funnyContainerID").Build())
 	call = f.nextCall()
 	assert.True(t, call.oneImageState().OneContainerInfo().Empty())
 	assert.False(t, call.oneImageState().FullBuildTriggered)
@@ -369,6 +380,9 @@ func TestCrashRebuildTwoContainersOneImage(t *testing.T) {
 		WithK8sYAML(testyaml.SanchoTwoContainersOneImageYAML).
 		WithImageTarget(NewSanchoLiveUpdateImageTarget(f)).
 		Build()
+	// basePB is used for all pods so that they share the same deployment
+	basePB := f.registerForDeployer(manifest)
+
 	f.Start([]model.Manifest{manifest})
 
 	call := f.nextCall()
@@ -376,10 +390,10 @@ func TestCrashRebuildTwoContainersOneImage(t *testing.T) {
 	f.waitForCompletedBuildCount(1)
 
 	f.b.nextLiveUpdateContainerIDs = []container.ID{"c1", "c2"}
-	f.podEvent(podbuilder.New(t, manifest).
+	f.podEvent(basePB.
 		WithContainerIDAtIndex("c1", 0).
 		WithContainerIDAtIndex("c2", 1).
-		Build(), manifest.Name)
+		Build())
 	f.fsWatcher.Events <- watch.NewFileEvent(f.JoinPath("main.go"))
 
 	call = f.nextCall()
@@ -389,10 +403,10 @@ func TestCrashRebuildTwoContainersOneImage(t *testing.T) {
 	})
 
 	// Simulate pod event where one of the containers has been restarted with a new ID.
-	f.podEvent(podbuilder.New(t, manifest).
+	f.podEvent(basePB.
 		WithContainerID("c1").
 		WithContainerIDAtIndex("c3", 1).
-		Build(), manifest.Name)
+		Build())
 
 	call = f.nextCall()
 	f.waitForCompletedBuildCount(3)
@@ -418,6 +432,9 @@ func TestCrashRebuildTwoContainersTwoImages(t *testing.T) {
 		WithImageTarget(NewSanchoLiveUpdateImageTarget(f)).
 		WithImageTarget(NewSanchoSidecarLiveUpdateImageTarget(f)).
 		Build()
+	// basePB is used for all pods so that they share the same deployment
+	basePB := f.registerForDeployer(manifest)
+
 	f.Start([]model.Manifest{manifest})
 
 	call := f.nextCall()
@@ -428,10 +445,10 @@ func TestCrashRebuildTwoContainersTwoImages(t *testing.T) {
 	f.waitForCompletedBuildCount(1)
 
 	f.b.nextLiveUpdateContainerIDs = []container.ID{"c1", "c2"}
-	f.podEvent(podbuilder.New(t, manifest).
+	f.podEvent(basePB.
 		WithContainerIDAtIndex("c1", 0).
 		WithContainerIDAtIndex("c2", 1).
-		Build(), manifest.Name)
+		Build())
 	f.fsWatcher.Events <- watch.NewFileEvent(f.JoinPath("main.go"))
 
 	call = f.nextCall()
@@ -441,10 +458,10 @@ func TestCrashRebuildTwoContainersTwoImages(t *testing.T) {
 	})
 
 	// Simulate pod event where one of the containers has been restarted with a new ID.
-	f.podEvent(podbuilder.New(t, manifest).
+	f.podEvent(basePB.
 		WithContainerID("c1").
 		WithContainerIDAtIndex("c3", 1).
-		Build(), manifest.Name)
+		Build())
 
 	call = f.nextCall()
 	f.waitForCompletedBuildCount(3)
@@ -466,6 +483,7 @@ func TestRecordLiveUpdatedContainerIDsForFailedLiveUpdate(t *testing.T) {
 		WithK8sYAML(testyaml.SanchoTwoContainersOneImageYAML).
 		WithImageTarget(NewSanchoLiveUpdateImageTarget(f)).
 		Build()
+	basePB := f.registerForDeployer(manifest)
 	f.Start([]model.Manifest{manifest})
 
 	call := f.nextCall()
@@ -475,10 +493,10 @@ func TestRecordLiveUpdatedContainerIDsForFailedLiveUpdate(t *testing.T) {
 	expectedErr := fmt.Errorf("i can't let you do that dave")
 	f.SetNextLiveUpdateCompileError(expectedErr, []container.ID{"c1", "c2"})
 
-	f.podEvent(podbuilder.New(t, manifest).
+	f.podEvent(basePB.
 		WithContainerIDAtIndex("c1", 0).
 		WithContainerIDAtIndex("c2", 1).
-		Build(), manifest.Name)
+		Build())
 	f.fsWatcher.Events <- watch.NewFileEvent(f.JoinPath("main.go"))
 
 	call = f.nextCall()
@@ -504,7 +522,6 @@ func TestBuildControllerManualTriggerBuildReasonInit(t *testing.T) {
 			f := newTestFixture(t)
 			defer f.TearDown()
 			mName := model.ManifestName("foobar")
-
 			manifest := f.newManifest(mName.String()).WithTriggerMode(tc.triggerMode)
 			manifests := []model.Manifest{manifest}
 			f.Start(manifests)
@@ -639,12 +656,12 @@ func TestBuildControllerManualTriggerWithFileChangesSinceLastSuccessfulBuildButB
 	mName := model.ManifestName("foobar")
 
 	manifest := f.newManifest(mName.String())
-	manifests := []model.Manifest{manifest}
-	f.Start(manifests)
+	basePB := f.registerForDeployer(manifest)
+	f.Start([]model.Manifest{manifest})
 
 	f.nextCallComplete()
 
-	f.podEvent(podbuilder.New(f.T(), manifest).Build(), manifest.Name)
+	f.podEvent(basePB.Build())
 
 	f.b.nextBuildError = errors.New("build failure!")
 	f.fsWatcher.Events <- watch.NewFileEvent(f.JoinPath("main.go"))
@@ -675,16 +692,16 @@ func TestFullBuildTriggerClearsLiveUpdate(t *testing.T) {
 	mName := model.ManifestName("foobar")
 
 	manifest := f.newManifest(mName.String())
-	manifests := []model.Manifest{manifest}
+	basePB := f.registerForDeployer(manifest)
 	opt := func(ia InitAction) InitAction {
 		ia.TerminalMode = store.TerminalModeStream
 		return ia
 	}
-	f.Start(manifests, opt)
+	f.Start([]model.Manifest{manifest}, opt)
 
 	f.nextCallComplete()
 
-	f.podEvent(podbuilder.New(f.T(), manifest).Build(), manifest.Name)
+	f.podEvent(basePB.Build())
 	f.WaitUntilManifestState("foobar loaded", "foobar", func(ms store.ManifestState) bool {
 		return len(ms.K8sRuntimeState().Pods) == 1
 	})
@@ -989,14 +1006,14 @@ func TestBuildControllerResourceDeps(t *testing.T) {
 	}
 
 	var manifests []model.Manifest
-	manifestsByName := make(map[string]model.Manifest)
+	podBuilders := make(map[string]podbuilder.PodBuilder)
 	for name, deps := range depGraph {
 		m := f.newManifest(name)
 		for _, dep := range deps {
 			m.ResourceDependencies = append(m.ResourceDependencies, model.ManifestName(dep))
 		}
 		manifests = append(manifests, m)
-		manifestsByName[name] = m
+		podBuilders[name] = f.registerForDeployer(m)
 	}
 
 	f.Start(manifests)
@@ -1006,8 +1023,7 @@ func TestBuildControllerResourceDeps(t *testing.T) {
 		call := f.nextCall("%dth build. have built: %v", i, observedOrder)
 		name := call.k8s().Name.String()
 		observedOrder = append(observedOrder, name)
-		pb := podbuilder.New(t, manifestsByName[name]).WithContainerReady(true)
-		f.podEvent(pb.Build(), model.ManifestName(name))
+		f.podEvent(podBuilders[name].WithContainerReady(true).Build())
 	}
 
 	var expectedManifests []string
@@ -1038,6 +1054,7 @@ func TestBuildControllerResourceDepTrumpsLocalResourcePriority(t *testing.T) {
 	defer f.TearDown()
 
 	k8sManifest := f.newManifest("foo")
+	pb := f.registerForDeployer(k8sManifest)
 	localManifest := manifestbuilder.New(f, "bar").
 		WithLocalResource("echo bar", nil).
 		WithResourceDeps("foo").Build()
@@ -1049,8 +1066,8 @@ func TestBuildControllerResourceDepTrumpsLocalResourcePriority(t *testing.T) {
 		call := f.nextCall()
 		if !call.k8s().Empty() {
 			observedBuildOrder = append(observedBuildOrder, call.k8s().Name.String())
-			pb := podbuilder.New(t, k8sManifest).WithContainerReady(true)
-			f.podEvent(pb.Build(), k8sManifest.Name)
+			pb = pb.WithContainerReady(true)
+			f.podEvent(pb.Build())
 			continue
 		}
 		observedBuildOrder = append(observedBuildOrder, call.local().Name.String())
@@ -1167,9 +1184,11 @@ func TestBuildControllerWontBuildManifestThatsAlreadyBuilding(t *testing.T) {
 	f.setMaxParallelUpdates(3)
 
 	manifest := f.newManifest("fe")
+	basePB := f.registerForDeployer(manifest)
+
 	f.Start([]model.Manifest{manifest})
 	f.completeAndCheckBuildsForManifests(manifest)
-	f.podEvent(podbuilder.New(f.T(), manifest).Build(), manifest.Name)
+	f.podEvent(basePB.Build())
 
 	f.waitUntilNumBuildSlots(3)
 
@@ -1187,7 +1206,7 @@ func TestBuildControllerWontBuildManifestThatsAlreadyBuilding(t *testing.T) {
 	call := f.nextCall("expect build from first pending file change (A.txt)")
 	f.assertCallIsForManifestAndFiles(call, manifest, "A.txt")
 	f.waitForCompletedBuildCount(2)
-	f.podEvent(podbuilder.New(f.T(), manifest).Build(), manifest.Name)
+	f.podEvent(basePB.Build())
 
 	// we freed up a build slot; expect the second build to start
 	f.waitUntilManifestBuilding("fe")

--- a/internal/hud/fake_hud.go
+++ b/internal/hud/fake_hud.go
@@ -67,6 +67,7 @@ func (h *FakeHud) WaitUntilResource(t testing.TB, ctx context.Context, msg strin
 }
 
 func (h *FakeHud) WaitUntil(t testing.TB, ctx context.Context, msg string, isDone func(view.View) bool) {
+	t.Helper()
 	ctx, cancel := context.WithTimeout(ctx, time.Second)
 	defer cancel()
 

--- a/internal/testutils/podbuilder/podbuilder.go
+++ b/internal/testutils/podbuilder/podbuilder.go
@@ -187,7 +187,7 @@ func (b PodBuilder) PodID() k8s.PodID {
 	if b.podID != "" {
 		return k8s.PodID(b.podID)
 	}
-	return "fakePodID"
+	return k8s.PodID(fmt.Sprintf("%s-fakePodID", b.manifest.Name))
 }
 
 func (b PodBuilder) buildPodUID() types.UID {

--- a/pkg/webview/view.pb.go
+++ b/pkg/webview/view.pb.go
@@ -7,6 +7,7 @@ import (
 	context "context"
 	fmt "fmt"
 	math "math"
+
 	v1alpha1 "github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
 
 	proto "github.com/golang/protobuf/proto"


### PR DESCRIPTION
The upper/buildcontroller tests (which share a fixture) were
simulating pod events by manually dispatching events, thus bypassing
the `PodWatcher` entirely.

That in and of itself isn't hugely problematic (although since these
are more integration than unit tests, it was skipping a lot of logic
that's useful to exercise).

The problem arises from the fact that events are dispatched per-pod
(`PodChangeAction`) currently, but as part of the changes for api
server, the `KubernetesDiscovery` status includes _all_ pods. Since
thigns are dispatched async, this presents new synchronization to
manage in the test.

Instead of trying to work around it further, this changes the tests
to rely on emitting Pod events from the fake K8s client and letting
`PodWatcher` see them and dispatch events.

This does present a complication because the pods generated by the
`PodWatcher` don't have any real relationship to the YAML in the
manifest. A new map on the fake build and deployer uses the provided
entities instead of trying to derive things from the YAML if
populated to accommodate this.