### PR TITLE
test: k8s fakes (client + pod builder) improvements

### DIFF
--- a/internal/cli/down_test.go
+++ b/internal/cli/down_test.go
@@ -179,7 +179,7 @@ func newDownFixture(t *testing.T) downFixture {
 	ctx, cancel := context.WithCancel(ctx)
 	tfl := tiltfile.NewFakeTiltfileLoader()
 	dcc := dockercompose.NewFakeDockerComposeClient(t, ctx)
-	kCli := k8s.NewFakeK8sClient()
+	kCli := k8s.NewFakeK8sClient(t)
 	downDeps := DownDeps{tfl, dcc, kCli}
 	cmd := &downCmd{downDepsProvider: func(ctx context.Context, tiltAnalytics *analytics.TiltAnalytics, subcommand model.TiltSubcommand) (deps DownDeps, err error) {
 		return downDeps, nil

--- a/internal/containerupdate/exec_updater_test.go
+++ b/internal/containerupdate/exec_updater_test.go
@@ -139,7 +139,7 @@ type execUpdaterFixture struct {
 }
 
 func newExecFixture(t testing.TB) *execUpdaterFixture {
-	fakeCli := k8s.NewFakeK8sClient()
+	fakeCli := k8s.NewFakeK8sClient(t)
 	cu := &ExecUpdater{
 		kCli: fakeCli,
 	}

--- a/internal/controllers/core/podlogstream/podlogstreamcontroller_test.go
+++ b/internal/controllers/core/podlogstream/podlogstreamcontroller_test.go
@@ -457,7 +457,7 @@ type plmFixture struct {
 
 func newPLMFixture(t *testing.T) *plmFixture {
 	f := tempdir.NewTempDirFixture(t)
-	kClient := k8s.NewFakeK8sClient()
+	kClient := k8s.NewFakeK8sClient(t)
 
 	out := bufsync.NewThreadSafeBuffer()
 	ctx, cancel := context.WithCancel(context.Background())

--- a/internal/engine/analytics/analytics_reporter_test.go
+++ b/internal/engine/analytics/analytics_reporter_test.go
@@ -42,7 +42,7 @@ var (
 )
 
 func TestAnalyticsReporter_Everything(t *testing.T) {
-	tf := newAnalyticsReporterTestFixture()
+	tf := newAnalyticsReporterTestFixture(t)
 
 	tf.addManifest(tf.nextManifest().WithImageTarget(imgTargDB).WithDeployTarget(kTarg))       // k8s
 	tf.addManifest(tf.nextManifest().WithImageTarget(imgTargDBWithLU))                         // liveupdate
@@ -87,7 +87,7 @@ func TestAnalyticsReporter_Everything(t *testing.T) {
 }
 
 func TestAnalyticsReporter_SameImageMultiContainer(t *testing.T) {
-	tf := newAnalyticsReporterTestFixture()
+	tf := newAnalyticsReporterTestFixture(t)
 
 	injectCountsA := map[string]int{
 		r1: 1,
@@ -115,7 +115,7 @@ func TestAnalyticsReporter_SameImageMultiContainer(t *testing.T) {
 }
 
 func TestAnalyticsReporter_SameImageMultiContainer_NoIncr(t *testing.T) {
-	tf := newAnalyticsReporterTestFixture()
+	tf := newAnalyticsReporterTestFixture(t)
 
 	injectCounts := map[string]int{
 		r1: 1,
@@ -133,7 +133,7 @@ func TestAnalyticsReporter_SameImageMultiContainer_NoIncr(t *testing.T) {
 }
 
 func TestAnalyticsReporter_TiltfileError(t *testing.T) {
-	tf := newAnalyticsReporterTestFixture()
+	tf := newAnalyticsReporterTestFixture(t)
 
 	tf.addManifest(tf.nextManifest().WithImageTarget(model.ImageTarget{BuildDetails: model.DockerBuild{}}))
 	tf.addManifest(tf.nextManifest().WithDeployTarget(model.K8sTarget{}))
@@ -175,11 +175,11 @@ type analyticsReporterTestFixture struct {
 	st            *store.TestingStore
 }
 
-func newAnalyticsReporterTestFixture() *analyticsReporterTestFixture {
+func newAnalyticsReporterTestFixture(t testing.TB) *analyticsReporterTestFixture {
 	st := store.NewTestingStore()
 	opter := tiltanalytics.NewFakeOpter(analytics.OptIn)
 	ma, a := tiltanalytics.NewMemoryTiltAnalyticsForTest(opter)
-	kClient := k8s.NewFakeK8sClient()
+	kClient := k8s.NewFakeK8sClient(t)
 	ar := ProvideAnalyticsReporter(a, st, kClient, k8s.EnvDockerDesktop)
 	return &analyticsReporterTestFixture{
 		manifestCount: 0,

--- a/internal/engine/build_and_deployer_test.go
+++ b/internal/engine/build_and_deployer_test.go
@@ -783,7 +783,7 @@ func newBDFixtureWithUpdateMode(t *testing.T, env k8s.Env, runtime container.Run
 			},
 		},
 	}
-	k8s := k8s.NewFakeK8sClient()
+	k8s := k8s.NewFakeK8sClient(t)
 	k8s.Runtime = runtime
 	mode := buildcontrol.UpdateModeFlag(um)
 	dcc := dockercompose.NewFakeDockerComposeClient(t, ctx)

--- a/internal/engine/buildcontrol/image_build_and_deployer_test.go
+++ b/internal/engine/buildcontrol/image_build_and_deployer_test.go
@@ -1006,7 +1006,7 @@ func newIBDFixture(t *testing.T, env k8s.Env) *ibdFixture {
 	l := logger.NewLogger(logger.DebugLvl, out)
 	ctx, _, ta := testutils.CtxAndAnalyticsForTest()
 	ctx = logger.WithLogger(ctx, l)
-	kClient := k8s.NewFakeK8sClient()
+	kClient := k8s.NewFakeK8sClient(t)
 	kl := &fakeKINDLoader{}
 	clock := fakeClock{time.Date(2019, 1, 1, 1, 1, 1, 1, time.UTC)}
 	ibd, err := ProvideImageBuildAndDeployer(ctx, docker, kClient, env, dir, clock, kl, ta)

--- a/internal/engine/buildcontroller_test.go
+++ b/internal/engine/buildcontroller_test.go
@@ -68,8 +68,8 @@ func TestBuildControllerTooManyPodsForLiveUpdateErrorMessage(t *testing.T) {
 	assert.Equal(t, manifest.ImageTargetAt(0), call.firstImgTarg())
 	assert.Equal(t, []string{}, call.oneImageState().FilesChanged())
 
-	pb1 := basePB.WithPodID("pod1")
-	pb2 := basePB.WithPodID("pod2")
+	pb1 := basePB.WithPodName("pod1")
+	pb2 := basePB.WithPodName("pod2")
 	f.podEvent(pb1.Build())
 	f.podEvent(pb2.Build())
 	f.fsWatcher.Events <- watch.NewFileEvent(f.JoinPath("main.go"))
@@ -104,8 +104,8 @@ func TestBuildControllerTooManyPodsForDockerBuildNoErrorMessage(t *testing.T) {
 	assert.Equal(t, manifest.ImageTargetAt(0), call.firstImgTarg())
 	assert.Equal(t, []string{}, call.oneImageState().FilesChanged())
 
-	p1 := basePB.WithPodID("pod1").Build()
-	p2 := basePB.WithPodID("pod2").Build()
+	p1 := basePB.WithPodName("pod1").Build()
+	p2 := basePB.WithPodName("pod2").Build()
 
 	f.podEvent(p1)
 	f.podEvent(p2)
@@ -138,7 +138,7 @@ func TestBuildControllerIgnoresImageTags(t *testing.T) {
 	assert.Equal(t, []string{}, call.oneImageState().FilesChanged())
 
 	pod := basePB.
-		WithPodID("pod-id").
+		WithPodName("pod-id").
 		WithImage("image-foo:othertag").
 		Build()
 	f.podEvent(pod)
@@ -215,8 +215,8 @@ func TestBuildControllerWontContainerBuildWithTwoPods(t *testing.T) {
 	assert.Equal(t, []string{}, call.oneImageState().FilesChanged())
 
 	// Associate the pods with the manifest state
-	podA := basePB.WithPodID("pod1").Build()
-	podB := basePB.WithPodID("pod2").Build()
+	podA := basePB.WithPodName("pod1").Build()
+	podB := basePB.WithPodName("pod2").Build()
 	f.podEvent(podA)
 	f.podEvent(podB)
 

--- a/internal/engine/k8swatch/event_watch_manager_test.go
+++ b/internal/engine/k8swatch/event_watch_manager_test.go
@@ -36,7 +36,7 @@ func TestEventWatchManager_dispatchesEvent(t *testing.T) {
 	pb := podbuilder.New(t, manifest)
 	entities := pb.ObjectTreeEntities()
 	f.addDeployedEntity(manifest, entities.Deployment())
-	f.kClient.InjectEntityByName(entities...)
+	f.kClient.Inject(entities...)
 
 	evt := f.makeEvent(k8s.NewK8sEntity(pb.Build()))
 
@@ -57,7 +57,7 @@ func TestEventWatchManager_dispatchesNamespaceEvent(t *testing.T) {
 	pb := podbuilder.New(t, manifest)
 	entities := pb.ObjectTreeEntities()
 	f.addDeployedEntity(manifest, entities.Deployment())
-	f.kClient.InjectEntityByName(entities...)
+	f.kClient.Inject(entities...)
 
 	evt1 := f.makeEvent(k8s.NewK8sEntity(pb.Build()))
 	evt1.ObjectMeta.Namespace = "kube-system"
@@ -86,7 +86,7 @@ func TestEventWatchManager_duplicateDeployIDs(t *testing.T) {
 	entities := pb.ObjectTreeEntities()
 	f.addDeployedEntity(m1, entities.Deployment())
 	f.addDeployedEntity(m2, entities.Deployment())
-	f.kClient.InjectEntityByName(entities...)
+	f.kClient.Inject(entities...)
 
 	evt := f.makeEvent(k8s.NewK8sEntity(pb.Build()))
 
@@ -123,7 +123,7 @@ func TestEventWatchManagerDifferentEvents(t *testing.T) {
 			pb := podbuilder.New(t, manifest)
 			entities := pb.ObjectTreeEntities()
 			f.addDeployedEntity(manifest, entities.Deployment())
-			f.kClient.InjectEntityByName(entities...)
+			f.kClient.Inject(entities...)
 
 			evt := f.makeEvent(k8s.NewK8sEntity(pb.Build()))
 			evt.Reason = c.Reason
@@ -181,7 +181,7 @@ func TestEventWatchManager_eventBeforeUID(t *testing.T) {
 
 	pb := podbuilder.New(t, manifest)
 	entities := pb.ObjectTreeEntities()
-	f.kClient.InjectEntityByName(entities...)
+	f.kClient.Inject(entities...)
 
 	evt := f.makeEvent(k8s.NewK8sEntity(pb.Build()))
 
@@ -208,7 +208,7 @@ func TestEventWatchManager_ignoresPreStartEvents(t *testing.T) {
 	pb := podbuilder.New(t, manifest)
 	entities := pb.ObjectTreeEntities()
 	f.addDeployedEntity(manifest, entities.Deployment())
-	f.kClient.InjectEntityByName(entities...)
+	f.kClient.Inject(entities...)
 
 	entity := k8s.NewK8sEntity(pb.Build())
 	evt1 := f.makeEvent(entity)
@@ -251,7 +251,7 @@ type ewmFixture struct {
 }
 
 func newEWMFixture(t *testing.T) *ewmFixture {
-	kClient := k8s.NewFakeK8sClient()
+	kClient := k8s.NewFakeK8sClient(t)
 
 	ctx, _, _ := testutils.CtxAndAnalyticsForTest()
 	ctx, cancel := context.WithCancel(ctx)

--- a/internal/engine/k8swatch/pod_watch_test.go
+++ b/internal/engine/k8swatch/pod_watch_test.go
@@ -46,7 +46,7 @@ func TestPodWatch(t *testing.T) {
 	entities := pb.ObjectTreeEntities()
 	f.addDeployedEntity(manifest, entities.Deployment())
 	f.requireWatchForEntity(manifest.Name, entities.Deployment())
-	f.kClient.InjectEntityByName(entities...)
+	f.kClient.Inject(entities...)
 
 	f.kClient.EmitPod(labels.Everything(), p)
 
@@ -63,7 +63,7 @@ func TestPodWatchChangeEventBeforeUID(t *testing.T) {
 	p := pb.Build()
 
 	entities := pb.ObjectTreeEntities()
-	f.kClient.InjectEntityByName(entities...)
+	f.kClient.Inject(entities...)
 	// emit an event before this manifest knows of anything deployed
 	f.kClient.EmitPod(labels.Everything(), p)
 
@@ -94,7 +94,7 @@ func TestPodWatchResourceVersionStringLessThan(t *testing.T) {
 	// Simulate the deployed entities in the engine state
 	entities := pb.ObjectTreeEntities()
 	f.addDeployedEntity(manifest, entities.Deployment())
-	f.kClient.InjectEntityByName(entities...)
+	f.kClient.Inject(entities...)
 
 	p1 := pb.Build()
 	f.kClient.EmitPod(labels.Everything(), p1)
@@ -147,31 +147,31 @@ func TestPodWatchHandleSelectorChange(t *testing.T) {
 	// remove the first manifest and wait it to propagate
 	f.removeManifest(manifest.Name)
 
-	pb2 := podbuilder.New(t, manifest2).WithPodID("pod2")
+	pb2 := podbuilder.New(t, manifest2).WithPodName("pod2")
 	p2 := pb2.Build()
 	p2Entities := pb2.ObjectTreeEntities()
 	f.addDeployedEntity(manifest2, p2Entities.Deployment())
-	f.kClient.InjectEntityByName(p2Entities...)
+	f.kClient.Inject(p2Entities...)
 	f.kClient.EmitPod(labels.Everything(), p2)
 	f.assertObservedPods(p2)
 	f.clearPods()
 
 	p3 := podbuilder.New(t, manifest2).
-		WithPodID("pod3").
+		WithPodName("pod3").
 		WithPodLabel("foo", "bar").
 		WithUnknownOwner().
 		Build()
 	f.kClient.EmitPod(labels.Everything(), p3)
 
 	p4 := podbuilder.New(t, manifest2).
-		WithPodID("pod4").
+		WithPodName("pod4").
 		WithPodLabel("baz", "quu").
 		WithUnknownOwner().
 		Build()
 	f.kClient.EmitPod(labels.Everything(), p4)
 
 	p5 := podbuilder.New(t, manifest2).
-		WithPodID("pod5").
+		WithPodName("pod5").
 		Build()
 	f.kClient.EmitPod(labels.Everything(), p5)
 
@@ -188,7 +188,7 @@ func TestPodsDispatchedInOrder(t *testing.T) {
 	entities := pb.ObjectTreeEntities()
 	f.addDeployedEntity(manifest, entities.Deployment())
 	f.requireWatchForEntity(manifest.Name, entities.Deployment())
-	f.kClient.InjectEntityByName(entities...)
+	f.kClient.Inject(entities...)
 
 	count := 20
 	pods := []*v1.Pod{}
@@ -229,7 +229,7 @@ func TestPodWatchReadd(t *testing.T) {
 	p := pb.Build()
 	entities := pb.ObjectTreeEntities()
 	f.addDeployedEntity(manifest, entities.Deployment())
-	f.kClient.InjectEntityByName(entities...)
+	f.kClient.Inject(entities...)
 	f.kClient.EmitPod(labels.Everything(), p)
 
 	f.assertObservedPods(p)
@@ -259,7 +259,7 @@ func TestPodWatchDuplicates(t *testing.T) {
 	m4 := f.addManifestWithSelectors("server4", l)
 
 	pb := podbuilder.New(t, m1).
-		WithPodID("shared-pod").
+		WithPodName("shared-pod").
 		WithPodLabel("foo", "bar")
 	p := pb.Build()
 	entities := pb.ObjectTreeEntities()
@@ -269,7 +269,7 @@ func TestPodWatchDuplicates(t *testing.T) {
 	// only m1 is expected to watch the UID
 	f.requireWatchForEntity(m1.Name, entities.Deployment())
 
-	f.kClient.InjectEntityByName(entities...)
+	f.kClient.Inject(entities...)
 	f.kClient.EmitPod(labels.Everything(), p)
 
 	f.assertObservedManifests(m1.Name)
@@ -428,7 +428,7 @@ func (pw *pwFixture) reducer(ctx context.Context, state *store.EngineState, acti
 }
 
 func newPWFixture(t *testing.T) *pwFixture {
-	kClient := k8s.NewFakeK8sClient()
+	kClient := k8s.NewFakeK8sClient(t)
 
 	ctx, _, _ := testutils.CtxAndAnalyticsForTest()
 	ctx, cancel := context.WithCancel(ctx)

--- a/internal/engine/k8swatch/service_watch_test.go
+++ b/internal/engine/k8swatch/service_watch_test.go
@@ -124,7 +124,7 @@ type swFixture struct {
 func newSWFixture(t *testing.T) *swFixture {
 	nip := k8s.NodeIP("fakeip")
 
-	kClient := k8s.NewFakeK8sClient()
+	kClient := k8s.NewFakeK8sClient(t)
 	kClient.FakeNodeIP = nip
 
 	ctx, _, _ := testutils.CtxAndAnalyticsForTest()

--- a/internal/engine/portforward/subscriber_test.go
+++ b/internal/engine/portforward/subscriber_test.go
@@ -420,7 +420,7 @@ type plcFixture struct {
 func newPLCFixture(t *testing.T) *plcFixture {
 	f := tempdir.NewTempDirFixture(t)
 	st := store.NewTestingStore()
-	kCli := k8s.NewFakeK8sClient()
+	kCli := k8s.NewFakeK8sClient(t)
 	plc := NewSubscriber(kCli)
 
 	out := bufsync.NewThreadSafeBuffer()

--- a/internal/k8s/owner_fetcher_test.go
+++ b/internal/k8s/owner_fetcher_test.go
@@ -12,11 +12,11 @@ import (
 )
 
 func TestVisitOneParent(t *testing.T) {
-	kCli := &FakeK8sClient{}
+	kCli := NewFakeK8sClient(t)
 	ov := ProvideOwnerFetcher(context.Background(), kCli)
 
 	pod, rs := fakeOneParentChain()
-	kCli.InjectEntityByName(NewK8sEntity(rs))
+	kCli.Inject(NewK8sEntity(rs))
 
 	tree, err := ov.OwnerTreeOf(context.Background(), K8sEntity{Obj: pod})
 	assert.NoError(t, err)
@@ -25,11 +25,11 @@ func TestVisitOneParent(t *testing.T) {
 }
 
 func TestVisitTwoParentsEnsureListCaching(t *testing.T) {
-	kCli := &FakeK8sClient{}
+	kCli := NewFakeK8sClient(t)
 	ov := ProvideOwnerFetcher(context.Background(), kCli)
 
 	pod, rs, dep := fakeTwoParentChain()
-	kCli.InjectEntityByName(NewK8sEntity(rs), NewK8sEntity(dep))
+	kCli.Inject(NewK8sEntity(rs), NewK8sEntity(dep))
 
 	tree, err := ov.OwnerTreeOf(context.Background(), K8sEntity{Obj: pod})
 	assert.NoError(t, err)
@@ -41,11 +41,12 @@ func TestVisitTwoParentsEnsureListCaching(t *testing.T) {
 }
 
 func TestVisitTwoParentsNoList(t *testing.T) {
-	kCli := &FakeK8sClient{listReturnsEmpty: true}
+	kCli := NewFakeK8sClient(t)
+	kCli.listReturnsEmpty = true
 	ov := ProvideOwnerFetcher(context.Background(), kCli)
 
 	pod, rs, dep := fakeTwoParentChain()
-	kCli.InjectEntityByName(NewK8sEntity(rs), NewK8sEntity(dep))
+	kCli.Inject(NewK8sEntity(rs), NewK8sEntity(dep))
 
 	tree, err := ov.OwnerTreeOf(context.Background(), K8sEntity{Obj: pod})
 	assert.NoError(t, err)
@@ -57,11 +58,12 @@ func TestVisitTwoParentsNoList(t *testing.T) {
 }
 
 func TestOwnerFetcherParallelism(t *testing.T) {
-	kCli := &FakeK8sClient{listReturnsEmpty: true}
+	kCli := NewFakeK8sClient(t)
+	kCli.listReturnsEmpty = true
 	ov := ProvideOwnerFetcher(context.Background(), kCli)
 
 	pod, rs := fakeOneParentChain()
-	kCli.InjectEntityByName(NewK8sEntity(rs))
+	kCli.Inject(NewK8sEntity(rs))
 
 	count := 30
 	g, ctx := errgroup.WithContext(context.Background())

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -5421,7 +5421,7 @@ func newFixture(t *testing.T) *fixture {
 	out := new(bytes.Buffer)
 	ctx, ma, ta := testutils.ForkedCtxAndAnalyticsForTest(out)
 	f := tempdir.NewTempDirFixture(t)
-	kCli := k8s.NewFakeK8sClient()
+	kCli := k8s.NewFakeK8sClient(t)
 
 	r := &fixture{
 		ctx:            ctx,


### PR DESCRIPTION
 * `PodBuilder` now allows customizing the PodUID
   * To avoid confusion, `PodID` is now `PodName` on the builder
 * `PodBuilder` considers Deployment UID when generating ReplicaSet
   UID
   * This ensures that `ReplicaSet`s for non-default Deployments
     aren't erroneously associated (in terms of OwnerRef) with the
     default Deployment
 * `FakeK8sClient` internally tracks entities by UID to allow old
   versions to be fetched to aid in simulating out-of-order/stale
   data scenarios
   * This should PROBABLY be more appropriately handled by targeted
     tests with more specific mocks (e.g. a fake `OwnerFetcher`)
     but this is the path of least resistance for now

All these changes are in support of test adjustments in `test_upper` which currently does some sneaky things since it bypasses a lot of logic that won't be practical anymore imminently. Pulled this into its own PR to ensure no regressions from these changes and limit diff sizes.