### PR TITLE
local: do not run serve_cmd with auto_init=False on start

### DIFF
--- a/internal/store/manifest_target.go
+++ b/internal/store/manifest_target.go
@@ -29,11 +29,6 @@ func (mt *ManifestTarget) UpdateStatus() v1alpha1.UpdateStatus {
 	m := mt.Manifest
 	us := mt.State.UpdateStatus(m.TriggerMode)
 
-	if us == v1alpha1.UpdateStatusPending {
-		// A resource with no update command can still be in pending mode.
-		return us
-	}
-
 	if m.IsLocal() && m.LocalTarget().UpdateCmd.Empty() {
 		// NOTE(nick): We currently model a local_resource(serve_cmd) as a Manifest
 		// with a no-op Update. BuildController treats it like any other
@@ -48,16 +43,23 @@ func (mt *ManifestTarget) UpdateStatus() v1alpha1.UpdateStatus {
 			return v1alpha1.UpdateStatusPending
 		}
 
-		// If the local_resource has auto_init=False and has not built yet (i.e. it has
-		// not been manually triggered), use UpdateStatusNone to indicate that the resource
-		// has not yet had a reason to trigger so that it blocks the serve_cmd from executing.
-		// Once manually triggered, a no-op build will exist, and subsequent calls will return
-		// UpdateStatusNotApplicable so that the server controller knows it does not need to
-		// wait for anything.
-		if !m.TriggerMode.AutoInitial() && !mt.State.StartedFirstBuild() {
-			return v1alpha1.UpdateStatusNone
+		if us == v1alpha1.UpdateStatusOK {
+			// The no-op build job completed, but it's confusing/misleading to show
+			// the status of something non-existent as having succeeded, so instead
+			// return the special N/A status so that it can be distinguished from a
+			// true update.
+			//
+			// Note that for local resources with auto_init=False that have not been
+			// triggered, the update status will be UpdateStatusNone until such a time
+			// as they are triggered, and will be UpdateStatusNotApplicable thereafter.
+			//
+			// This is a bit odd, but currently this is how the server controller
+			// determines whether to launch the serve_cmd, so it needs to be able to
+			// distinguish between "resource has never been triggered" (so the server
+			// should not be launched) and "resource has been triggered but has no
+			// update command to wait for" (and thus the server should be launched).
+			return v1alpha1.UpdateStatusNotApplicable
 		}
-		return v1alpha1.UpdateStatusNotApplicable
 	}
 
 	return us


### PR DESCRIPTION
If a `local_resource` had no `update_cmd` (i.e. just a `serve_cmd`)
but was set to `auto_init=False`, it would end up starting anyway
because the server controller saw that the dependency status was
`not_applicable` (technically true).

To fix this, the dependency status is set to `none` for local
resources with `auto_init=False` that have not yet had a build
(either from being manually triggered or having `TRIGGER_MODE_AUTO`
and a file change). Once a build has happened, it will resume
returning `not_applicable` to indicate that there is no longer a
reason to block on a dependency.

Fixes #4548.