### PR TITLE
logger: set PYTHONUNBUFFERED by default

### DIFF
--- a/pkg/logger/env.go
+++ b/pkg/logger/env.go
@@ -21,6 +21,7 @@ func PrepareEnv(l Logger, env []string) []string {
 	hasLines := false
 	hasColumns := false
 	hasForceColor := false
+	hasPythonUnbuffered := false
 
 	for _, e := range env {
 		// LINES and COLUMNS are posix standards.
@@ -30,6 +31,11 @@ func PrepareEnv(l Logger, env []string) []string {
 
 		// FORCE_COLOR is common in nodejs https://github.com/tilt-dev/tilt/issues/3038
 		hasForceColor = hasForceColor || strings.HasPrefix("FORCE_COLOR=", e)
+
+		// PYTHONUNBUFFERED tells old Python versions not to buffer their output (< Python 3.7)
+		// AIUI, older versions of Python buffer output aggressively when not connected to a TTY,
+		// because they assume they're connected to a file and don't need realtime streaming.
+		hasPythonUnbuffered = hasPythonUnbuffered || strings.HasPrefix("PYTHONUNBUFFERED=", e)
 	}
 
 	if !hasLines {
@@ -40,6 +46,9 @@ func PrepareEnv(l Logger, env []string) []string {
 	}
 	if !hasForceColor && supportsColor {
 		env = append(env, "FORCE_COLOR=1")
+	}
+	if !hasPythonUnbuffered {
+		env = append(env, "PYTHONUNBUFFERED=1")
 	}
 	return env
 }

--- a/pkg/logger/env_test.go
+++ b/pkg/logger/env_test.go
@@ -1,0 +1,31 @@
+package logger
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDefaultEnv(t *testing.T) {
+	out := &bytes.Buffer{}
+	ctx := WithLogger(context.Background(), NewLogger(DebugLvl, out))
+	assert.Equal(t, []string{
+		"LINES=24",
+		"COLUMNS=80",
+		"FORCE_COLOR=1",
+		"PYTHONUNBUFFERED=1",
+	}, PrepareEnv(Get(ctx), nil))
+}
+
+func TestPreservePythonUnbuffered(t *testing.T) {
+	out := &bytes.Buffer{}
+	ctx := WithLogger(context.Background(), NewLogger(DebugLvl, out))
+	assert.Equal(t, []string{
+		"PYTHONUNBUFFERED=",
+		"LINES=24",
+		"COLUMNS=80",
+		"FORCE_COLOR=1",
+	}, PrepareEnv(Get(ctx), []string{"PYTHONUNBUFFERED="}))
+}


### PR DESCRIPTION
Hello @milas,

Please review the following commits I made in branch nicks/ch12001:

8cfaeb2bd37ccdff9197c8b9323069cb4a1397d2 (2021-05-18 12:51:28 -0400)
logger: set PYTHONUNBUFFERED by default
fixes https://github.com/tilt-dev/tilt/issues/4558

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics