### PR TITLE
webview: only send updated objects

### DIFF
--- a/internal/cloud/snapshot_uploader.go
+++ b/internal/cloud/snapshot_uploader.go
@@ -20,7 +20,7 @@ import (
 type SnapshotID string
 
 func ToSnapshot(state store.EngineState) (*proto_webview.Snapshot, error) {
-	view, err := webview.StateToProtoView(state, 0)
+	view, err := webview.ChangeSummaryToProtoView(state, 0, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/hud/server/logs_reader.go
+++ b/internal/hud/server/logs_reader.go
@@ -174,38 +174,5 @@ func (wsr *WebsocketReader) handleTextMessage(ctx context.Context, reader io.Rea
 		return errors.Wrap(err, "Handling Tilt state from websocket")
 	}
 
-	// If server is using the incremental logs protocol, send back an ACK
-	if v.LogList != nil && v.LogList.ToCheckpoint > 0 {
-		err = wsr.sendIncrementalLogResp(ctx, &v)
-		if err != nil {
-			return errors.Wrap(err, "sending websocket ack")
-		}
-	}
-	return nil
-}
-
-// Ack a websocket message so the next time the websocket sends data, it only
-// sends logs from here on forward
-func (wsr *WebsocketReader) sendIncrementalLogResp(ctx context.Context, v *proto_webview.View) error {
-	resp := proto_webview.AckWebsocketRequest{
-		ToCheckpoint:  v.LogList.ToCheckpoint,
-		TiltStartTime: v.TiltStartTime,
-	}
-
-	w, err := wsr.conn.NextWriter(websocket.TextMessage)
-	if err != nil {
-		return errors.Wrap(err, "getting writer")
-	}
-	defer func() {
-		err := w.Close()
-		if err != nil {
-			logger.Get(ctx).Verbosef("closing writer: %v", err)
-		}
-	}()
-
-	err = wsr.marshaller.Marshal(w, &resp)
-	if err != nil {
-		return errors.Wrap(err, "sending response")
-	}
 	return nil
 }

--- a/internal/hud/server/server.go
+++ b/internal/hud/server/server.go
@@ -113,7 +113,7 @@ func (s *HeadsUpServer) Router() http.Handler {
 
 func (s *HeadsUpServer) ViewJSON(w http.ResponseWriter, req *http.Request) {
 	state := s.store.RLockState()
-	view, err := webview.StateToProtoView(state, 0)
+	view, err := webview.ChangeSummaryToProtoView(state, 0, nil)
 	s.store.RUnlockState()
 	if err != nil {
 		http.Error(w, fmt.Sprintf("Error converting view to proto: %v", err), http.StatusInternalServerError)
@@ -143,7 +143,7 @@ func (s *HeadsUpServer) DumpEngineJSON(w http.ResponseWriter, req *http.Request)
 
 func (s *HeadsUpServer) SnapshotJSON(w http.ResponseWriter, req *http.Request) {
 	state := s.store.RLockState()
-	view, err := webview.StateToProtoView(state, 0)
+	view, err := webview.ChangeSummaryToProtoView(state, 0, nil)
 	s.store.RUnlockState()
 	if err != nil {
 		http.Error(w, fmt.Sprintf("Error converting view to proto: %v", err), http.StatusInternalServerError)

--- a/internal/hud/server/websocket_reader_test.go
+++ b/internal/hud/server/websocket_reader_test.go
@@ -32,22 +32,6 @@ func TestViewsHandled(t *testing.T) {
 	f.tearDown()
 }
 
-func TestIncrementalLogAck(t *testing.T) {
-	f := newWebsocketReaderFixture(t)
-	f.start()
-
-	v := &proto_webview.View{Log: "hello world", LogList: &proto_webview.LogList{ToCheckpoint: 123}}
-	f.sendView(v)
-
-	f.assertHandlerCallCount(1)
-	assert.Equal(t, "hello world", f.handler.lastViewLog)
-
-	// Expect client to send an Ack, so make sure that that message was written to the conn
-	f.assertMessageWritten()
-
-	f.tearDown()
-}
-
 func TestHandlerErrorDoesntStopLoop(t *testing.T) {
 	f := newWebsocketReaderFixture(t)
 	f.start()
@@ -139,10 +123,6 @@ func (f *websocketReaderFixture) sendView(v *proto_webview.View) {
 	assert.NoError(f.t, err)
 
 	f.conn.newMessageToRead(buf)
-}
-
-func (f *websocketReaderFixture) assertMessageWritten() {
-	f.conn.AssertNextWriteMsg(f.t).Ack()
 }
 
 func (f *websocketReaderFixture) assertHandlerCallCount(n int) {

--- a/internal/store/summary.go
+++ b/internal/store/summary.go
@@ -19,6 +19,10 @@ func NewChangeSet(names ...types.NamespacedName) ChangeSet {
 	return cs
 }
 
+func (s *ChangeSet) Empty() bool {
+	return len(s.Changes) == 0
+}
+
 // Add a changed resource name.
 func (s *ChangeSet) Add(nn types.NamespacedName) {
 	if s.Changes == nil {

--- a/pkg/webview/view.proto
+++ b/pkg/webview/view.proto
@@ -160,6 +160,17 @@ message VersionSettings {
   bool check_updates = 1;
 }
 
+// Our websocket service has two kinds of View messages:
+//
+// 1) On initialization, we send down the complete view state
+//    (TiltStartTime, UISession, UIResources, and LogList)
+//
+// 2) On every change, we send down the resources that have
+//    changed since the last send().
+//    (new logs and any updated UISession/UIResource objects).
+//
+// All other fields are obsolete, but are needed for deserializing
+// old snapshots.
 message View {
   string log = 1;
   repeated Resource resources = 2;
@@ -196,8 +207,7 @@ message View {
   reserved "metrics_serving";
   reserved 18;
 
-  // New API-server based data models. These will eventually obsolete the fields
-  // above.
+  // New API-server based data models.
   github.com.tilt_dev.tilt.pkg.apis.core.v1alpha1.UISession ui_session = 19;
   repeated github.com.tilt_dev.tilt.pkg.apis.core.v1alpha1.UIResource ui_resources = 20;
 }
@@ -230,12 +240,12 @@ message UploadSnapshotResponse {
   string url = 1;
 }
 
-// The webclient needs to notify the server what logs it has,
-// so the server knows what to send.
+// NOTE(nick): This is obsolete.
 //
-// The socket protocol doesn't have any concept of a StatusCode
-// to confirm that the receiver got the message, so we need to send this
-// in a separate message.
+// Our websocket service has two kinds of messages:
+// 1) On initialization, we send down the complete view state
+// 2) On every change, we send down the resources that have
+//    changed since the last send().
 message AckWebsocketRequest {
   // The to_checkpoint on the received LogList
   int32 to_checkpoint = 1;

--- a/web/src/AppController.test.ts
+++ b/web/src/AppController.test.ts
@@ -3,10 +3,10 @@ import AppController from "./AppController"
 import PathBuilder from "./PathBuilder"
 
 let fakeSetHistoryLocation = jest.fn()
-let fakeSetAppState = jest.fn()
+let fakeOnAppChange = jest.fn()
 
 const HUD = {
-  setAppState: fakeSetAppState,
+  onAppChange: fakeOnAppChange,
   setHistoryLocation: fakeSetHistoryLocation,
 }
 
@@ -32,7 +32,7 @@ describe("AppController", () => {
     ac.setStateFromSnapshot()
 
     await flushPromises()
-    expect(fakeSetAppState.mock.calls.length).toBe(1)
+    expect(fakeOnAppChange.mock.calls.length).toBe(1)
     expect(fakeSetHistoryLocation.mock.calls.length).toBe(0)
   })
 
@@ -47,7 +47,7 @@ describe("AppController", () => {
     ac.setStateFromSnapshot()
 
     await flushPromises()
-    expect(fakeSetAppState.mock.calls.length).toBe(1)
+    expect(fakeOnAppChange.mock.calls.length).toBe(1)
     expect(fakeSetHistoryLocation.mock.calls.length).toBe(1)
     expect(fakeSetHistoryLocation.mock.calls[0][0]).toBe("/snapshot/aaaaaa/foo")
   })
@@ -70,8 +70,8 @@ describe("AppController", () => {
     ac.setStateFromSnapshot()
 
     await flushPromises()
-    expect(fakeSetAppState.mock.calls.length).toBe(2)
-    expect(fakeSetAppState.mock.calls[1][0]).toStrictEqual({
+    expect(fakeOnAppChange.mock.calls.length).toBe(2)
+    expect(fakeOnAppChange.mock.calls[1][0]).toStrictEqual({
       snapshotHighlight: snapshotHighlight,
     })
   })

--- a/web/src/HUD.test.tsx
+++ b/web/src/HUD.test.tsx
@@ -4,9 +4,9 @@ import React from "react"
 import ReactDOM from "react-dom"
 import ReactModal from "react-modal"
 import { MemoryRouter } from "react-router"
-import HUD from "./HUD"
+import HUD, { mergeAppUpdate } from "./HUD"
 import SocketBar from "./SocketBar"
-import { oneResourceView } from "./testdata"
+import { oneResourceView, twoResourceView } from "./testdata"
 import { SocketState } from "./types"
 
 // Note: `body` is used as the app element _only_ in a test env
@@ -85,7 +85,7 @@ it("loads logs incrementally", async () => {
     fromCheckpoint: 0,
     toCheckpoint: 2,
   }
-  hud.setAppState({ view: resourceView })
+  hud.onAppChange({ view: resourceView })
 
   let resourceView2 = oneResourceView()
   resourceView2.logList = {
@@ -99,7 +99,7 @@ it("loads logs incrementally", async () => {
     fromCheckpoint: 2,
     toCheckpoint: 4,
   }
-  hud.setAppState({ view: resourceView2 })
+  hud.onAppChange({ view: resourceView2 })
 
   root.update()
   let snapshot = hud.snapshotFromState(hud.state)
@@ -115,6 +115,7 @@ it("loads logs incrementally", async () => {
     ],
   })
 })
+
 it("renders logs to snapshot", async () => {
   const root = mount(emptyHUD())
   const hud = root.find(HUD).instance() as HUD
@@ -132,7 +133,7 @@ it("renders logs to snapshot", async () => {
     fromCheckpoint: 0,
     toCheckpoint: 2,
   }
-  hud.setAppState({ view: resourceView })
+  hud.onAppChange({ view: resourceView })
 
   root.update()
   let snapshot = hud.snapshotFromState(hud.state)
@@ -144,5 +145,80 @@ it("renders logs to snapshot", async () => {
       { text: "line1\n", time: now, spanId: "_", level: "WARN" },
       { text: "line2\n", time: now, spanId: "_", fields: { buildEvent: "1" } },
     ],
+  })
+})
+
+describe("mergeAppUpdates", () => {
+  // It's important to maintain reference equality when nothing changes.
+  it("handles no view update", () => {
+    let resourceView = oneResourceView()
+    let prevState = { view: resourceView }
+    let result = mergeAppUpdate(prevState as any, {}) as any
+    expect(result.view).toBe(resourceView)
+  })
+
+  it("handles empty view update", () => {
+    let resourceView = oneResourceView()
+    let prevState = { view: resourceView }
+    let result = mergeAppUpdate(prevState as any, { view: {} })
+    expect(result.view).toBe(resourceView)
+  })
+
+  it("handles replace view update", () => {
+    let prevState = { view: oneResourceView() }
+    let update = { view: oneResourceView() }
+    let result = mergeAppUpdate(prevState as any, update)
+    expect(result.view).not.toBe(update.view)
+    expect(result.view).not.toBe(prevState.view)
+    expect(result.view.uiSession).toBe(update.view.uiSession)
+  })
+
+  it("handles add resource", () => {
+    let prevState = { view: oneResourceView() }
+    let update = { view: { uiResources: [twoResourceView().uiResources[1]] } }
+    let result = mergeAppUpdate(prevState as any, update)
+    expect(result.view).not.toBe(prevState.view)
+    expect(result.view.uiSession).toBe(prevState.view.uiSession)
+    expect(result.view.uiResources!.length).toEqual(2)
+    expect(result.view.uiResources![0].metadata!.name).toEqual("vigoda")
+    expect(result.view.uiResources![1].metadata!.name).toEqual("snack")
+  })
+
+  it("handles delete resource", () => {
+    let prevState = { view: twoResourceView() }
+    let update = {
+      view: {
+        uiResources: [
+          {
+            metadata: {
+              name: "vigoda",
+              deletionTimestamp: new Date().toString(),
+            },
+          },
+        ],
+      },
+    }
+    let result = mergeAppUpdate(prevState as any, update)
+    expect(result.view).not.toBe(prevState.view)
+    expect(result.view.uiResources!.length).toEqual(1)
+    expect(result.view.uiResources![0].metadata!.name).toEqual("snack")
+  })
+
+  it("handles replace resource", () => {
+    let prevState = { view: twoResourceView() }
+    let update = { view: { uiResources: [{ metadata: { name: "vigoda" } }] } }
+    let result = mergeAppUpdate(prevState as any, update)
+    expect(result.view).not.toBe(prevState.view)
+    expect(result.view.uiResources!.length).toEqual(2)
+    expect(result.view.uiResources![0]).toBe(update.view.uiResources[0])
+    expect(result.view.uiResources![1]).toBe(prevState.view.uiResources[1])
+  })
+
+  it("handles socket state", () => {
+    let prevState = { view: twoResourceView(), socketState: SocketState.Active }
+    let update = { socketState: SocketState.Reconnecting }
+    let result = mergeAppUpdate(prevState as any, update) as any
+    expect(result.view).toBe(prevState.view)
+    expect(result.socketState).toBe(SocketState.Reconnecting)
   })
 })


### PR DESCRIPTION
Hello @landism, @milas,

Please review the following commits I made in branch nicks/incremental:

0dbdfd17046b9cbb00e62a6f70f3e3eeb43069d7 (2021-05-25 16:12:36 -0400)
webview: only send updated objects
This has two big benefits:

1) We want to make it easier to read directly from the APIServer,
   which uses List/Watch model for API access

2) Web UI performance should be much better and easier to optimize
   going forward, since we know exactly what changed and
   don't need to do a lot of JSON parsing/re-rendering
   for objects that didn't change

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics