### PR TITLE
web: update the ui to read uiSession instead of view

### DIFF
--- a/internal/cloud/io_test.go
+++ b/internal/cloud/io_test.go
@@ -18,29 +18,28 @@ func TestWriteSnapshotTo(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, `{
   "view": {
-    "runningTiltBuild": {
-
-    },
-    "versionSettings": {
-      "checkUpdates": true
-    },
-    "tiltCloudSchemeHost": "https:",
     "logList": {
       "fromCheckpoint": -1,
       "toCheckpoint": -1
     },
     "tiltStartTime": "0001-01-01T00:00:00Z",
+    "uiSession": {
+      "metadata": {
+        "name": "Tiltfile"
+      },
+      "status": {
+        "versionSettings": {
+          "checkUpdates": true
+        },
+        "tiltCloudSchemeHost": "https:"
+      }
+    },
     "uiResources": [
       {
         "metadata": {
           "name": "(Tiltfile)"
         },
         "status": {
-          "buildHistory": [
-            {
-
-            }
-          ],
           "runtimeStatus": "not_applicable",
           "updateStatus": "pending"
         }

--- a/internal/hud/server/websocket.go
+++ b/internal/hud/server/websocket.go
@@ -142,7 +142,7 @@ func (ws *WebsocketSubscriber) OnChange(ctx context.Context, s store.RStore, _ s
 
 	ws.setTiltStartTime(tiltStartTime)
 
-	if view.NeedsAnalyticsNudge && !state.AnalyticsNudgeSurfaced {
+	if view.UiSession.Status.NeedsAnalyticsNudge && !state.AnalyticsNudgeSurfaced {
 		// If we're showing the nudge and no one's told the engine
 		// state about it yet... tell the engine state.
 		s.Dispatch(store.AnalyticsNudgeSurfacedAction{})

--- a/internal/hud/webview/convert_test.go
+++ b/internal/hud/webview/convert_test.go
@@ -190,14 +190,14 @@ func TestNeedsNudgeSet(t *testing.T) {
 
 	v := stateToProtoView(t, *state)
 
-	assert.False(t, v.NeedsAnalyticsNudge,
+	assert.False(t, v.UiSession.Status.NeedsAnalyticsNudge,
 		"LastSuccessfulDeployTime not set, so NeedsNudge should not be set")
 
 	targ.State = &store.ManifestState{LastSuccessfulDeployTime: time.Now()}
 	state.UpsertManifestTarget(targ)
 
 	v = stateToProtoView(t, *state)
-	assert.True(t, v.NeedsAnalyticsNudge)
+	assert.True(t, v.UiSession.Status.NeedsAnalyticsNudge)
 }
 
 func TestTriggerMode(t *testing.T) {
@@ -220,7 +220,9 @@ func TestFeatureFlags(t *testing.T) {
 	state.Features = map[string]bool{"foo_feature": true}
 
 	v := stateToProtoView(t, *state)
-	assert.Equal(t, v.FeatureFlags, map[string]bool{"foo_feature": true})
+	assert.Equal(t, v.UiSession.Status.FeatureFlags, []v1alpha1.UIFeatureFlag{
+		v1alpha1.UIFeatureFlag{Name: "foo_feature", Value: true},
+	})
 }
 
 func TestReadinessCheckFailing(t *testing.T) {

--- a/web/src/AppController.ts
+++ b/web/src/AppController.ts
@@ -53,7 +53,8 @@ class AppController {
       let data: Proto.webviewView = JSON.parse(event.data)
       let toCheckpoint = data.logList?.toCheckpoint
       if (toCheckpoint && toCheckpoint > 0) {
-        let tiltStartTime = data.tiltStartTime
+        let tiltStartTime =
+          data.tiltStartTime || data.uiSession?.status?.tiltStartTime
         let response: Proto.webviewAckWebsocketRequest = {
           toCheckpoint,
           tiltStartTime,

--- a/web/src/GlobalNav.tsx
+++ b/web/src/GlobalNav.tsx
@@ -19,6 +19,8 @@ import {
 } from "./style-helpers"
 import UpdateDialog from "./UpdateDialog"
 
+type TiltBuild = Proto.corev1alpha1TiltBuild
+
 export const GlobalNavRoot = styled.div`
   display: flex;
   align-items: stretch;
@@ -133,7 +135,7 @@ type GlobalNavProps = {
   snapshot: SnapshotAction
   showUpdate: boolean
   suggestedVersion: string | null | undefined
-  runningBuild: Proto.webviewTiltBuild | undefined
+  runningBuild: TiltBuild | undefined
 }
 
 export function GlobalNav(props: GlobalNavProps) {

--- a/web/src/HeaderBar.stories.tsx
+++ b/web/src/HeaderBar.stories.tsx
@@ -38,9 +38,10 @@ export const OneHundredResources = () => <HeaderBar view={nResourceView(100)} />
 
 export const UpgradeAvailable = () => {
   let view = twoResourceView()
-  view.suggestedTiltVersion = "0.18.1"
-  view.runningTiltBuild = { version: "0.18.0", dev: false }
-  view.versionSettings = { checkUpdates: true }
+  let status = view.uiSession!.status
+  status!.suggestedTiltVersion = "0.18.1"
+  status!.runningTiltBuild = { version: "0.18.0", dev: false }
+  status!.versionSettings = { checkUpdates: true }
   return <HeaderBar view={view} />
 }
 

--- a/web/src/HeaderBar.tsx
+++ b/web/src/HeaderBar.tsx
@@ -60,8 +60,9 @@ export default function HeaderBar(props: HeaderBarProps) {
   let isSnapshot = usePathBuilder().isSnapshot()
   let snapshot = useSnapshotAction()
   let view = props.view
-  let runningBuild = view?.runningTiltBuild
-  let suggestedVersion = view?.suggestedTiltVersion
+  let session = view?.uiSession?.status
+  let runningBuild = session?.runningTiltBuild
+  let suggestedVersion = session?.suggestedTiltVersion
   let resources = view?.uiResources || []
   let hasK8s = resources.some((r) => {
     let specs = r.status?.specs ?? []
@@ -74,10 +75,10 @@ export default function HeaderBar(props: HeaderBarProps) {
     showUpdate: showUpdate(view),
     suggestedVersion,
     runningBuild,
-    tiltCloudUsername: view.tiltCloudUsername ?? "",
-    tiltCloudSchemeHost: view.tiltCloudSchemeHost ?? "",
-    tiltCloudTeamID: view.tiltCloudTeamID ?? "",
-    tiltCloudTeamName: view.tiltCloudTeamName ?? "",
+    tiltCloudUsername: session?.tiltCloudUsername ?? "",
+    tiltCloudSchemeHost: session?.tiltCloudSchemeHost ?? "",
+    tiltCloudTeamID: session?.tiltCloudTeamID ?? "",
+    tiltCloudTeamName: session?.tiltCloudTeamName ?? "",
   }
 
   const pb = usePathBuilder()

--- a/web/src/OverviewResourceBar.stories.tsx
+++ b/web/src/OverviewResourceBar.stories.tsx
@@ -46,9 +46,10 @@ export const OneHundredResources = () => (
 
 export const UpgradeAvailable = () => {
   let view = twoResourceView()
-  view.suggestedTiltVersion = "0.18.1"
-  view.runningTiltBuild = { version: "0.18.0", dev: false }
-  view.versionSettings = { checkUpdates: true }
+  let status = view.uiSession!.status
+  status!.suggestedTiltVersion = "0.18.1"
+  status!.runningTiltBuild = { version: "0.18.0", dev: false }
+  status!.versionSettings = { checkUpdates: true }
   return <OverviewResourceBar view={view} />
 }
 

--- a/web/src/OverviewResourceBar.tsx
+++ b/web/src/OverviewResourceBar.tsx
@@ -28,8 +28,9 @@ export default function OverviewResourceBar(props: OverviewResourceBarProps) {
   let isSnapshot = usePathBuilder().isSnapshot()
   let snapshot = useSnapshotAction()
   let view = props.view
-  let runningBuild = view?.runningTiltBuild
-  let suggestedVersion = view?.suggestedTiltVersion
+  let session = view?.uiSession?.status
+  let runningBuild = session?.runningTiltBuild
+  let suggestedVersion = session?.suggestedTiltVersion
   let resources = view?.uiResources || []
   let hasK8s = resources.some((r) => {
     let specs = r.status?.specs ?? []
@@ -42,10 +43,10 @@ export default function OverviewResourceBar(props: OverviewResourceBarProps) {
     showUpdate: showUpdate(view),
     suggestedVersion,
     runningBuild,
-    tiltCloudUsername: view.tiltCloudUsername ?? "",
-    tiltCloudSchemeHost: view.tiltCloudSchemeHost ?? "",
-    tiltCloudTeamID: view.tiltCloudTeamID ?? "",
-    tiltCloudTeamName: view.tiltCloudTeamName ?? "",
+    tiltCloudUsername: session?.tiltCloudUsername ?? "",
+    tiltCloudSchemeHost: session?.tiltCloudSchemeHost ?? "",
+    tiltCloudTeamID: session?.tiltCloudTeamID ?? "",
+    tiltCloudTeamName: session?.tiltCloudTeamName ?? "",
   }
 
   return (

--- a/web/src/UpdateDialog.test.tsx
+++ b/web/src/UpdateDialog.test.tsx
@@ -1,11 +1,15 @@
 import { showUpdate } from "./UpdateDialog"
 
 it("compares versions correctly", () => {
-  function v(current: string, suggested: string) {
+  function v(current: string, suggested: string): Proto.webviewView {
     return {
-      runningTiltBuild: { version: current },
-      suggestedTiltVersion: suggested,
-      versionSettings: { checkUpdates: true },
+      uiSession: {
+        status: {
+          runningTiltBuild: { version: current },
+          suggestedTiltVersion: suggested,
+          versionSettings: { checkUpdates: true },
+        },
+      },
     }
   }
 

--- a/web/src/UpdateDialog.tsx
+++ b/web/src/UpdateDialog.tsx
@@ -15,9 +15,10 @@ type props = {
 }
 
 export function showUpdate(view: Proto.webviewView): boolean {
-  let runningBuild = view?.runningTiltBuild
-  let suggestedVersion = view?.suggestedTiltVersion
-  const versionSettings = view?.versionSettings
+  let session = view?.uiSession?.status
+  let runningBuild = session?.runningTiltBuild
+  let suggestedVersion = session?.suggestedTiltVersion
+  const versionSettings = session?.versionSettings
   const checkUpdates = versionSettings?.checkUpdates
   if (!checkUpdates || !suggestedVersion || !runningBuild) {
     return false

--- a/web/src/testdata.tsx
+++ b/web/src/testdata.tsx
@@ -3,6 +3,7 @@ import { RouteComponentProps } from "react-router-dom"
 import { TriggerMode } from "./types"
 
 type UIResource = Proto.v1alpha1UIResource
+type UISession = Proto.v1alpha1UISession
 type Link = Proto.v1alpha1UIResourceLink
 
 const unnamedEndpointLink: Link = { url: "1.2.3.4:8080" }
@@ -10,12 +11,8 @@ const namedEndpointLink: Link = { url: "1.2.3.4:9090", name: "debugger" }
 
 type view = {
   uiResources: Array<UIResource>
+  uiSession?: UISession
   logList?: Proto.webviewLogList
-  featureFlags?: { [featureFlag: string]: boolean }
-  tiltfileKey?: string
-  runningTiltBuild?: Proto.webviewTiltBuild
-  suggestedTiltVersion?: string
-  versionSettings?: Proto.webviewVersionSettings
 }
 
 let runningTiltBuild = {
@@ -314,7 +311,10 @@ function oneResourceTest(): UIResource {
 }
 
 function oneResourceView(): view {
-  return { uiResources: [oneResource()], tiltfileKey: "test", runningTiltBuild }
+  return {
+    uiResources: [oneResource()],
+    uiSession: { status: { tiltfileKey: "test", runningTiltBuild } },
+  }
 }
 
 function twoResourceView(): view {
@@ -356,7 +356,10 @@ function twoResourceView(): view {
       specs: vigodaSpecs(),
     },
   }
-  return { uiResources: [vigoda, snack], tiltfileKey: "test", runningTiltBuild }
+  return {
+    uiResources: [vigoda, snack],
+    uiSession: { status: { tiltfileKey: "test", runningTiltBuild } },
+  }
 }
 
 export function tenResourceView(): view {
@@ -375,7 +378,10 @@ export function nResourceView(n: number): view {
       resources.push(res)
     }
   }
-  return { uiResources: resources, tiltfileKey: "test", runningTiltBuild }
+  return {
+    uiResources: resources,
+    uiSession: { status: { tiltfileKey: "test", runningTiltBuild } },
+  }
 }
 
 function oneResourceFailedToBuild(): UIResource[] {


### PR DESCRIPTION
Hello @milas, @landism,

Please review the following commits I made in branch nicks/uisession7:

4d9b9844265cc51ec2d22b92a08d5812bee12684 (2021-05-06 16:41:50 -0400)
web: update the ui to read uiSession instead of view

0a7e237529d504b74e4ada9b3d74f0d73fdb9f62 (2021-05-06 16:41:22 -0400)
apis: add UISession (a straight port of the old view.proto)

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics