### PR TITLE
containerupdate: use the exec API instead of the cp API for copying files

### DIFF
--- a/internal/containerupdate/docker_container_updater.go
+++ b/internal/containerupdate/docker_container_updater.go
@@ -40,16 +40,22 @@ func (cu *DockerUpdater) UpdateContainer(ctx context.Context, cInfo store.Contai
 		return errors.Wrap(err, "rmPathsFromContainer")
 	}
 
-	// TODO(maia): catch errors -- CopyToContainer doesn't return errors if e.g. it
-	// fails to write a file b/c of permissions =(
-	err = cu.dCli.CopyToContainerRoot(ctx, cInfo.ContainerID.String(), archiveToCopy)
+	// Use `tar` to unpack the files into the container.
+	//
+	// Although docker has a copy API, it's buggy and not well-maintained
+	// (whereas the Exec API is part of the CRI and much more battle-tested).
+	// Discussion:
+	// https://github.com/tilt-dev/tilt/issues/3708
+	err = cu.dCli.ExecInContainer(ctx, cInfo.ContainerID, model.Cmd{
+		Argv: tarArgv(),
+	}, archiveToCopy, l.Writer(logger.InfoLvl))
 	if err != nil {
-		return err
+		return errors.Wrap(err, "copying files")
 	}
 
 	// Exec run's on container
 	for _, s := range cmds {
-		err = cu.dCli.ExecInContainer(ctx, cInfo.ContainerID, s, l.Writer(logger.InfoLvl))
+		err = cu.dCli.ExecInContainer(ctx, cInfo.ContainerID, s, nil, l.Writer(logger.InfoLvl))
 		if err != nil {
 			return build.WrapContainerExecError(err, cInfo.ContainerID, s)
 		}
@@ -75,7 +81,7 @@ func (cu *DockerUpdater) rmPathsFromContainer(ctx context.Context, cID container
 	}
 
 	out := bytes.NewBuffer(nil)
-	err := cu.dCli.ExecInContainer(ctx, cID, model.Cmd{Argv: makeRmCmd(paths)}, out)
+	err := cu.dCli.ExecInContainer(ctx, cID, model.Cmd{Argv: makeRmCmd(paths)}, nil, out)
 	if err != nil {
 		if docker.IsExitError(err) {
 			return fmt.Errorf("Error deleting files from container: %s", out.String())

--- a/internal/containerupdate/exec_updater.go
+++ b/internal/containerupdate/exec_updater.go
@@ -51,7 +51,7 @@ func (cu *ExecUpdater) UpdateContainer(ctx context.Context, cInfo store.Containe
 	buf := bytes.NewBuffer(nil)
 	tarWriter := io.MultiWriter(w, buf)
 	err := cu.kCli.Exec(ctx, cInfo.PodID, cInfo.ContainerName, cInfo.Namespace,
-		[]string{"tar", "-C", "/", "-x", "-f", "-"}, archiveToCopy, tarWriter, tarWriter)
+		tarArgv(), archiveToCopy, tarWriter, tarWriter)
 	if err != nil {
 		return fmt.Errorf("copying changed files: %v", handleK8sExecError(buf, err))
 	}

--- a/internal/containerupdate/tar.go
+++ b/internal/containerupdate/tar.go
@@ -1,0 +1,5 @@
+package containerupdate
+
+func tarArgv() []string {
+	return []string{"tar", "-C", "/", "-x", "-f", "-"}
+}

--- a/internal/docker/exploding.go
+++ b/internal/docker/exploding.go
@@ -47,10 +47,7 @@ func (c explodingClient) ContainerList(ctx context.Context, options types.Contai
 func (c explodingClient) ContainerRestartNoWait(ctx context.Context, containerID string) error {
 	return c.err
 }
-func (c explodingClient) CopyToContainerRoot(ctx context.Context, container string, content io.Reader) error {
-	return c.err
-}
-func (c explodingClient) ExecInContainer(ctx context.Context, cID container.ID, cmd model.Cmd, out io.Writer) error {
+func (c explodingClient) ExecInContainer(ctx context.Context, cID container.ID, cmd model.Cmd, in io.Reader, out io.Writer) error {
 	return c.err
 }
 func (c explodingClient) ImagePush(ctx context.Context, ref reference.NamedTagged) (io.ReadCloser, error) {

--- a/internal/docker/fake_client.go
+++ b/internal/docker/fake_client.go
@@ -203,7 +203,14 @@ func (c *FakeClient) ContainerRestartNoWait(ctx context.Context, containerID str
 	return nil
 }
 
-func (c *FakeClient) ExecInContainer(ctx context.Context, cID container.ID, cmd model.Cmd, out io.Writer) error {
+func (c *FakeClient) ExecInContainer(ctx context.Context, cID container.ID, cmd model.Cmd, in io.Reader, out io.Writer) error {
+	if cmd.Argv[0] == "tar" {
+		c.CopyCount++
+		c.CopyContainer = string(cID)
+		c.CopyContent = in
+		return nil
+	}
+
 	execCall := ExecCall{
 		Container: cID.String(),
 		Cmd:       cmd,
@@ -219,13 +226,6 @@ func (c *FakeClient) ExecInContainer(ctx context.Context, cID container.ID, cmd 
 	}
 
 	return err
-}
-
-func (c *FakeClient) CopyToContainerRoot(ctx context.Context, container string, content io.Reader) error {
-	c.CopyCount++
-	c.CopyContainer = container
-	c.CopyContent = content
-	return nil
 }
 
 func (c *FakeClient) ImagePush(ctx context.Context, ref reference.NamedTagged) (io.ReadCloser, error) {

--- a/internal/docker/switch.go
+++ b/internal/docker/switch.go
@@ -66,11 +66,8 @@ func (c *switchCli) ContainerList(ctx context.Context, options types.ContainerLi
 func (c *switchCli) ContainerRestartNoWait(ctx context.Context, containerID string) error {
 	return c.client().ContainerRestartNoWait(ctx, containerID)
 }
-func (c *switchCli) CopyToContainerRoot(ctx context.Context, container string, content io.Reader) error {
-	return c.client().CopyToContainerRoot(ctx, container, content)
-}
-func (c *switchCli) ExecInContainer(ctx context.Context, cID container.ID, cmd model.Cmd, out io.Writer) error {
-	return c.client().ExecInContainer(ctx, cID, cmd, out)
+func (c *switchCli) ExecInContainer(ctx context.Context, cID container.ID, cmd model.Cmd, in io.Reader, out io.Writer) error {
+	return c.client().ExecInContainer(ctx, cID, cmd, in, out)
 }
 func (c *switchCli) ImagePush(ctx context.Context, ref reference.NamedTagged) (io.ReadCloser, error) {
 	return c.client().ImagePush(ctx, ref)


### PR DESCRIPTION
Hello @maiamcc,

Please review the following commits I made in branch nicks/ch8967:

c8c15dcbd00827dcda42b3a6089a087c88e5a7c2 (2021-06-08 17:15:23 -0400)
containerupdate: use the exec API instead of the cp API for copying files
Fixes https://github.com/tilt-dev/tilt/issues/3708

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics