### PR TITLE
docker: change how we model "image builds show up in the cluster immediately"

### DIFF
--- a/internal/build/test_utils.go
+++ b/internal/build/test_utils.go
@@ -48,7 +48,7 @@ func newDockerBuildFixture(t testing.TB) *dockerBuildFixture {
 	ctx, _, _ := testutils.CtxAndAnalyticsForTest()
 	env := k8s.EnvGKE
 
-	dEnv := docker.ProvideClusterEnv(ctx, env, wmcontainer.RuntimeDocker, k8s.FakeMinikube{})
+	dEnv := docker.ProvideClusterEnv(ctx, "gke", env, wmcontainer.RuntimeDocker, k8s.FakeMinikube{})
 	dCli := docker.NewDockerClient(ctx, docker.Env(dEnv))
 	_, ok := dCli.(*docker.Cli)
 	// If it wasn't an actual Docker client, it's an exploding client

--- a/internal/containerupdate/docker_container_updater.go
+++ b/internal/containerupdate/docker_container_updater.go
@@ -11,6 +11,7 @@ import (
 	"github.com/tilt-dev/tilt/internal/build"
 	"github.com/tilt-dev/tilt/internal/container"
 	"github.com/tilt-dev/tilt/internal/docker"
+	"github.com/tilt-dev/tilt/internal/k8s"
 	"github.com/tilt-dev/tilt/internal/store"
 	"github.com/tilt-dev/tilt/pkg/logger"
 	"github.com/tilt-dev/tilt/pkg/model"
@@ -24,6 +25,10 @@ var _ ContainerUpdater = &DockerUpdater{}
 
 func NewDockerUpdater(dCli docker.Client) *DockerUpdater {
 	return &DockerUpdater{dCli: dCli}
+}
+
+func (cu *DockerUpdater) WillBuildToKubeContext(kctx k8s.KubeContext) bool {
+	return cu.dCli.Env().WillBuildToKubeContext(kctx)
 }
 
 func (cu *DockerUpdater) UpdateContainer(ctx context.Context, cInfo store.ContainerInfo,

--- a/internal/docker/client_test.go
+++ b/internal/docker/client_test.go
@@ -132,10 +132,13 @@ func TestProvideEnv(t *testing.T) {
 			},
 		},
 		{
-			env:             k8s.EnvMicroK8s,
-			runtime:         container.RuntimeDocker,
-			expectedCluster: Env{Host: microK8sDockerHost},
-			expectedLocal:   Env{},
+			env:     k8s.EnvMicroK8s,
+			runtime: container.RuntimeDocker,
+			expectedCluster: Env{
+				Host:                microK8sDockerHost,
+				BuildToKubeContexts: []string{"microk8s-me"},
+			},
+			expectedLocal: Env{},
 		},
 		{
 			env:     k8s.EnvMicroK8s,
@@ -151,11 +154,12 @@ func TestProvideEnv(t *testing.T) {
 				"DOCKER_API_VERSION": "1.35",
 			},
 			expectedCluster: Env{
-				TLSVerify:     "1",
-				Host:          "tcp://192.168.99.100:2376",
-				CertPath:      "/home/nick/.minikube/certs",
-				APIVersion:    "1.35",
-				IsOldMinikube: true,
+				TLSVerify:           "1",
+				Host:                "tcp://192.168.99.100:2376",
+				CertPath:            "/home/nick/.minikube/certs",
+				APIVersion:          "1.35",
+				IsOldMinikube:       true,
+				BuildToKubeContexts: []string{"minikube-me"},
 			},
 		},
 		{
@@ -169,10 +173,11 @@ func TestProvideEnv(t *testing.T) {
 				"DOCKER_API_VERSION": "1.35",
 			},
 			expectedCluster: Env{
-				TLSVerify:  "1",
-				Host:       "tcp://192.168.99.100:2376",
-				CertPath:   "/home/nick/.minikube/certs",
-				APIVersion: "1.35",
+				TLSVerify:           "1",
+				Host:                "tcp://192.168.99.100:2376",
+				CertPath:            "/home/nick/.minikube/certs",
+				APIVersion:          "1.35",
+				BuildToKubeContexts: []string{"minikube-me"},
 			},
 		},
 		{
@@ -210,16 +215,18 @@ func TestProvideEnv(t *testing.T) {
 				"DOCKER_CERT_PATH":  "/home/nick/.minikube/certs",
 			},
 			expectedCluster: Env{
-				TLSVerify:     "1",
-				Host:          "tcp://192.168.99.100:2376",
-				CertPath:      "/home/nick/.minikube/certs",
-				IsOldMinikube: true,
+				TLSVerify:           "1",
+				Host:                "tcp://192.168.99.100:2376",
+				CertPath:            "/home/nick/.minikube/certs",
+				IsOldMinikube:       true,
+				BuildToKubeContexts: []string{"minikube-me"},
 			},
 			expectedLocal: Env{
-				TLSVerify:     "1",
-				Host:          "tcp://192.168.99.100:2376",
-				CertPath:      "/home/nick/.minikube/certs",
-				IsOldMinikube: true,
+				TLSVerify:           "1",
+				Host:                "tcp://192.168.99.100:2376",
+				CertPath:            "/home/nick/.minikube/certs",
+				IsOldMinikube:       true,
+				BuildToKubeContexts: []string{"minikube-me"},
 			},
 		},
 		{
@@ -275,10 +282,11 @@ func TestProvideEnv(t *testing.T) {
 			}
 
 			mkClient := k8s.FakeMinikube{DockerEnvMap: c.mkEnv, FakeVersion: minikubeV}
-			cluster := ProvideClusterEnv(context.Background(), c.env, c.runtime, mkClient)
+			kubeContext := k8s.KubeContext(fmt.Sprintf("%s-me", c.env))
+			cluster := ProvideClusterEnv(context.Background(), kubeContext, c.env, c.runtime, mkClient)
 			assert.Equal(t, c.expectedCluster, Env(cluster))
 
-			local := ProvideLocalEnv(context.Background(), cluster)
+			local := ProvideLocalEnv(context.Background(), kubeContext, c.env, cluster)
 			assert.Equal(t, c.expectedLocal, Env(local))
 		})
 	}

--- a/internal/docker/clients.go
+++ b/internal/docker/clients.go
@@ -2,6 +2,8 @@ package docker
 
 import (
 	"context"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 type LocalClient Client
@@ -16,7 +18,7 @@ func ProvideClusterCli(ctx context.Context, lEnv LocalEnv, cEnv ClusterEnv, lCli
 	// If the Cluster Env and the LocalEnv are the same, we can re-use the cluster
 	// client as a local client.
 	var cClient ClusterClient
-	if Env(lEnv) == Env(cEnv) {
+	if cmp.Equal(Env(lEnv), Env(cEnv)) {
 		cClient = ClusterClient(lClient)
 	} else {
 		cClient = NewDockerClient(ctx, Env(cEnv))

--- a/internal/docker/env.go
+++ b/internal/docker/env.go
@@ -37,7 +37,7 @@ type Env struct {
 	// as their container runtime. Any images built on that daemon will
 	// show up automatically in the runtime.
 	//
-	// We store this as a field of the Docker Env, because this
+	// We used to store this as a property of the k8s env but now store it as a field of the Docker Env, because this
 	// really affects how we interact with the Docker Env (rather than
 	// how we interact with the K8s Env).
 	//

--- a/internal/docker/fake_client.go
+++ b/internal/docker/fake_client.go
@@ -82,6 +82,8 @@ type ExecCall struct {
 }
 
 type FakeClient struct {
+	FakeEnv Env
+
 	PushCount   int
 	PushImage   string
 	PushOptions types.ImagePushOptions
@@ -148,7 +150,7 @@ func (c *FakeClient) CheckConnected() error {
 	return c.CheckConnectedErr
 }
 func (c *FakeClient) Env() Env {
-	return Env{}
+	return c.FakeEnv
 }
 func (c *FakeClient) BuilderVersion() types.BuilderVersion {
 	return types.BuilderV1

--- a/internal/engine/build_and_deployer_test.go
+++ b/internal/engine/build_and_deployer_test.go
@@ -775,8 +775,8 @@ func newBDFixtureWithUpdateMode(t *testing.T, env k8s.Env, runtime container.Run
 	ctx, cancel := context.WithCancel(ctx)
 	f := tempdir.NewTempDirFixture(t)
 	dir := dirs.NewTiltDevDirAt(f.Path())
-	docker := docker.NewFakeClient()
-	docker.ContainerListOutput = map[string][]types.Container{
+	dockerClient := docker.NewFakeClient()
+	dockerClient.ContainerListOutput = map[string][]types.Container{
 		"pod": []types.Container{
 			types.Container{
 				ID: k8s.MagicTestContainerID,
@@ -788,7 +788,7 @@ func newBDFixtureWithUpdateMode(t *testing.T, env k8s.Env, runtime container.Run
 	mode := buildcontrol.UpdateModeFlag(um)
 	dcc := dockercompose.NewFakeDockerComposeClient(t, ctx)
 	kl := &fakeKINDLoader{}
-	bd, err := provideBuildAndDeployer(ctx, docker, k8s, dir, env, mode, dcc, fakeClock{now: time.Unix(1551202573, 0)}, kl, ta)
+	bd, err := provideFakeBuildAndDeployer(ctx, dockerClient, k8s, dir, env, mode, dcc, fakeClock{now: time.Unix(1551202573, 0)}, kl, ta)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -799,7 +799,7 @@ func newBDFixtureWithUpdateMode(t *testing.T, env k8s.Env, runtime container.Run
 		TempDirFixture: f,
 		ctx:            ctx,
 		cancel:         cancel,
-		docker:         docker,
+		docker:         dockerClient,
 		k8s:            k8s,
 		bd:             bd,
 		st:             st,

--- a/internal/engine/buildcontrol/live_update_build_and_deployer.go
+++ b/internal/engine/buildcontrol/live_update_build_and_deployer.go
@@ -26,24 +26,24 @@ import (
 var _ BuildAndDeployer = &LiveUpdateBuildAndDeployer{}
 
 type LiveUpdateBuildAndDeployer struct {
-	dcu     *containerupdate.DockerUpdater
-	ecu     *containerupdate.ExecUpdater
-	updMode UpdateMode
-	env     k8s.Env
-	runtime container.Runtime
-	clock   build.Clock
+	dcu         *containerupdate.DockerUpdater
+	ecu         *containerupdate.ExecUpdater
+	updMode     UpdateMode
+	kubeContext k8s.KubeContext
+	clock       build.Clock
 }
 
 func NewLiveUpdateBuildAndDeployer(dcu *containerupdate.DockerUpdater,
 	ecu *containerupdate.ExecUpdater,
-	updMode UpdateMode, env k8s.Env, runtime container.Runtime, c build.Clock) *LiveUpdateBuildAndDeployer {
+	updMode UpdateMode,
+	kubeContext k8s.KubeContext,
+	c build.Clock) *LiveUpdateBuildAndDeployer {
 	return &LiveUpdateBuildAndDeployer{
-		dcu:     dcu,
-		ecu:     ecu,
-		updMode: updMode,
-		env:     env,
-		runtime: runtime,
-		clock:   c,
+		dcu:         dcu,
+		ecu:         ecu,
+		updMode:     updMode,
+		kubeContext: kubeContext,
+		clock:       c,
 	}
 }
 
@@ -254,7 +254,7 @@ func (lubad *LiveUpdateBuildAndDeployer) containerUpdaterForSpecs(specs []model.
 		return lubad.ecu
 	}
 
-	if lubad.runtime == container.RuntimeDocker && lubad.env.UsesLocalDockerRegistry() {
+	if lubad.dcu.WillBuildToKubeContext(lubad.kubeContext) {
 		return lubad.dcu
 	}
 

--- a/internal/engine/buildcontrol/live_update_build_and_deployer_test.go
+++ b/internal/engine/buildcontrol/live_update_build_and_deployer_test.go
@@ -9,12 +9,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/tilt-dev/tilt/internal/container"
-	"github.com/tilt-dev/tilt/internal/k8s"
-
 	"github.com/tilt-dev/tilt/internal/build"
 	"github.com/tilt-dev/tilt/internal/containerupdate"
 	"github.com/tilt-dev/tilt/internal/docker"
+	"github.com/tilt-dev/tilt/internal/k8s"
 	"github.com/tilt-dev/tilt/internal/store"
 	"github.com/tilt-dev/tilt/internal/testutils"
 	"github.com/tilt-dev/tilt/internal/testutils/tempdir"
@@ -356,7 +354,7 @@ type lcbadFixture struct {
 func newFixture(t testing.TB) *lcbadFixture {
 	// HACK(maia): we don't need any real container updaters on this LiveUpdBaD since we're testing
 	// a func further down the flow that takes a ContainerUpdater as an arg, so just pass nils
-	lubad := NewLiveUpdateBuildAndDeployer(nil, nil, UpdateModeAuto, k8s.EnvDockerDesktop, container.RuntimeDocker, fakeClock{})
+	lubad := NewLiveUpdateBuildAndDeployer(nil, nil, UpdateModeAuto, k8s.KubeContext("fake-context"), fakeClock{})
 	fakeContainerUpdater := &containerupdate.FakeContainerUpdater{}
 	ctx, _, _ := testutils.CtxAndAnalyticsForTest()
 	st := store.NewTestingStore()

--- a/internal/engine/buildcontrol/update_mode.go
+++ b/internal/engine/buildcontrol/update_mode.go
@@ -3,7 +3,7 @@ package buildcontrol
 import (
 	"fmt"
 
-	"github.com/tilt-dev/tilt/internal/container"
+	"github.com/tilt-dev/tilt/internal/docker"
 	"github.com/tilt-dev/tilt/internal/k8s"
 )
 
@@ -34,7 +34,7 @@ var AllUpdateModes = []UpdateMode{
 	UpdateModeKubectlExec,
 }
 
-func ProvideUpdateMode(flag UpdateModeFlag, env k8s.Env, runtime container.Runtime) (UpdateMode, error) {
+func ProvideUpdateMode(flag UpdateModeFlag, kubeContext k8s.KubeContext, env docker.ClusterEnv) (UpdateMode, error) {
 	valid := false
 	for _, mode := range AllUpdateModes {
 		if mode == UpdateMode(flag) {
@@ -48,8 +48,8 @@ func ProvideUpdateMode(flag UpdateModeFlag, env k8s.Env, runtime container.Runti
 
 	mode := UpdateMode(flag)
 	if mode == UpdateModeContainer {
-		if !env.UsesLocalDockerRegistry() || runtime != container.RuntimeDocker {
-			return "", fmt.Errorf("update mode %q is only valid with local Docker clusters like Docker For Mac, Minikube, and MicroK8s", flag)
+		if !docker.Env(env).WillBuildToKubeContext(kubeContext) {
+			return "", fmt.Errorf("update mode %q is only valid with local Docker clusters like Docker For Mac or Minikube", flag)
 		}
 	}
 

--- a/internal/engine/buildcontrol/wire.go
+++ b/internal/engine/buildcontrol/wire.go
@@ -48,6 +48,8 @@ func ProvideImageBuildAndDeployer(
 	docker docker.Client,
 	kClient k8s.Client,
 	env k8s.Env,
+	kubeContext k8s.KubeContext,
+	clusterEnv docker.ClusterEnv,
 	dir *dirs.TiltDevDir,
 	clock build.Clock,
 	kp KINDLoader,
@@ -55,7 +57,6 @@ func ProvideImageBuildAndDeployer(
 	wire.Build(
 		BaseWireSet,
 		wire.Value(UpdateModeFlag(UpdateModeAuto)),
-		k8s.ProvideContainerRuntime,
 	)
 
 	return nil, nil
@@ -70,18 +71,12 @@ func ProvideDockerComposeBuildAndDeployer(
 		BaseWireSet,
 		wire.Value(UpdateModeFlag(UpdateModeAuto)),
 		build.ProvideClock,
+		wire.Value(docker.ClusterEnv(docker.Env{})),
 
 		// EnvNone ensures that we get an exploding k8s client.
-		wire.Value(k8s.Env(k8s.EnvNone)),
 		wire.Value(k8s.KubeContextOverride("")),
 		k8s.ProvideClientConfig,
-		k8s.ProvideConfigNamespace,
 		k8s.ProvideKubeContext,
-		k8s.ProvideK8sClient,
-		k8s.ProvideRESTConfig,
-		k8s.ProvideClientset,
-		k8s.ProvidePortForwardClient,
-		k8s.ProvideContainerRuntime,
 		k8s.ProvideKubeConfig,
 	)
 

--- a/internal/k8s/env.go
+++ b/internal/k8s/env.go
@@ -35,12 +35,15 @@ const (
 	EnvNone  Env = "none" // k8s not running (not neces. a problem, e.g. if using Tilt x Docker Compose)
 )
 
-func (e Env) UsesLocalDockerRegistry() bool {
-	return e == EnvMinikube || e == EnvDockerDesktop || e == EnvMicroK8s
-}
-
 func (e Env) IsDevCluster() bool {
-	return e == EnvMinikube || e == EnvDockerDesktop || e == EnvMicroK8s || e == EnvCRC || e == EnvKIND5 || e == EnvKIND6 || e == EnvK3D || e == EnvKrucible
+	return e == EnvMinikube ||
+		e == EnvDockerDesktop ||
+		e == EnvMicroK8s ||
+		e == EnvCRC ||
+		e == EnvKIND5 ||
+		e == EnvKIND6 ||
+		e == EnvK3D ||
+		e == EnvKrucible
 }
 
 func ProvideKubeContext(config *api.Config) (KubeContext, error) {

--- a/internal/k8s/minikube_fake.go
+++ b/internal/k8s/minikube_fake.go
@@ -11,8 +11,8 @@ func (c FakeMinikube) Version(ctx context.Context) (string, error) {
 	return c.FakeVersion, nil
 }
 
-func (c FakeMinikube) DockerEnv(ctx context.Context) (map[string]string, error) {
-	return c.DockerEnvMap, nil
+func (c FakeMinikube) DockerEnv(ctx context.Context) (map[string]string, bool, error) {
+	return c.DockerEnvMap, len(c.DockerEnvMap) > 0, nil
 }
 
 func (c FakeMinikube) NodeIP(ctx context.Context) (NodeIP, error) {

--- a/internal/k8s/minikube_test.go
+++ b/internal/k8s/minikube_test.go
@@ -25,10 +25,7 @@ export DOCKER_API_VERSION="1.35"
 # eval $(minikube docker-env)
 `)
 
-	env, err := dockerEnvFromOutput(output)
-	if err != nil {
-		t.Fatal(err)
-	}
+	env := dockerEnvFromOutput(output)
 
 	if len(env) != 4 ||
 		env["DOCKER_TLS_VERIFY"] != "1" ||


### PR DESCRIPTION
Hello @maiamcc,

Please review the following commits I made in branch nicks/ch12079:

cb46eee7205d6078b33247a62901e2d8b47e731f (2021-05-27 17:28:54 -0400)
docker: change how we model "image builds show up in the cluster immediately"
We used to treat this as a property of the cluster type + the container runtime.

But this made it impossible to support clusters that sometimes use your docker
runtime, and sometimes do not.

For examples, see:
- https://github.com/tilt-dev/tilt/issues/4587
- https://github.com/tilt-dev/tilt/issues/3654
- https://github.com/tilt-dev/tilt/issues/1729
- https://github.com/tilt-dev/tilt/issues/4544

This changes the data model so that "image builds show up in the cluster"
is a property of the Docker client, not of the cluster.

This should be much more flexible and correct, and help us support multiple
clusters.

Fixes https://github.com/tilt-dev/tilt/issues/4544

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics