### PR TITLE
rollout: make clear when tilt is attaching to an existing pod rather than rolling out a new one

### DIFF
--- a/internal/engine/k8srollout/podmonitor_test.go
+++ b/internal/engine/k8srollout/podmonitor_test.go
@@ -218,7 +218,3 @@ func (s *testStore) Dispatch(action store.Action) {
 		_, _ = s.out.Write(logAction.Message())
 	}
 }
-
-func normalize(s string) string {
-	return strings.Replace(s, "\r\n", "\n", -1)
-}

--- a/internal/engine/k8srollout/podmonitor_test.go
+++ b/internal/engine/k8srollout/podmonitor_test.go
@@ -2,33 +2,23 @@ package k8srollout
 
 import (
 	"context"
-	"fmt"
 	"io"
-	"io/ioutil"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
-
-	"github.com/tilt-dev/tilt/pkg/apis"
-
-	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
-
-	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 
 	"github.com/tilt-dev/tilt/internal/store"
 	"github.com/tilt-dev/tilt/internal/testutils/bufsync"
 	"github.com/tilt-dev/tilt/internal/testutils/manifestutils"
 	"github.com/tilt-dev/tilt/internal/testutils/tempdir"
+	"github.com/tilt-dev/tilt/pkg/apis"
+	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
 	"github.com/tilt-dev/tilt/pkg/logger"
 	"github.com/tilt-dev/tilt/pkg/model"
 )
