### PR TITLE
test: dump apiserver state on integration test failure

### DIFF
--- a/integration/fixture_test.go
+++ b/integration/fixture_test.go
@@ -194,12 +194,28 @@ func (f *fixture) StartTearDown() {
 
 	isTiltStillUp := f.activeTiltUp != nil && f.activeTiltUp.Err() == nil
 	if f.t.Failed() && isTiltStillUp {
-		fmt.Printf("Test failed, dumping engine state\n----\n")
+		fmt.Printf("Test failed, dumping internals\n----\n")
+		fmt.Printf("Engine\n----\n")
 		err := f.tilt.DumpEngine(os.Stdout)
 		if err != nil {
-			fmt.Printf("Error: %v", err)
+			fmt.Printf("Error dumping engine: %v", err)
 		}
-		fmt.Printf("\n----\n")
+
+		fmt.Printf("\n----\nAPI Server\n----\n")
+		apiTypes, err := f.tilt.APIResources()
+		if err != nil {
+			fmt.Printf("Error determining available API resources: %v\n", err)
+		} else {
+			for _, apiType := range apiTypes {
+				fmt.Printf("\n----\n%s\n----\n", strings.ToUpper(apiType))
+				getOut, err := f.tilt.Get(apiType)
+				fmt.Print(string(getOut))
+				if err != nil {
+					fmt.Printf("Error getting %s: %v", apiType, err)
+				}
+				fmt.Printf("\n----\n")
+			}
+		}
 
 		err = f.activeTiltUp.KillAndDumpThreads()
 		if err != nil {

--- a/integration/tilt.go
+++ b/integration/tilt.go
@@ -1,6 +1,8 @@
 package integration
 
 import (
+	"bufio"
+	"bytes"
 	"fmt"
 	"go/build"
 	"io"
@@ -133,6 +135,29 @@ func (d *TiltDriver) Up(out io.Writer, args ...string) (*TiltUpResponse, error) 
 func (d *TiltDriver) Args(args []string, out io.Writer) error {
 	cmd := d.cmd(append([]string{"args"}, args...), out)
 	return cmd.Run()
+}
+
+func (d *TiltDriver) APIResources() ([]string, error) {
+	var out bytes.Buffer
+	cmd := d.cmd([]string{"api-resources", "-o=name"}, &out)
+	err := cmd.Run()
+	if err != nil {
+		return nil, err
+	}
+	var resources []string
+	s := bufio.NewScanner(&out)
+	for s.Scan() {
+		resources = append(resources, s.Text())
+	}
+	return resources, nil
+}
+
+func (d *TiltDriver) Get(apiType string, names ...string) ([]byte, error) {
+	var out bytes.Buffer
+	args := append([]string{"get", "-o=json", apiType}, names...)
+	cmd := d.cmd(args, &out)
+	err := cmd.Run()
+	return out.Bytes(), err
 }
 
 type TiltUpResponse struct {


### PR DESCRIPTION
Now that more and more state is in the apiserver, it's really
helpful to see its state when an integration test fails, particularly
for debugging issues where the engine state and apiserver are out
of sync.