### PR TITLE
engine: fix a race condition in Tiltfile reload

### DIFF
--- a/internal/engine/buildcontrol/build_control.go
+++ b/internal/engine/buildcontrol/build_control.go
@@ -20,7 +20,8 @@ func NextTargetToBuild(state store.EngineState) (*store.ManifestTarget, HoldSet)
 
 	// Don't build anything if there are pending config file changes.
 	// We want the Tiltfile to re-run first.
-	if len(state.PendingConfigFileChanges) > 0 {
+	tiltfileHasPendingChanges, _ := state.TiltfileState.HasPendingChanges()
+	if tiltfileHasPendingChanges {
 		holds.Fill(targets, store.HoldTiltfileReload)
 		return nil, holds
 	}

--- a/internal/engine/configs/configs_controller.go
+++ b/internal/engine/configs/configs_controller.go
@@ -83,10 +83,9 @@ func (cc *ConfigsController) needsBuild(ctx context.Context, st store.RStore) (b
 		reason = reason.With(model.BuildReasonFlagInit)
 	}
 
-	for _, changeTime := range state.PendingConfigFileChanges {
-		if changeTime.After(lastStartTime) {
-			reason = reason.With(model.BuildReasonFlagChangedFiles)
-		}
+	hasPendingChanges, _ := tfState.HasPendingChanges()
+	if hasPendingChanges {
+		reason = reason.With(model.BuildReasonFlagChangedFiles)
 	}
 
 	if state.UserConfigState.ArgsChangeTime.After(lastStartTime) {
@@ -101,9 +100,11 @@ func (cc *ConfigsController) needsBuild(ctx context.Context, st store.RStore) (b
 		return buildEntry{}, false
 	}
 
-	filesChanged := make([]string, 0, len(state.PendingConfigFileChanges))
-	for k := range state.PendingConfigFileChanges {
-		filesChanged = append(filesChanged, k)
+	filesChanged := []string{}
+	for _, st := range state.TiltfileState.BuildStatuses {
+		for k := range st.PendingFileChanges {
+			filesChanged = append(filesChanged, k)
+		}
 	}
 	filesChanged = sliceutils.DedupedAndSorted(filesChanged)
 

--- a/internal/engine/configs/configs_controller_test.go
+++ b/internal/engine/configs/configs_controller_test.go
@@ -176,7 +176,10 @@ func newCCFixture(t *testing.T) *ccFixture {
 
 	state := st.LockMutableStateForTesting()
 	state.TiltfilePath = f.JoinPath("Tiltfile")
-	state.PendingConfigFileChanges["Tiltfile"] = time.Now()
+	state.TiltfileState.AddPendingFileChange(model.TargetID{
+		Type: model.TargetTypeConfigs,
+		Name: "singleton",
+	}, f.JoinPath("Tiltfile"), time.Now())
 	st.UnlockMutableState()
 
 	return &ccFixture{

--- a/internal/engine/fswatch/action.go
+++ b/internal/engine/fswatch/action.go
@@ -122,13 +122,6 @@ func processFileWatchStatus(ctx context.Context, state *store.EngineState, fw *f
 		return
 	}
 
-	if targetID.Type == model.TargetTypeConfigs {
-		for _, f := range latestEvent.SeenFiles {
-			state.PendingConfigFileChanges[f] = latestEvent.Time.Time
-		}
-		return
-	}
-
 	mns := state.ManifestNamesForTargetID(targetID)
 	for _, mn := range mns {
 		ms, ok := state.ManifestState(mn)

--- a/internal/engine/session/conv.go
+++ b/internal/engine/session/conv.go
@@ -265,7 +265,7 @@ func tiltfileTarget(state store.EngineState) session.Target {
 		target.State.Active = &session.TargetStateActive{
 			StartTime: apis.NewMicroTime(state.TiltfileState.CurrentBuild.StartTime),
 		}
-	} else if len(state.PendingConfigFileChanges) != 0 {
+	} else if hasPendingChanges, _ := state.TiltfileState.HasPendingChanges(); hasPendingChanges {
 		target.State.Waiting = &session.TargetStateWaiting{
 			WaitReason: "config-changed",
 		}


### PR DESCRIPTION
Hello @milas,

Please review the following commits I made in branch nicks/miss:

7b2ea03e1eb6cd9cd72c1d3d5bbb80706341347f (2021-05-18 17:45:30 -0400)
engine: fix a race condition in Tiltfile reload
PendingConfigFileChanges had its own change tracking,
which didn't get the fixes we applied in
https://github.com/tilt-dev/tilt/pull/4397

This removes that state completely and unifies
Tiltfile change tracking with other stuff

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics