### PR TITLE
engine: fix a flaky test that depends on ui resource order

### DIFF
--- a/internal/engine/uiresource/subscriber_test.go
+++ b/internal/engine/uiresource/subscriber_test.go
@@ -2,6 +2,7 @@ package uiresource
 
 import (
 	"context"
+	"sort"
 	"testing"
 	"time"
 
@@ -59,10 +60,13 @@ func TestDeleteManifest(t *testing.T) {
 
 	f.sub.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
 	assert.Equal(t, 2, len(f.store.Actions()))
-	assert.Equal(t, "(Tiltfile)",
-		f.store.Actions()[0].(UIResourceCreateAction).UIResource.Name)
-	assert.Equal(t, "fe",
-		f.store.Actions()[1].(UIResourceCreateAction).UIResource.Name)
+
+	names := []string{
+		f.store.Actions()[0].(UIResourceCreateAction).UIResource.Name,
+		f.store.Actions()[1].(UIResourceCreateAction).UIResource.Name,
+	}
+	sort.Strings(names)
+	assert.Equal(t, []string{"(Tiltfile)", "fe"}, names)
 
 	f.store.WithState(func(state *store.EngineState) {
 		state.RemoveManifestTarget("fe")


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/flake3:

564bc3d09133d2ef19ee57fb5f5dc419a8376c04 (2021-05-17 18:40:53 -0400)
engine: fix a flaky test that depends on ui resource order

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics