### PR TITLE
k8swatch: remove portforward warning

### DIFF
--- a/internal/engine/k8swatch/reducers.go
+++ b/internal/engine/k8swatch/reducers.go
@@ -10,7 +10,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/tilt-dev/tilt/internal/container"
-	"github.com/tilt-dev/tilt/internal/engine/portforward"
 	"github.com/tilt-dev/tilt/internal/k8s"
 	"github.com/tilt-dev/tilt/internal/store"
 	"github.com/tilt-dev/tilt/pkg/apis"
@@ -83,13 +82,8 @@ func UpdateK8sRuntimeState(ctx context.Context, state *store.EngineState, key ty
 		if !maybeUpdateStateForPod(ms, pod) {
 			continue
 		}
+
 		anyPodsUpdated = true
-		fwdsValid := portforward.PortForwardsAreValid(mt.Manifest, *pod)
-		if !fwdsValid {
-			logger.Get(ctx).Warnf(
-				"Resource %s is using port forwards, but no container ports on pod %s",
-				mn, pod.Name)
-		}
 	}
 
 	for podID := range krs.Pods {


### PR DESCRIPTION
Hello @maiamcc, @milas,

Please review the following commits I made in branch nicks/ch11991:

cbf578ac611d895c9426101a426aa22a671cedcd (2021-05-13 15:56:25 -0400)
k8swatch: remove portforward warning
This warning is incorrect. From https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#ports :

> List of ports to expose from the container. Exposing a port here gives the
> system additional information about the network connections a container uses,
> but is primarily informational.

I could imagine a better warning here in the future like "Hey, you're trying to
connect to port 1234, but the container says it's listening on 1235, was that
intentional?". But I don't think the current warning addresses that well.

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics