### PR TITLE
tiltfile: fix a bug where we were reading the wrong .dockerignore

### DIFF
--- a/internal/tiltfile/docker.go
+++ b/internal/tiltfile/docker.go
@@ -505,10 +505,12 @@ func (s *tiltfileState) dockerignoresFromPathsAndContextFilters(source string, p
 		}
 
 		diFile := filepath.Join(path, ".dockerignore")
-		customDiFile := dbDockerfilePath + ".dockerignore"
-		_, err := os.Stat(customDiFile)
-		if !os.IsNotExist(err) {
-			diFile = customDiFile
+		if dbDockerfilePath != "" {
+			customDiFile := dbDockerfilePath + ".dockerignore"
+			_, err := os.Stat(customDiFile)
+			if !os.IsNotExist(err) {
+				diFile = customDiFile
+			}
 		}
 
 		s.postExecReadFiles = sliceutils.AppendWithoutDupes(s.postExecReadFiles, diFile)


### PR DESCRIPTION
Hello @landism, @milas,

Please review the following commits I made in branch nicks/ch12145:

2556b036f404e8e7a6f577bc4349669c9d71b4c7 (2021-06-09 11:42:00 -0400)
tiltfile: fix a bug where we were reading the wrong .dockerignore
Fixes https://github.com/tilt-dev/tilt/issues/4605

I feel like all the ignore-interpreting code could use a rewrite/refactor
in general...but it might not be worth it depending on how
we start to integrate the tiltfile better with the apiserver

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics