### PR TITLE
webview: always read from the apiserver

### DIFF
--- a/internal/cli/ci.go
+++ b/internal/cli/ci.go
@@ -11,7 +11,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/tilt-dev/tilt/internal/analytics"
-	"github.com/tilt-dev/tilt/internal/cloud"
 	"github.com/tilt-dev/tilt/internal/hud/prompt"
 	"github.com/tilt-dev/tilt/internal/store"
 	"github.com/tilt-dev/tilt/pkg/logger"
@@ -90,7 +89,7 @@ func (c *ciCmd) run(ctx context.Context, args []string) error {
 	deferred.SetOutput(l)
 	ctx = redirectLogs(ctx, l)
 	if c.outputSnapshotOnExit != "" {
-		defer cloud.WriteSnapshot(ctx, cmdCIDeps.Store, c.outputSnapshotOnExit)
+		defer cmdCIDeps.Snapshotter.WriteSnapshot(ctx, c.outputSnapshotOnExit)
 	}
 
 	engineMode := store.EngineModeCI

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -14,7 +14,6 @@ import (
 	"k8s.io/klog/v2"
 
 	"github.com/tilt-dev/tilt/internal/analytics"
-	"github.com/tilt-dev/tilt/internal/cloud"
 	engineanalytics "github.com/tilt-dev/tilt/internal/engine/analytics"
 	"github.com/tilt-dev/tilt/internal/engine/buildcontrol"
 	"github.com/tilt-dev/tilt/internal/hud/prompt"
@@ -157,7 +156,7 @@ func (c *upCmd) run(ctx context.Context, args []string) error {
 	deferred.SetOutput(l)
 	ctx = redirectLogs(ctx, l)
 	if c.outputSnapshotOnExit != "" {
-		defer cloud.WriteSnapshot(ctx, cmdUpDeps.Store, c.outputSnapshotOnExit)
+		defer cmdUpDeps.Snapshotter.WriteSnapshot(ctx, c.outputSnapshotOnExit)
 	}
 
 	ctx, cancel := context.WithCancel(ctx)

--- a/internal/cli/wire.go
+++ b/internal/cli/wire.go
@@ -181,6 +181,7 @@ func wireDockerPrune(ctx context.Context, analytics *analytics.TiltAnalytics, su
 
 func wireCmdUp(ctx context.Context, analytics *analytics.TiltAnalytics, cmdTags engineanalytics.CmdTags, subcommand model.TiltSubcommand) (CmdUpDeps, error) {
 	wire.Build(UpWireSet,
+		cloud.NewSnapshotter,
 		wire.Struct(new(CmdUpDeps), "*"))
 	return CmdUpDeps{}, nil
 }
@@ -190,12 +191,13 @@ type CmdUpDeps struct {
 	TiltBuild    model.TiltBuild
 	Token        token.Token
 	CloudAddress cloudurl.Address
-	Store        *store.Store
 	Prompt       *prompt.TerminalPrompt
+	Snapshotter  *cloud.Snapshotter
 }
 
 func wireCmdCI(ctx context.Context, analytics *analytics.TiltAnalytics, subcommand model.TiltSubcommand) (CmdCIDeps, error) {
 	wire.Build(UpWireSet,
+		cloud.NewSnapshotter,
 		wire.Value(engineanalytics.CmdTags(map[string]string{})),
 		wire.Struct(new(CmdCIDeps), "*"),
 	)
@@ -207,7 +209,7 @@ type CmdCIDeps struct {
 	TiltBuild    model.TiltBuild
 	Token        token.Token
 	CloudAddress cloudurl.Address
-	Store        *store.Store
+	Snapshotter  *cloud.Snapshotter
 }
 
 func wireCmdUpdog(ctx context.Context,

--- a/internal/cloud/snapshot_uploader.go
+++ b/internal/cloud/snapshot_uploader.go
@@ -11,24 +11,13 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/tilt-dev/tilt/internal/cloud/cloudurl"
-	"github.com/tilt-dev/tilt/internal/hud/webview"
-	"github.com/tilt-dev/tilt/internal/store"
 	"github.com/tilt-dev/tilt/internal/token"
 	proto_webview "github.com/tilt-dev/tilt/pkg/webview"
 )
 
 type SnapshotID string
 
-func ToSnapshot(state store.EngineState) (*proto_webview.Snapshot, error) {
-	view, err := webview.ChangeSummaryToProtoView(state, 0, nil)
-	if err != nil {
-		return nil, err
-	}
-	return &proto_webview.Snapshot{View: view}, nil
-}
-
 type SnapshotUploader interface {
-	TakeAndUpload(state store.EngineState) (SnapshotID, error)
 	Upload(token token.Token, teamID string, snapshot *proto_webview.Snapshot) (SnapshotID, error)
 	IDToSnapshotURL(id SnapshotID) string
 }
@@ -59,14 +48,6 @@ func (s snapshotUploader) IDToSnapshotURL(id SnapshotID) string {
 
 type snapshotIDResponse struct {
 	ID string
-}
-
-func (s snapshotUploader) TakeAndUpload(state store.EngineState) (SnapshotID, error) {
-	snapshot, err := ToSnapshot(state)
-	if err != nil {
-		return "", err
-	}
-	return s.Upload(state.Token, state.TeamID, snapshot)
 }
 
 func (s snapshotUploader) Upload(token token.Token, teamID string, snapshot *proto_webview.Snapshot) (SnapshotID, error) {

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -4730,15 +4730,9 @@ func assertContainsOnce(t *testing.T, s string, val string) {
 }
 
 type fakeSnapshotUploader struct {
-	count int
 }
 
 var _ cloud.SnapshotUploader = &fakeSnapshotUploader{}
-
-func (f *fakeSnapshotUploader) TakeAndUpload(state store.EngineState) (cloud.SnapshotID, error) {
-	f.count++
-	return cloud.SnapshotID(fmt.Sprintf("snapshot%d", f.count)), nil
-}
 
 func (f *fakeSnapshotUploader) Upload(token token.Token, teamID string, snapshot *proto_webview.Snapshot) (cloud.SnapshotID, error) {
 	panic("not implemented")

--- a/internal/hud/server/server_test.go
+++ b/internal/hud/server/server_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/tilt-dev/tilt/internal/controllers/fake"
 	"github.com/tilt-dev/tilt/internal/testutils"
 	"github.com/tilt-dev/tilt/internal/user"
 
@@ -404,7 +405,8 @@ func newTestFixture(t *testing.T) *serverFixture {
 	uploader := cloud.NewSnapshotUploader(snapshotHTTP, addr)
 	up := user.NewFakePrefs()
 	wsl := server.NewWebsocketList()
-	serv, err := server.ProvideHeadsUpServer(context.Background(), st, assets.NewFakeServer(), ta, uploader, wsl)
+	ctrlClient := fake.NewTiltClient()
+	serv, err := server.ProvideHeadsUpServer(context.Background(), st, assets.NewFakeServer(), ta, uploader, wsl, ctrlClient)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/hud/server/websocket_test.go
+++ b/internal/hud/server/websocket_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/tilt-dev/tilt/internal/controllers/fake"
 	"github.com/tilt-dev/tilt/internal/testutils"
 
 	"github.com/tilt-dev/tilt/internal/store"
@@ -25,12 +26,13 @@ func TestWebsocketCloseOnReadErr(t *testing.T) {
 	_ = st.SetUpSubscribersForTesting(ctx)
 
 	conn := newFakeConn()
-	ws := NewWebsocketSubscriber(ctx, st, conn)
+	ctrlClient := fake.NewTiltClient()
+	ws := NewWebsocketSubscriber(ctx, ctrlClient, st, conn)
 	require.NoError(t, st.AddSubscriber(ctx, ws))
 
 	done := make(chan bool)
 	go func() {
-		ws.Stream(ctx, st)
+		ws.Stream(ctx)
 		_ = st.RemoveSubscriber(context.Background(), ws)
 		close(done)
 	}()
@@ -54,12 +56,13 @@ func TestWebsocketReadErrDuringMsg(t *testing.T) {
 	_ = st.SetUpSubscribersForTesting(ctx)
 
 	conn := newFakeConn()
-	ws := NewWebsocketSubscriber(ctx, st, conn)
+	ctrlClient := fake.NewTiltClient()
+	ws := NewWebsocketSubscriber(ctx, ctrlClient, st, conn)
 	require.NoError(t, st.AddSubscriber(ctx, ws))
 
 	done := make(chan bool)
 	go func() {
-		ws.Stream(ctx, st)
+		ws.Stream(ctx)
 		_ = st.RemoveSubscriber(context.Background(), ws)
 		close(done)
 	}()
@@ -89,12 +92,13 @@ func TestWebsocketNextWriterError(t *testing.T) {
 
 	conn := newFakeConn()
 	conn.nextWriterError = fmt.Errorf("fake NextWriter error")
-	ws := NewWebsocketSubscriber(ctx, st, conn)
+	ctrlClient := fake.NewTiltClient()
+	ws := NewWebsocketSubscriber(ctx, ctrlClient, st, conn)
 	require.NoError(t, st.AddSubscriber(ctx, ws))
 
 	done := make(chan bool)
 	go func() {
-		ws.Stream(ctx, st)
+		ws.Stream(ctx)
 		_ = st.RemoveSubscriber(context.Background(), ws)
 		close(done)
 	}()

--- a/internal/hud/webview/view.go
+++ b/internal/hud/webview/view.go
@@ -2,26 +2,13 @@ package webview
 
 import (
 	"fmt"
-	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
 	"github.com/tilt-dev/tilt/pkg/model"
 	"github.com/tilt-dev/tilt/pkg/model/logstore"
-
-	"github.com/golang/protobuf/ptypes"
-	"github.com/golang/protobuf/ptypes/timestamp"
 )
-
-func timeToProto(t time.Time) (*timestamp.Timestamp, error) {
-	ts, err := ptypes.TimestampProto(t)
-	if err != nil {
-		return nil, err
-	}
-
-	return ts, nil
-}
 
 func toAPITargetSpec(spec model.TargetSpec) (v1alpha1.UIResourceTargetSpec, error) {
 	switch typ := spec.(type) {


### PR DESCRIPTION
Hello @landism, @milas,

Please review the following commits I made in branch nicks/uisession16:

9e2a9ae87e3c6fd660a08c6dd78b99d10c032f83 (2021-05-26 20:40:09 -0400)
webview: always read from the apiserver

294b972f8479aa8a7829ccd760e3d3afa7e9d8cb (2021-05-26 20:37:27 -0400)
controllers: use reconcilers to send webview updates

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics