### PR TITLE
websocket: ignore empty loglists

### DIFF
--- a/internal/hud/server/websocket.go
+++ b/internal/hud/server/websocket.go
@@ -132,6 +132,11 @@ func (ws *WebsocketSubscriber) OnChange(ctx context.Context, s store.RStore, sum
 		return // Not much we can do on error right now.
 	}
 
+	// [-1,-1) means there are no logs
+	if view.LogList.ToCheckpoint == -1 && view.LogList.FromCheckpoint == -1 {
+		return
+	}
+
 	ws.sendView(ctx, view)
 
 	// A simple throttle -- don't call ws.OnChange too many times in quick succession,

--- a/internal/hud/server/websocket_test.go
+++ b/internal/hud/server/websocket_test.go
@@ -12,9 +12,9 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/tilt-dev/tilt/internal/controllers/fake"
-	"github.com/tilt-dev/tilt/internal/testutils"
-
 	"github.com/tilt-dev/tilt/internal/store"
+	"github.com/tilt-dev/tilt/internal/testutils"
+	"github.com/tilt-dev/tilt/pkg/logger"
 )
 
 func TestWebsocketCloseOnReadErr(t *testing.T) {
@@ -39,10 +39,10 @@ func TestWebsocketCloseOnReadErr(t *testing.T) {
 
 	conn.AssertNextWriteMsg(t).Ack()
 
-	st.NotifySubscribers(ctx, store.ChangeSummary{Log: true})
+	writeLogAndNotify(ctx, st)
 	conn.AssertNextWriteMsg(t).Ack()
 
-	st.NotifySubscribers(ctx, store.ChangeSummary{Log: true})
+	writeLogAndNotify(ctx, st)
 	conn.AssertNextWriteMsg(t).Ack()
 
 	conn.readCh <- readerOrErr{err: fmt.Errorf("read error")}
@@ -69,7 +69,7 @@ func TestWebsocketReadErrDuringMsg(t *testing.T) {
 
 	conn.AssertNextWriteMsg(t).Ack()
 
-	st.NotifySubscribers(ctx, store.ChangeSummary{Log: true})
+	writeLogAndNotify(ctx, st)
 
 	m := conn.AssertNextWriteMsg(t)
 
@@ -103,11 +103,44 @@ func TestWebsocketNextWriterError(t *testing.T) {
 		close(done)
 	}()
 
-	st.NotifySubscribers(ctx, store.ChangeSummary{Log: true})
+	writeLogAndNotify(ctx, st)
 	time.Sleep(10 * time.Millisecond)
 
 	conn.readCh <- readerOrErr{err: fmt.Errorf("read error")}
 	conn.AssertClose(t, done)
+}
+
+// It's possible to get a ChangeSummary where Log is true but all logs have already been processed,
+// in which case ToLogList returns [-1,-1).
+// Presumably this happens when:
+// 1. store writes logevent A to logstore
+// 2. store notifies subscribers with a changesummary indicating there are logs
+// 3. store writes logevent B to logstore
+// 4. subscriber gets the changesummary from (2) and reads logevents A and B
+// 5. store notifies subscribers of logevent B
+// 6. subscriber reads logevents, but its checkpoint is already all caught up
+// https://github.com/tilt-dev/tilt/issues/4604
+func TestWebsocketIgnoreEmptyLogList(t *testing.T) {
+	ctx, _, _ := testutils.CtxAndAnalyticsForTest()
+	st, _ := store.NewStoreWithFakeReducer()
+	_ = st.SetUpSubscribersForTesting(ctx)
+
+	conn := newFakeConn()
+	ctrlClient := fake.NewTiltClient()
+	ws := NewWebsocketSubscriber(ctx, ctrlClient, st, conn)
+	require.NoError(t, st.AddSubscriber(ctx, ws))
+
+	done := make(chan bool)
+	go func() {
+		ws.Stream(ctx)
+		_ = st.RemoveSubscriber(context.Background(), ws)
+		close(done)
+	}()
+
+	conn.AssertNextWriteMsg(t).Ack()
+
+	ws.OnChange(ctx, st, store.ChangeSummary{Log: true})
+	require.NotEqual(t, -1, ws.clientCheckpoint)
 }
 
 type readerOrErr struct {
@@ -199,4 +232,11 @@ type msg struct {
 func (m msg) Ack() {
 	m.callback <- nil
 	close(m.callback)
+}
+
+func writeLogAndNotify(ctx context.Context, st *store.Store) {
+	state := st.LockMutableStateForTesting()
+	state.LogStore.Append(store.NewGlobalLogAction(logger.InfoLvl, []byte("test")), nil)
+	st.UnlockMutableState()
+	st.NotifySubscribers(ctx, store.ChangeSummary{Log: true})
 }


### PR DESCRIPTION
Fixes #4604.

### Problem
A race condition can cause the HUD to wipe out its state and go back to "Loading..."
My understanding of how this happens is:
1. Store writes a LogEvent to the LogStore.
2. Store notifies WebsocketSubscriber with a ChangeSummary w/ Log: true for the LogEvent from (1)
3. Store writes a second LogEvent to the LogStore
4. WebsocketSubscriber processes the ChangeSummary from (2), asks LogStore for the LogList, gets the messages from both (1) and (3), and updates its checkpoint to indicate it's fully caught up.
5. Store notifies WebsocketSubscriber with a ChangeSummary w/ Log: true for the LogEvent from (2)
6. WebsocketSubscriber processes the ChangeSummary from (5), asks LogStore for the LogList since ws's checkpoint. Since there are no new log messages, LogStore [returns -1, -1](https://github.com/tilt-dev/tilt/blob/31f52e847be1583418893ac0e8b04f662510893a/pkg/model/logstore/logstore.go#L522-L525). WebsocketSubscriber then [sets its own fromCheckpoint to -1](https://github.com/tilt-dev/tilt/blob/db7bebb023d6e9d11141d159e71fb3e10a7c5abf/internal/hud/server/websocket.go#L210-L212)
7. The next time a log message, comes through, WebsocketSubscriber asks for logs w/ a checkpoint of -1, which gets [bounded to 0](https://github.com/tilt-dev/tilt/blob/31f52e847be1583418893ac0e8b04f662510893a/pkg/model/logstore/logstore.go#L184-L193).
8. WebsocketSubscriber sends that LogList w/ fromCheckpoint=0 to the frontend, which assumes the incoming update is a full update w/ uisession and uiresources, and [wipes out its previous uisession and uiresources](https://github.com/tilt-dev/tilt/blob/c7a500bbeae4807e796b9dd7064f0112bc59b3ec/web/src/HUD.tsx#L373-L382)
9. Since uisession.tiltfileKey is unset, [the HUD shows "Loading..."](https://github.com/tilt-dev/tilt/blob/c7a500bbeae4807e796b9dd7064f0112bc59b3ec/web/src/HUD.tsx#L217-L219)

### Solution
If logstore.ToLogList returns [-1, -1), just return immediately.

### Notes
1. I'm tempted to instead change the "no new logs to send down" contract to return `{fromCheckpoint: fromCheckpoint, toCheckpoint: fromCheckpoint}` instead of -1, -1. That seems like it'd be harder for a caller to screw up. I ended up not going that route when realizing that contract made it into [the proto docs](https://github.com/tilt-dev/tilt/blob/ba1de77456a46ff72f5de798aaac092f47f481e7/pkg/webview/log.proto#L56-L57).
2. Inferring `isRefresh` from `!logListUpdate?.fromCheckpoint` still feels error-prone. AFAICT, we only ever send a full view on WS initialization, while `fromCheckpoint` could could technically be 0 in other cases (like, a bunch of logs fill the buffer and truncate the existing checkpoint out of the buffer). It might be worth formalizing the notion of a refresh.