### PR TITLE
web: fix issue with UI becoming inaccessible to assistive tech when snapshot modal is opened

### DIFF
--- a/web/src/AccountMenu.test.tsx
+++ b/web/src/AccountMenu.test.tsx
@@ -8,6 +8,9 @@ import {
 } from "./AccountMenu"
 
 beforeEach(() => {
+  // Note: `body` is used as the app element _only_ in a test env
+  // since the app root element isn't available; in prod, it should
+  // be set as the app root so that accessibility features are set correctly
   ReactModal.setAppElement(document.body)
 })
 

--- a/web/src/FatalErrorModal.test.tsx
+++ b/web/src/FatalErrorModal.test.tsx
@@ -10,6 +10,9 @@ let originalCreatePortal = ReactDOM.createPortal
 
 describe("FatalErrorModal", () => {
   beforeEach(() => {
+    // Note: `body` is used as the app element _only_ in a test env
+    // since the app root element isn't available; in prod, it should
+    // be set as the app root so that accessibility features are set correctly
     ReactModal.setAppElement(document.body)
     let mock: any = (node: any) => node
     ReactDOM.createPortal = mock

--- a/web/src/HUD.test.tsx
+++ b/web/src/HUD.test.tsx
@@ -9,6 +9,9 @@ import SocketBar from "./SocketBar"
 import { oneResourceView } from "./testdata"
 import { SocketState } from "./types"
 
+// Note: `body` is used as the app element _only_ in a test env
+// since the app root element isn't available; in prod, it should
+// be set as the app root so that accessibility features are set correctly
 ReactModal.setAppElement(document.body)
 
 declare global {

--- a/web/src/ShareSnapshotModal.stories.tsx
+++ b/web/src/ShareSnapshotModal.stories.tsx
@@ -2,7 +2,7 @@ import React from "react"
 import ReactModal from "react-modal"
 import ShareSnapshotModal from "./ShareSnapshotModal"
 
-ReactModal.setAppElement(document.body)
+ReactModal.setAppElement("#root")
 
 let handleSendSnapshot = () => console.log("sendSnapshot")
 let handleClose = () => console.log("close")

--- a/web/src/ShareSnapshotModal.test.tsx
+++ b/web/src/ShareSnapshotModal.test.tsx
@@ -10,6 +10,9 @@ let originalCreatePortal = ReactDOM.createPortal
 
 describe("ShareSnapshotModal", () => {
   beforeEach(() => {
+    // Note: `body` is used as the app element _only_ in a test env
+    // since the app root element isn't available; in prod, it should
+    // be set as the app root so that accessibility features are set correctly
     ReactModal.setAppElement(document.body)
     let mock: any = (node: any) => node
     ReactDOM.createPortal = mock

--- a/web/src/ShareSnapshotModal.tsx
+++ b/web/src/ShareSnapshotModal.tsx
@@ -24,7 +24,7 @@ export default class ShareSnapshotModal extends PureComponent<props> {
         isOpen={this.props.isOpen}
         className="ShareSnapshotModal"
       >
-        <h2 className="ShareSnapshotModal-title">Share a Shapshot</h2>
+        <h2 className="ShareSnapshotModal-title">Share a Snapshot</h2>
         <section className="ShareSnapshotModal-pane u-flexColumn">
           <p className="ShareSnapshotModal-description">
             Get a link to a{" "}

--- a/web/src/__snapshots__/ShareSnapshotModal.test.tsx.snap
+++ b/web/src/__snapshots__/ShareSnapshotModal.test.tsx.snap
@@ -30,7 +30,7 @@ exports[`ShareSnapshotModal renders team link 1`] = `
     <h2
       className="ShareSnapshotModal-title"
     >
-      Share a Shapshot
+      Share a Snapshot
     </h2>
     <section
       className="ShareSnapshotModal-pane u-flexColumn"
@@ -155,7 +155,7 @@ exports[`ShareSnapshotModal renders with modal open w/ known username 1`] = `
     <h2
       className="ShareSnapshotModal-title"
     >
-      Share a Shapshot
+      Share a Snapshot
     </h2>
     <section
       className="ShareSnapshotModal-pane u-flexColumn"
@@ -260,7 +260,7 @@ exports[`ShareSnapshotModal renders with modal open w/o known username 1`] = `
     <h2
       className="ShareSnapshotModal-title"
     >
-      Share a Shapshot
+      Share a Snapshot
     </h2>
     <section
       className="ShareSnapshotModal-pane u-flexColumn"
@@ -372,7 +372,7 @@ exports[`ShareSnapshotModal renders without snapshotUrl 1`] = `
     <h2
       className="ShareSnapshotModal-title"
     >
-      Share a Shapshot
+      Share a Snapshot
     </h2>
     <section
       className="ShareSnapshotModal-pane u-flexColumn"

--- a/web/src/index.tsx
+++ b/web/src/index.tsx
@@ -6,7 +6,7 @@ import { HUDFromContext } from "./HUD"
 import "./index.scss"
 import { InterfaceVersionProvider } from "./InterfaceVersion"
 
-ReactModal.setAppElement(document.body)
+ReactModal.setAppElement("#root")
 
 let app = (
   <BrowserRouter>


### PR DESCRIPTION
This PR fixes issue #4424, where a user reports that they have trouble interacting with the UI using VoiceOver after the `Make a snapshot` button is clicked. I was able to reproduce the issue with VO and saw that `aria-hidden=true` was set on the `body` whenever the snapshot modal was visible. :sob:

The docs for `ReactModal` specify that the (`setAppElement`)[http://reactcommunity.org/react-modal/accessibility/] should be called on the app root so that the component can hide the main app content while the modal is displaying. Updating that method call with the app root id, instead of the document `body` fixed the issue. 

~I'm not sure how we want to fix the tests since the app root isn't available in the testing environment. (Probably just the limits of my react testing knowledge!) `ReactModal` does expose an option to turn off its ARIA-property management which we could add support for. Not setting the app element is an option, too, but it adds a bunch of noisy warning logs to the tests.~

Thanks to @hyu for pairing with me!