-
-// NOTE(han): set at runtime with:
-// go test -ldflags="-X 'github.com/tilt-dev/tilt/internal/engine/k8srollout.PodmonitorWriteGoldenMaster=1'" ./internal/engine/k8srollout
-var PodmonitorWriteGoldenMaster = "0"
 
 func TestMonitorReady(t *testing.T) {
 	f := newPMFixture(t)
@@ -37,34 +27,42 @@ func TestMonitorReady(t *testing.T) {
 	start := time.Now()
 	p := v1alpha1.Pod{
 		Name:      "pod-id",
-		CreatedAt: apis.NewTime(start),
+		CreatedAt: apis.NewTime(start.Add(5 * time.Second)),
 		Conditions: []v1alpha1.PodCondition{
 			{
 				Type:               string(v1.PodScheduled),
 				Status:             string(v1.ConditionTrue),
-				LastTransitionTime: apis.NewTime(start.Add(time.Second)),
+				LastTransitionTime: apis.NewTime(start.Add(6 * time.Second)),
 			},
 			{
 				Type:               string(v1.PodInitialized),
 				Status:             string(v1.ConditionTrue),
-				LastTransitionTime: apis.NewTime(start.Add(5 * time.Second)),
+				LastTransitionTime: apis.NewTime(start.Add(10 * time.Second)),
 			},
 			{
 				Type:               string(v1.PodReady),
 				Status:             string(v1.ConditionTrue),
-				LastTransitionTime: apis.NewTime(start.Add(10 * time.Second)),
+				LastTransitionTime: apis.NewTime(start.Add(15 * time.Second)),
 			},
 		},
 	}
 
 	state := store.NewState()
-	state.UpsertManifestTarget(manifestutils.NewManifestTargetWithPod(
-		model.Manifest{Name: "server"}, p))
-	f.store.SetState(*state)
+	mt := manifestutils.NewManifestTargetWithPod(model.Manifest{Name: "server"}, p)
+	mt.State.BuildHistory = []model.BuildRecord{{StartTime: start}}
+	state.UpsertManifestTarget(mt)
 
-	f.pm.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
+	f.onChange(*state)
 
-	assertSnapshot(t, f.out.String())
+	expectedLines := []string{
+		"Tracking new pod rollout (pod-id):",
+		"     ┊ Scheduled       - 1s",
+		"     ┊ Initialized     - 4s",
+		"     ┊ Ready           - 5s",
+	}
+	actualLines := strings.Split(strings.TrimSpace(f.out.String()), "\n")
+
+	require.Equal(t, expectedLines, actualLines)
 }
 
 func TestAttachToExistingPod(t *testing.T) {
@@ -95,26 +93,69 @@ func TestAttachToExistingPod(t *testing.T) {
 	}
 
 	state := store.NewState()
+	mt := manifestutils.NewManifestTargetWithPod(model.Manifest{Name: "server"}, p)
+	mt.State.BuildHistory = []model.BuildRecord{{StartTime: start.Add(20 * time.Second)}}
+	state.UpsertManifestTarget(mt)
 
-	setBuildFinishTime := func(ft time.Time) {
-		mt := manifestutils.NewManifestTargetWithPod(
-			model.Manifest{Name: "server"}, p)
-		mt.State.BuildHistory = []model.BuildRecord{{FinishTime: ft}}
-		state.UpsertManifestTarget(mt)
-		f.store.SetState(*state)
-	}
+	f.onChange(*state)
 
-	setBuildFinishTime(start.Add(20 * time.Second))
-	f.pm.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
-
-	// a previous implementation of this wouldn't re-log pod info on subsequent builds, so
-	// make sure if we attach to an existing pod twice, we get a log each time
-	setBuildFinishTime(start.Add(30 * time.Second))
-	f.pm.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
+	// make sure we log every time a build finishes
+	mt.State.AddCompletedBuild(model.BuildRecord{StartTime: start.Add(30 * time.Second)})
+	state.UpsertManifestTarget(mt)
+	f.onChange(*state)
 
 	// two builds, two logs
-	msg := "Using existing pod that matches spec (pod-id)\n\nUsing existing pod that matches spec (pod-id)"
-	require.Contains(t, f.out.String(), msg)
+	msg := "Existing pod still matches build (pod-id)\n\nExisting pod still matches build (pod-id)"
+	require.Equal(t, msg, strings.TrimSpace(f.out.String()))
+}
+
+func TestAttachToExistingPodDuringActiveBuild(t *testing.T) {
+	f := newPMFixture(t)
+	defer f.TearDown()
+
+	start := time.Now()
+	p := v1alpha1.Pod{
+		Name:      "pod-id",
+		CreatedAt: apis.NewTime(start),
+		Conditions: []v1alpha1.PodCondition{
+			{
+				Type:               string(v1.PodScheduled),
+				Status:             string(v1.ConditionTrue),
+				LastTransitionTime: apis.NewTime(start.Add(time.Second)),
+			},
+			{
+				Type:               string(v1.PodInitialized),
+				Status:             string(v1.ConditionTrue),
+				LastTransitionTime: apis.NewTime(start.Add(5 * time.Second)),
+			},
+			{
+				Type:               string(v1.PodReady),
+				Status:             string(v1.ConditionTrue),
+				LastTransitionTime: apis.NewTime(start.Add(10 * time.Second)),
+			},
+		},
+	}
+
+	state := store.NewState()
+
+	// the manifest knows about the pod, and there is a build in progress
+	mt := manifestutils.NewManifestTargetWithPod(model.Manifest{Name: "server"}, p)
+	mt.State.BuildHistory = []model.BuildRecord{{StartTime: start}}
+	mt.State.CurrentBuild = model.BuildRecord{StartTime: start.Add(15 * time.Second)}
+	state.UpsertManifestTarget(mt)
+	f.onChange(*state)
+
+	// nothing should be logged while a build is in progress
+	require.Equal(t, "", f.out.String())
+
+	mt.State.AddCompletedBuild(mt.State.CurrentBuild)
+	mt.State.CurrentBuild = model.BuildRecord{}
+	state.UpsertManifestTarget(mt)
+	f.onChange(*state)
+
+	// now that the build has finished, we should recognize the pod
+	msg := "Existing pod still matches build (pod-id)"
+	require.Equal(t, msg, strings.TrimSpace(f.out.String()))
 }
 
 type pmFixture struct {
@@ -152,6 +193,11 @@ func (f *pmFixture) TearDown() {
 	f.TempDirFixture.TearDown()
 }
 
+func (f *pmFixture) onChange(state store.EngineState) {
+	f.store.SetState(state)
+	f.pm.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
+}
+
 type testStore struct {
 	*store.TestingStore
 	out io.Writer
@@ -171,23 +217,6 @@ func (s *testStore) Dispatch(action store.Action) {
 	if ok {
 		_, _ = s.out.Write(logAction.Message())
 	}
-}
-
-func assertSnapshot(t *testing.T, output string) {
-	d1 := []byte(output)
-	gmPath := fmt.Sprintf("testdata/%s_master", t.Name())
-	if PodmonitorWriteGoldenMaster == "1" {
-		err := ioutil.WriteFile(gmPath, d1, 0644)
-		if err != nil {
-			t.Fatal(err)
-		}
-	}
-	expected, err := ioutil.ReadFile(gmPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	assert.Equal(t, normalize(string(expected)), normalize(output))
 }
 
 func normalize(s string) string {


### PR DESCRIPTION
Fixes #4566

### Problems

1. When you run `tilt up` and the existing pod suffices, the tilt log still makes it look like it's rolling out a new pod, which is confusing:
```
Tracking new pod rollout (matt-fortune-6b8dc4dc74-24llm):
     ┊ Scheduled       - <1s
     ┊ Initialized     - <1s
     ┊ Ready           - 2s
```
2. On subsequent builds where the existing pod suffices, tilt will just omit that section entirely and not log anything in its place, which feels kind of weird (e.g, "why hasn't it rolled the pod out yet?"), and also leaves the user in the position of seeing runtime logs from the pod without seeing any of the startup logs they might expect, with no explanation
```
     2b7fb36704d4: Layer already exists 
     c1df871adf38: Layer already exists 
     503e53e365f3: Layer already exists 

STEP 3/3 — Deploying
     Injecting images into Kubernetes YAML
     Applying via kubectl:
     → myprefix-matt-vigoda:deployment

     Step 1 - 0.76s (Building Dockerfile: [vigoda])
     Step 2 - 0.12s (Pushing localhost:50380/vigoda:tilt-bfed53112d6c0507)
     Step 3 - 0.01s (Deploying)
     DONE IN: 0.89s 

2021/05/19 20:47:20 Server status: All good
2021/05/19 20:47:32 Server status: All good
```

### Solution

Have the rollout logger explicitly log when Tilt is using an existing pod instead of rolling out a new one, and do it on every build, e.g.:

```
STEP 3/3 — Deploying
     Injecting images into Kubernetes YAML
     Applying via kubectl:
     → myprefix-matt-vigoda:deployment

     Step 1 - 0.67s (Building Dockerfile: [vigoda])
     Step 2 - 0.09s (Pushing localhost:50380/vigoda:tilt-bfed53112d6c0507)
     Step 3 - 0.01s (Deploying)
     DONE IN: 0.77s 


Using existing pod that matches spec (myprefix-matt-vigoda-5c75bf9577-mb47n)
2021/05/19 21:02:32 Server status: All good
```

note this also affects live update, which is probably fine? (also this means the update log now has the pod id, which I think is nice)
```
STEP 1/1 — updating image localhost:50380/fortune
     Updating container: c796b906b3
Will copy 1 file(s) to container: c796b906b3
- '/Users/matt/go/src/github.com/tilt-dev/servantes/fortune/main.go' --> '/go/src/github.com/tilt-dev/servantes/fortune/main.go'
[CMD 1/3] sh -c cd src/github.com/tilt-dev/servantes/fortune && make proto
protoc --go_out=. -I. api/fortune.proto
[CMD 2/3] sh -c go install github.com/tilt-dev/servantes/fortune
[CMD 3/3] sh -c date > /tmp/.restart-proc
  → Container c796b906b3 updated!

     Step 1 - 0.59s (updating image localhost:50380/fortune)
     DONE IN: 0.59s 


Using existing pod that matches spec (myprefix-matt-fortune-6b8dc4dc74-7zq9p)
2021/05/19 21:03:28 Starting Fortune Service on :8082!!
```

1. It feels a bit weird to have this line hanging out here by itself and it'd probably be better to put in the build log, but this was cheap and is probably better than status quo? (and implementation-wise it's nice to have this logic in the same place for rollout vs attach)
2. I don't think "Using existing pod that matches spec" will do a great job of getting the point across, but I've struggled to come up with anything better, and would appreciate suggestions!