### PR TITLE
klog: suppress empty group-version errors

### DIFF
--- a/internal/cli/klog.go
+++ b/internal/cli/klog.go
@@ -59,6 +59,18 @@ func newFilteredWriter(underlying io.Writer, filterFunc func(s string) bool) io.
 // https://github.com/kubernetes/kubernetes/issues/22024
 var isResourceVersionTooOldRegexp = regexp.MustCompile("reflector.go.*watch of.*ended with: too old resource version")
 
+// isGroupVersionEmptyRegexp matches errors that are logged deep within K8s when
+// populating the cache of resource types for a group-version if the group-version
+// has no resource types registered. This is an uncommon but valid scenario that
+// most commonly occurs with prometheus-adapter and the `external.metrics.k8s.io/v1beta1`
+// group if no external metrics are actually registered (but the group will still
+// exist). The K8s code returns an error instead of treating it as empty, which gets
+// logged at an error level so will show up in Tilt logs and leads to confusion,
+// particularly on `tilt down` where they show up mixed in the CLI output.
+// https://github.com/kubernetes/kubernetes/blob/a4e5239bdc3d85f1f90c7811b03dc153d5121ffe/staging/src/k8s.io/client-go/discovery/cached/memory/memcache.go#L212-L221
+// https://github.com/kubernetes/kubernetes/issues/92480
+var isGroupVersionEmptyRegexp = regexp.MustCompile("couldn't get resource list for.*Got empty response")
+
 // HACK(nick): The Kubernetes libs we use sometimes use klog to log things to
 // os.Stderr. There are no API hooks to configure this. And printing to Stderr
 // scrambles the HUD tty.
@@ -69,7 +81,10 @@ func initKlog(w io.Writer) {
 	var tmpFlagSet = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 	klog.InitFlags(tmpFlagSet)
 	if klogLevel == 0 {
-		w = newFilteredWriter(w, isResourceVersionTooOldRegexp.MatchString)
+		w = newFilteredWriter(w, filterMux(
+			isResourceVersionTooOldRegexp.MatchString,
+			isGroupVersionEmptyRegexp.MatchString,
+		))
 	}
 	klog.SetOutput(w)
 
@@ -85,5 +100,17 @@ func initKlog(w io.Writer) {
 	err := tmpFlagSet.Parse(flags)
 	if err != nil {
 		log.Fatal(err)
+	}
+}
+
+// filterMux combines multiple filter functions, returning true if any match.
+func filterMux(filterFuncs ...func(s string) bool) func(s string) bool {
+	return func(s string) bool {
+		for _, fn := range filterFuncs {
+			if fn(s) {
+				return true
+			}
+		}
+		return false
 	}
 }

--- a/internal/cli/klog_test.go
+++ b/internal/cli/klog_test.go
@@ -37,6 +37,16 @@ func TestResourceVersionTooOldWarningsPrinted(t *testing.T) {
 	assert.Contains(t, out.String(), "watch ended")
 }
 
+func TestEmptyGroupVersionErrorsSilenced(t *testing.T) {
+	out := bytes.NewBuffer(nil)
+	initKlog(out)
+
+	klog.Error("couldn't get resource list for external.metrics.k8s.io/v1beta1: Got empty response for: external.metrics.k8s.io/v1beta1")
+	klog.Flush()
+
+	assert.Empty(t, out.String())
+}
+
 func PrintWatchEndedV4() {
 	klog.V(4).Infof("watch ended")
 }


### PR DESCRIPTION
These error messages are benign and represent an uncommon yet
valid scenario where a group-version has no resource types.

This seems to be most common with the `prometheus-adapter` if
there are no external/custom metrics registered, at which point
the `external.metrics.k8s.io/v1beta1` (or `custom.`) group(s)
are empty.

The error/log does not impact Tilt operation but is confusing,
particularly during a `tilt down` where it's interleaved with
the actual Tilt output and makes it seem as though the operation
has failed.

Fixes #4610.