### PR TITLE
cli: fix a bug in 'create filewatch'

### DIFF
--- a/internal/cli/create_filewatch.go
+++ b/internal/cli/create_filewatch.go
@@ -140,6 +140,10 @@ func (c *createFileWatchCmd) ignores() ([]v1alpha1.IgnoreDef, error) {
 		return nil, err
 	}
 
+	if len(c.ignoreValues) == 0 {
+		return nil, nil
+	}
+
 	result.BasePath = cwd
 	result.Patterns = append([]string{}, c.ignoreValues...)
 	return []v1alpha1.IgnoreDef{result}, nil


### PR DESCRIPTION
Hello @milas,

Please review the following commits I made in branch nicks/filewatch2:

57b06406e2cdee0324d56f4c0af86c1a8d627ed2 (2021-05-12 19:55:09 -0400)
cli: fix a bug in 'create filewatch'

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics