### PR TITLE
(web) Add term input field to filters bar to filter resource logs by string

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -28,6 +28,7 @@
     "react-scripts": "^4.0.1",
     "react-storage-hooks": "^4.0.1",
     "react-timeago": "^4.4.0",
+    "regex-escape": "^3.4.10",
     "styled-components": "^5.1.1"
   },
   "scripts": {

--- a/web/src/OverviewActionBar.stories.tsx
+++ b/web/src/OverviewActionBar.stories.tsx
@@ -1,7 +1,13 @@
 import { createMemoryHistory } from "history"
 import React from "react"
 import { Router } from "react-router"
-import { FilterLevel, FilterSource, useFilterSet } from "./logfilters"
+import {
+  EMPTY_FILTER_TERM,
+  FilterLevel,
+  FilterSet,
+  FilterSource,
+  useFilterSet,
+} from "./logfilters"
 import OverviewActionBar from "./OverviewActionBar"
 import { StarredResourceMemoryProvider } from "./StarredResourcesContext"
 import { oneButton, oneResource } from "./testdata"
@@ -41,7 +47,11 @@ export default {
   },
 }
 
-let defaultFilter = { source: FilterSource.all, level: FilterLevel.all }
+let defaultFilter: FilterSet = {
+  source: FilterSource.all,
+  level: FilterLevel.all,
+  term: EMPTY_FILTER_TERM,
+}
 
 export const OverflowTextBar = () => {
   let filterSet = useFilterSet()

--- a/web/src/OverviewActionBar.stories.tsx
+++ b/web/src/OverviewActionBar.stories.tsx
@@ -33,12 +33,14 @@ export default {
   ],
   argTypes: {
     source: {
+      name: "Source",
       control: {
         type: "select",
         options: [FilterSource.all, FilterSource.build, FilterSource.runtime],
       },
     },
     level: {
+      name: "Level",
       control: {
         type: "select",
         options: [FilterLevel.all, FilterLevel.warn, FilterLevel.error],

--- a/web/src/OverviewActionBar.test.tsx
+++ b/web/src/OverviewActionBar.test.tsx
@@ -85,7 +85,7 @@ it("navigates to build warning filter", () => {
   let buildItem = sourceItems.filter({ "data-filter": FilterSource.build })
   expect(buildItem).toHaveLength(1)
   buildItem.simulate("click")
-  expect(history.location.search).toEqual("?source=build&level=warn")
+  expect(history.location.search).toEqual("?level=warn&source=build")
 })
 
 it("shows buttons", () => {

--- a/web/src/OverviewActionBar.tsx
+++ b/web/src/OverviewActionBar.tsx
@@ -1,25 +1,48 @@
+import {
+  debounce,
+  InputAdornment,
+  InputProps,
+  TextField,
+} from "@material-ui/core"
 import Menu from "@material-ui/core/Menu"
 import MenuItem from "@material-ui/core/MenuItem"
 import { PopoverOrigin } from "@material-ui/core/Popover"
 import { makeStyles } from "@material-ui/core/styles"
 import ExpandMoreIcon from "@material-ui/icons/ExpandMore"
 import moment from "moment"
-import React, { useRef, useState } from "react"
+import { History } from "history"
+import React, { ChangeEvent, useRef, useState } from "react"
 import { useHistory, useLocation } from "react-router"
 import styled from "styled-components"
 import { Alert } from "./alerts"
 import { incr } from "./analytics"
 import { ReactComponent as CheckmarkSvg } from "./assets/svg/checkmark.svg"
+import { ReactComponent as CloseSvg } from "./assets/svg/close.svg"
 import { ReactComponent as CopySvg } from "./assets/svg/copy.svg"
+import { ReactComponent as FilterSvg } from "./assets/svg/filter.svg"
 import { ReactComponent as LinkSvg } from "./assets/svg/link.svg"
 import { InstrumentedButton } from "./instrumentedComponents"
 import { displayURL } from "./links"
 import LogActions from "./LogActions"
-import { FilterLevel, FilterSet, FilterSource } from "./logfilters"
+import {
+  EMPTY_TERM,
+  FilterLevel,
+  FilterSet,
+  FilterSource,
+  TermState,
+} from "./logfilters"
 import { useLogStore } from "./LogStore"
 import OverviewActionBarKeyboardShortcuts from "./OverviewActionBarKeyboardShortcuts"
 import { usePathBuilder } from "./PathBuilder"
-import { AnimDuration, Color, Font, FontSize, SizeUnit } from "./style-helpers"
+import SrOnly from "./SrOnly"
+import {
+  AnimDuration,
+  Color,
+  Font,
+  FontSize,
+  mixinResetButtonStyle,
+  SizeUnit,
+} from "./style-helpers"
 import { ResourceName } from "./types"
 
 type UIResource = Proto.v1alpha1UIResource
@@ -73,9 +96,7 @@ function FilterSourceMenu(props: FilterSourceMenuProps) {
   let l = useLocation()
   let onClick = (e: any) => {
     let source = e.currentTarget.getAttribute("data-filter")
-    let search = new URLSearchParams(l.search)
-    search.set("source", source)
-    search.set("level", level)
+    const search = createLogSearch(l.search, { source, level })
     history.push({
       pathname: l.pathname,
       search: search.toString(),
@@ -236,6 +257,43 @@ export let ButtonRightPill = styled(ButtonRoot)`
   border-radius: 0 4px 4px 0;
 `
 
+const FilterTermTextField = styled(TextField)`
+  & .MuiOutlinedInput-root {
+    border-radius: ${SizeUnit(0.125)};
+    border: 1px solid ${Color.grayLighter};
+    background-color: ${Color.gray};
+    transition: border-color ${AnimDuration.default} ease;
+
+    &:hover {
+      border-color: ${Color.blue};
+    }
+    & fieldset {
+      border-color: 1px solid ${Color.grayLighter};
+    }
+    &:hover fieldset {
+      border: 1px solid ${Color.grayLighter};
+    }
+    & .Mui-focused fieldset {
+      border: 1px solid ${Color.grayLighter};
+    }
+    & .MuiOutlinedInput-input {
+      padding: ${SizeUnit(0.2)};
+    }
+  }
+
+  & .MuiInputBase-input {
+    font-family: ${Font.monospace};
+    color: ${Color.gray7};
+    font-size: ${FontSize.small};
+  }
+`
+
+const ClearFilterTermTextButton = styled(InstrumentedButton)`
+  ${mixinResetButtonStyle}
+  align-items: center;
+  display: flex;
+`
+
 type FilterRadioButtonProps = {
   // The level that this button toggles.
   level: FilterLevel
@@ -245,6 +303,32 @@ type FilterRadioButtonProps = {
 
   // All the alerts for the current resource.
   alerts?: Alert[]
+}
+
+function createLogSearch(
+  currentSearch: string,
+  {
+    level,
+    source,
+    term,
+  }: { level?: FilterLevel; source?: FilterSource; term?: string }
+) {
+  // Start with the existing search params
+  const newSearch = new URLSearchParams(currentSearch)
+
+  if (level !== undefined) {
+    newSearch.set("level", level)
+  }
+
+  if (source !== undefined) {
+    newSearch.set("source", source)
+  }
+
+  if (term !== undefined) {
+    newSearch.set("term", term)
+  }
+
+  return newSearch
 }
 
 export function FilterRadioButton(props: FilterRadioButtonProps) {
@@ -291,9 +375,10 @@ export function FilterRadioButton(props: FilterRadioButtonProps) {
   let history = useHistory()
   let l = useLocation()
   let onClick = () => {
-    let search = new URLSearchParams(l.search)
-    search.set("level", level)
-    search.set("source", "")
+    const search = createLogSearch(l.search, {
+      level,
+      source: FilterSource.all,
+    })
     history.push({
       pathname: l.pathname,
       search: search.toString(),
@@ -335,6 +420,93 @@ export function FilterRadioButton(props: FilterRadioButtonProps) {
         onClose={() => setSourceMenuAnchor(null)}
       />
     </ButtonPill>
+  )
+}
+
+export const FILTER_INPUT_DEBOUNCE = 500 // in ms
+
+const debounceFilterLogs = debounce((history: History, search: string) => {
+  history.push({ pathname: location.pathname, search })
+}, FILTER_INPUT_DEBOUNCE)
+
+function FilterTermField(props: { filterSet: FilterSet }) {
+  // The global term is set from the url, which is passed
+  // down through props and used to set the initial value
+  const globalTerm = props.filterSet.term
+  const [filterTerm, setFilterTerm] = useState(globalTerm.input ?? EMPTY_TERM)
+
+  const history = useHistory()
+  const location = history.location
+
+  const inputProps: InputProps = {
+    startAdornment: (
+      <InputAdornment position="start" disablePointerEvents={true}>
+        <FilterSvg fill={Color.grayDark} role="presentation" />
+      </InputAdornment>
+    ),
+  }
+
+  // If there's a search term, add a button to clear that term
+  if (filterTerm) {
+    const onClearClick = () => {
+      // Clear the input field's value
+      setFilterTerm(EMPTY_TERM)
+
+      // Clear the global term's value
+      const emptyTermSearch = createLogSearch(location.search, {
+        term: EMPTY_TERM,
+      })
+      history.push({
+        pathname: location.pathname,
+        search: emptyTermSearch.toString(),
+      })
+    }
+
+    const endAdornment = (
+      <InputAdornment position="end">
+        <ClearFilterTermTextButton analyticsName="TODO" onClick={onClearClick}>
+          <SrOnly>Clear filter term</SrOnly>
+          <CloseSvg fill={Color.grayLightest} role="presentation" />
+        </ClearFilterTermTextButton>
+      </InputAdornment>
+    )
+
+    inputProps.endAdornment = endAdornment
+  }
+
+  /**
+   * Note: debouncing allows us to wait to execute log filtration until a set
+   * amount of time has passed without the filter term changing. To implement
+   * debouncing, it's necessary to separate the term field's value from the url
+   * search params, otherwise the field that a user types in doesn't update.
+   * The term field updates without any debouncing, while the url search params
+   * (which actually triggers log filtering) updates with the debounce delay.
+   */
+  const onChange = (
+    event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+  ) => {
+    const term = event.target.value ?? EMPTY_TERM
+    const search = createLogSearch(location.search, { term })
+
+    setFilterTerm(term)
+    debounceFilterLogs(history, search.toString())
+  }
+
+  return (
+    <>
+      <FilterTermTextField
+        aria-invalid={globalTerm.state === TermState.Error}
+        id="FilterTermTextInput"
+        InputProps={inputProps}
+        onChange={onChange}
+        placeholder="Filter logs by string"
+        value={filterTerm}
+        variant="outlined"
+      />
+      <SrOnly component="label" htmlFor="FilterTermTextInput">
+        Filter resource logs by string
+      </SrOnly>
+    </>
   )
 }
 
@@ -574,6 +746,7 @@ export default function OverviewActionBar(props: OverviewActionBarProps) {
           filterSet={props.filterSet}
           alerts={alerts}
         />
+        <FilterTermField filterSet={props.filterSet} />
         <LogActions resourceName={resourceName} isSnapshot={isSnapshot} />
       </ActionBarBottomRow>
     </ActionBarRoot>

--- a/web/src/OverviewActionBar.tsx
+++ b/web/src/OverviewActionBar.tsx
@@ -305,7 +305,7 @@ type FilterRadioButtonProps = {
   alerts?: Alert[]
 }
 
-function createLogSearch(
+export function createLogSearch(
   currentSearch: string,
   {
     level,
@@ -424,12 +424,13 @@ export function FilterRadioButton(props: FilterRadioButtonProps) {
 }
 
 export const FILTER_INPUT_DEBOUNCE = 500 // in ms
+export const FILTER_FIELD_ID = "FilterTermTextInput"
 
 const debounceFilterLogs = debounce((history: History, search: string) => {
   history.push({ pathname: location.pathname, search })
 }, FILTER_INPUT_DEBOUNCE)
 
-function FilterTermField(props: { filterSet: FilterSet }) {
+export function FilterTermField(props: { filterSet: FilterSet }) {
   // The global term is set from the url, which is passed
   // down through props and used to set the initial value
   const globalTerm = props.filterSet.term
@@ -496,14 +497,14 @@ function FilterTermField(props: { filterSet: FilterSet }) {
     <>
       <FilterTermTextField
         aria-invalid={globalTerm.state === TermState.Error}
-        id="FilterTermTextInput"
+        id={FILTER_FIELD_ID}
         InputProps={inputProps}
         onChange={onChange}
         placeholder="Filter logs by string"
         value={filterTerm}
         variant="outlined"
       />
-      <SrOnly component="label" htmlFor="FilterTermTextInput">
+      <SrOnly component="label" htmlFor={FILTER_FIELD_ID}>
         Filter resource logs by string
       </SrOnly>
     </>

--- a/web/src/OverviewLogPane.stories.tsx
+++ b/web/src/OverviewLogPane.stories.tsx
@@ -1,6 +1,11 @@
 import React, { Component, useEffect, useState } from "react"
 import { MemoryRouter } from "react-router"
-import { FilterLevel, FilterSource } from "./logfilters"
+import {
+  EMPTY_FILTER_TERM,
+  FilterLevel,
+  FilterSet,
+  FilterSource,
+} from "./logfilters"
 import LogStore, { LogStoreProvider } from "./LogStore"
 import OverviewLogPane from "./OverviewLogPane"
 import { appendLines } from "./testlogs"
@@ -26,7 +31,11 @@ export default {
   ],
 }
 
-let defaultFilter = { source: FilterSource.all, level: FilterLevel.all }
+let defaultFilter: FilterSet = {
+  source: FilterSource.all,
+  level: FilterLevel.all,
+  term: EMPTY_FILTER_TERM,
+}
 
 export const ThreeLines = () => {
   let logStore = new LogStore()
@@ -306,7 +315,11 @@ export const BuildLogAndRunLog = (args: any) => {
     <LogStoreProvider value={logStore}>
       <OverviewLogPane
         manifestName={"vigoda_1"}
-        filterSet={{ source: args.source, level: args.level }}
+        filterSet={{
+          source: args.source,
+          level: args.level,
+          term: EMPTY_FILTER_TERM,
+        }}
       />
     </LogStoreProvider>
   )

--- a/web/src/OverviewLogPane.stories.tsx
+++ b/web/src/OverviewLogPane.stories.tsx
@@ -318,7 +318,7 @@ export const BuildLogAndRunLog = (args: any) => {
         filterSet={{
           source: args.source,
           level: args.level,
-          term: EMPTY_FILTER_TERM,
+          term: args.term || EMPTY_FILTER_TERM,
         }}
       />
     </LogStoreProvider>
@@ -328,16 +328,19 @@ export const BuildLogAndRunLog = (args: any) => {
 BuildLogAndRunLog.args = {
   source: "",
   level: "",
+  term: EMPTY_FILTER_TERM,
 }
 
 BuildLogAndRunLog.argTypes = {
   source: {
+    name: "Source",
     control: {
       type: "select",
       options: [FilterSource.all, FilterSource.build, FilterSource.runtime],
     },
   },
   level: {
+    name: "Level",
     control: {
       type: "select",
       options: [FilterLevel.all, FilterLevel.warn, FilterLevel.error],

--- a/web/src/OverviewLogPane.test.tsx
+++ b/web/src/OverviewLogPane.test.tsx
@@ -1,6 +1,11 @@
 import { mount } from "enzyme"
 import { MemoryRouter } from "react-router"
-import { FilterLevel, FilterSource } from "./logfilters"
+import {
+  createFilterTermState,
+  EMPTY_FILTER_TERM,
+  FilterLevel,
+  FilterSource,
+} from "./logfilters"
 import { LogUpdateAction } from "./LogStore"
 import {
   OverviewLogComponent,
@@ -50,7 +55,11 @@ it("filters by source", () => {
   expect(el.querySelectorAll(".LogPaneLine")).toHaveLength(40)
 
   let root2 = logPaneMount(
-    <BuildLogAndRunLog level="" source={FilterSource.runtime} />
+    <BuildLogAndRunLog
+      level=""
+      source={FilterSource.runtime}
+      term={EMPTY_FILTER_TERM}
+    />
   )
   let el2 = root2.getDOMNode()
   expect(el2.querySelectorAll(".LogPaneLine")).toHaveLength(20)
@@ -60,7 +69,11 @@ it("filters by source", () => {
   )
 
   let root3 = logPaneMount(
-    <BuildLogAndRunLog level="" source={FilterSource.build} />
+    <BuildLogAndRunLog
+      level=""
+      source={FilterSource.build}
+      term={EMPTY_FILTER_TERM}
+    />
   )
   let el3 = root3.getDOMNode()
   expect(el3.querySelectorAll(".LogPaneLine")).toHaveLength(20)
@@ -69,12 +82,18 @@ it("filters by source", () => {
 })
 
 it("filters by level", () => {
-  let root = logPaneMount(<BuildLogAndRunLog source="" level="" />)
+  let root = logPaneMount(
+    <BuildLogAndRunLog source="" level="" term={EMPTY_FILTER_TERM} />
+  )
   let el = root.getDOMNode()
   expect(el.querySelectorAll(".LogPaneLine")).toHaveLength(40)
 
   let root2 = logPaneMount(
-    <BuildLogAndRunLog level={FilterLevel.warn} source="" />
+    <BuildLogAndRunLog
+      level={FilterLevel.warn}
+      source=""
+      term={EMPTY_FILTER_TERM}
+    />
   )
   let el2 = root2.getDOMNode()
   expect(el2.querySelectorAll(".LogPaneLine")).toHaveLength(
@@ -94,7 +113,11 @@ it("filters by level", () => {
   )
 
   let root3 = logPaneMount(
-    <BuildLogAndRunLog level={FilterLevel.error} source="" />
+    <BuildLogAndRunLog
+      level={FilterLevel.error}
+      source=""
+      term={EMPTY_FILTER_TERM}
+    />
   )
   let el3 = root3.getDOMNode()
   expect(el3.querySelectorAll(".LogPaneLine")).toHaveLength(
@@ -111,6 +134,37 @@ it("filters by level", () => {
   )
   expect(alertEnd.innerHTML).toEqual(
     expect.stringContaining("Vigoda pod error line")
+  )
+})
+
+it("filters by term", () => {
+  const noFilterRoot = logPaneMount(
+    <BuildLogAndRunLog source="" level="" term={EMPTY_FILTER_TERM} />
+  )
+  const noTermEl = noFilterRoot.getDOMNode()
+  expect(noTermEl.querySelectorAll(".LogPaneLine")).toHaveLength(40)
+
+  const termWithResults = createFilterTermState("line 5")
+  const filterWithResults = logPaneMount(
+    <BuildLogAndRunLog source="" level="" term={termWithResults} />
+  )
+  const elWithResults = filterWithResults.getDOMNode()
+
+  expect(elWithResults.querySelectorAll(".LogPaneLine")).toHaveLength(2)
+  expect(elWithResults.innerHTML).toEqual(expect.stringContaining("line 5"))
+  expect(elWithResults.innerHTML).toEqual(
+    expect.not.stringContaining("line 15")
+  )
+
+  const termWithNoResults = createFilterTermState("spaghetti")
+  const filterWithNoResults = logPaneMount(
+    <BuildLogAndRunLog source="" level="" term={termWithNoResults} />
+  )
+  const elWithNoResults = filterWithNoResults.getDOMNode()
+
+  expect(elWithNoResults.querySelectorAll(".LogPaneLine")).toHaveLength(0)
+  expect(elWithNoResults.innerHTML).toEqual(
+    expect.not.stringContaining("Vigoda")
   )
 })
 

--- a/web/src/OverviewLogPane.tsx
+++ b/web/src/OverviewLogPane.tsx
@@ -405,11 +405,11 @@ export class OverviewLogComponent extends Component<OverviewLogComponentProps> {
     const { term } = this.props.filterSet
 
     // Don't consider a filter term if the term hasn't been parsed for matching
-    if (term.state !== TermState.Parsed) {
+    if (!term || term.state !== TermState.Parsed) {
       return true
     }
 
-    return term.regex.test(line.text)
+    return term.regexp.test(line.text)
   }
 
   // If we have a level filter on, check if this line matches the level filter.

--- a/web/src/OverviewLogPane.tsx
+++ b/web/src/OverviewLogPane.tsx
@@ -1,4 +1,5 @@
 import Anser from "anser"
+import { History } from "history"
 import React, { Component } from "react"
 import { useHistory, useLocation } from "react-router"
 import styled, { keyframes } from "styled-components"
@@ -8,6 +9,7 @@ import {
   FilterSet,
   filterSetsEqual,
   FilterSource,
+  TermState,
 } from "./logfilters"
 import "./LogPane.scss"
 import "./LogPaneLine.scss"
@@ -30,7 +32,7 @@ type OverviewLogComponentProps = {
   logStore: LogStore
   raf: RafContext
   filterSet: FilterSet
-  history: any
+  history: History
   scrollToStoredLineIndex: number | null
 }
 
@@ -181,7 +183,7 @@ export class OverviewLogComponent extends Component<OverviewLogComponentProps> {
   // The element containing all the log lines.
   rootRef: React.RefObject<any> = React.createRef()
 
-  // The blinking cursor at the end fo the component.
+  // The blinking cursor at the end of the component.
   private cursorRef: React.RefObject<HTMLParagraphElement> = React.createRef()
 
   // Track the scrollTop of the root element to see if the user is scrolling upwards.
@@ -399,6 +401,17 @@ export class OverviewLogComponent extends Component<OverviewLogComponentProps> {
     }
   }
 
+  matchesTermFilter(line: LogLine): boolean {
+    const { term } = this.props.filterSet
+
+    // Don't consider a filter term if the term hasn't been parsed for matching
+    if (term.state !== TermState.Parsed) {
+      return true
+    }
+
+    return term.regex.test(line.text)
+  }
+
   // If we have a level filter on, check if this line matches the level filter.
   matchesLevelFilter(line: LogLine): boolean {
     let level = this.props.filterSet.level
@@ -430,7 +443,7 @@ export class OverviewLogComponent extends Component<OverviewLogComponentProps> {
       return false
     }
 
-    return this.matchesLevelFilter(line)
+    return this.matchesLevelFilter(line) && this.matchesTermFilter(line)
   }
 
   // Index this line so that we can display prologues to errors.

--- a/web/src/SrOnly.tsx
+++ b/web/src/SrOnly.tsx
@@ -1,0 +1,31 @@
+import { Typography, TypographyTypeMap } from "@material-ui/core"
+import {
+  DefaultComponentProps,
+  OverrideProps,
+} from "@material-ui/core/OverridableComponent"
+import React, { ElementType, PropsWithChildren } from "react"
+
+/**
+ * A lightweight wrapper for content that should only be available
+ * to assistive technology, using Material UI's Typography component
+ * with `srOnly` class. Screen-reader-only classes are a common pattern
+ * that allows useful content to be present in the DOM (and therefore
+ * available to screen-readers), but not visible to sighted users.
+ * https://material-ui.com/api/typography/
+ */
+
+// Note: types are copy-pasta'd and adapted from Typography.d.ts
+type SrOnlyProps<C extends ElementType> =
+  | ({ component: C } & OverrideProps<TypographyTypeMap, C> &
+      DefaultComponentProps<TypographyTypeMap>)
+  | DefaultComponentProps<TypographyTypeMap>
+
+export default function SrOnly<C extends ElementType = "span">(
+  props: PropsWithChildren<SrOnlyProps<C>>
+) {
+  return (
+    <Typography {...props} variant="srOnly">
+      {props.children}
+    </Typography>
+  )
+}

--- a/web/src/assets/svg/filter.svg
+++ b/web/src/assets/svg/filter.svg
@@ -1,0 +1,3 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M0 0L5.54492 5.54492V16L10.4551 11.9824V5.54492L16 0H0Z" fill="#586E75"/>
+</svg>

--- a/web/src/logfilters.test.ts
+++ b/web/src/logfilters.test.ts
@@ -1,0 +1,92 @@
+import { Location } from "history"
+import {
+  EMPTY_FILTER_TERM,
+  filterSetFromLocation,
+  parseTermInput,
+  TermState,
+} from "./logfilters"
+
+enum TestStrings {
+  Basic = "abc",
+  BuildCommand = 'Step 1 - 0.00s (Running command: [sh -c services="red" ./generate-start.sh] (in "/Users/lizz/Documents/Repos/pixeltilt/full"))',
+  BuildError404 = "Build Failed: ImageBuild: failed to compute cache key: failed to walk /var/lib/docker/tmp/buildkit-mount767282166/red: lstat /var/lib/docker/tmp/buildkit-mount767282166/red: no such file or directory",
+  BuildErrorInFile = "ERROR IN: [5/5] ADD storage/main ./",
+  BuildInfoLine = "[1/5] FROM docker.io/library/alpine@sha256:69e70a79f2d41ab5d637de98c1e0b055206ba40a8145e7bddb55ccc04e13cf8f",
+  SyntaxError = "→ render/start.go:9:33: syntax error: unexpected N, expecting comma or )",
+}
+
+describe("Log filters", () => {
+  describe("state generation", () => {
+    describe("for term filter", () => {
+      it("gets set with an empty state if no term is present", () => {
+        const emptyTermLocation = { search: "term=" } as Location
+        expect(filterSetFromLocation(emptyTermLocation).term).toEqual(
+          EMPTY_FILTER_TERM
+        )
+
+        const noTermLocation = { search: "" } as Location
+        expect(filterSetFromLocation(noTermLocation).term).toEqual(
+          EMPTY_FILTER_TERM
+        )
+      })
+
+      it("gets set with a parsed state if a valid term is present", () => {
+        const location = { search: "term=docker+build" } as Location
+        const parsedTerm = filterSetFromLocation(location).term
+        expect(parsedTerm.state).toEqual(TermState.Parsed)
+        expect(parsedTerm.input).toEqual("docker build")
+        expect(parsedTerm.hasOwnProperty("regexp")).toBe(true)
+      })
+
+      // TODO(LT): when regex input is supported in term filter field, add a test for error case
+    })
+
+    describe("term parsing", () => {
+      describe("for string literals", () => {
+        it("matches on the expected text", () => {
+          expect(parseTermInput("abc").test(TestStrings.Basic)).toBe(true)
+          expect(parseTermInput("SERVICE").test(TestStrings.BuildCommand)).toBe(
+            true
+          )
+          expect(
+            parseTermInput("random phrase").test(TestStrings.BuildInfoLine)
+          ).toBe(false)
+          expect(parseTermInput("ab5d63").test(TestStrings.BuildInfoLine)).toBe(
+            true
+          )
+          expect(parseTermInput("error").test(TestStrings.SyntaxError)).toBe(
+            true
+          )
+          expect(parseTermInput("mount").test(TestStrings.BuildError404)).toBe(
+            true
+          )
+          expect(parseTermInput("mount ").test(TestStrings.BuildError404)).toBe(
+            false
+          )
+        })
+
+        it("escapes any RegExp-specific characters", () => {
+          expect(parseTermInput("ab?c").test(TestStrings.Basic)).toBe(false)
+          expect(parseTermInput('"red"').test(TestStrings.BuildCommand)).toBe(
+            true
+          )
+          expect(
+            parseTermInput("generate-start.sh").test(TestStrings.BuildCommand)
+          ).toBe(true)
+          expect(parseTermInput("w").test(TestStrings.BuildInfoLine)).toBe(
+            false
+          )
+          expect(
+            parseTermInput("comma or )").test(TestStrings.SyntaxError)
+          ).toBe(true)
+          expect(
+            parseTermInput("ERROR.+").test(TestStrings.BuildErrorInFile)
+          ).toBe(false)
+          expect(parseTermInput("[1/5]").test(TestStrings.BuildInfoLine)).toBe(
+            true
+          )
+        })
+      })
+    })
+  })
+})

--- a/web/src/regex-escape.d.ts
+++ b/web/src/regex-escape.d.ts
@@ -1,0 +1,5 @@
+declare module "regex-escape" {
+  const RegexEscape: (string) => string
+
+  export default RegexEscape
+}

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -13041,6 +13041,11 @@ regenerator-transform@^0.14.2:
   dependencies:
     "@babel/runtime" "^7.8.4"
 
+regex-escape@^3.4.10:
+  version "3.4.10"
+  resolved "https://registry.yarnpkg.com/regex-escape/-/regex-escape-3.4.10.tgz#b45afec7a6e793b786ad193dc3d18b46b5ae08e6"
+  integrity sha512-qEqf7uzW+iYcKNLMDFnMkghhQBnGdivT6KqVQyKsyjSWnoFyooXVnxrw9dtv3AFLnD6VBGXxtZGAQNFGFTnCqA==
+
 regex-not@^1.0.0, regex-not@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/regex-not/-/regex-not-1.0.2.tgz#1f4ece27e00b0b65e0247a6810e6a85d83a5752c"


### PR DESCRIPTION
*  Add support for filtering log spans based on a string input that behaves like the existing source and term filters
*  Add a term input field in the filter bar with a debounce delay; (this does behave a tiny bit quirky which i outlined in a code note. I think this is probably okay for mvp, but happy to chat more in-depth if needed.)

Styles and tests are still a wip, but otherwise code is ready for review. 

Term input field:
<img width="653" alt="Screen Shot 2021-06-02 at 5 47 34 PM" src="https://user-images.githubusercontent.com/23283986/120558470-83178200-c3cd-11eb-8782-b5fa0f92db08.png">

Filtering logs by term and level filters:
![2021-06-02 17 53 26](https://user-images.githubusercontent.com/23283986/120558531-9cb8c980-c3cd-11eb-846d-af4304d24eaa.gif)

Closes ticket #12046
