### PR TITLE
uisession: separate subscriber the writes UISession from code that reads it

### DIFF
--- a/internal/cloud/io_test.go
+++ b/internal/cloud/io_test.go
@@ -5,7 +5,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/types"
 
+	"github.com/tilt-dev/tilt/internal/hud/webview"
 	"github.com/tilt-dev/tilt/internal/store"
 	"github.com/tilt-dev/tilt/internal/testutils"
 )
@@ -14,6 +16,7 @@ func TestWriteSnapshotTo(t *testing.T) {
 	ctx, _, _ := testutils.CtxAndAnalyticsForTest()
 	buf := bytes.NewBuffer(nil)
 	state := store.NewState()
+	state.UISessions[types.NamespacedName{Name: webview.UISessionName}] = webview.ToUISession(*state)
 	err := WriteSnapshotTo(ctx, *state, buf)
 	assert.NoError(t, err)
 	assert.Equal(t, `{

--- a/internal/engine/uisession/reducers.go
+++ b/internal/engine/uisession/reducers.go
@@ -1,22 +1,25 @@
 package uisession
 
 import (
-	"context"
-
 	"github.com/tilt-dev/tilt/internal/store"
 	"github.com/tilt-dev/tilt/pkg/apis"
+	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
 )
 
-func HandleUISessionCreateAction(_ context.Context, state *store.EngineState, a UISessionCreateAction) {
+func HandleUISessionCreateAction(state *store.EngineState, a UISessionCreateAction) {
 	key := apis.Key(a.UISession)
 	if _, ok := state.UISessions[key]; !ok {
 		state.UISessions[key] = a.UISession
 	}
 }
 
-func HandleUISessionUpdateStatusAction(ctx context.Context, state *store.EngineState, a UISessionUpdateStatusAction) {
+func HandleUISessionUpdateStatusAction(state *store.EngineState, a UISessionUpdateStatusAction) {
 	key := apis.KeyFromMeta(*a.ObjectMeta)
-	if _, ok := state.UISessions[key]; ok {
-		state.UISessions[key].Status = *a.Status
+	if orig, ok := state.UISessions[key]; ok {
+		state.UISessions[key] = &v1alpha1.UISession{
+			ObjectMeta: orig.ObjectMeta,
+			Spec:       orig.Spec,
+			Status:     *a.Status,
+		}
 	}
 }

--- a/internal/engine/uisession/subscriber.go
+++ b/internal/engine/uisession/subscriber.go
@@ -3,10 +3,15 @@ package uisession
 import (
 	"context"
 
+	"k8s.io/apimachinery/pkg/api/equality"
+
+	"github.com/tilt-dev/tilt/internal/hud/webview"
 	"github.com/tilt-dev/tilt/internal/store"
+	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
 )
 
 type Subscriber struct {
+	lastSession *v1alpha1.UISession
 }
 
 func NewSubscriber() *Subscriber {
@@ -14,6 +19,25 @@ func NewSubscriber() *Subscriber {
 }
 
 func (s *Subscriber) OnChange(ctx context.Context, store store.RStore, summary store.ChangeSummary) {
+	if summary.IsLogOnly() {
+		return
+	}
+
+	state := store.RLockState()
+	session := webview.ToUISession(state)
+	store.RUnlockState()
+
+	exists := s.lastSession != nil
+	if !exists {
+		store.Dispatch(NewUISessionCreateAction(session))
+		s.lastSession = session
+		return
+	}
+
+	if !equality.Semantic.DeepEqual(session.Status, s.lastSession.Status) {
+		store.Dispatch(NewUISessionUpdateStatusAction(session))
+		s.lastSession = session
+	}
 }
 
 var _ store.Subscriber = &Subscriber{}

--- a/internal/engine/uisession/subscriber_test.go
+++ b/internal/engine/uisession/subscriber_test.go
@@ -1,0 +1,68 @@
+package uisession
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/tilt-dev/tilt/internal/store"
+)
+
+func TestCreate(t *testing.T) {
+	f := newFixture(t)
+	f.sub.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
+	assert.Equal(t, 1, len(f.store.Actions()))
+	assert.Equal(t, "Tiltfile", f.store.Actions()[0].(UISessionCreateAction).UISession.Name)
+
+	f.sub.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
+	assert.Equal(t, 1, len(f.store.Actions()))
+}
+
+func TestUpdate(t *testing.T) {
+	f := newFixture(t)
+	f.sub.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
+	assert.Equal(t, 1, len(f.store.Actions()))
+	assert.Equal(t, "Tiltfile", f.store.Actions()[0].(UISessionCreateAction).UISession.Name)
+
+	f.store.WithState(func(es *store.EngineState) {
+		es.CloudStatus.Username = "sparkle"
+	})
+
+	f.sub.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
+	assert.Equal(t, 2, len(f.store.Actions()))
+	assert.Equal(t, "sparkle", f.store.Actions()[1].(UISessionUpdateStatusAction).Status.TiltCloudUsername)
+}
+
+type testStore struct {
+	*store.TestingStore
+}
+
+func (s *testStore) Dispatch(a store.Action) {
+	s.TestingStore.Dispatch(a)
+
+	state := s.LockMutableStateForTesting()
+	defer s.UnlockMutableState()
+	switch a := a.(type) {
+	case UISessionUpdateStatusAction:
+		HandleUISessionUpdateStatusAction(state, a)
+	case UISessionCreateAction:
+		HandleUISessionCreateAction(state, a)
+	}
+}
+
+type fixture struct {
+	ctx   context.Context
+	store *testStore
+	sub   *Subscriber
+}
+
+func newFixture(t *testing.T) *fixture {
+	return &fixture{
+		ctx: context.Background(),
+		sub: NewSubscriber(),
+		store: &testStore{
+			TestingStore: store.NewTestingStore(),
+		},
+	}
+}

--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -146,9 +146,9 @@ func upperReducerFn(ctx context.Context, state *store.EngineState, action store.
 	case k8swatch.KubernetesDiscoveryDeleteAction:
 		k8swatch.HandleKubernetesDiscoveryDeleteAction(ctx, state, action)
 	case uisession.UISessionCreateAction:
-		uisession.HandleUISessionCreateAction(ctx, state, action)
+		uisession.HandleUISessionCreateAction(state, action)
 	case uisession.UISessionUpdateStatusAction:
-		uisession.HandleUISessionUpdateStatusAction(ctx, state, action)
+		uisession.HandleUISessionUpdateStatusAction(state, action)
 	case uiresource.UIResourceCreateAction:
 		uiresource.HandleUIResourceCreateAction(ctx, state, action)
 	case uiresource.UIResourceUpdateStatusAction:

--- a/internal/hud/server/websocket.go
+++ b/internal/hud/server/websocket.go
@@ -128,7 +128,7 @@ func (ws *WebsocketSubscriber) updateClientCheckpoint(msg *proto_webview.AckWebs
 	return nil
 }
 
-func (ws *WebsocketSubscriber) OnChange(ctx context.Context, s store.RStore, _ store.ChangeSummary) {
+func (ws *WebsocketSubscriber) OnChange(ctx context.Context, s store.RStore, summary store.ChangeSummary) {
 	checkpoint := ws.readClientCheckpoint()
 
 	state := s.RLockState()
@@ -142,7 +142,7 @@ func (ws *WebsocketSubscriber) OnChange(ctx context.Context, s store.RStore, _ s
 
 	ws.setTiltStartTime(tiltStartTime)
 
-	if view.UiSession.Status.NeedsAnalyticsNudge && !state.AnalyticsNudgeSurfaced {
+	if view.UiSession != nil && view.UiSession.Status.NeedsAnalyticsNudge && !state.AnalyticsNudgeSurfaced {
 		// If we're showing the nudge and no one's told the engine
 		// state about it yet... tell the engine state.
 		s.Dispatch(store.AnalyticsNudgeSurfacedAction{})

--- a/internal/hud/webview/convert.go
+++ b/internal/hud/webview/convert.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/tilt-dev/tilt/internal/cloud/cloudurl"
 	"github.com/tilt-dev/tilt/internal/store"
@@ -15,6 +16,10 @@ import (
 
 	proto_webview "github.com/tilt-dev/tilt/pkg/webview"
 )
+
+// We call the main session the Tiltfile session, for compatibility
+// with the other Session API.
+const UISessionName = "Tiltfile"
 
 func StateToProtoView(s store.EngineState, logCheckpoint logstore.Checkpoint) (*proto_webview.View, error) {
 	ret := &proto_webview.View{}
@@ -47,7 +52,7 @@ func StateToProtoView(s store.EngineState, logCheckpoint logstore.Checkpoint) (*
 	}
 
 	ret.LogList = logList
-	ret.UiSession = toUISession(s)
+	ret.UiSession = s.UISessions[types.NamespacedName{Name: UISessionName}]
 
 	// We grandfather in TiltStartTime from the old protocol,
 	// because it tells the UI to reload.
@@ -61,12 +66,10 @@ func StateToProtoView(s store.EngineState, logCheckpoint logstore.Checkpoint) (*
 }
 
 // Converts EngineState into the public data model representation, a UISession.
-func toUISession(s store.EngineState) *v1alpha1.UISession {
+func ToUISession(s store.EngineState) *v1alpha1.UISession {
 	ret := &v1alpha1.UISession{
 		ObjectMeta: metav1.ObjectMeta{
-			// We call the main session the Tiltfile session, for compatibility
-			// with the other Session API.
-			Name: "Tiltfile",
+			Name: UISessionName,
 		},
 		Status: v1alpha1.UISessionStatus{},
 	}

--- a/internal/hud/webview/convert_test.go
+++ b/internal/hud/webview/convert_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	"k8s.io/apimachinery/pkg/types"
+
 	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
 
 	"github.com/stretchr/testify/assert"
@@ -25,6 +27,7 @@ import (
 var fooManifest = model.Manifest{Name: "foo"}.WithDeployTarget(model.K8sTarget{})
 
 func stateToProtoView(t *testing.T, s store.EngineState) *proto_webview.View {
+	s.UISessions[types.NamespacedName{Name: UISessionName}] = ToUISession(s)
 	v, err := StateToProtoView(s, 0)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Hello @milas, @maiamcc,

Please review the following commits I made in branch nicks/uisession10:

317e380463c7e065904a927c9132c9a6b531fb22 (2021-05-07 18:14:00 -0400)
uisession: separate subscriber the writes UISession from code that reads it

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics