### PR TITLE
controllers: use reconcilers to send webview updates

### DIFF
--- a/internal/cli/wire_gen.go
+++ b/internal/cli/wire_gen.go
@@ -194,7 +194,8 @@ func wireCmdUp(ctx context.Context, analytics3 *analytics.TiltAnalytics, cmdTags
 	httpClient := cloud.ProvideHttpClient()
 	address := cloudurl.ProvideAddress()
 	snapshotUploader := cloud.NewSnapshotUploader(httpClient, address)
-	headsUpServer, err := server.ProvideHeadsUpServer(ctx, storeStore, assetsServer, analytics3, snapshotUploader)
+	websocketList := server.NewWebsocketList()
+	headsUpServer, err := server.ProvideHeadsUpServer(ctx, storeStore, assetsServer, analytics3, snapshotUploader, websocketList)
 	if err != nil {
 		return CmdUpDeps{}, err
 	}
@@ -237,8 +238,8 @@ func wireCmdUp(ctx context.Context, analytics3 *analytics.TiltAnalytics, cmdTags
 	ownerFetcher := k8s.ProvideOwnerFetcher(ctx, client)
 	containerRestartDetector := kubernetesdiscovery.NewContainerRestartDetector()
 	reconciler := kubernetesdiscovery.NewReconciler(client, ownerFetcher, containerRestartDetector, storeStore)
-	uisessionReconciler := uisession.NewReconciler()
-	uiresourceReconciler := uiresource.NewReconciler()
+	uisessionReconciler := uisession.NewReconciler(websocketList)
+	uiresourceReconciler := uiresource.NewReconciler(websocketList)
 	v := controllers.ProvideControllers(controller, cmdController, podlogstreamController, reconciler, uisessionReconciler, uiresourceReconciler)
 	controllerBuilder := controllers.NewControllerBuilder(tiltServerControllerManager, v)
 	v2 := provideClock()
@@ -386,7 +387,8 @@ func wireCmdCI(ctx context.Context, analytics3 *analytics.TiltAnalytics, subcomm
 	httpClient := cloud.ProvideHttpClient()
 	address := cloudurl.ProvideAddress()
 	snapshotUploader := cloud.NewSnapshotUploader(httpClient, address)
-	headsUpServer, err := server.ProvideHeadsUpServer(ctx, storeStore, assetsServer, analytics3, snapshotUploader)
+	websocketList := server.NewWebsocketList()
+	headsUpServer, err := server.ProvideHeadsUpServer(ctx, storeStore, assetsServer, analytics3, snapshotUploader, websocketList)
 	if err != nil {
 		return CmdCIDeps{}, err
 	}
@@ -429,8 +431,8 @@ func wireCmdCI(ctx context.Context, analytics3 *analytics.TiltAnalytics, subcomm
 	ownerFetcher := k8s.ProvideOwnerFetcher(ctx, client)
 	containerRestartDetector := kubernetesdiscovery.NewContainerRestartDetector()
 	reconciler := kubernetesdiscovery.NewReconciler(client, ownerFetcher, containerRestartDetector, storeStore)
-	uisessionReconciler := uisession.NewReconciler()
-	uiresourceReconciler := uiresource.NewReconciler()
+	uisessionReconciler := uisession.NewReconciler(websocketList)
+	uiresourceReconciler := uiresource.NewReconciler(websocketList)
 	v := controllers.ProvideControllers(controller, cmdController, podlogstreamController, reconciler, uisessionReconciler, uiresourceReconciler)
 	controllerBuilder := controllers.NewControllerBuilder(tiltServerControllerManager, v)
 	v2 := provideClock()
@@ -575,7 +577,8 @@ func wireCmdUpdog(ctx context.Context, analytics3 *analytics.TiltAnalytics, cmdT
 	httpClient := cloud.ProvideHttpClient()
 	address := cloudurl.ProvideAddress()
 	snapshotUploader := cloud.NewSnapshotUploader(httpClient, address)
-	headsUpServer, err := server.ProvideHeadsUpServer(ctx, storeStore, assetsServer, analytics3, snapshotUploader)
+	websocketList := server.NewWebsocketList()
+	headsUpServer, err := server.ProvideHeadsUpServer(ctx, storeStore, assetsServer, analytics3, snapshotUploader, websocketList)
 	if err != nil {
 		return CmdUpdogDeps{}, err
 	}
@@ -618,8 +621,8 @@ func wireCmdUpdog(ctx context.Context, analytics3 *analytics.TiltAnalytics, cmdT
 	ownerFetcher := k8s.ProvideOwnerFetcher(ctx, k8sClient)
 	containerRestartDetector := kubernetesdiscovery.NewContainerRestartDetector()
 	reconciler := kubernetesdiscovery.NewReconciler(k8sClient, ownerFetcher, containerRestartDetector, storeStore)
-	uisessionReconciler := uisession.NewReconciler()
-	uiresourceReconciler := uiresource.NewReconciler()
+	uisessionReconciler := uisession.NewReconciler(websocketList)
+	uiresourceReconciler := uiresource.NewReconciler(websocketList)
 	v := controllers.ProvideControllers(controller, cmdController, podlogstreamController, reconciler, uisessionReconciler, uiresourceReconciler)
 	controllerBuilder := controllers.NewControllerBuilder(tiltServerControllerManager, v)
 	stdout := hud.ProvideStdout()

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -4013,13 +4013,15 @@ func newTestFixture(t *testing.T) *testFixture {
 	h := hud.NewFakeHud()
 	tscm, err := controllers.NewTiltServerControllerManager(serverOptions, v1alpha1.NewScheme(), ccb)
 	require.NoError(t, err, "Failed to create Tilt API server controller manager")
+
+	wsl := server.NewWebsocketList()
 	cb := controllers.NewControllerBuilder(tscm, controllers.ProvideControllers(
 		fwc,
 		cmds,
 		plsc,
 		kdc,
-		ctrluisession.NewReconciler(),
-		ctrluiresource.NewReconciler(),
+		ctrluisession.NewReconciler(wsl),
+		ctrluiresource.NewReconciler(wsl),
 	))
 
 	dp := dockerprune.NewDockerPruner(dockerClient)

--- a/internal/hud/server/server.go
+++ b/internal/hud/server/server.go
@@ -49,12 +49,12 @@ type overrideTriggerModePayload struct {
 }
 
 type HeadsUpServer struct {
-	ctx               context.Context
-	store             *store.Store
-	router            *mux.Router
-	a                 *tiltanalytics.TiltAnalytics
-	uploader          cloud.SnapshotUploader
-	numWebsocketConns int32
+	ctx      context.Context
+	store    *store.Store
+	router   *mux.Router
+	a        *tiltanalytics.TiltAnalytics
+	uploader cloud.SnapshotUploader
+	wsList   *WebsocketList
 }
 
 func ProvideHeadsUpServer(
@@ -62,7 +62,8 @@ func ProvideHeadsUpServer(
 	store *store.Store,
 	assetServer assets.Server,
 	analytics *tiltanalytics.TiltAnalytics,
-	uploader cloud.SnapshotUploader) (*HeadsUpServer, error) {
+	uploader cloud.SnapshotUploader,
+	wsList *WebsocketList) (*HeadsUpServer, error) {
 	r := mux.NewRouter().UseEncodedPath()
 	s := &HeadsUpServer{
 		ctx:      ctx,
@@ -70,6 +71,7 @@ func ProvideHeadsUpServer(
 		router:   r,
 		a:        analytics,
 		uploader: uploader,
+		wsList:   wsList,
 	}
 
 	r.HandleFunc("/api/view", s.ViewJSON)

--- a/internal/hud/server/server_test.go
+++ b/internal/hud/server/server_test.go
@@ -403,7 +403,8 @@ func newTestFixture(t *testing.T) *serverFixture {
 	addr := cloudurl.Address("nonexistent.example.com")
 	uploader := cloud.NewSnapshotUploader(snapshotHTTP, addr)
 	up := user.NewFakePrefs()
-	serv, err := server.ProvideHeadsUpServer(context.Background(), st, assets.NewFakeServer(), ta, uploader)
+	wsl := server.NewWebsocketList()
+	serv, err := server.ProvideHeadsUpServer(context.Background(), st, assets.NewFakeServer(), ta, uploader, wsl)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/hud/server/websocketlist.go
+++ b/internal/hud/server/websocketlist.go
@@ -1,0 +1,47 @@
+package server
+
+import (
+	"sync"
+)
+
+type WebsocketList struct {
+	items []*WebsocketSubscriber
+	mu    sync.RWMutex
+}
+
+func NewWebsocketList() *WebsocketList {
+	return &WebsocketList{}
+}
+
+func (l *WebsocketList) Add(w *WebsocketSubscriber) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.items = append(l.items, w)
+}
+
+func (l *WebsocketList) Remove(w *WebsocketSubscriber) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	for i, item := range l.items {
+		if item == w {
+			l.items = append(l.items[:i], l.items[i+1:]...)
+			return
+		}
+	}
+}
+
+// Operate on all websockets in the list.
+//
+// While the ForEach is running, the list may not be modified.
+//
+// In the future, it might make sense allow modification of the list while the
+// foreach runs, but then we'd need additional synchronization to make sure
+// we don't get websocket send() after removal.
+func (l *WebsocketList) ForEach(f func(w *WebsocketSubscriber)) {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+
+	for _, item := range l.items {
+		f(item)
+	}
+}

--- a/internal/hud/server/wire.go
+++ b/internal/hud/server/wire.go
@@ -18,4 +18,5 @@ var WireSet = wire.NewSet(
 	ProvideTiltDynamic,
 	ProvideHeadsUpServer,
 	ProvideHeadsUpServerController,
+	NewWebsocketList,
 )


### PR DESCRIPTION
Hello @milas, @landism,

Please review the following commits I made in branch nicks/uisession15:

294b972f8479aa8a7829ccd760e3d3afa7e9d8cb (2021-05-26 20:37:27 -0400)
controllers: use reconcilers to send webview updates

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics