### PR TITLE
test: fix a race condition

### DIFF
--- a/internal/engine/k8swatch/event_watch_manager_test.go
+++ b/internal/engine/k8swatch/event_watch_manager_test.go
@@ -41,7 +41,7 @@ func TestEventWatchManager_dispatchesEvent(t *testing.T) {
 	evt := f.makeEvent(k8s.NewK8sEntity(pb.Build()))
 
 	f.ewm.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
-	f.kClient.EmitEvent(f.ctx, evt)
+	f.kClient.UpsertEvent(evt)
 	expected := store.K8sEventAction{Event: evt, ManifestName: mn}
 	f.assertActions(expected)
 }
@@ -65,8 +65,8 @@ func TestEventWatchManager_dispatchesNamespaceEvent(t *testing.T) {
 	evt2 := f.makeEvent(k8s.NewK8sEntity(pb.Build()))
 
 	f.ewm.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
-	f.kClient.EmitEvent(f.ctx, evt1)
-	f.kClient.EmitEvent(f.ctx, evt2)
+	f.kClient.UpsertEvent(evt1)
+	f.kClient.UpsertEvent(evt2)
 
 	expected := store.K8sEventAction{Event: evt2, ManifestName: mn}
 	f.assertActions(expected)
@@ -90,7 +90,7 @@ func TestEventWatchManager_duplicateDeployIDs(t *testing.T) {
 
 	evt := f.makeEvent(k8s.NewK8sEntity(pb.Build()))
 
-	f.kClient.EmitEvent(f.ctx, evt)
+	f.kClient.UpsertEvent(evt)
 	f.ewm.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
 	f.ewm.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
 	expected := store.K8sEventAction{Event: evt, ManifestName: fe1}
@@ -130,7 +130,7 @@ func TestEventWatchManagerDifferentEvents(t *testing.T) {
 			evt.Type = c.Type
 
 			f.ewm.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
-			f.kClient.EmitEvent(f.ctx, evt)
+			f.kClient.UpsertEvent(evt)
 			if c.Expected {
 				expected := store.K8sEventAction{Event: evt, ManifestName: mn}
 				f.assertActions(expected)
@@ -187,7 +187,7 @@ func TestEventWatchManager_eventBeforeUID(t *testing.T) {
 
 	// The UIDs haven't shown up in the engine state yet, so
 	// we shouldn't emit the events.
-	f.kClient.EmitEvent(f.ctx, evt)
+	f.kClient.UpsertEvent(evt)
 	f.assertNoActions()
 
 	// When the UIDs of the deployed objects show up, then
@@ -214,11 +214,11 @@ func TestEventWatchManager_ignoresPreStartEvents(t *testing.T) {
 	evt1 := f.makeEvent(entity)
 	evt1.CreationTimestamp = apis.NewTime(f.clock.Now().Add(-time.Minute))
 
-	f.kClient.EmitEvent(f.ctx, evt1)
+	f.kClient.UpsertEvent(evt1)
 
 	evt2 := f.makeEvent(entity)
 
-	f.kClient.EmitEvent(f.ctx, evt2)
+	f.kClient.UpsertEvent(evt2)
 
 	// first event predates tilt start time, so should be ignored
 	expected := store.K8sEventAction{Event: evt2, ManifestName: mn}

--- a/internal/engine/k8swatch/pod_watch_test.go
+++ b/internal/engine/k8swatch/pod_watch_test.go
@@ -48,7 +48,7 @@ func TestPodWatch(t *testing.T) {
 	f.requireWatchForEntity(manifest.Name, entities.Deployment())
 	f.kClient.Inject(entities...)
 
-	f.kClient.EmitPod(labels.Everything(), p)
+	f.kClient.UpsertPod(p)
 
 	f.assertObservedPods(p)
 }
@@ -65,7 +65,7 @@ func TestPodWatchChangeEventBeforeUID(t *testing.T) {
 	entities := pb.ObjectTreeEntities()
 	f.kClient.Inject(entities...)
 	// emit an event before this manifest knows of anything deployed
-	f.kClient.EmitPod(labels.Everything(), p)
+	f.kClient.UpsertPod(p)
 
 	require.Never(t, func() bool {
 		f.mu.Lock()
@@ -97,12 +97,12 @@ func TestPodWatchResourceVersionStringLessThan(t *testing.T) {
 	f.kClient.Inject(entities...)
 
 	p1 := pb.Build()
-	f.kClient.EmitPod(labels.Everything(), p1)
+	f.kClient.UpsertPod(p1)
 
 	f.assertObservedPods(p1)
 
 	p2 := pb.WithResourceVersion("10").Build()
-	f.kClient.EmitPod(labels.Everything(), p2)
+	f.kClient.UpsertPod(p2)
 
 	f.assertObservedPods(p1, p2)
 }
@@ -119,7 +119,7 @@ func TestPodWatchExtraSelectors(t *testing.T) {
 		WithPodLabel("foo", "bar").
 		WithUnknownOwner().
 		Build()
-	f.kClient.EmitPod(labels.Everything(), p)
+	f.kClient.UpsertPod(p)
 
 	f.assertObservedPods(p)
 	f.assertObservedManifests(manifest.Name)
@@ -136,7 +136,7 @@ func TestPodWatchHandleSelectorChange(t *testing.T) {
 		WithPodLabel("foo", "bar").
 		WithUnknownOwner().
 		Build()
-	f.kClient.EmitPod(labels.Everything(), p)
+	f.kClient.UpsertPod(p)
 
 	f.assertObservedPods(p)
 	f.clearPods()
@@ -152,7 +152,7 @@ func TestPodWatchHandleSelectorChange(t *testing.T) {
 	p2Entities := pb2.ObjectTreeEntities()
 	f.addDeployedEntity(manifest2, p2Entities.Deployment())
 	f.kClient.Inject(p2Entities...)
-	f.kClient.EmitPod(labels.Everything(), p2)
+	f.kClient.UpsertPod(p2)
 	f.assertObservedPods(p2)
 	f.clearPods()
 
@@ -161,19 +161,19 @@ func TestPodWatchHandleSelectorChange(t *testing.T) {
 		WithPodLabel("foo", "bar").
 		WithUnknownOwner().
 		Build()
-	f.kClient.EmitPod(labels.Everything(), p3)
+	f.kClient.UpsertPod(p3)
 
 	p4 := podbuilder.New(t, manifest2).
 		WithPodName("pod4").
 		WithPodLabel("baz", "quu").
 		WithUnknownOwner().
 		Build()
-	f.kClient.EmitPod(labels.Everything(), p4)
+	f.kClient.UpsertPod(p4)
 
 	p5 := podbuilder.New(t, manifest2).
 		WithPodName("pod5").
 		Build()
-	f.kClient.EmitPod(labels.Everything(), p5)
+	f.kClient.UpsertPod(p5)
 
 	f.assertObservedPods(p4, p5)
 	assert.Equal(t, []model.ManifestName{manifest2.Name, manifest2.Name}, f.manifestNames)
@@ -202,7 +202,7 @@ func TestPodsDispatchedInOrder(t *testing.T) {
 	}
 
 	for _, pod := range pods {
-		f.kClient.EmitPod(labels.Everything(), pod)
+		f.kClient.UpsertPod(pod)
 	}
 
 	f.waitForPodActionCount(count)
@@ -230,7 +230,7 @@ func TestPodWatchReadd(t *testing.T) {
 	entities := pb.ObjectTreeEntities()
 	f.addDeployedEntity(manifest, entities.Deployment())
 	f.kClient.Inject(entities...)
-	f.kClient.EmitPod(labels.Everything(), p)
+	f.kClient.UpsertPod(p)
 
 	f.assertObservedPods(p)
 
@@ -270,7 +270,7 @@ func TestPodWatchDuplicates(t *testing.T) {
 	f.requireWatchForEntity(m1.Name, entities.Deployment())
 
 	f.kClient.Inject(entities...)
-	f.kClient.EmitPod(labels.Everything(), p)
+	f.kClient.UpsertPod(p)
 
 	f.assertObservedManifests(m1.Name)
 	f.assertObservedPods(p)
@@ -289,7 +289,7 @@ func TestPodWatchDuplicates(t *testing.T) {
 
 	// NOTE: label matches do NOT get re-dispatched events for known pods currently,
 	// 	so we re-emit a Pod event
-	f.kClient.EmitPod(labels.Everything(), p)
+	f.kClient.UpsertPod(p)
 
 	// m3 should now be allowed to match, but m4 still shouldn't because
 	// we restrict label matches to one watcher
@@ -301,7 +301,7 @@ func TestPodWatchDuplicates(t *testing.T) {
 
 	// NOTE: label matches do NOT get re-dispatched events for known pods currently,
 	// 	so we re-emit a Pod event
-	f.kClient.EmitPod(labels.Everything(), p)
+	f.kClient.UpsertPod(p)
 
 	// finally, m4 can see it
 	f.assertObservedManifests(m4.Name)

--- a/internal/engine/k8swatch/service_watch_test.go
+++ b/internal/engine/k8swatch/service_watch_test.go
@@ -31,7 +31,6 @@ func TestServiceWatch(t *testing.T) {
 	uid := types.UID("fake-uid")
 	manifest := f.addManifest("server")
 
-	ls := k8s.ManagedByTiltSelector()
 	s := servicebuilder.New(f.t, manifest).
 		WithPort(9998).
 		WithNodePort(int32(nodePort)).
@@ -39,7 +38,7 @@ func TestServiceWatch(t *testing.T) {
 		WithUID(uid).
 		Build()
 	f.addDeployedService(manifest, s)
-	f.kClient.EmitService(ls, s)
+	f.kClient.UpsertService(s)
 
 	expectedSCA := ServiceChangeAction{
 		Service:      s,
@@ -67,11 +66,10 @@ func TestServiceWatchUIDDelayed(t *testing.T) {
 
 	f.sw.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
 
-	ls := k8s.ManagedByTiltSelector()
 	s := servicebuilder.New(f.t, manifest).
 		WithUID(uid).
 		Build()
-	f.kClient.EmitService(ls, s)
+	f.kClient.UpsertService(s)
 	f.waitUntilServiceKnown(uid)
 
 	f.addDeployedService(manifest, s)

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -18,7 +18,6 @@ import (
 	"time"
 
 	"github.com/davecgh/go-spew/spew"
-	"k8s.io/apimachinery/pkg/labels"
 
 	"k8s.io/apimachinery/pkg/api/equality"
 
@@ -2548,7 +2547,7 @@ func TestK8sEventGlobalLogAndManifestLog(t *testing.T) {
 			Namespace:         k8s.DefaultNamespace.String(),
 		},
 	}
-	f.kClient.EmitEvent(f.ctx, warnEvt)
+	f.kClient.UpsertEvent(warnEvt)
 
 	f.WaitUntil("event message appears in manifest log", func(st store.EngineState) bool {
 		return strings.Contains(st.LogStore.ManifestLog(name), "something has happened zomg")
@@ -2581,7 +2580,7 @@ func TestK8sEventNotLoggedIfNoManifestForUID(t *testing.T) {
 			Namespace:         k8s.DefaultNamespace.String(),
 		},
 	}
-	f.kClient.EmitEvent(f.ctx, warnEvt)
+	f.kClient.UpsertEvent(warnEvt)
 
 	time.Sleep(10 * time.Millisecond)
 
@@ -4421,7 +4420,7 @@ func (f *testFixture) podEvent(pod *v1.Pod) {
 		}
 	}
 
-	f.kClient.EmitPod(labels.Nothing(), pod)
+	f.kClient.UpsertPod(pod)
 }
 
 func (f *testFixture) newManifest(name string) model.Manifest {

--- a/internal/k8s/fake_client.go
+++ b/internal/k8s/fake_client.go
@@ -15,7 +15,6 @@ import (
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -58,6 +57,8 @@ type FakeK8sClient struct {
 	podWatches     []fakePodWatch
 	serviceWatches []fakeServiceWatch
 	eventWatches   []fakeEventWatch
+	events         map[types.NamespacedName]*v1.Event
+	services       map[types.NamespacedName]*v1.Service
 	pods           map[types.NamespacedName]*v1.Pod
 
 	EventsWatchErr error
@@ -97,23 +98,28 @@ type ExecCall struct {
 }
 
 type fakeServiceWatch struct {
-	ns Namespace
-	ch chan *v1.Service
+	cancel func()
+	ns     Namespace
+	ch     chan *v1.Service
 }
 
 type fakePodWatch struct {
-	ns Namespace
-	ch chan ObjectUpdate
+	cancel func()
+	ns     Namespace
+	ch     chan ObjectUpdate
 }
 
 type fakeEventWatch struct {
-	ns Namespace
-	ch chan *v1.Event
+	cancel func()
+	ns     Namespace
+	ch     chan *v1.Event
 }
 
-func (c *FakeK8sClient) EmitService(ls labels.Selector, s *v1.Service) {
+func (c *FakeK8sClient) UpsertService(s *v1.Service) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+
+	c.services[types.NamespacedName{Name: s.Name, Namespace: s.Namespace}] = s
 	for _, w := range c.serviceWatches {
 		if w.ns != Namespace(s.Namespace) {
 			continue
@@ -127,6 +133,27 @@ func (c *FakeK8sClient) UpsertPod(pod *v1.Pod) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.pods[types.NamespacedName{Name: pod.Name, Namespace: pod.Namespace}] = pod
+	for _, w := range c.podWatches {
+		if w.ns != Namespace(pod.Namespace) {
+			continue
+		}
+
+		w.ch <- ObjectUpdate{obj: pod}
+	}
+}
+
+func (c *FakeK8sClient) UpsertEvent(event *v1.Event) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.events[types.NamespacedName{Name: event.Name, Namespace: event.Namespace}] = event
+	for _, w := range c.eventWatches {
+		if w.ns != Namespace(event.Namespace) {
+			continue
+		}
+
+		w.ch <- event
+	}
 }
 
 func (c *FakeK8sClient) PodFromInformerCache(ctx context.Context, nn types.NamespacedName) (*v1.Pod, error) {
@@ -140,14 +167,28 @@ func (c *FakeK8sClient) PodFromInformerCache(ctx context.Context, nn types.Names
 }
 
 func (c *FakeK8sClient) WatchServices(ctx context.Context, ns Namespace) (<-chan *v1.Service, error) {
+	ctx, cancel := context.WithCancel(ctx)
+
 	c.mu.Lock()
 	ch := make(chan *v1.Service, 20)
-	c.serviceWatches = append(c.serviceWatches, fakeServiceWatch{ns, ch})
+	c.serviceWatches = append(c.serviceWatches, fakeServiceWatch{cancel, ns, ch})
+	toEmit := []*v1.Service{}
+	for _, service := range c.services {
+		if Namespace(service.Namespace) == ns {
+			toEmit = append(toEmit, service)
+		}
+	}
 	c.mu.Unlock()
 
 	go func() {
+		// Initial list of objects
+		for _, obj := range toEmit {
+			ch <- obj
+		}
+
 		// when ctx is canceled, remove the label selector from the list of watched label selectors
 		<-ctx.Done()
+
 		c.mu.Lock()
 		var newWatches []fakeServiceWatch
 		for _, e := range c.serviceWatches {
@@ -157,6 +198,8 @@ func (c *FakeK8sClient) WatchServices(ctx context.Context, ns Namespace) (<-chan
 		}
 		c.serviceWatches = newWatches
 		c.mu.Unlock()
+
+		close(ch)
 	}()
 	return ch, nil
 }
@@ -168,13 +211,27 @@ func (c *FakeK8sClient) WatchEvents(ctx context.Context, ns Namespace) (<-chan *
 		return nil, err
 	}
 
+	ctx, cancel := context.WithCancel(ctx)
+
 	c.mu.Lock()
 	ch := make(chan *v1.Event, 20)
-	c.eventWatches = append(c.eventWatches, fakeEventWatch{ns, ch})
+	c.eventWatches = append(c.eventWatches, fakeEventWatch{cancel, ns, ch})
+	toEmit := []*v1.Event{}
+	for _, event := range c.events {
+		if Namespace(event.Namespace) == ns {
+			toEmit = append(toEmit, event)
+		}
+	}
 	c.mu.Unlock()
 
 	go func() {
+		// Initial list of objects
+		for _, obj := range toEmit {
+			ch <- obj
+		}
+
 		<-ctx.Done()
+
 		c.mu.Lock()
 		var newWatches []fakeEventWatch
 		for _, e := range c.eventWatches {
@@ -184,6 +241,8 @@ func (c *FakeK8sClient) WatchEvents(ctx context.Context, ns Namespace) (<-chan *
 		}
 		c.eventWatches = newWatches
 		c.mu.Unlock()
+
+		close(ch)
 	}()
 	return ch, nil
 }
@@ -192,34 +251,11 @@ func (c *FakeK8sClient) WatchMeta(ctx context.Context, gvk schema.GroupVersionKi
 	return make(chan ObjectMeta), nil
 }
 
-func (c *FakeK8sClient) EmitEvent(ctx context.Context, evt *v1.Event) {
+func (c *FakeK8sClient) EmitPodDelete(p *v1.Pod) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	for _, w := range c.eventWatches {
-		if w.ns != "" && w.ns != Namespace(evt.Namespace) {
-			continue
-		}
-
-		w.ch <- evt
-	}
-}
-
-func (c *FakeK8sClient) EmitPod(ls labels.Selector, p *v1.Pod) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	for _, w := range c.podWatches {
-		if w.ns != Namespace(p.Namespace) {
-			continue
-		}
-
-		w.ch <- ObjectUpdate{obj: p}
-	}
-}
-
-func (c *FakeK8sClient) EmitPodDelete(ls labels.Selector, p *v1.Pod) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
+	delete(c.pods, types.NamespacedName{Name: p.Name, Namespace: p.Namespace})
 	for _, w := range c.podWatches {
 		if w.ns != Namespace(p.Namespace) {
 			continue
@@ -230,14 +266,27 @@ func (c *FakeK8sClient) EmitPodDelete(ls labels.Selector, p *v1.Pod) {
 }
 
 func (c *FakeK8sClient) WatchPods(ctx context.Context, ns Namespace) (<-chan ObjectUpdate, error) {
+	ctx, cancel := context.WithCancel(ctx)
+
 	c.mu.Lock()
 	ch := make(chan ObjectUpdate, 20)
-	c.podWatches = append(c.podWatches, fakePodWatch{ns, ch})
+	c.podWatches = append(c.podWatches, fakePodWatch{cancel, ns, ch})
+	toEmit := []*v1.Pod{}
+	for _, pod := range c.pods {
+		if Namespace(pod.Namespace) == ns {
+			toEmit = append(toEmit, pod)
+		}
+	}
 	c.mu.Unlock()
 
 	go func() {
-		// when ctx is canceled, remove the label selector from the list of watched label selectors
+		// Initial list of objects
+		for _, obj := range toEmit {
+			ch <- ObjectUpdate{obj: obj}
+		}
+
 		<-ctx.Done()
+
 		c.mu.Lock()
 		var newWatches []fakePodWatch
 		for _, e := range c.podWatches {
@@ -247,7 +296,10 @@ func (c *FakeK8sClient) WatchPods(ctx context.Context, ns Namespace) (<-chan Obj
 		}
 		c.podWatches = newWatches
 		c.mu.Unlock()
+
+		close(ch)
 	}()
+
 	return ch, nil
 }
 
@@ -256,6 +308,8 @@ func NewFakeK8sClient(t testing.TB) *FakeK8sClient {
 		t:                        t,
 		PodLogsByPodAndContainer: make(map[PodAndCName]ReaderCloser),
 		pods:                     make(map[types.NamespacedName]*v1.Pod),
+		services:                 make(map[types.NamespacedName]*v1.Service),
+		events:                   make(map[types.NamespacedName]*v1.Event),
 		entities:                 make(map[types.UID]K8sEntity),
 		currentVersions:          make(map[string]types.UID),
 	}
@@ -263,16 +317,25 @@ func NewFakeK8sClient(t testing.TB) *FakeK8sClient {
 
 func (c *FakeK8sClient) TearDown() {
 	c.mu.Lock()
-	defer c.mu.Unlock()
+	podWatches := append([]fakePodWatch{}, c.podWatches...)
+	serviceWatches := append([]fakeServiceWatch{}, c.serviceWatches...)
+	eventWatches := append([]fakeEventWatch{}, c.eventWatches...)
+	c.mu.Unlock()
 
-	for _, watch := range c.podWatches {
-		close(watch.ch)
+	for _, watch := range podWatches {
+		watch.cancel()
+		for range watch.ch {
+		}
 	}
-	for _, watch := range c.serviceWatches {
-		close(watch.ch)
+	for _, watch := range serviceWatches {
+		watch.cancel()
+		for range watch.ch {
+		}
 	}
-	for _, watch := range c.eventWatches {
-		close(watch.ch)
+	for _, watch := range eventWatches {
+		watch.cancel()
+		for range watch.ch {
+		}
 	}
 }
 


### PR DESCRIPTION
Hello @milas, @landism,

Please review the following commits I made in branch nicks/pod:

83d123bcb13698830226a0f727aead9150d0bce8 (2021-05-05 20:02:58 -0400)
test: fix a race condition
In a real kubernetes client, the first time you watch pods, you get the listing
of all the pods in Kubernetes.

Update our fake client to behave the same way.

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics