### PR TITLE
Revert "rollout: make clear when tilt is attaching to an existing pod…

### DIFF
--- a/internal/engine/k8srollout/podmonitor.go
+++ b/internal/engine/k8srollout/podmonitor.go
@@ -54,16 +54,7 @@ func (m *PodMonitor) diff(st store.RStore) []podStatus {
 		key := podManifest{pod: podID, manifest: manifest.Name}
 		active[key] = true
 
-		// pod status updates during an active build are likely to be misleading or lost
-		// in the noise, so wait until the build finishes to process them
-		if !mt.State.ActiveBuild().Empty() {
-			continue
-		}
-		// ignore updates to pods that don't match the currently deployed pod template spec
-		if !mt.State.K8sRuntimeState().HasOKPodTemplateSpecHash(&pod) {
-			continue
-		}
-		currentStatus := newPodStatus(pod, mt.State.LastBuild().StartTime, manifest.Name)
+		currentStatus := newPodStatus(pod, manifest.Name)
 		if !podStatusesEqual(currentStatus, m.pods[key]) {
 			updates = append(updates, currentStatus)
 			m.pods[key] = currentStatus
@@ -92,19 +83,13 @@ func (m *PodMonitor) OnChange(ctx context.Context, st store.RStore, _ store.Chan
 }
 
 func (m *PodMonitor) print(ctx context.Context, update podStatus) {
-	reusingPod := update.podStartTime.Before(update.updateStartTime)
-	if reusingPod {
-		logger.Get(ctx).Infof("\nExisting pod still matches build (%s)", update.podID)
-		return
-	}
-
 	key := podManifest{pod: update.podID, manifest: update.manifestName}
 	if !m.trackingStarted[key] {
 		logger.Get(ctx).Infof("\nTracking new pod rollout (%s):", update.podID)
 		m.trackingStarted[key] = true
 	}
 
-	m.printCondition(ctx, "Scheduled", update.scheduled, update.podStartTime)
+	m.printCondition(ctx, "Scheduled", update.scheduled, update.startTime)
 	m.printCondition(ctx, "Initialized", update.initialized, update.scheduled.LastTransitionTime.Time)
 	m.printCondition(ctx, "Ready", update.ready, update.initialized.LastTransitionTime.Time)
 }
@@ -149,22 +134,16 @@ func (m *PodMonitor) printCondition(ctx context.Context, name string, cond v1alp
 }
 
 type podStatus struct {
-	podID           k8s.PodID
-	manifestName    model.ManifestName
-	updateStartTime time.Time
-	podStartTime    time.Time
-	scheduled       v1alpha1.PodCondition
-	initialized     v1alpha1.PodCondition
-	ready           v1alpha1.PodCondition
+	podID        k8s.PodID
+	manifestName model.ManifestName
+	startTime    time.Time
+	scheduled    v1alpha1.PodCondition
+	initialized  v1alpha1.PodCondition
+	ready        v1alpha1.PodCondition
 }
 
-func newPodStatus(pod v1alpha1.Pod, updateStartTime time.Time, manifestName model.ManifestName) podStatus {
-	s := podStatus{
-		podID:           k8s.PodID(pod.Name),
-		manifestName:    manifestName,
-		updateStartTime: updateStartTime,
-		podStartTime:    pod.CreatedAt.Time,
-	}
+func newPodStatus(pod v1alpha1.Pod, manifestName model.ManifestName) podStatus {
+	s := podStatus{podID: k8s.PodID(pod.Name), manifestName: manifestName, startTime: pod.CreatedAt.Time}
 	for _, condition := range pod.Conditions {
 		switch v1.PodConditionType(condition.Type) {
 		case v1.PodScheduled:

--- a/internal/engine/k8srollout/podmonitor_test.go
+++ b/internal/engine/k8srollout/podmonitor_test.go
@@ -2,23 +2,31 @@ package k8srollout
 
 import (
 	"context"
+	"fmt"
 	"io"
+	"io/ioutil"
 	"strings"
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/require"
+	"github.com/tilt-dev/tilt/pkg/apis"
+
+	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
+
+	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 
 	"github.com/tilt-dev/tilt/internal/store"
 	"github.com/tilt-dev/tilt/internal/testutils/bufsync"
 	"github.com/tilt-dev/tilt/internal/testutils/manifestutils"
 	"github.com/tilt-dev/tilt/internal/testutils/tempdir"
-	"github.com/tilt-dev/tilt/pkg/apis"
-	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
 	"github.com/tilt-dev/tilt/pkg/logger"
 	"github.com/tilt-dev/tilt/pkg/model"
 )
+
+// NOTE(han): set at runtime with:
+// go test -ldflags="-X 'github.com/tilt-dev/tilt/internal/engine/k8srollout.PodmonitorWriteGoldenMaster=1'" ./internal/engine/k8srollout
+var PodmonitorWriteGoldenMaster = "0"
 
 func TestMonitorReady(t *testing.T) {
 	f := newPMFixture(t)
@@ -27,51 +35,6 @@ func TestMonitorReady(t *testing.T) {
 	start := time.Now()
 	p := v1alpha1.Pod{
 		Name:      "pod-id",
-		CreatedAt: apis.NewTime(start.Add(5 * time.Second)),
-		Conditions: []v1alpha1.PodCondition{
-			{
-				Type:               string(v1.PodScheduled),
-				Status:             string(v1.ConditionTrue),
-				LastTransitionTime: apis.NewTime(start.Add(6 * time.Second)),
-			},
-			{
-				Type:               string(v1.PodInitialized),
-				Status:             string(v1.ConditionTrue),
-				LastTransitionTime: apis.NewTime(start.Add(10 * time.Second)),
-			},
-			{
-				Type:               string(v1.PodReady),
-				Status:             string(v1.ConditionTrue),
-				LastTransitionTime: apis.NewTime(start.Add(15 * time.Second)),
-			},
-		},
-	}
-
-	state := store.NewState()
-	mt := manifestutils.NewManifestTargetWithPod(model.Manifest{Name: "server"}, p)
-	mt.State.BuildHistory = []model.BuildRecord{{StartTime: start}}
-	state.UpsertManifestTarget(mt)
-
-	f.onChange(*state)
-
-	expectedLines := []string{
-		"Tracking new pod rollout (pod-id):",
-		"     ┊ Scheduled       - 1s",
-		"     ┊ Initialized     - 4s",
-		"     ┊ Ready           - 5s",
-	}
-	actualLines := strings.Split(strings.TrimSpace(f.out.String()), "\n")
-
-	require.Equal(t, expectedLines, actualLines)
-}
-
-func TestAttachToExistingPod(t *testing.T) {
-	f := newPMFixture(t)
-	defer f.TearDown()
-
-	start := time.Now()
-	p := v1alpha1.Pod{
-		Name:      "pod-id",
 		CreatedAt: apis.NewTime(start),
 		Conditions: []v1alpha1.PodCondition{
 			{
@@ -93,69 +56,13 @@ func TestAttachToExistingPod(t *testing.T) {
 	}
 
 	state := store.NewState()
-	mt := manifestutils.NewManifestTargetWithPod(model.Manifest{Name: "server"}, p)
-	mt.State.BuildHistory = []model.BuildRecord{{StartTime: start.Add(20 * time.Second)}}
-	state.UpsertManifestTarget(mt)
+	state.UpsertManifestTarget(manifestutils.NewManifestTargetWithPod(
+		model.Manifest{Name: "server"}, p))
+	f.store.SetState(*state)
 
-	f.onChange(*state)
+	f.pm.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
 
-	// make sure we log every time a build finishes
-	mt.State.AddCompletedBuild(model.BuildRecord{StartTime: start.Add(30 * time.Second)})
-	state.UpsertManifestTarget(mt)
-	f.onChange(*state)
-
-	// two builds, two logs
-	msg := "Existing pod still matches build (pod-id)\n\nExisting pod still matches build (pod-id)"
-	require.Equal(t, msg, strings.TrimSpace(f.out.String()))
-}
-
-func TestAttachToExistingPodDuringActiveBuild(t *testing.T) {
-	f := newPMFixture(t)
-	defer f.TearDown()
-
-	start := time.Now()
-	p := v1alpha1.Pod{
-		Name:      "pod-id",
-		CreatedAt: apis.NewTime(start),
-		Conditions: []v1alpha1.PodCondition{
-			{
-				Type:               string(v1.PodScheduled),
-				Status:             string(v1.ConditionTrue),
-				LastTransitionTime: apis.NewTime(start.Add(time.Second)),
-			},
-			{
-				Type:               string(v1.PodInitialized),
-				Status:             string(v1.ConditionTrue),
-				LastTransitionTime: apis.NewTime(start.Add(5 * time.Second)),
-			},
-			{
-				Type:               string(v1.PodReady),
-				Status:             string(v1.ConditionTrue),
-				LastTransitionTime: apis.NewTime(start.Add(10 * time.Second)),
-			},
-		},
-	}
-
-	state := store.NewState()
-
-	// the manifest knows about the pod, and there is a build in progress
-	mt := manifestutils.NewManifestTargetWithPod(model.Manifest{Name: "server"}, p)
-	mt.State.BuildHistory = []model.BuildRecord{{StartTime: start}}
-	mt.State.CurrentBuild = model.BuildRecord{StartTime: start.Add(15 * time.Second)}
-	state.UpsertManifestTarget(mt)
-	f.onChange(*state)
-
-	// nothing should be logged while a build is in progress
-	require.Equal(t, "", f.out.String())
-
-	mt.State.AddCompletedBuild(mt.State.CurrentBuild)
-	mt.State.CurrentBuild = model.BuildRecord{}
-	state.UpsertManifestTarget(mt)
-	f.onChange(*state)
-
-	// now that the build has finished, we should recognize the pod
-	msg := "Existing pod still matches build (pod-id)"
-	require.Equal(t, msg, strings.TrimSpace(f.out.String()))
+	assertSnapshot(t, f.out.String())
 }
 
 type pmFixture struct {
@@ -192,11 +99,6 @@ func (f *pmFixture) TearDown() {
 	f.TempDirFixture.TearDown()
 }
 
-func (f *pmFixture) onChange(state store.EngineState) {
-	f.store.SetState(state)
-	f.pm.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
-}
-
 type testStore struct {
 	*store.TestingStore
 	out io.Writer
@@ -216,4 +118,25 @@ func (s *testStore) Dispatch(action store.Action) {
 	if ok {
 		_, _ = s.out.Write(logAction.Message())
 	}
+}
+
+func assertSnapshot(t *testing.T, output string) {
+	d1 := []byte(output)
+	gmPath := fmt.Sprintf("testdata/%s_master", t.Name())
+	if PodmonitorWriteGoldenMaster == "1" {
+		err := ioutil.WriteFile(gmPath, d1, 0644)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	expected, err := ioutil.ReadFile(gmPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, normalize(string(expected)), normalize(output))
+}
+
+func normalize(s string) string {
+	return strings.Replace(s, "\r\n", "\n", -1)
 }


### PR DESCRIPTION
… rather than rolling out a new one (#4570)"

fixes #4594 (and reintroduces #4566)

This reverts commit 93c8908124268ebc87a87fab8cf889cf190f983f.