### PR TITLE
engine: use KubernetesApplySpec to apply to the cluster

### DIFF
--- a/internal/cli/down_test.go
+++ b/internal/cli/down_test.go
@@ -147,7 +147,7 @@ metadata:
   name: %s
 spec: {}
 status: {}`, name)
-	return model.Manifest{Name: model.ManifestName(name)}.WithDeployTarget(model.K8sTarget{YAML: yaml})
+	return model.Manifest{Name: model.ManifestName(name)}.WithDeployTarget(model.NewK8sTargetForTesting(yaml))
 }
 
 func newK8sPVCManifest(name string, downPolicy string) model.Manifest {
@@ -160,7 +160,7 @@ metadata:
     tilt.dev/down-policy: %s
 spec: {}
 status: {}`, name, downPolicy)
-	return model.Manifest{Name: model.ManifestName(name)}.WithDeployTarget(model.K8sTarget{YAML: yaml})
+	return model.Manifest{Name: model.ManifestName(name)}.WithDeployTarget(model.NewK8sTargetForTesting(yaml))
 }
 
 type downFixture struct {

--- a/internal/engine/buildcontrol/image_build_and_deployer_test.go
+++ b/internal/engine/buildcontrol/image_build_and_deployer_test.go
@@ -1056,7 +1056,7 @@ metadata:
   name: %s-deployment
 spec: {}
 status: {}`, name, name)
-	return model.Manifest{Name: model.ManifestName(name)}.WithDeployTarget(model.K8sTarget{YAML: yaml})
+	return model.Manifest{Name: model.ManifestName(name)}.WithDeployTarget(model.NewK8sTargetForTesting(yaml))
 }
 
 type fakeKINDLoader struct {

--- a/internal/k8s/target.go
+++ b/internal/k8s/target.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
 	"github.com/tilt-dev/tilt/pkg/model"
 )
 
@@ -55,16 +56,20 @@ func NewTarget(
 		}
 	}
 
+	apply := v1alpha1.KubernetesApplySpec{
+		YAML: yaml,
+	}
+
 	return model.K8sTarget{
-		Name:              name,
-		YAML:              yaml,
-		PortForwards:      portForwards,
-		ExtraPodSelectors: extraPodSelectors,
-		DisplayNames:      displayNames,
-		ObjectRefs:        objectRefs,
-		PodReadinessMode:  podReadinessMode,
-		ImageLocators:     myLocators,
-		Links:             links,
+		KubernetesApplySpec: apply,
+		Name:                name,
+		PortForwards:        portForwards,
+		ExtraPodSelectors:   extraPodSelectors,
+		DisplayNames:        displayNames,
+		ObjectRefs:          objectRefs,
+		PodReadinessMode:    podReadinessMode,
+		ImageLocators:       myLocators,
+		Links:               links,
 	}.WithDependencyIDs(dependencyIDs).WithRefInjectCounts(refInjectCounts), nil
 }
 

--- a/internal/store/json_test.go
+++ b/internal/store/json_test.go
@@ -32,7 +32,7 @@ func TestToJSON(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	assert.Contains(t, buf.String(), "YAML")
+	assert.Contains(t, buf.String(), "yaml")
 	assert.Contains(t, buf.String(), "kind: Deployment")
 
 	// Make sure the data can decode successfully.

--- a/internal/testutils/manifestbuilder/manifestbuilder.go
+++ b/internal/testutils/manifestbuilder/manifestbuilder.go
@@ -6,6 +6,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 
 	"github.com/tilt-dev/tilt/internal/k8s"
+	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
 	"github.com/tilt-dev/tilt/pkg/model"
 )
 
@@ -26,7 +27,7 @@ type ManifestBuilder struct {
 	k8sPodReadiness    model.PodReadinessMode
 	k8sYAML            string
 	k8sPodSelectors    []labels.Set
-	k8sImageLocators   []k8s.ImageLocator
+	k8sImageLocators   []v1alpha1.KubernetesImageLocator
 	dcConfigPaths      []string
 	localCmd           string
 	localServeCmd      string
@@ -55,9 +56,10 @@ func New(f Fixture, name model.ManifestName) ManifestBuilder {
 }
 
 func (b ManifestBuilder) WithNamedJSONPathImageLocator(name, path string) ManifestBuilder {
-	selector := k8s.MustNameSelector(name)
-	jp := k8s.MustJSONPathImageLocator(selector, path)
-	b.k8sImageLocators = append(b.k8sImageLocators, jp)
+	b.k8sImageLocators = append(b.k8sImageLocators, v1alpha1.KubernetesImageLocator{
+		ObjectSelector: k8s.MustNameSelector(name).ToSpec(),
+		Path:           path,
+	})
 	return b
 }
 
@@ -151,9 +153,7 @@ func (b ManifestBuilder) Build() model.Manifest {
 	if b.k8sYAML != "" {
 		k8sTarget := k8s.MustTarget(model.TargetName(b.name), b.k8sYAML)
 		k8sTarget.ExtraPodSelectors = b.k8sPodSelectors
-		for _, locator := range b.k8sImageLocators {
-			k8sTarget.ImageLocators = append(k8sTarget.ImageLocators, locator)
-		}
+		k8sTarget.ImageLocators = append(k8sTarget.ImageLocators, b.k8sImageLocators...)
 		k8sTarget.PodReadinessMode = b.k8sPodReadiness
 
 		m = assembleK8s(

--- a/pkg/model/k8s_target.go
+++ b/pkg/model/k8s_target.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 )
@@ -30,8 +31,13 @@ const PodReadinessWait PodReadinessMode = "wait"
 const PodReadinessIgnore PodReadinessMode = "ignore"
 
 type K8sTarget struct {
+	// An apiserver-driven data model for applying Kubernetes YAML.
+	//
+	// This will eventually replace K8sTarget. We represent this as an embedded
+	// struct while we're migrating fields.
+	v1alpha1.KubernetesApplySpec
+
 	Name         TargetName
-	YAML         string
 	PortForwards []PortForward
 	// labels for pods that we should watch and associate with this resource
 	ExtraPodSelectors []labels.Set
@@ -65,6 +71,13 @@ type K8sTarget struct {
 	// zero+ links assoc'd with this resource (to be displayed in UIs,
 	// in addition to any port forwards/LB endpoints)
 	Links []Link
+}
+
+func NewK8sTargetForTesting(yaml string) K8sTarget {
+	apply := v1alpha1.KubernetesApplySpec{
+		YAML: yaml,
+	}
+	return K8sTarget{KubernetesApplySpec: apply}
 }
 
 func (k8s K8sTarget) Empty() bool { return reflect.DeepEqual(k8s, K8sTarget{}) }

--- a/pkg/model/k8s_target.go
+++ b/pkg/model/k8s_target.go
@@ -5,14 +5,11 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
-)
 
-type K8sImageLocator interface {
-	EqualsImageLocator(other interface{}) bool
-}
+	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
+)
 
 // Whether or not to wait for pods to become ready before
 // marking the k8s resource healthy.
@@ -51,13 +48,6 @@ type K8sTarget struct {
 	ObjectRefs []v1.ObjectReference
 
 	PodReadinessMode PodReadinessMode
-
-	// Implementations of k8s.ImageLocator
-	//
-	// NOTE(nick): Untangling the circular dependency between k8s and pkg/model is
-	// a longer project. The k8s package needs to be split up a bit between the
-	// API objects and the client objects.
-	ImageLocators []K8sImageLocator
 
 	// Map configRef -> number of times we (expect to) inject it.
 	// NOTE(maia): currently this map is only for use in metrics, though someday

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -462,10 +462,6 @@ var dockerRefEqual = cmp.Comparer(func(a, b reference.Named) bool {
 	return a.String() == b.String()
 })
 
-var imageLocatorEqual = cmp.Comparer(func(a, b K8sImageLocator) bool {
-	return a.EqualsImageLocator(b)
-})
-
 // Determine whether interfaces x and y are equal, excluding fields that don't invalidate a build.
 func equalForBuildInvalidation(x, y interface{}) bool {
 	return cmp.Equal(x, y,
@@ -480,7 +476,6 @@ func equalForBuildInvalidation(x, y interface{}) bool {
 		registryAllowUnexported,
 		portForwardPathAllowUnexported,
 		dockerRefEqual,
-		imageLocatorEqual,
 
 		// deps changes don't invalidate a build, so don't compare fields used only for deps
 		ignoreCustomBuildDepsField,

--- a/pkg/model/manifest_test.go
+++ b/pkg/model/manifest_test.go
@@ -159,14 +159,14 @@ var equalitytests = []struct {
 	},
 	{
 		"k8s.YAML equal",
-		Manifest{}.WithDeployTarget(K8sTarget{YAML: "hello world"}),
-		Manifest{}.WithDeployTarget(K8sTarget{YAML: "hello world"}),
+		Manifest{}.WithDeployTarget(NewK8sTargetForTesting("hello world")),
+		Manifest{}.WithDeployTarget(NewK8sTargetForTesting("hello world")),
 		false,
 	},
 	{
 		"k8s.YAML unequal",
-		Manifest{}.WithDeployTarget(K8sTarget{YAML: "hello world"}),
-		Manifest{}.WithDeployTarget(K8sTarget{YAML: "goodbye world"}),
+		Manifest{}.WithDeployTarget(NewK8sTargetForTesting("hello world")),
+		Manifest{}.WithDeployTarget(NewK8sTargetForTesting("goodbye world")),
 		true,
 	},
 	{
@@ -209,8 +209,8 @@ var equalitytests = []struct {
 	},
 	{
 		"Name & k8s YAML unequal",
-		Manifest{Name: "foo"}.WithDeployTarget(K8sTarget{YAML: "hello world"}),
-		Manifest{Name: "bar"}.WithDeployTarget(K8sTarget{YAML: "goodbye world"}),
+		Manifest{Name: "foo"}.WithDeployTarget(NewK8sTargetForTesting("hello world")),
+		Manifest{Name: "bar"}.WithDeployTarget(NewK8sTargetForTesting("goodbye world")),
 		true,
 	},
 	{


### PR DESCRIPTION
Hello @milas, @landism,

Please review the following commits I made in branch nicks/k8s2:

ee58f44909bb080a5f8e9bb197687f406486d855 (2021-06-09 18:32:02 -0400)
apis: use ImageLocators field in KubernetesApplySpec

ee0804a46236ce20d3718378145ade8c0a197626 (2021-06-09 18:31:50 -0400)
apis: use ImageMaps field in KubernetesApplySpec

96cf109538f3a15b009bee17e19f6bcf5f9c7255 (2021-06-09 18:31:35 -0400)
apis: use YAML field to KubernetesApplySpec

dbc136af27c5d04e3bff013737aac6f3d6225c80 (2021-06-09 18:29:27 -0400)
apis: flesh out KubernetesApplySpec

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics