### PR TITLE
test: upgrade integration tests to use kind 0.11

### DIFF
--- a/.circleci/Dockerfile.integration
+++ b/.circleci/Dockerfile.integration
@@ -34,7 +34,8 @@ RUN go get gotest.tools/gotestsum
 RUN apt update && apt install -y jq
 
 # install Kind (Kubernetes in Docker)
-RUN curl -fLo ./kind-linux-amd64 https://github.com/kubernetes-sigs/kind/releases/download/v0.10.0/kind-linux-amd64 \
+ENV KIND_VERSION=v0.11.0
+RUN curl -fLo ./kind-linux-amd64 https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-linux-amd64 \
   && chmod +x ./kind-linux-amd64 \
   && mv ./kind-linux-amd64 /go/bin/kind
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,7 +87,7 @@ jobs:
 
   build-integration:
     docker:
-      - image: gcr.io/windmill-public-containers/tilt-integration-ci@sha256:0015947db3c4200b50c90d32deddca0a56ccabcc53e43d34edd45bd9b7d42a98
+      - image: gcr.io/windmill-public-containers/tilt-integration-ci@sha256:63c00a2aa79dc1dff7537329dcc8b5598285e793f2c1d53298b08f9d8def6008
     steps:
       - checkout
       - run: echo 'export PATH=/go/bin:$PATH' >> $BASH_ENV


### PR DESCRIPTION
Hello @landism,

Please review the following commits I made in branch nicks/kind11:

984c1a1372e633ef41016bb42461f67c8daa3620 (2021-05-20 12:42:22 -0400)
test: upgrade integration tests to use kind 0.11

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics