### PR TITLE
portforward: move the logic to run port forwards from subscriber to reconciler [ch11908]

### DIFF
--- a/internal/controllers/core/portforward/reconciler.go
+++ b/internal/controllers/core/portforward/reconciler.go
@@ -16,11 +16,6 @@ import (
 )
 
 type Reconciler struct {
-	// until PortForwarding behavior is moved off the PortForwardSubscriber and onto
-	// the reconciler, we set the reconciler to active/not with a flag (there should
-	// be no PortForwards on the EngineState anyway, but this is a failsafe).
-	isActive bool
-
 	kClient k8s.Client
 
 	// map of PortForward object name --> running forward(s)
@@ -32,11 +27,6 @@ func NewReconciler(kClient k8s.Client) *Reconciler {
 		kClient:        kClient,
 		activeForwards: make(map[string]portForwardEntry),
 	}
-}
-
-func (r *Reconciler) SetActive() {
-	// Should only be used for tests; should be deprecated when migration is complete
-	r.isActive = true
 }
 
 // Figure out the diff between what's in the data store and
@@ -90,10 +80,6 @@ func (r *Reconciler) addToShutdown(toShutdown []portForwardEntry, entry portForw
 }
 
 func (r *Reconciler) OnChange(ctx context.Context, st store.RStore, summary store.ChangeSummary) {
-	if !r.isActive {
-		return
-	}
-
 	if summary.IsLogOnly() {
 		return
 	}

--- a/internal/controllers/core/portforward/reconciler_test.go
+++ b/internal/controllers/core/portforward/reconciler_test.go
@@ -240,7 +240,6 @@ func newPFRFixture(t *testing.T) *pfrFixture {
 	st := store.NewTestingStore()
 	kCli := k8s.NewFakeK8sClient(t)
 	r := NewReconciler(kCli)
-	r.SetActive()
 
 	out := bufsync.NewThreadSafeBuffer()
 	l := logger.NewLogger(logger.DebugLvl, out)

--- a/internal/engine/portforward/reducers.go
+++ b/internal/engine/portforward/reducers.go
@@ -5,11 +5,9 @@ import (
 )
 
 func HandlePortForwardCreateAction(state *store.EngineState, action PortForwardCreateAction) {
+	// will also overwrite an existing PortForward of the same name
 	pf := action.PortForward
-	_, exists := state.PortForwards[pf.Name]
-	if !exists {
-		state.PortForwards[pf.Name] = pf
-	}
+	state.PortForwards[pf.Name] = pf
 }
 
 func HandlePortForwardDeleteAction(state *store.EngineState, action PortForwardDeleteAction) {

--- a/internal/engine/portforward/subscriber.go
+++ b/internal/engine/portforward/subscriber.go
@@ -3,7 +3,6 @@ package portforward
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -13,36 +12,31 @@ import (
 	"github.com/tilt-dev/tilt/internal/store/k8sconv"
 
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/tilt-dev/tilt/internal/k8s"
 	"github.com/tilt-dev/tilt/internal/store"
-	"github.com/tilt-dev/tilt/pkg/logger"
 	"github.com/tilt-dev/tilt/pkg/model"
 )
 
 type Subscriber struct {
 	kClient k8s.Client
-
-	// We store active forwards here so that we have a way of canceling running
-	// forwards--soon this will be the responsibility of the PortForwardReconciler
-	activeForwards map[k8s.PodID]portForwardEntry
 }
 
 func NewSubscriber(kClient k8s.Client) *Subscriber {
 	return &Subscriber{
-		kClient:        kClient,
-		activeForwards: make(map[k8s.PodID]portForwardEntry),
+		kClient: kClient,
 	}
 }
 
-// Figure out the diff between what's in the data store and
-// what port-forwarding is currently active.
-func (s *Subscriber) diff(ctx context.Context, st store.RStore) (toStart []portForwardEntry, toShutdown []portForwardEntry) {
+// Figure out the diff between what port forwards ought to be running (given the
+// current manifests and pods) and what the EngineState/API think ought to be running
+func (s *Subscriber) diff(st store.RStore) (toStart []*PortForward, toShutdown []string) {
 	state := st.RLockState()
 	defer st.RUnlockState()
 
 	statePods := make(map[k8s.PodID]bool, len(state.ManifestTargets))
+	statePFs := state.PortForwards
+	expectedPFs := map[string]bool{} // names of all the port forwards that should be running
 
 	// Find all the port-forwards that need to be created.
 	for _, mt := range state.Targets() {
@@ -66,7 +60,7 @@ func (s *Subscriber) diff(ctx context.Context, st store.RStore) (toStart []portF
 
 		statePods[podID] = true
 
-		apiPf := &v1alpha1.PortForward{
+		pf := &v1alpha1.PortForward{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: fmt.Sprintf("port-forward-%s", podID),
 				Annotations: map[string]string{
@@ -83,131 +77,46 @@ func (s *Subscriber) diff(ctx context.Context, st store.RStore) (toStart []portF
 			},
 		}
 
-		ctx, cancel := context.WithCancel(ctx)
-		entry := portForwardEntry{
-			PortForward: apiPf,
-			ctx:         ctx,
-			cancel:      cancel,
-		}
+		expectedPFs[pf.Name] = true
 
-		oldEntry, isActive := s.activeForwards[podID]
-		if isActive {
-			if equality.Semantic.DeepEqual(oldEntry.Spec, apiPf.Spec) {
-				// We're already running this port forward, nothing to do
+		oldPF, onState := statePFs[pf.Name]
+		if onState {
+			// This PortForward is already on the state -- do we need to do anything further?
+			if equality.Semantic.DeepEqual(oldPF.Spec, pf.Spec) && equality.Semantic.DeepEqual(oldPF.ObjectMeta, pf.ObjectMeta) {
+				// Nothing has changed, nothing to do
 				continue
 			}
-
-			// Tear down the old version so we can start the new one
-			toShutdown = append(toShutdown, oldEntry)
+			// The port forward needs to be UPDATED--which today is the same as a "create"
+			// event, which overwrites the current info for this port forward name
 		}
-
-		toStart = append(toStart, entry)
-		s.activeForwards[podID] = entry
+		toStart = append(toStart, pf)
 	}
 
-	// Find all the port-forwards that belong to old pods--these need to be shut down.
-	for podID, entry := range s.activeForwards {
-		_, inState := statePods[podID]
-		if inState {
-			continue
+	// Find any PFs on the state that our latest loop doesn't think should exist;
+	// these need to be shut down
+	for pfName := range statePFs {
+		if !expectedPFs[pfName] {
+			toShutdown = append(toShutdown, pfName)
 		}
-
-		toShutdown = append(toShutdown, entry)
-		delete(s.activeForwards, podID)
 	}
 
 	return toStart, toShutdown
 }
 
 func (s *Subscriber) OnChange(ctx context.Context, st store.RStore, _ store.ChangeSummary) {
-	toStart, toShutdown := s.diff(ctx, st)
-	for _, entry := range toShutdown {
-		entry.cancel()
-
-		// TODO(maia): st.Dispatch(NewPortForwardDeleteAction(entry.Name))
+	toStart, toShutdown := s.diff(st)
+	for _, name := range toShutdown {
+		st.Dispatch(NewPortForwardDeleteAction(name))
 		// TODO(maia): delete PF object in API
 	}
 
-	for _, entry := range toStart {
-		// Treat port-forwarding errors as part of the pod log
-		ctx := logger.CtxWithLogHandler(entry.ctx, PodLogActionWriter{
-			Store:        st,
-			PodID:        k8s.PodID(entry.Spec.PodName),
-			ManifestName: model.ManifestName(entry.ObjectMeta.Annotations[v1alpha1.AnnotationManifest]),
-		})
-
-		for _, forward := range entry.Spec.Forwards {
-			entry := entry
-			forward := forward
-			go s.startPortForwardLoop(ctx, entry, forward)
-		}
-
-		// TODO(maia): st.Dispatch(NewPortForwardCreateAction(entry.PortForward))
+	for _, pf := range toStart {
+		st.Dispatch(NewPortForwardCreateAction(pf))
 		// TODO(maia): create PF object in API
 	}
 }
 
-func (s *Subscriber) startPortForwardLoop(ctx context.Context, entry portForwardEntry, forward v1alpha1.Forward) {
-	originalBackoff := wait.Backoff{
-		Steps:    1000,
-		Duration: 50 * time.Millisecond,
-		Factor:   2.0,
-		Jitter:   0.1,
-		Cap:      15 * time.Second,
-	}
-	currentBackoff := originalBackoff
-
-	for {
-		start := time.Now()
-		err := s.onePortForward(ctx, entry, forward)
-		if ctx.Err() != nil {
-			// If the context was canceled, we're satisfied.
-			// Ignore any errors.
-			return
-		}
-
-		// Otherwise, repeat the loop, maybe logging the error
-		if err != nil {
-			logger.Get(ctx).Infof("Reconnecting... Error port-forwarding %s (%d -> %d): %v",
-				entry.ObjectMeta.Annotations[v1alpha1.AnnotationManifest],
-				forward.LocalPort, forward.ContainerPort, err)
-		}
-
-		// If this failed in less than a second, then we should advance the backoff.
-		// Otherwise, reset the backoff.
-		if time.Since(start) < time.Second {
-			time.Sleep(currentBackoff.Step())
-		} else {
-			currentBackoff = originalBackoff
-		}
-	}
-}
-
-func (s *Subscriber) onePortForward(ctx context.Context, entry portForwardEntry, forward v1alpha1.Forward) error {
-	ns := k8s.Namespace(entry.Spec.Namespace)
-	podID := k8s.PodID(entry.Spec.PodName)
-
-	pf, err := s.kClient.CreatePortForwarder(ctx, ns, podID, int(forward.LocalPort), int(forward.ContainerPort), forward.Host)
-	if err != nil {
-		return err
-	}
-
-	err = pf.ForwardPorts()
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
 var _ store.Subscriber = &Subscriber{}
-
-// NOTE(maia): this struct is temporary, soon this subscriber won't maintain the state of PF's
-//   or be responsible for canceling them
-type portForwardEntry struct {
-	*v1alpha1.PortForward
-	ctx    context.Context
-	cancel func()
-}
 
 // Extract the port-forward specs from the manifest. If any of them
 // have ContainerPort = 0, populate them with the default port for the pod.
@@ -239,17 +148,6 @@ func PortForwardsAreValid(m model.Manifest, pod v1alpha1.Pod) bool {
 	expectedFwds := m.K8sTarget().PortForwards
 	actualFwds := populatePortForwards(m, pod)
 	return len(actualFwds) == len(expectedFwds)
-}
-
-type PodLogActionWriter struct {
-	Store        store.RStore
-	PodID        k8s.PodID
-	ManifestName model.ManifestName
-}
-
-func (w PodLogActionWriter) Write(level logger.Level, fields logger.Fields, p []byte) error {
-	w.Store.Dispatch(store.NewLogAction(w.ManifestName, k8sconv.SpanIDForPod(w.ManifestName, w.PodID), level, fields, p))
-	return nil
 }
 
 func modelForwardsToApiForwards(forwards []model.PortForward) []v1alpha1.Forward {

--- a/internal/engine/portforward/subscriber_test.go
+++ b/internal/engine/portforward/subscriber_test.go
@@ -2,12 +2,15 @@ package portforward
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
 
-	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 
 	"github.com/tilt-dev/tilt/internal/k8s"
@@ -16,15 +19,13 @@ import (
 	"github.com/tilt-dev/tilt/pkg/model"
 )
 
-func TestPortForward(t *testing.T) {
+func TestPortForwardNewPod(t *testing.T) {
 	f := newPFSFixture(t)
 	f.Start()
 	defer f.TearDown()
 
 	state := f.st.LockMutableStateForTesting()
-	m := model.Manifest{
-		Name: "fe",
-	}
+	m := model.Manifest{Name: "fe"}
 	m = m.WithDeployTarget(model.K8sTarget{
 		PortForwards: []model.PortForward{
 			{
@@ -52,368 +53,363 @@ func TestPortForward(t *testing.T) {
 		if len(pfs) != 1 {
 			return false
 		}
-		for _, pf := range pfs {
-			assert.Equal(t, "pod-A", pf.Spec.PodName)
-			f.assertOneForward(8080, 8081, pf)
-		}
-		return true
+		pf := f.onlyPFFromMap(pfs)
+		return pf.Spec.PodName == "pod-A" && f.oneForwardMatches(8080, 8081, pf)
 	})
 
-	// assert.Equal(t, 1, len(f.s.activeForwards))
-	// assert.Equal(t, "pod-A", f.kCli.LastForwardPortPodID().String())
-	// firstPodForwardCtx := f.kCli.LastForwardContext()
-	//
-	// state = f.st.LockMutableStateForTesting()
-	// mt = state.ManifestTargets["fe"]
-	// mt.State.RuntimeState = store.NewK8sRuntimeStateWithPods(mt.Manifest,
-	// 	v1alpha1.Pod{Name: "pod-B", Phase: string(v1.PodRunning)})
-	// f.st.UnlockMutableState()
-	//
-	// f.onChange()
-	// assert.Equal(t, 1, len(f.s.activeForwards))
-	// assert.Equal(t, "pod-id2", f.kCli.LastForwardPortPodID().String())
-	//
-	// state = f.st.LockMutableStateForTesting()
-	// mt = state.ManifestTargets["fe"]
-	// mt.State.RuntimeState = store.NewK8sRuntimeStateWithPods(mt.Manifest,
-	// 	v1alpha1.Pod{Name: "pod-id2", Phase: string(v1.PodPending)})
-	// f.st.UnlockMutableState()
-	//
-	// f.onChange()
-	// assert.Equal(t, 0, len(f.s.activeForwards))
-	//
-	// assert.Equal(t, context.Canceled, firstPodForwardCtx.Err(),
-	// 	"Expected first port-forward to be canceled")
+	state = f.st.LockMutableStateForTesting()
+	mt = state.ManifestTargets["fe"]
+	mt.State.RuntimeState = store.NewK8sRuntimeStateWithPods(mt.Manifest,
+		v1alpha1.Pod{Name: "pod-B", Phase: string(v1.PodRunning)})
+	f.st.UnlockMutableState()
+
+	f.onChange()
+	f.waitUntilStatePortForwards("one port forward for pod B (replacing port forward for pod A)", func(pfs map[string]*PortForward) bool {
+		if len(pfs) != 1 {
+			return false
+		}
+		pf := f.onlyPFFromMap(pfs)
+		return pf.Spec.PodName == "pod-B" && f.oneForwardMatches(8080, 8081, pf)
+	})
+
+	state = f.st.LockMutableStateForTesting()
+	mt = state.ManifestTargets["fe"]
+	mt.State.RuntimeState = store.NewK8sRuntimeStateWithPods(mt.Manifest,
+		v1alpha1.Pod{Name: "pod-B", Phase: string(v1.PodPending)})
+	f.st.UnlockMutableState()
+
+	f.onChange()
+	f.waitUntilStatePortForwards("port forward for pod B has been torn down", func(pfs map[string]*PortForward) bool {
+		return len(pfs) == 0
+	})
 }
 
-// func TestMultiplePortForwardsForOnePod(t *testing.T) {
-// 	f := newPFSFixture(t)
-// 	defer f.TearDown()
-//
-// 	state := f.st.LockMutableStateForTesting()
-// 	m := model.Manifest{
-// 		Name: "fe",
-// 	}
-// 	m = m.WithDeployTarget(model.K8sTarget{
-// 		PortForwards: []model.PortForward{
-// 			{
-// 				LocalPort:     8000,
-// 				ContainerPort: 8080,
-// 			},
-// 			{
-// 				LocalPort:     8001,
-// 				ContainerPort: 8081,
-// 			},
-// 		},
-// 	})
-// 	state.UpsertManifestTarget(store.NewManifestTarget(m))
-// 	f.st.UnlockMutableState()
-//
-// 	f.onChange()
-// 	assert.Equal(t, 0, len(f.s.activeForwards))
-//
-// 	state = f.st.LockMutableStateForTesting()
-// 	mt := state.ManifestTargets["fe"]
-// 	mt.State.RuntimeState = store.NewK8sRuntimeStateWithPods(mt.Manifest,
-// 		v1alpha1.Pod{Name: "pod-id", Phase: string(v1.PodRunning)})
-// 	f.st.UnlockMutableState()
-//
-// 	f.onChange()
-// 	require.Equal(t, 1, len(f.s.activeForwards))
-// 	require.Equal(t, 2, f.kCli.CreatePortForwardCallCount())
-//
-// 	// PortForwards are executed async so we can't guarantee the order;
-// 	// just make sure each expected call appears exactly once
-// 	expectedRemotePorts := []int{8080, 8081}
-// 	var actualRemotePorts []int
-// 	var contexts []context.Context
-// 	for _, call := range f.kCli.PortForwardCalls() {
-// 		actualRemotePorts = append(actualRemotePorts, call.RemotePort)
-// 		contexts = append(contexts, call.Context)
-// 		assert.Equal(t, "pod-id", call.PodID.String())
-// 	}
-// 	assert.ElementsMatch(t, expectedRemotePorts, actualRemotePorts, "remote ports for which PortForward was called")
-//
-// 	state = f.st.LockMutableStateForTesting()
-// 	mt = state.ManifestTargets["fe"]
-// 	mt.State.RuntimeState = store.NewK8sRuntimeStateWithPods(mt.Manifest,
-// 		v1alpha1.Pod{Name: "pod-id", Phase: string(v1.PodPending)})
-// 	f.st.UnlockMutableState()
-//
-// 	f.onChange()
-// 	assert.Equal(t, 0, len(f.s.activeForwards))
-//
-// 	for _, ctx := range contexts {
-// 		assert.Equal(t, context.Canceled, ctx.Err(),
-// 			"found uncancelled port forward context")
-// 	}
-// }
-//
-// func TestPortForwardAutoDiscovery(t *testing.T) {
-// 	f := newPFSFixture(t)
-// 	defer f.TearDown()
-//
-// 	state := f.st.LockMutableStateForTesting()
-// 	m := model.Manifest{
-// 		Name: "fe",
-// 	}
-// 	m = m.WithDeployTarget(model.K8sTarget{
-// 		PortForwards: []model.PortForward{
-// 			{
-// 				LocalPort: 8080,
-// 			},
-// 		},
-// 	})
-// 	state.UpsertManifestTarget(store.NewManifestTarget(m))
-//
-// 	mt := state.ManifestTargets["fe"]
-// 	mt.State.RuntimeState = store.NewK8sRuntimeStateWithPods(mt.Manifest,
-// 		v1alpha1.Pod{Name: "pod-id", Phase: string(v1.PodRunning)})
-// 	f.st.UnlockMutableState()
-//
-// 	f.onChange()
-// 	assert.Equal(t, 0, len(f.s.activeForwards))
-// 	state = f.st.LockMutableStateForTesting()
-// 	state.ManifestTargets["fe"].State.K8sRuntimeState().Pods["pod-id"].Containers = []v1alpha1.Container{
-// 		v1alpha1.Container{Ports: []int32{8000}},
-// 	}
-// 	f.st.UnlockMutableState()
-//
-// 	f.onChange()
-// 	assert.Equal(t, 1, len(f.s.activeForwards))
-// 	assert.Equal(t, 8000, f.kCli.LastForwardPortRemotePort())
-// }
-//
-// func TestPortForwardAutoDiscovery2(t *testing.T) {
-// 	f := newPFSFixture(t)
-// 	defer f.TearDown()
-//
-// 	state := f.st.LockMutableStateForTesting()
-// 	m := model.Manifest{
-// 		Name: "fe",
-// 	}
-// 	m = m.WithDeployTarget(model.K8sTarget{
-// 		PortForwards: []model.PortForward{
-// 			{
-// 				LocalPort: 8080,
-// 			},
-// 		},
-// 	})
-// 	state.UpsertManifestTarget(store.NewManifestTarget(m))
-//
-// 	mt := state.ManifestTargets["fe"]
-// 	mt.State.RuntimeState = store.NewK8sRuntimeStateWithPods(mt.Manifest, v1alpha1.Pod{
-// 		Name:  "pod-id",
-// 		Phase: string(v1.PodRunning),
-// 		Containers: []v1alpha1.Container{
-// 			{Ports: []int32{8000, 8080}},
-// 		},
-// 	})
-// 	f.st.UnlockMutableState()
-//
-// 	f.onChange()
-// 	assert.Equal(t, 1, len(f.s.activeForwards))
-// 	assert.Equal(t, 8080, f.kCli.LastForwardPortRemotePort())
-// }
-//
-// func TestPortForwardChangePort(t *testing.T) {
-// 	f := newPFSFixture(t)
-// 	defer f.TearDown()
-//
-// 	state := f.st.LockMutableStateForTesting()
-// 	m := model.Manifest{Name: "fe"}.WithDeployTarget(model.K8sTarget{
-// 		PortForwards: []model.PortForward{
-// 			{
-// 				LocalPort:     8080,
-// 				ContainerPort: 8081,
-// 			},
-// 		},
-// 	})
-// 	state.UpsertManifestTarget(store.NewManifestTarget(m))
-// 	mt := state.ManifestTargets["fe"]
-// 	mt.State.RuntimeState = store.NewK8sRuntimeStateWithPods(mt.Manifest,
-// 		v1alpha1.Pod{Name: "pod-id", Phase: string(v1.PodRunning)})
-// 	f.st.UnlockMutableState()
-//
-// 	f.onChange()
-// 	assert.Equal(t, 1, len(f.s.activeForwards))
-// 	assert.Equal(t, 8081, f.kCli.LastForwardPortRemotePort())
-//
-// 	state = f.st.LockMutableStateForTesting()
-// 	kTarget := state.ManifestTargets["fe"].Manifest.K8sTarget()
-// 	kTarget.PortForwards[0].ContainerPort = 8082
-// 	f.st.UnlockMutableState()
-//
-// 	f.onChange()
-// 	assert.Equal(t, 1, len(f.s.activeForwards))
-// 	assert.Equal(t, 8082, f.kCli.LastForwardPortRemotePort())
-// }
-//
-// func TestPortForwardChangeHost(t *testing.T) {
-// 	f := newPFSFixture(t)
-// 	defer f.TearDown()
-//
-// 	state := f.st.LockMutableStateForTesting()
-// 	m := model.Manifest{Name: "fe"}.WithDeployTarget(model.K8sTarget{
-// 		PortForwards: []model.PortForward{
-// 			{
-// 				LocalPort:     8080,
-// 				ContainerPort: 8081,
-// 				Host:          "someHostA",
-// 			},
-// 		},
-// 	})
-// 	state.UpsertManifestTarget(store.NewManifestTarget(m))
-// 	mt := state.ManifestTargets["fe"]
-// 	mt.State.RuntimeState = store.NewK8sRuntimeStateWithPods(mt.Manifest,
-// 		v1alpha1.Pod{Name: "pod-id", Phase: string(v1.PodRunning)})
-// 	f.st.UnlockMutableState()
-//
-// 	f.onChange()
-// 	assert.Equal(t, 1, len(f.s.activeForwards))
-// 	assert.Equal(t, 8081, f.kCli.LastForwardPortRemotePort())
-// 	assert.Equal(t, "someHostA", f.kCli.LastForwardPortHost())
-//
-// 	state = f.st.LockMutableStateForTesting()
-// 	kTarget := state.ManifestTargets["fe"].Manifest.K8sTarget()
-// 	kTarget.PortForwards[0].Host = "otherHostB"
-// 	f.st.UnlockMutableState()
-//
-// 	f.onChange()
-// 	assert.Equal(t, 1, len(f.s.activeForwards))
-// 	assert.Equal(t, 8081, f.kCli.LastForwardPortRemotePort())
-// 	assert.Equal(t, "otherHostB", f.kCli.LastForwardPortHost())
-// }
-//
-// func TestPortForwardChangeManifestName(t *testing.T) {
-// 	f := newPFSFixture(t)
-// 	defer f.TearDown()
-//
-// 	state := f.st.LockMutableStateForTesting()
-// 	m := model.Manifest{Name: "manifestA"}.WithDeployTarget(model.K8sTarget{
-// 		PortForwards: []model.PortForward{
-// 			{
-// 				LocalPort:     8080,
-// 				ContainerPort: 8081,
-// 			},
-// 		},
-// 	})
-// 	state.UpsertManifestTarget(store.NewManifestTarget(m))
-// 	mt := state.ManifestTargets["manifestA"]
-// 	mt.State.RuntimeState = store.NewK8sRuntimeStateWithPods(mt.Manifest,
-// 		v1alpha1.Pod{Name: "pod-id", Phase: string(v1.PodRunning)})
-// 	f.st.UnlockMutableState()
-//
-// 	f.onChange()
-// 	assert.Equal(t, 1, len(f.s.activeForwards))
-// 	assert.Equal(t, 8081, f.kCli.LastForwardPortRemotePort())
-//
-// 	state = f.st.LockMutableStateForTesting()
-// 	delete(state.ManifestTargets, "manifestA")
-// 	m = model.Manifest{Name: "manifestB"}.WithDeployTarget(model.K8sTarget{
-// 		PortForwards: []model.PortForward{
-// 			{
-// 				LocalPort:     8080,
-// 				ContainerPort: 8081,
-// 			},
-// 		},
-// 	})
-// 	state.UpsertManifestTarget(store.NewManifestTarget(m))
-// 	mt = state.ManifestTargets["manifestB"]
-// 	mt.State.RuntimeState = store.NewK8sRuntimeStateWithPods(mt.Manifest,
-// 		v1alpha1.Pod{Name: "pod-id", Phase: string(v1.PodRunning)})
-// 	f.st.UnlockMutableState()
-//
-// 	f.onChange()
-// 	assert.Equal(t, 1, len(f.s.activeForwards))
-// 	assert.Equal(t, 8081, f.kCli.LastForwardPortRemotePort())
-// }
-//
-// func TestPortForwardRestart(t *testing.T) {
-// 	if runtime.GOOS == "windows" {
-// 		t.Skip("TODO(nick): investigate")
-// 	}
-// 	f := newPFSFixture(t)
-// 	defer f.TearDown()
-//
-// 	state := f.st.LockMutableStateForTesting()
-// 	m := model.Manifest{Name: "fe"}.WithDeployTarget(model.K8sTarget{
-// 		PortForwards: []model.PortForward{
-// 			{
-// 				LocalPort:     8080,
-// 				ContainerPort: 8081,
-// 			},
-// 		},
-// 	})
-// 	state.UpsertManifestTarget(store.NewManifestTarget(m))
-// 	mt := state.ManifestTargets["fe"]
-// 	mt.State.RuntimeState = store.NewK8sRuntimeStateWithPods(mt.Manifest,
-// 		v1alpha1.Pod{Name: "pod-id", Phase: string(v1.PodRunning)})
-// 	f.st.UnlockMutableState()
-//
-// 	f.onChange()
-// 	assert.Equal(t, 1, len(f.s.activeForwards))
-// 	assert.Equal(t, 1, f.kCli.CreatePortForwardCallCount())
-//
-// 	err := fmt.Errorf("unique-error")
-// 	f.kCli.LastForwarder().Done <- err
-//
-// 	assert.Contains(t, "unique-error", f.out.String())
-// 	time.Sleep(100 * time.Millisecond)
-//
-// 	assert.Equal(t, 1, len(f.s.activeForwards))
-// 	assert.Equal(t, 2, f.kCli.CreatePortForwardCallCount())
-// }
-//
-// type portForwardTestCase struct {
-// 	spec           []model.PortForward
-// 	containerPorts []int32
-// 	expected       []model.PortForward
-// }
-//
-// func TestPopulatePortForward(t *testing.T) {
-// 	cases := []portForwardTestCase{
-// 		{
-// 			spec:           []model.PortForward{{LocalPort: 8080}},
-// 			containerPorts: []int32{8080},
-// 			expected:       []model.PortForward{{ContainerPort: 8080, LocalPort: 8080}},
-// 		},
-// 		{
-// 			spec:           []model.PortForward{{LocalPort: 8080}},
-// 			containerPorts: []int32{8000, 8080, 8001},
-// 			expected:       []model.PortForward{{ContainerPort: 8080, LocalPort: 8080}},
-// 		},
-// 		{
-// 			spec:           []model.PortForward{{LocalPort: 8080}, {LocalPort: 8000}},
-// 			containerPorts: []int32{8000, 8080, 8001},
-// 			expected: []model.PortForward{
-// 				{ContainerPort: 8080, LocalPort: 8080},
-// 				{ContainerPort: 8000, LocalPort: 8000},
-// 			},
-// 		},
-// 		{
-// 			spec:           []model.PortForward{{ContainerPort: 8000, LocalPort: 8080}},
-// 			containerPorts: []int32{8000, 8080, 8001},
-// 			expected:       []model.PortForward{{ContainerPort: 8000, LocalPort: 8080}},
-// 		},
-// 	}
-//
-// 	for i, c := range cases {
-// 		t.Run(fmt.Sprintf("Case%d", i), func(t *testing.T) {
-// 			m := model.Manifest{Name: "fe"}.WithDeployTarget(model.K8sTarget{
-// 				PortForwards: c.spec,
-// 			})
-// 			pod := v1alpha1.Pod{
-// 				Containers: []v1alpha1.Container{
-// 					v1alpha1.Container{Ports: c.containerPorts},
-// 				},
-// 			}
-//
-// 			actual := populatePortForwards(m, pod)
-// 			assert.Equal(t, c.expected, actual)
-// 		})
-// 	}
-// }
+func TestPortForwardChangePort(t *testing.T) {
+	f := newPFSFixture(t)
+	f.Start()
+	defer f.TearDown()
+
+	state := f.st.LockMutableStateForTesting()
+	m := model.Manifest{Name: "fe"}
+	m = m.WithDeployTarget(model.K8sTarget{
+		PortForwards: []model.PortForward{
+			{
+				LocalPort:     8080,
+				ContainerPort: 8081,
+			},
+		},
+	})
+	mt := store.NewManifestTarget(m)
+	mt.State.RuntimeState = store.NewK8sRuntimeStateWithPods(mt.Manifest,
+		v1alpha1.Pod{Name: "pod-id", Phase: string(v1.PodRunning)})
+	state.UpsertManifestTarget(mt)
+	f.st.UnlockMutableState()
+
+	f.onChange()
+	f.waitUntilStatePortForwards("initial port forward", func(pfs map[string]*PortForward) bool {
+		if len(pfs) != 1 {
+			return false
+		}
+		pf := f.onlyPFFromMap(pfs)
+		return pf.Spec.PodName == "pod-id" && f.oneForwardMatches(8080, 8081, pf)
+	})
+
+	state = f.st.LockMutableStateForTesting()
+	kTarget := state.ManifestTargets["fe"].Manifest.K8sTarget()
+	kTarget.PortForwards[0].ContainerPort = 8082
+	f.st.UnlockMutableState()
+
+	f.onChange()
+	f.waitUntilStatePortForwards("updated container port", func(pfs map[string]*PortForward) bool {
+		if len(pfs) != 1 {
+			return false
+		}
+		pf := f.onlyPFFromMap(pfs)
+		return pf.Spec.PodName == "pod-id" && f.oneForwardMatches(8080, 8082, pf)
+	})
+}
+
+func TestPortForwardChangeHost(t *testing.T) {
+	f := newPFSFixture(t)
+	f.Start()
+	defer f.TearDown()
+
+	state := f.st.LockMutableStateForTesting()
+	m := model.Manifest{Name: "fe"}
+	m = m.WithDeployTarget(model.K8sTarget{
+		PortForwards: []model.PortForward{
+			{
+				LocalPort:     8080,
+				ContainerPort: 8081,
+				Host:          "hostA",
+			},
+		},
+	})
+	mt := store.NewManifestTarget(m)
+	mt.State.RuntimeState = store.NewK8sRuntimeStateWithPods(mt.Manifest,
+		v1alpha1.Pod{Name: "pod-id", Phase: string(v1.PodRunning)})
+	state.UpsertManifestTarget(mt)
+	f.st.UnlockMutableState()
+
+	f.onChange()
+	f.waitUntilStatePortForwards("initial port forward", func(pfs map[string]*PortForward) bool {
+		if len(pfs) != 1 {
+			return false
+		}
+		pf := f.onlyPFFromMap(pfs)
+		return pf.Spec.PodName == "pod-id" && f.oneForwardWithHostMatches(8080, 8081, "hostA", pf)
+	})
+
+	state = f.st.LockMutableStateForTesting()
+	kTarget := state.ManifestTargets["fe"].Manifest.K8sTarget()
+	kTarget.PortForwards[0].Host = "hostB"
+	f.st.UnlockMutableState()
+
+	f.onChange()
+	f.waitUntilStatePortForwards("updated host", func(pfs map[string]*PortForward) bool {
+		if len(pfs) != 1 {
+			return false
+		}
+		pf := f.onlyPFFromMap(pfs)
+		return pf.Spec.PodName == "pod-id" && f.oneForwardWithHostMatches(8080, 8081, "hostB", pf)
+	})
+}
+
+func TestPortForwardChangeManifestName(t *testing.T) {
+	f := newPFSFixture(t)
+	f.Start()
+	defer f.TearDown()
+
+	state := f.st.LockMutableStateForTesting()
+	m := model.Manifest{Name: "fe"}
+	m = m.WithDeployTarget(model.K8sTarget{
+		PortForwards: []model.PortForward{
+			{
+				LocalPort:     8080,
+				ContainerPort: 8081,
+			},
+		},
+	})
+	mt := store.NewManifestTarget(m)
+	mt.State.RuntimeState = store.NewK8sRuntimeStateWithPods(mt.Manifest,
+		v1alpha1.Pod{Name: "pod-id", Phase: string(v1.PodRunning)})
+	state.UpsertManifestTarget(mt)
+	f.st.UnlockMutableState()
+
+	f.onChange()
+	f.waitUntilStatePortForwards("one port forward for manifest fe", func(pfs map[string]*PortForward) bool {
+		if len(pfs) != 1 {
+			return false
+		}
+		pf := f.onlyPFFromMap(pfs)
+		return pf.Spec.PodName == "pod-id" && f.oneForwardMatches(8080, 8081, pf) &&
+			pf.ObjectMeta.Annotations[v1alpha1.AnnotationManifest] == "fe"
+	})
+
+	state = f.st.LockMutableStateForTesting()
+	// the exact same manifest, pod, etc., just with a different name
+	mt = state.ManifestTargets["fe"]
+	state.RemoveManifestTarget("fe")
+	mt.Manifest.Name = "not-fe"
+	state.UpsertManifestTarget(mt)
+	f.st.UnlockMutableState()
+
+	f.onChange()
+	f.waitUntilStatePortForwards("one port forward for manifest not-fe", func(pfs map[string]*PortForward) bool {
+		if len(pfs) != 1 {
+			return false
+		}
+		pf := f.onlyPFFromMap(pfs)
+		return pf.Spec.PodName == "pod-id" && f.oneForwardMatches(8080, 8081, pf) &&
+			pf.ObjectMeta.Annotations[v1alpha1.AnnotationManifest] == "not-fe"
+	})
+}
+
+func TestMultipleForwardsOnePod(t *testing.T) {
+	f := newPFSFixture(t)
+	f.Start()
+	defer f.TearDown()
+
+	state := f.st.LockMutableStateForTesting()
+	m := model.Manifest{Name: "fe"}
+	m = m.WithDeployTarget(model.K8sTarget{
+		PortForwards: []model.PortForward{
+			{
+				LocalPort:     8000,
+				ContainerPort: 8080,
+				Host:          "first-host",
+			},
+			{
+				LocalPort:     9000,
+				ContainerPort: 9090,
+				Host:          "second-host",
+			},
+		},
+	})
+	state.UpsertManifestTarget(store.NewManifestTarget(m))
+	f.st.UnlockMutableState()
+
+	f.onChange()
+	f.waitUntilStatePortForwards("no port forwards running yet", func(pfs map[string]*PortForward) bool {
+		return len(pfs) == 0
+	})
+
+	state = f.st.LockMutableStateForTesting()
+	mt := state.ManifestTargets["fe"]
+	mt.State.RuntimeState = store.NewK8sRuntimeStateWithPods(mt.Manifest,
+		v1alpha1.Pod{Name: "pod-id", Phase: string(v1.PodRunning)})
+	f.st.UnlockMutableState()
+
+	f.onChange()
+	f.waitUntilStatePortForwards("one port forward with multiple Forwards", func(pfs map[string]*PortForward) bool {
+		if len(pfs) != 1 {
+			return false
+		}
+
+		var seen8000, seen9000 bool
+		pf := f.onlyPFFromMap(pfs)
+		if pf.Spec.PodName != "pod-id" {
+			return false
+		}
+
+		for _, fwd := range pf.Spec.Forwards {
+			if fwd.LocalPort == 8000 {
+				seen8000 = true
+				f.forwardWithHostMatches(fwd, 8000, 8080, "first-host")
+			} else if fwd.LocalPort == 9000 {
+				seen9000 = true
+				f.forwardWithHostMatches(fwd, 9000, 9090, "second-host")
+			} else {
+				t.Fatalf("found Forward to unexpected LocalPort: %+v", fwd)
+			}
+		}
+
+		return seen8000 && seen9000
+	})
+
+	state = f.st.LockMutableStateForTesting()
+	state.RemoveManifestTarget("fe")
+	f.st.UnlockMutableState()
+
+	f.onChange()
+	f.waitUntilStatePortForwards("port forward torn down", func(pfs map[string]*PortForward) bool {
+		return len(pfs) == 0
+	})
+}
+
+func TestPortForwardAutoDiscovery(t *testing.T) {
+	f := newPFSFixture(t)
+	f.Start()
+	defer f.TearDown()
+
+	state := f.st.LockMutableStateForTesting()
+	m := model.Manifest{Name: "fe"}
+	m = m.WithDeployTarget(model.K8sTarget{
+		PortForwards: []model.PortForward{{LocalPort: 8080}},
+	})
+	state.UpsertManifestTarget(store.NewManifestTarget(m))
+
+	mt := state.ManifestTargets["fe"]
+	mt.State.RuntimeState = store.NewK8sRuntimeStateWithPods(mt.Manifest, v1alpha1.Pod{
+		Name:  "pod-id",
+		Phase: string(v1.PodRunning),
+		Containers: []v1alpha1.Container{
+			{Ports: []int32{8000}},
+		},
+	})
+	f.st.UnlockMutableState()
+
+	f.onChange()
+	f.waitUntilStatePortForwards("running port forward with auto-discovered container port", func(pfs map[string]*PortForward) bool {
+		if len(pfs) != 1 {
+			return false
+		}
+		pf := f.onlyPFFromMap(pfs)
+		return pf.Spec.PodName == "pod-id" && f.oneForwardMatches(8080, 8000, pf)
+	})
+}
+
+func TestPortForwardAutoDiscovery2(t *testing.T) {
+	f := newPFSFixture(t)
+	f.Start()
+	defer f.TearDown()
+
+	state := f.st.LockMutableStateForTesting()
+	m := model.Manifest{Name: "fe"}
+	m = m.WithDeployTarget(model.K8sTarget{
+		PortForwards: []model.PortForward{{LocalPort: 8080}},
+	})
+	state.UpsertManifestTarget(store.NewManifestTarget(m))
+
+	mt := state.ManifestTargets["fe"]
+	mt.State.RuntimeState = store.NewK8sRuntimeStateWithPods(mt.Manifest, v1alpha1.Pod{
+		Name:  "pod-id",
+		Phase: string(v1.PodRunning),
+		Containers: []v1alpha1.Container{
+			{Ports: []int32{8000, 8080}},
+		},
+	})
+	f.st.UnlockMutableState()
+
+	f.onChange()
+	f.waitUntilStatePortForwards("running port forward with auto-discovered container port", func(pfs map[string]*PortForward) bool {
+		if len(pfs) != 1 {
+			return false
+		}
+		pf := f.onlyPFFromMap(pfs)
+		return pf.Spec.PodName == "pod-id" && f.oneForwardMatches(8080, 8080, pf)
+	})
+}
+
+type portForwardTestCase struct {
+	spec           []model.PortForward
+	containerPorts []int32
+	expected       []model.PortForward
+}
+
+func TestPopulatePortForward(t *testing.T) {
+	cases := []portForwardTestCase{
+		{
+			spec:           []model.PortForward{{LocalPort: 8080}},
+			containerPorts: []int32{8080},
+			expected:       []model.PortForward{{ContainerPort: 8080, LocalPort: 8080}},
+		},
+		{
+			spec:           []model.PortForward{{LocalPort: 8080}},
+			containerPorts: []int32{8000, 8080, 8001},
+			expected:       []model.PortForward{{ContainerPort: 8080, LocalPort: 8080}},
+		},
+		{
+			spec:           []model.PortForward{{LocalPort: 8080}, {LocalPort: 8000}},
+			containerPorts: []int32{8000, 8080, 8001},
+			expected: []model.PortForward{
+				{ContainerPort: 8080, LocalPort: 8080},
+				{ContainerPort: 8000, LocalPort: 8000},
+			},
+		},
+		{
+			spec:           []model.PortForward{{ContainerPort: 8000, LocalPort: 8080}},
+			containerPorts: []int32{8000, 8080, 8001},
+			expected:       []model.PortForward{{ContainerPort: 8000, LocalPort: 8080}},
+		},
+	}
+
+	for i, c := range cases {
+		t.Run(fmt.Sprintf("Case%d", i), func(t *testing.T) {
+			m := model.Manifest{Name: "fe"}.WithDeployTarget(model.K8sTarget{
+				PortForwards: c.spec,
+			})
+			pod := v1alpha1.Pod{
+				Containers: []v1alpha1.Container{
+					v1alpha1.Container{Ports: c.containerPorts},
+				},
+			}
+
+			actual := populatePortForwards(m, pod)
+			assert.Equal(t, c.expected, actual)
+		})
+	}
+}
 
 type pfsFixture struct {
 	*tempdir.TempDirFixture
@@ -471,16 +467,30 @@ func (f pfsFixture) WaitUntilDone() {
 	}
 }
 
-func (f *pfsFixture) assertForward(fwd Forward, expectedLocal, expectedContainer int32) {
-	assert.Equal(f.T(), expectedLocal, fwd.LocalPort)
-	assert.Equal(f.T(), expectedContainer, fwd.ContainerPort)
+func (f *pfsFixture) forwardMatches(fwd Forward, expectedLocal, expectedContainer int32) bool {
+	return expectedLocal == fwd.LocalPort && expectedContainer == fwd.ContainerPort
 }
 
-func (f *pfsFixture) assertOneForward(expectedLocal, expectedContainer int32, pf *PortForward) {
-	if assert.Len(f.T(), pf.Spec.Forwards, 1) {
-		assert.Equal(f.T(), expectedLocal, pf.Spec.Forwards[0].LocalPort)
-		assert.Equal(f.T(), expectedContainer, pf.Spec.Forwards[0].ContainerPort)
+func (f *pfsFixture) oneForwardMatches(expectedLocal, expectedContainer int32, pf *PortForward) bool {
+	return len(pf.Spec.Forwards) == 1 && f.forwardMatches(pf.Spec.Forwards[0], expectedLocal, expectedContainer)
+}
+
+func (f *pfsFixture) forwardWithHostMatches(fwd Forward, expectedLocal, expectedContainer int32, expectedHost string) bool {
+	return expectedLocal == fwd.LocalPort &&
+		expectedContainer == fwd.ContainerPort &&
+		expectedHost == fwd.Host
+}
+
+func (f *pfsFixture) oneForwardWithHostMatches(expectedLocal, expectedContainer int32, expectedHost string, pf *PortForward) bool {
+	return len(pf.Spec.Forwards) == 1 && f.forwardWithHostMatches(pf.Spec.Forwards[0], expectedLocal, expectedContainer, expectedHost)
+}
+
+func (f *pfsFixture) onlyPFFromMap(pfs map[string]*PortForward) *PortForward {
+	require.Len(f.T(), pfs, 1, "`onlyPFFromMap` requires a map of length one (got %d)", len(pfs))
+	for _, pf := range pfs { // there's only one thing in the map, we just don't know its key 🙃
+		return pf
 	}
+	return nil
 }
 
 func (f *pfsFixture) waitUntilStatePortForwards(msg string, isDone func(map[string]*PortForward) bool) {

--- a/internal/engine/portforward/types.go
+++ b/internal/engine/portforward/types.go
@@ -10,3 +10,4 @@ type PortForward = v1alpha1.PortForward
 type PortForwardSpec = v1alpha1.PortForwardSpec
 type PortForwardStatus = v1alpha1.PortForwardStatus
 type ObjectMeta = metav1.ObjectMeta
+type Forward = v1alpha1.Forward

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -3944,6 +3944,7 @@ func newTestFixture(t *testing.T) *testFixture {
 	ccb := controllers.NewClientBuilder(cdc).WithUncached(&v1alpha1.FileWatch{})
 	fwms := fswatch.NewManifestSubscriber(cdc)
 	pfs := portforward.NewSubscriber(b.kClient)
+	pfs.DisableForTesting()
 	au := engineanalytics.NewAnalyticsUpdater(ta, engineanalytics.CmdTags{})
 	ar := engineanalytics.ProvideAnalyticsReporter(ta, st, b.kClient, env)
 	fakeDcc := dockercompose.NewFakeDockerComposeClient(t, ctx)


### PR DESCRIPTION
Hello @nicks, @milas,

Please review the following commits I made in branch maiamcc/move-pf-logic:

d66885548fa3f2bf4e904ff696a712551ade9f9e (2021-05-07 18:13:07 -0400)
blargh so many tests

0db6a2264cf260a59eee31ea52e9819aeb260517 (2021-05-07 16:52:05 -0400)
do it the other way wip

cbf260794c866537d35738ce9fd975def40cd94f (2021-05-07 16:22:18 -0400)
wip

e91cff84d2d46dc07c5fcb8fccbed2eafde89c08 (2021-05-07 14:54:38 -0400)
first pass at moving logic

4323930fb0cb168a0626f06761947e36c901ca14 (2021-05-07 14:54:33 -0400)
don't turn off reconciler

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics