### PR TITLE
uiresource: separate subscriber that writes UIResource from code that reads it

### DIFF
--- a/internal/cloud/io_test.go
+++ b/internal/cloud/io_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/tilt-dev/tilt/internal/hud/webview"
@@ -15,9 +16,17 @@ import (
 func TestWriteSnapshotTo(t *testing.T) {
 	ctx, _, _ := testutils.CtxAndAnalyticsForTest()
 	buf := bytes.NewBuffer(nil)
+
 	state := store.NewState()
 	state.UISessions[types.NamespacedName{Name: webview.UISessionName}] = webview.ToUISession(*state)
-	err := WriteSnapshotTo(ctx, *state, buf)
+
+	resources, err := webview.ToUIResourceList(*state)
+	require.NoError(t, err)
+	for _, r := range resources {
+		state.UIResources[types.NamespacedName{Name: r.Name}] = r
+	}
+
+	err = WriteSnapshotTo(ctx, *state, buf)
 	assert.NoError(t, err)
 	assert.Equal(t, `{
   "view": {

--- a/internal/engine/uiresource/reducers.go
+++ b/internal/engine/uiresource/reducers.go
@@ -1,26 +1,29 @@
 package uiresource
 
 import (
-	"context"
-
 	"github.com/tilt-dev/tilt/internal/store"
 	"github.com/tilt-dev/tilt/pkg/apis"
+	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
 )
 
-func HandleUIResourceCreateAction(_ context.Context, state *store.EngineState, a UIResourceCreateAction) {
+func HandleUIResourceCreateAction(state *store.EngineState, a UIResourceCreateAction) {
 	key := apis.Key(a.UIResource)
 	if _, ok := state.UIResources[key]; !ok {
 		state.UIResources[key] = a.UIResource
 	}
 }
 
-func HandleUIResourceUpdateStatusAction(ctx context.Context, state *store.EngineState, a UIResourceUpdateStatusAction) {
+func HandleUIResourceUpdateStatusAction(state *store.EngineState, a UIResourceUpdateStatusAction) {
 	key := apis.KeyFromMeta(*a.ObjectMeta)
-	if _, ok := state.UIResources[key]; ok {
-		state.UIResources[key].Status = *a.Status
+	if orig, ok := state.UIResources[key]; ok {
+		state.UIResources[key] = &v1alpha1.UIResource{
+			ObjectMeta: orig.ObjectMeta,
+			Spec:       orig.Spec,
+			Status:     *a.Status,
+		}
 	}
 }
 
-func HandleUIResourceDeleteAction(_ context.Context, state *store.EngineState, a UIResourceDeleteAction) {
+func HandleUIResourceDeleteAction(state *store.EngineState, a UIResourceDeleteAction) {
 	delete(state.UIResources, a.Name)
 }

--- a/internal/engine/uiresource/subscriber.go
+++ b/internal/engine/uiresource/subscriber.go
@@ -2,18 +2,76 @@ package uiresource
 
 import (
 	"context"
+	"fmt"
 
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/tilt-dev/tilt/internal/hud/webview"
 	"github.com/tilt-dev/tilt/internal/store"
+	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
 )
 
+// Creates UIResource objects from the EngineState
 type Subscriber struct {
+	lastResources map[types.NamespacedName]*v1alpha1.UIResource
 }
 
 func NewSubscriber() *Subscriber {
-	return &Subscriber{}
+	return &Subscriber{
+		lastResources: make(map[types.NamespacedName]*v1alpha1.UIResource),
+	}
 }
 
-func (s *Subscriber) OnChange(ctx context.Context, store store.RStore, summary store.ChangeSummary) {
+func (s *Subscriber) currentResources(store store.RStore) ([]*v1alpha1.UIResource, error) {
+	state := store.RLockState()
+	defer store.RUnlockState()
+	return webview.ToUIResourceList(state)
+}
+
+func (s *Subscriber) OnChange(ctx context.Context, st store.RStore, summary store.ChangeSummary) {
+	if summary.IsLogOnly() {
+		return
+	}
+
+	currentResources, err := s.currentResources(st)
+	if err != nil {
+		st.Dispatch(store.NewErrorAction(fmt.Errorf("cannot convert UIResource: %v", err)))
+		return
+	}
+
+	// Collect a list of all the resources to reconcile and their most recent version.
+	toReconcile := make(map[types.NamespacedName]*v1alpha1.UIResource, len(currentResources))
+	for _, r := range s.lastResources {
+		toReconcile[types.NamespacedName{Name: r.Name}] = nil
+	}
+	for _, r := range currentResources {
+		toReconcile[types.NamespacedName{Name: r.Name}] = r
+	}
+
+	for name, current := range toReconcile {
+		if current == nil {
+			// If there's no current version of this resource, we should delete it.
+			st.Dispatch(NewUIResourceDeleteAction(name))
+			delete(s.lastResources, name)
+			continue
+		}
+
+		last, exists := s.lastResources[name]
+		if !exists {
+			// If there's a current version but no last version of this resource,
+			// create it.
+			st.Dispatch(NewUIResourceCreateAction(current))
+			s.lastResources[name] = current
+			continue
+		}
+
+		if !equality.Semantic.DeepEqual(last.Status, current.Status) {
+			// If the current version is different than the last version, update it.
+			st.Dispatch(NewUIResourceUpdateStatusAction(current))
+			s.lastResources[name] = current
+		}
+	}
 }
 
 var _ store.Subscriber = &Subscriber{}

--- a/internal/engine/uiresource/subscriber_test.go
+++ b/internal/engine/uiresource/subscriber_test.go
@@ -1,0 +1,112 @@
+package uiresource
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/tilt-dev/tilt/internal/k8s/testyaml"
+	"github.com/tilt-dev/tilt/internal/store"
+	"github.com/tilt-dev/tilt/internal/testutils/manifestbuilder"
+	"github.com/tilt-dev/tilt/internal/testutils/tempdir"
+	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
+)
+
+func TestCreate(t *testing.T) {
+	f := newFixture(t)
+	defer f.TearDown()
+
+	f.sub.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
+	assert.Equal(t, 1, len(f.store.Actions()))
+	assert.Equal(t, "(Tiltfile)",
+		f.store.Actions()[0].(UIResourceCreateAction).UIResource.Name)
+
+	f.sub.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
+	assert.Equal(t, 1, len(f.store.Actions()))
+}
+
+func TestUpdateTiltfile(t *testing.T) {
+	f := newFixture(t)
+	defer f.TearDown()
+
+	f.sub.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
+	assert.Equal(t, 1, len(f.store.Actions()))
+	assert.Equal(t, "(Tiltfile)",
+		f.store.Actions()[0].(UIResourceCreateAction).UIResource.Name)
+
+	f.store.WithState(func(es *store.EngineState) {
+		es.TiltfileState.CurrentBuild.StartTime = time.Now()
+	})
+
+	f.sub.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
+	assert.Equal(t, 2, len(f.store.Actions()))
+	assert.Equal(t, v1alpha1.UpdateStatusInProgress,
+		f.store.Actions()[1].(UIResourceUpdateStatusAction).Status.UpdateStatus)
+}
+
+func TestDeleteManifest(t *testing.T) {
+	f := newFixture(t)
+	defer f.TearDown()
+
+	f.store.WithState(func(state *store.EngineState) {
+		m := manifestbuilder.New(f, "fe").
+			WithK8sYAML(testyaml.SanchoYAML).
+			Build()
+		state.UpsertManifestTarget(store.NewManifestTarget(m))
+	})
+
+	f.sub.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
+	assert.Equal(t, 2, len(f.store.Actions()))
+	assert.Equal(t, "(Tiltfile)",
+		f.store.Actions()[0].(UIResourceCreateAction).UIResource.Name)
+	assert.Equal(t, "fe",
+		f.store.Actions()[1].(UIResourceCreateAction).UIResource.Name)
+
+	f.store.WithState(func(state *store.EngineState) {
+		state.RemoveManifestTarget("fe")
+	})
+
+	f.sub.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
+	assert.Equal(t, 3, len(f.store.Actions()))
+	assert.Equal(t, "fe",
+		f.store.Actions()[2].(UIResourceDeleteAction).Name.Name)
+}
+
+type testStore struct {
+	*store.TestingStore
+}
+
+func (s *testStore) Dispatch(a store.Action) {
+	s.TestingStore.Dispatch(a)
+
+	state := s.LockMutableStateForTesting()
+	defer s.UnlockMutableState()
+	switch a := a.(type) {
+	case UIResourceUpdateStatusAction:
+		HandleUIResourceUpdateStatusAction(state, a)
+	case UIResourceCreateAction:
+		HandleUIResourceCreateAction(state, a)
+	case UIResourceDeleteAction:
+		HandleUIResourceDeleteAction(state, a)
+	}
+}
+
+type fixture struct {
+	*tempdir.TempDirFixture
+	ctx   context.Context
+	store *testStore
+	sub   *Subscriber
+}
+
+func newFixture(t *testing.T) *fixture {
+	return &fixture{
+		TempDirFixture: tempdir.NewTempDirFixture(t),
+		ctx:            context.Background(),
+		sub:            NewSubscriber(),
+		store: &testStore{
+			TestingStore: store.NewTestingStore(),
+		},
+	}
+}

--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -150,11 +150,11 @@ func upperReducerFn(ctx context.Context, state *store.EngineState, action store.
 	case uisession.UISessionUpdateStatusAction:
 		uisession.HandleUISessionUpdateStatusAction(state, action)
 	case uiresource.UIResourceCreateAction:
-		uiresource.HandleUIResourceCreateAction(ctx, state, action)
+		uiresource.HandleUIResourceCreateAction(state, action)
 	case uiresource.UIResourceUpdateStatusAction:
-		uiresource.HandleUIResourceUpdateStatusAction(ctx, state, action)
+		uiresource.HandleUIResourceUpdateStatusAction(state, action)
 	case uiresource.UIResourceDeleteAction:
-		uiresource.HandleUIResourceDeleteAction(ctx, state, action)
+		uiresource.HandleUIResourceDeleteAction(state, action)
 	case store.PodResetRestartsAction:
 		handlePodResetRestartsAction(state, action)
 	case k8swatch.ServiceChangeAction:

--- a/internal/hud/webview/convert_test.go
+++ b/internal/hud/webview/convert_test.go
@@ -28,6 +28,13 @@ var fooManifest = model.Manifest{Name: "foo"}.WithDeployTarget(model.K8sTarget{}
 
 func stateToProtoView(t *testing.T, s store.EngineState) *proto_webview.View {
 	s.UISessions[types.NamespacedName{Name: UISessionName}] = ToUISession(s)
+
+	resources, err := ToUIResourceList(s)
+	require.NoError(t, err)
+	for _, r := range resources {
+		s.UIResources[types.NamespacedName{Name: r.Name}] = r
+	}
+
 	v, err := StateToProtoView(s, 0)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Hello @milas, @maiamcc,

Please review the following commits I made in branch nicks/uisession11:

522e3e21c3f897ad66c99e2bf82d15db6cfd31bf (2021-05-10 12:06:52 -0400)
uiresource: separate subscriber that writes UIResource from code that reads it

ab8aa236b4c1607d6425d528dd7097d0849bbff3 (2021-05-10 09:55:37 -0400)
uisession: separate subscriber the writes UISession from code that reads it

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics