### PR TITLE
hud: remove EmitDefault from all json serializers

### DIFF
--- a/internal/cloud/snapshot_uploader.go
+++ b/internal/cloud/snapshot_uploader.go
@@ -71,7 +71,7 @@ func (s snapshotUploader) TakeAndUpload(state store.EngineState) (SnapshotID, er
 
 func (s snapshotUploader) Upload(token token.Token, teamID string, snapshot *proto_webview.Snapshot) (SnapshotID, error) {
 	b := &bytes.Buffer{}
-	jsEncoder := &runtime.JSONPb{OrigName: false, EmitDefaults: true}
+	jsEncoder := &runtime.JSONPb{}
 	err := jsEncoder.NewEncoder(b).Encode(snapshot)
 	if err != nil {
 		return "", errors.Wrap(err, "encoding snapshot")

--- a/internal/hud/server/logs_reader.go
+++ b/internal/hud/server/logs_reader.go
@@ -40,7 +40,7 @@ func newWebsocketReaderForLogs(conn WebsocketConn, persistent bool, resources []
 func newWebsocketReader(conn WebsocketConn, persistent bool, handler ViewHandler) *WebsocketReader {
 	return &WebsocketReader{
 		conn:         conn,
-		marshaller:   jsonpb.Marshaler{OrigName: false, EmitDefaults: true},
+		marshaller:   jsonpb.Marshaler{},
 		unmarshaller: jsonpb.Unmarshaler{},
 		persistent:   persistent,
 		handler:      handler,

--- a/internal/hud/server/server.go
+++ b/internal/hud/server/server.go
@@ -129,7 +129,7 @@ func (s *HeadsUpServer) ViewJSON(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	jsEncoder := &runtime.JSONPb{OrigName: false, EmitDefaults: true}
+	jsEncoder := &runtime.JSONPb{}
 
 	w.Header().Set("Content-Type", "application/json")
 	err = jsEncoder.NewEncoder(w).Encode(view)
@@ -347,7 +347,7 @@ func (s *HeadsUpServer) HandleNewSnapshot(w http.ResponseWriter, req *http.Reque
 		return
 	}
 
-	jspb := &runtime.JSONPb{OrigName: false, EmitDefaults: true}
+	jspb := &runtime.JSONPb{}
 	decoder := jspb.NewDecoder(bytes.NewBuffer(b))
 	var snapshot *proto_webview.Snapshot
 

--- a/internal/hud/server/server_test.go
+++ b/internal/hud/server/server_test.go
@@ -348,7 +348,7 @@ func TestHandleNewSnapshot(t *testing.T) {
 	lastReq := f.snapshotHTTP.lastReq
 	if assert.NotNil(t, lastReq) {
 		var snapshot proto_webview.Snapshot
-		jspb := &grpcRuntime.JSONPb{OrigName: false, EmitDefaults: true}
+		jspb := &grpcRuntime.JSONPb{}
 		decoder := jspb.NewDecoder(lastReq.Body)
 		err := decoder.Decode(&snapshot)
 		require.NoError(t, err)

--- a/internal/hud/server/websocket.go
+++ b/internal/hud/server/websocket.go
@@ -148,7 +148,7 @@ func (ws *WebsocketSubscriber) OnChange(ctx context.Context, s store.RStore, _ s
 		s.Dispatch(store.AnalyticsNudgeSurfacedAction{})
 	}
 
-	jsEncoder := &runtime.JSONPb{OrigName: false, EmitDefaults: true}
+	jsEncoder := &runtime.JSONPb{}
 	w, err := ws.conn.NextWriter(websocket.TextMessage)
 	if err != nil {
 		logger.Get(ctx).Verbosef("getting writer: %v", err)
@@ -172,9 +172,9 @@ func (ws *WebsocketSubscriber) OnChange(ctx context.Context, s store.RStore, _ s
 	//     at this point in the code, we're not) the only thing ws.OnChange blocks
 	//     is subsequent ws.OnChange calls.
 	//
-	// In future, we can maybe solve this problem more elegantly by replacing our JSON
-	//     marshaling with jsoniter (would require either working around the lack of an
-	//     `EmitDefaults` option in jsoniter, or writing our own proto marshaling code).
+	// In future, we can maybe solve this problem more elegantly by replacing our
+	//     JSON marshaling with jsoniter (though changing json marshalers is
+	//     always fraught with peril).
 	time.Sleep(time.Millisecond * 100)
 }
 


### PR DESCRIPTION
Hello @maiamcc, @landism,

Please review the following commits I made in branch nicks/omit:

7442f697326d6a520a47f119b9ad1273f1b7093b (2021-05-06 19:51:04 -0400)
hud: remove EmitDefault from all json serializers
I think this is a holdover from the pre-typescript days
when we weren't able to remove props safely.

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics