### PR TITLE
docker: support DOCKER_HOST=ssh://... remotes

### DIFF
--- a/internal/docker/client.go
+++ b/internal/docker/client.go
@@ -264,6 +264,9 @@ func CreateClientOpts(_ context.Context, env Env) ([]client.Opt, error) {
 		// Docker 18.09+ supports DOCKER_HOST=ssh://remote-docker-host connection strings,
 		// but the Moby client doesn't natively know how to handle them
 		// adapted from https://github.com/docker/cli/blob/a32cd16160f1b41c1c4ae7bee4dac929d1484e59/cli/context/docker/load.go#L93-L134
+		//
+		// WARNING: due to the complexity of this setup, there is currently NO integration test that covers
+		// 	using an SSH remote executor (CI DOES use a remote executor, but not via SSH)
 		connHelper, err := connhelper.GetConnectionHelper(env.Host)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Docker 18.09+ added support for SSH remote Docker connections.
The code to handle this isn't actually in the Moby client portions
that we use, but in the Docker CLI (which we already have a
dependency on).

This adapts some of the code from the Docker CLI that attempts
to create a `ConnectionHelper` if the host value is set. Currently,
the logic only creates a helper for `ssh://` hosts and returns nil
otherwise, in which case the former logic is used (i.e. pass the
host as-is to Moby). If a connection helper is created, it's used
to create a custom HTTP client/transport that will use SSH under
the hood.

Fixes #4603.