### PR TITLE
apis: add omitempty/optional annotations

### DIFF
--- a/pkg/apis/core/v1alpha1/generated.proto
+++ b/pkg/apis/core/v1alpha1/generated.proto
@@ -841,48 +841,60 @@ message TargetStateWaiting {
 // Information about the running tilt binary.
 message TiltBuild {
   // A semantic version string.
+  // +optional
   optional string version = 1;
 
   // The Git digest of the commit this binary was built at.
+  // +optional
   optional string commitSHA = 2;
 
   // A human-readable string representing when the binary was built.
+  // +optional
   optional string date = 3;
 
   // Indicates whether this is a development build (true) or an official release (false).
+  // +optional
   optional bool dev = 4;
 }
 
 // UIBuildRunning respresents an in-progress build/update in the user interface.
 message UIBuildRunning {
   // The time when the build started.
+  // +optional
   optional k8s.io.apimachinery.pkg.apis.meta.v1.MicroTime startTime = 1;
 
   // The log span where the build logs are stored in the logstore.
+  // +optional
   optional string spanID = 2;
 }
 
 // UIBuildRunning respresents a finished build/update in the user interface.
 message UIBuildTerminated {
   // A non-empty string if the build failed with an error.
+  // +optional
   optional string error = 1;
 
   // A list of warnings encountered while running the build.
   // These warnings will also be printed to the build's log.
+  // +optional
   repeated string warnings = 2;
 
   // The time when the build started.
+  // +optional
   optional k8s.io.apimachinery.pkg.apis.meta.v1.MicroTime startTime = 3;
 
   // The time when the build finished.
+  // +optional
   optional k8s.io.apimachinery.pkg.apis.meta.v1.MicroTime finishTime = 4;
 
   // The log span where the build logs are stored in the logstore.
+  // +optional
   optional string spanID = 5;
 
   // A crash rebuild happens when Tilt live-updated a container, then
   // the pod crashed, wiping out the live-updates. Tilt does a full
   // build+deploy to reset the pod state to what's on disk.
+  // +optional
   optional bool isCrashRebuild = 6;
 }
 
@@ -897,9 +909,11 @@ message UIBuildTerminated {
 // with a Tilt contributor).
 message UIFeatureFlag {
   // The name of the flag.
+  // +optional
   optional string name = 1;
 
   // The value of the flag.
+  // +optional
   optional bool value = 2;
 }
 
@@ -923,41 +937,52 @@ message UIResourceKubernetes {
   //
   // The active pod tends to be what Tilt defaults to for port-forwards,
   // live-updates, etc.
+  // +optional
   optional string podName = 1;
 
   // The creation time of the active pod.
+  // +optional
   optional k8s.io.apimachinery.pkg.apis.meta.v1.Time podCreationTime = 2;
 
   // The last update time of the active pod
+  // +optional
   optional k8s.io.apimachinery.pkg.apis.meta.v1.Time podUpdateStartTime = 3;
 
   // The status of the active pod.
+  // +optional
   optional string podStatus = 4;
 
   // Extra error messaging around the current status of the active pod.
+  // +optional
   optional string podStatusMessage = 5;
 
   // Whether all the containers in the pod are currently healthy
   // and have passed readiness checks.
+  // +optional
   optional bool allContainersReady = 6;
 
   // The number of pod restarts.
+  // +optional
   optional int32 podRestarts = 7;
 
   // The span where this pod stores its logs in the Tilt logstore.
+  // +optional
   optional string spanID = 8;
 
   // The list of all resources deployed in the Kubernetes deploy
   // for this resource.
+  // +optional
   repeated string displayNames = 9;
 }
 
 // UIResourceLink represents a link assocatiated with a UIResource.
 message UIResourceLink {
   // A URL to link to.
+  // +optional
   optional string url = 1;
 
   // The display label on a URL.
+  // +optional
   optional string name = 2;
 }
 
@@ -972,9 +997,11 @@ message UIResourceList {
 // UIResourceLocal contains status information specific to local commands.
 message UIResourceLocal {
   // The PID of the actively running local command.
+  // +optional
   optional int64 pid = 1;
 
   // Whether this represents a test job.
+  // +optional
   optional bool isTest = 2;
 }
 
@@ -987,37 +1014,47 @@ message UIResourceSpec {
 // UIResourceStatus defines the observed state of UIResource
 message UIResourceStatus {
   // The last time this resource was deployed.
+  // +optional
   optional k8s.io.apimachinery.pkg.apis.meta.v1.MicroTime lastDeployTime = 1;
 
   // Bit mask representing whether this resource is run when:
   // 1) When a file changes
   // 2) When the resource initializes
+  // +optional
   optional int32 triggerMode = 2;
 
   // Past completed builds.
+  // +optional
   repeated UIBuildTerminated buildHistory = 3;
 
   // The currently running build, if any.
+  // +optional
   optional UIBuildRunning currentBuild = 4;
 
   // When the build was put in the pending queue.
+  // +optional
   optional k8s.io.apimachinery.pkg.apis.meta.v1.MicroTime pendingBuildSince = 5;
 
   // True if the build was put in the pending queue due to file changes.
+  // +optional
   optional bool hasPendingChanges = 6;
 
   // Links attached to this resource.
+  // +optional
   repeated UIResourceLink endpointLinks = 7;
 
   // Extra data about Kubernetes resources.
+  // +optional
   optional UIResourceKubernetes k8sResourceInfo = 8;
 
   // Extra data about Local resources
+  // +optional
   optional UIResourceLocal localResourceInfo = 9;
 
   // The RuntimeStatus is a simple, high-level summary of the runtime state of a server.
   //
   // Not all resources run servers.
+  // +optional
   optional string runtimeStatus = 10;
 
   // The UpdateStatus is a simple, high-level summary of any update tasks to bring
@@ -1025,24 +1062,30 @@ message UIResourceStatus {
   //
   // If the resource runs a server, this may include both build tasks and live-update
   // syncing.
+  // +optional
   optional string updateStatus = 14;
 
   // Information about all the target specs that this resource summarizes.
+  // +optional
   repeated UIResourceTargetSpec specs = 12;
 
   // Queued is a simple indicator of whether the resource is queued for an update.
+  // +optional
   optional bool queued = 13;
 }
 
 // UIResourceTargetSpec represents the spec of a build or deploy that a resource summarizes.
 message UIResourceTargetSpec {
   // The ID of the target.
+  // +optional
   optional string id = 1;
 
   // The type of the target.
+  // +optional
   optional string type = 2;
 
   // Whether the target has a live update assocated with it.
+  // +optional
   optional bool hasLiveUpdate = 3;
 }
 
@@ -1080,60 +1123,73 @@ message UISessionSpec {
 message UISessionStatus {
   // FeatureFlags reports a list of experimental features that have been
   // enabled.
+  // +optional
   repeated UIFeatureFlag featureFlags = 1;
 
   // NeedsAnalyticsNudge reports whether the UI hasn't opted in or out
   // of analytics, and the UI should nudge them to do so.
+  // +optional
   optional bool needsAnalyticsNudge = 2;
 
   // RunningTiltBuild reports the currently running version of tilt
   // that this UI is talking to.
+  // +optional
   optional TiltBuild runningTiltBuild = 3;
 
   // SuggestedTiltVersion tells the UI the recommended version for this
   // user. If the version is different than what's running, the UI
   // may display a prompt to upgrade.
+  // +optional
   optional string suggestedTiltVersion = 4;
 
   // VersionSettings indicates whether version updates have been enabled/disabled
   // from the Tiltfile.
+  // +optional
   optional VersionSettings versionSettings = 12;
 
   // TiltCloudUsername reports the username if the user is signed into
   // TiltCloud.
+  // +optional
   optional string tiltCloudUsername = 5;
 
   // TiltCloudUsername reports the human-readable team name if the user is
   // signed into TiltCloud and the Tiltfile declares a team.
+  // +optional
   optional string tiltCloudTeamName = 6;
 
   // TiltCloudSchemeHost reports the base URL of the Tilt Cloud instance
   // associated with this Tilt process. Usually https://cloud.tilt.dev
+  // +optional
   optional string tiltCloudSchemeHost = 7;
 
   // TiltCloudTeamID reports the unique team id if the user is signed into
   // TiltCloud and the Tiltfile declares a team.
+  // +optional
   optional string tiltCloudTeamID = 8;
 
   // A FatalError is an error that forces Tilt to stop its control loop.
   // The API server will stay up and continue to serve the UI, but
   // no further builds will happen.
+  // +optional
   optional string fatalError = 9;
 
   // The time that this instance of tilt started.
   // Clients can use this to determine if the API server has restarted
   // and all the objects need to be refreshed.
+  // +optional
   optional k8s.io.apimachinery.pkg.apis.meta.v1.Time tiltStartTime = 10;
 
   // An identifier for the Tiltfile that is running.
   // Clients can use this to store data associated with a particular
   // project in LocalStorage or other persistent storage.
+  // +optional
   optional string tiltfileKey = 11;
 }
 
 // Information about how the Tilt binary handles updates.
 message VersionSettings {
   // Whether version updates have been enabled/disabled from the Tiltfile.
+  // +optional
   optional bool checkUpdates = 1;
 }
 

--- a/pkg/apis/core/v1alpha1/uiresource_types.go
+++ b/pkg/apis/core/v1alpha1/uiresource_types.go
@@ -106,37 +106,47 @@ func (in *UIResourceList) GetListMeta() *metav1.ListMeta {
 // UIResourceStatus defines the observed state of UIResource
 type UIResourceStatus struct {
 	// The last time this resource was deployed.
+	// +optional
 	LastDeployTime metav1.MicroTime `json:"lastDeployTime,omitempty" protobuf:"bytes,1,opt,name=lastDeployTime"`
 
 	// Bit mask representing whether this resource is run when:
 	// 1) When a file changes
 	// 2) When the resource initializes
+	// +optional
 	TriggerMode int32 `json:"triggerMode,omitempty" protobuf:"varint,2,opt,name=triggerMode"`
 
 	// Past completed builds.
+	// +optional
 	BuildHistory []UIBuildTerminated `json:"buildHistory,omitempty" protobuf:"bytes,3,rep,name=buildHistory"`
 
 	// The currently running build, if any.
+	// +optional
 	CurrentBuild *UIBuildRunning `json:"currentBuild,omitempty" protobuf:"bytes,4,opt,name=currentBuild"`
 
 	// When the build was put in the pending queue.
+	// +optional
 	PendingBuildSince metav1.MicroTime `json:"pendingBuildSince,omitempty" protobuf:"bytes,5,opt,name=pendingBuildSince"`
 
 	// True if the build was put in the pending queue due to file changes.
+	// +optional
 	HasPendingChanges bool `json:"hasPendingChanges,omitempty" protobuf:"varint,6,opt,name=hasPendingChanges"`
 
 	// Links attached to this resource.
+	// +optional
 	EndpointLinks []UIResourceLink `json:"endpointLinks,omitempty" protobuf:"bytes,7,rep,name=endpointLinks"`
 
 	// Extra data about Kubernetes resources.
+	// +optional
 	K8sResourceInfo *UIResourceKubernetes `json:"k8sResourceInfo,omitempty" protobuf:"bytes,8,opt,name=k8sResourceInfo"`
 
 	// Extra data about Local resources
+	// +optional
 	LocalResourceInfo *UIResourceLocal `json:"localResourceInfo,omitempty" protobuf:"bytes,9,opt,name=localResourceInfo"`
 
 	// The RuntimeStatus is a simple, high-level summary of the runtime state of a server.
 	//
 	// Not all resources run servers.
+	// +optional
 	RuntimeStatus RuntimeStatus `json:"runtimeStatus,omitempty" protobuf:"bytes,10,opt,name=runtimeStatus,casttype=RuntimeStatus"`
 
 	// The UpdateStatus is a simple, high-level summary of any update tasks to bring
@@ -144,12 +154,15 @@ type UIResourceStatus struct {
 	//
 	// If the resource runs a server, this may include both build tasks and live-update
 	// syncing.
+	// +optional
 	UpdateStatus UpdateStatus `json:"updateStatus,omitempty" protobuf:"bytes,14,opt,name=updateStatus,casttype=UpdateStatus"`
 
 	// Information about all the target specs that this resource summarizes.
+	// +optional
 	Specs []UIResourceTargetSpec `json:"specs,omitempty" protobuf:"bytes,12,rep,name=specs"`
 
 	// Queued is a simple indicator of whether the resource is queued for an update.
+	// +optional
 	Queued bool `json:"queued,omitempty" protobuf:"varint,13,opt,name=queued"`
 }
 
@@ -170,9 +183,11 @@ func (in UIResourceStatus) CopyTo(parent resource.ObjectWithStatusSubResource) {
 // UIResourceLink represents a link assocatiated with a UIResource.
 type UIResourceLink struct {
 	// A URL to link to.
+	// +optional
 	URL string `json:"url,omitempty" protobuf:"bytes,1,opt,name=url"`
 
 	// The display label on a URL.
+	// +optional
 	Name string `json:"name,omitempty" protobuf:"bytes,2,opt,name=name"`
 }
 
@@ -200,45 +215,56 @@ const (
 // UIResourceTargetSpec represents the spec of a build or deploy that a resource summarizes.
 type UIResourceTargetSpec struct {
 	// The ID of the target.
+	// +optional
 	ID string `json:"id,omitempty" protobuf:"bytes,1,opt,name=id"`
 
 	// The type of the target.
+	// +optional
 	Type UIResourceTargetType `json:"type,omitempty" protobuf:"bytes,2,opt,name=type,casttype=UIResourceTargetType"`
 
 	// Whether the target has a live update assocated with it.
+	// +optional
 	HasLiveUpdate bool `json:"hasLiveUpdate,omitempty" protobuf:"varint,3,opt,name=hasLiveUpdate"`
 }
 
 // UIBuildRunning respresents an in-progress build/update in the user interface.
 type UIBuildRunning struct {
 	// The time when the build started.
+	// +optional
 	StartTime metav1.MicroTime `json:"startTime,omitempty" protobuf:"bytes,1,opt,name=startTime"`
 
 	// The log span where the build logs are stored in the logstore.
+	// +optional
 	SpanID string `json:"spanID,omitempty" protobuf:"bytes,2,opt,name=spanID"`
 }
 
 // UIBuildRunning respresents a finished build/update in the user interface.
 type UIBuildTerminated struct {
 	// A non-empty string if the build failed with an error.
+	// +optional
 	Error string `json:"error,omitempty" protobuf:"bytes,1,opt,name=error"`
 
 	// A list of warnings encountered while running the build.
 	// These warnings will also be printed to the build's log.
+	// +optional
 	Warnings []string `json:"warnings,omitempty" protobuf:"bytes,2,rep,name=warnings"`
 
 	// The time when the build started.
+	// +optional
 	StartTime metav1.MicroTime `json:"startTime,omitempty" protobuf:"bytes,3,opt,name=startTime"`
 
 	// The time when the build finished.
+	// +optional
 	FinishTime metav1.MicroTime `json:"finishTime,omitempty" protobuf:"bytes,4,opt,name=finishTime"`
 
 	// The log span where the build logs are stored in the logstore.
+	// +optional
 	SpanID string `json:"spanID,omitempty" protobuf:"bytes,5,opt,name=spanID"`
 
 	// A crash rebuild happens when Tilt live-updated a container, then
 	// the pod crashed, wiping out the live-updates. Tilt does a full
 	// build+deploy to reset the pod state to what's on disk.
+	// +optional
 	IsCrashRebuild bool `json:"isCrashRebuild,omitempty" protobuf:"varint,6,opt,name=isCrashRebuild"`
 }
 
@@ -248,40 +274,51 @@ type UIResourceKubernetes struct {
 	//
 	// The active pod tends to be what Tilt defaults to for port-forwards,
 	// live-updates, etc.
+	// +optional
 	PodName string `json:"podName,omitempty" protobuf:"bytes,1,opt,name=podName"`
 
 	// The creation time of the active pod.
+	// +optional
 	PodCreationTime metav1.Time `json:"podCreationTime,omitempty" protobuf:"bytes,2,opt,name=podCreationTime"`
 
 	// The last update time of the active pod
+	// +optional
 	PodUpdateStartTime metav1.Time `json:"podUpdateStartTime,omitempty" protobuf:"bytes,3,opt,name=podUpdateStartTime"`
 
 	// The status of the active pod.
+	// +optional
 	PodStatus string `json:"podStatus,omitempty" protobuf:"bytes,4,opt,name=podStatus"`
 
 	// Extra error messaging around the current status of the active pod.
+	// +optional
 	PodStatusMessage string `json:"podStatusMessage,omitempty" protobuf:"bytes,5,opt,name=podStatusMessage"`
 
 	// Whether all the containers in the pod are currently healthy
 	// and have passed readiness checks.
+	// +optional
 	AllContainersReady bool `json:"allContainersReady,omitempty" protobuf:"varint,6,opt,name=allContainersReady"`
 
 	// The number of pod restarts.
+	// +optional
 	PodRestarts int32 `json:"podRestarts,omitempty" protobuf:"varint,7,opt,name=podRestarts"`
 
 	// The span where this pod stores its logs in the Tilt logstore.
+	// +optional
 	SpanID string `json:"spanID,omitempty" protobuf:"bytes,8,opt,name=spanID"`
 
 	// The list of all resources deployed in the Kubernetes deploy
 	// for this resource.
+	// +optional
 	DisplayNames []string `json:"displayNames,omitempty" protobuf:"bytes,9,rep,name=displayNames"`
 }
 
 // UIResourceLocal contains status information specific to local commands.
 type UIResourceLocal struct {
 	// The PID of the actively running local command.
+	// +optional
 	PID int64 `json:"pid,omitempty" protobuf:"varint,1,opt,name=pid"`
 
 	// Whether this represents a test job.
+	// +optional
 	IsTest bool `json:"isTest,omitempty" protobuf:"varint,2,opt,name=isTest"`
 }

--- a/pkg/apis/core/v1alpha1/uisession_types.go
+++ b/pkg/apis/core/v1alpha1/uisession_types.go
@@ -109,55 +109,67 @@ func (in *UISessionList) GetListMeta() *metav1.ListMeta {
 type UISessionStatus struct {
 	// FeatureFlags reports a list of experimental features that have been
 	// enabled.
-	FeatureFlags []UIFeatureFlag `json:"featureFlags" protobuf:"bytes,1,rep,name=featureFlags"`
+	// +optional
+	FeatureFlags []UIFeatureFlag `json:"featureFlags,omitempty" protobuf:"bytes,1,rep,name=featureFlags"`
 
 	// NeedsAnalyticsNudge reports whether the UI hasn't opted in or out
 	// of analytics, and the UI should nudge them to do so.
-	NeedsAnalyticsNudge bool `json:"needsAnalyticsNudge" protobuf:"varint,2,opt,name=needsAnalyticsNudge"`
+	// +optional
+	NeedsAnalyticsNudge bool `json:"needsAnalyticsNudge,omitempty" protobuf:"varint,2,opt,name=needsAnalyticsNudge"`
 
 	// RunningTiltBuild reports the currently running version of tilt
 	// that this UI is talking to.
-	RunningTiltBuild TiltBuild `json:"runningTiltBuild" protobuf:"bytes,3,opt,name=runningTiltBuild"`
+	// +optional
+	RunningTiltBuild TiltBuild `json:"runningTiltBuild,omitempty" protobuf:"bytes,3,opt,name=runningTiltBuild"`
 
 	// SuggestedTiltVersion tells the UI the recommended version for this
 	// user. If the version is different than what's running, the UI
 	// may display a prompt to upgrade.
-	SuggestedTiltVersion string `json:"suggestedTiltVersion" protobuf:"bytes,4,opt,name=suggestedTiltVersion"`
+	// +optional
+	SuggestedTiltVersion string `json:"suggestedTiltVersion,omitempty" protobuf:"bytes,4,opt,name=suggestedTiltVersion"`
 
 	// VersionSettings indicates whether version updates have been enabled/disabled
 	// from the Tiltfile.
-	VersionSettings VersionSettings `json:"versionSettings" protobuf:"bytes,12,opt,name=versionSettings"`
+	// +optional
+	VersionSettings VersionSettings `json:"versionSettings,omitempty" protobuf:"bytes,12,opt,name=versionSettings"`
 
 	// TiltCloudUsername reports the username if the user is signed into
 	// TiltCloud.
-	TiltCloudUsername string `json:"tiltCloudUsername" protobuf:"bytes,5,opt,name=tiltCloudUsername"`
+	// +optional
+	TiltCloudUsername string `json:"tiltCloudUsername,omitempty" protobuf:"bytes,5,opt,name=tiltCloudUsername"`
 
 	// TiltCloudUsername reports the human-readable team name if the user is
 	// signed into TiltCloud and the Tiltfile declares a team.
-	TiltCloudTeamName string `json:"tiltCloudTeamName" protobuf:"bytes,6,opt,name=tiltCloudTeamName"`
+	// +optional
+	TiltCloudTeamName string `json:"tiltCloudTeamName,omitempty" protobuf:"bytes,6,opt,name=tiltCloudTeamName"`
 
 	// TiltCloudSchemeHost reports the base URL of the Tilt Cloud instance
 	// associated with this Tilt process. Usually https://cloud.tilt.dev
-	TiltCloudSchemeHost string `json:"tiltCloudSchemeHost" protobuf:"bytes,7,opt,name=tiltCloudSchemeHost"`
+	// +optional
+	TiltCloudSchemeHost string `json:"tiltCloudSchemeHost,omitempty" protobuf:"bytes,7,opt,name=tiltCloudSchemeHost"`
 
 	// TiltCloudTeamID reports the unique team id if the user is signed into
 	// TiltCloud and the Tiltfile declares a team.
-	TiltCloudTeamID string `json:"tiltCloudTeamID" protobuf:"bytes,8,opt,name=tiltCloudTeamID"`
+	// +optional
+	TiltCloudTeamID string `json:"tiltCloudTeamID,omitempty" protobuf:"bytes,8,opt,name=tiltCloudTeamID"`
 
 	// A FatalError is an error that forces Tilt to stop its control loop.
 	// The API server will stay up and continue to serve the UI, but
 	// no further builds will happen.
-	FatalError string `json:"fatalError" protobuf:"bytes,9,opt,name=fatalError"`
+	// +optional
+	FatalError string `json:"fatalError,omitempty" protobuf:"bytes,9,opt,name=fatalError"`
 
 	// The time that this instance of tilt started.
 	// Clients can use this to determine if the API server has restarted
 	// and all the objects need to be refreshed.
-	TiltStartTime metav1.Time `json:"tiltStartTime" protobuf:"bytes,10,opt,name=tiltStartTime"`
+	// +optional
+	TiltStartTime metav1.Time `json:"tiltStartTime,omitempty" protobuf:"bytes,10,opt,name=tiltStartTime"`
 
 	// An identifier for the Tiltfile that is running.
 	// Clients can use this to store data associated with a particular
 	// project in LocalStorage or other persistent storage.
-	TiltfileKey string `json:"tiltfileKey" protobuf:"bytes,11,opt,name=tiltfileKey"`
+	// +optional
+	TiltfileKey string `json:"tiltfileKey,omitempty" protobuf:"bytes,11,opt,name=tiltfileKey"`
 }
 
 // UISession implements ObjectWithStatusSubResource interface.
@@ -185,29 +197,36 @@ func (in UISessionStatus) CopyTo(parent resource.ObjectWithStatusSubResource) {
 // with a Tilt contributor).
 type UIFeatureFlag struct {
 	// The name of the flag.
-	Name string `json:"name" protobuf:"bytes,1,opt,name=name"`
+	// +optional
+	Name string `json:"name,omitempty" protobuf:"bytes,1,opt,name=name"`
 
 	// The value of the flag.
-	Value bool `json:"value" protobuf:"varint,2,opt,name=value"`
+	// +optional
+	Value bool `json:"value,omitempty" protobuf:"varint,2,opt,name=value"`
 }
 
 // Information about the running tilt binary.
 type TiltBuild struct {
 	// A semantic version string.
-	Version string `json:"version" protobuf:"bytes,1,opt,name=version"`
+	// +optional
+	Version string `json:"version,omitempty" protobuf:"bytes,1,opt,name=version"`
 
 	// The Git digest of the commit this binary was built at.
-	CommitSHA string `json:"commitSHA" protobuf:"bytes,2,opt,name=commitSHA"`
+	// +optional
+	CommitSHA string `json:"commitSHA,omitempty" protobuf:"bytes,2,opt,name=commitSHA"`
 
 	// A human-readable string representing when the binary was built.
-	Date string `json:"date" protobuf:"bytes,3,opt,name=date"`
+	// +optional
+	Date string `json:"date,omitempty" protobuf:"bytes,3,opt,name=date"`
 
 	// Indicates whether this is a development build (true) or an official release (false).
-	Dev bool `json:"dev" protobuf:"varint,4,opt,name=dev"`
+	// +optional
+	Dev bool `json:"dev,omitempty" protobuf:"varint,4,opt,name=dev"`
 }
 
 // Information about how the Tilt binary handles updates.
 type VersionSettings struct {
 	// Whether version updates have been enabled/disabled from the Tiltfile.
-	CheckUpdates bool `json:"checkUpdates" protobuf:"varint,1,opt,name=checkUpdates"`
+	// +optional
+	CheckUpdates bool `json:"checkUpdates,omitempty" protobuf:"varint,1,opt,name=checkUpdates"`
 }

--- a/pkg/openapi/zz_generated.openapi.go
+++ b/pkg/openapi/zz_generated.openapi.go
@@ -2421,7 +2421,6 @@ func schema_pkg_apis_core_v1alpha1_TiltBuild(ref common.ReferenceCallback) commo
 					"version": {
 						SchemaProps: spec.SchemaProps{
 							Description: "A semantic version string.",
-							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -2429,7 +2428,6 @@ func schema_pkg_apis_core_v1alpha1_TiltBuild(ref common.ReferenceCallback) commo
 					"commitSHA": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The Git digest of the commit this binary was built at.",
-							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -2437,7 +2435,6 @@ func schema_pkg_apis_core_v1alpha1_TiltBuild(ref common.ReferenceCallback) commo
 					"date": {
 						SchemaProps: spec.SchemaProps{
 							Description: "A human-readable string representing when the binary was built.",
-							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -2445,13 +2442,11 @@ func schema_pkg_apis_core_v1alpha1_TiltBuild(ref common.ReferenceCallback) commo
 					"dev": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Indicates whether this is a development build (true) or an official release (false).",
-							Default:     false,
 							Type:        []string{"boolean"},
 							Format:      "",
 						},
 					},
 				},
-				Required: []string{"version", "commitSHA", "date", "dev"},
 			},
 		},
 	}
@@ -2561,7 +2556,6 @@ func schema_pkg_apis_core_v1alpha1_UIFeatureFlag(ref common.ReferenceCallback) c
 					"name": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The name of the flag.",
-							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -2569,13 +2563,11 @@ func schema_pkg_apis_core_v1alpha1_UIFeatureFlag(ref common.ReferenceCallback) c
 					"value": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The value of the flag.",
-							Default:     false,
 							Type:        []string{"boolean"},
 							Format:      "",
 						},
 					},
 				},
-				Required: []string{"name", "value"},
 			},
 		},
 	}
@@ -3117,7 +3109,6 @@ func schema_pkg_apis_core_v1alpha1_UISessionStatus(ref common.ReferenceCallback)
 					"needsAnalyticsNudge": {
 						SchemaProps: spec.SchemaProps{
 							Description: "NeedsAnalyticsNudge reports whether the UI hasn't opted in or out of analytics, and the UI should nudge them to do so.",
-							Default:     false,
 							Type:        []string{"boolean"},
 							Format:      "",
 						},
@@ -3132,7 +3123,6 @@ func schema_pkg_apis_core_v1alpha1_UISessionStatus(ref common.ReferenceCallback)
 					"suggestedTiltVersion": {
 						SchemaProps: spec.SchemaProps{
 							Description: "SuggestedTiltVersion tells the UI the recommended version for this user. If the version is different than what's running, the UI may display a prompt to upgrade.",
-							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -3147,7 +3137,6 @@ func schema_pkg_apis_core_v1alpha1_UISessionStatus(ref common.ReferenceCallback)
 					"tiltCloudUsername": {
 						SchemaProps: spec.SchemaProps{
 							Description: "TiltCloudUsername reports the username if the user is signed into TiltCloud.",
-							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -3155,7 +3144,6 @@ func schema_pkg_apis_core_v1alpha1_UISessionStatus(ref common.ReferenceCallback)
 					"tiltCloudTeamName": {
 						SchemaProps: spec.SchemaProps{
 							Description: "TiltCloudUsername reports the human-readable team name if the user is signed into TiltCloud and the Tiltfile declares a team.",
-							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -3163,7 +3151,6 @@ func schema_pkg_apis_core_v1alpha1_UISessionStatus(ref common.ReferenceCallback)
 					"tiltCloudSchemeHost": {
 						SchemaProps: spec.SchemaProps{
 							Description: "TiltCloudSchemeHost reports the base URL of the Tilt Cloud instance associated with this Tilt process. Usually https://cloud.tilt.dev",
-							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -3171,7 +3158,6 @@ func schema_pkg_apis_core_v1alpha1_UISessionStatus(ref common.ReferenceCallback)
 					"tiltCloudTeamID": {
 						SchemaProps: spec.SchemaProps{
 							Description: "TiltCloudTeamID reports the unique team id if the user is signed into TiltCloud and the Tiltfile declares a team.",
-							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -3179,7 +3165,6 @@ func schema_pkg_apis_core_v1alpha1_UISessionStatus(ref common.ReferenceCallback)
 					"fatalError": {
 						SchemaProps: spec.SchemaProps{
 							Description: "A FatalError is an error that forces Tilt to stop its control loop. The API server will stay up and continue to serve the UI, but no further builds will happen.",
-							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -3194,13 +3179,11 @@ func schema_pkg_apis_core_v1alpha1_UISessionStatus(ref common.ReferenceCallback)
 					"tiltfileKey": {
 						SchemaProps: spec.SchemaProps{
 							Description: "An identifier for the Tiltfile that is running. Clients can use this to store data associated with a particular project in LocalStorage or other persistent storage.",
-							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 				},
-				Required: []string{"featureFlags", "needsAnalyticsNudge", "runningTiltBuild", "suggestedTiltVersion", "versionSettings", "tiltCloudUsername", "tiltCloudTeamName", "tiltCloudSchemeHost", "tiltCloudTeamID", "fatalError", "tiltStartTime", "tiltfileKey"},
 			},
 		},
 		Dependencies: []string{
@@ -3218,13 +3201,11 @@ func schema_pkg_apis_core_v1alpha1_VersionSettings(ref common.ReferenceCallback)
 					"checkUpdates": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Whether version updates have been enabled/disabled from the Tiltfile.",
-							Default:     false,
 							Type:        []string{"boolean"},
 							Format:      "",
 						},
 					},
 				},
-				Required: []string{"checkUpdates"},
 			},
 		},
 	}


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/omitempty:

93f90f1554e6fcb230295855fcd87c3dea045f35 (2021-05-20 15:44:18 -0400)
apis: add omitempty/optional annotations
trying to follow the kube convention of defaulting to optional
for everything except real base-level structural fields (like spec and status)

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics