### PR TITLE
web: add UIButtons to UI

### DIFF
--- a/web/src/HUD.test.tsx
+++ b/web/src/HUD.test.tsx
@@ -9,9 +9,8 @@ import LogStore from "./LogStore"
 import SocketBar from "./SocketBar"
 import {
   logList,
-  oneButtonView,
+  nButtonView,
   oneResourceView,
-  twoButtonView,
   twoResourceView,
 } from "./testdata"
 import { SocketState } from "./types"
@@ -222,19 +221,19 @@ describe("mergeAppUpdates", () => {
   })
 
   it("handles add button", () => {
-    let prevState = { view: oneButtonView() }
-    let update = { view: { uiButtons: [twoButtonView().uiButtons[1]] } }
+    let prevState = { view: nButtonView(1) }
+    let update = { view: { uiButtons: [nButtonView(2).uiButtons[1]] } }
     let result = mergeAppUpdate(prevState as any, update)
     expect(result.view).not.toBe(prevState.view)
     expect(result.view.uiSession).toBe(prevState.view.uiSession)
     expect(result.view.uiResources).toBe(prevState.view.uiResources)
     expect(result.view.uiButtons!.length).toEqual(2)
-    expect(result.view.uiButtons![0].metadata!.name).toEqual("foo")
+    expect(result.view.uiButtons![0].metadata!.name).toEqual("button1")
     expect(result.view.uiButtons![1].metadata!.name).toEqual("button2")
   })
 
   it("handles delete button", () => {
-    let prevState = { view: twoButtonView() }
+    let prevState = { view: nButtonView(2) }
     let update = {
       view: {
         uiButtons: [
@@ -255,7 +254,7 @@ describe("mergeAppUpdates", () => {
   })
 
   it("handles replace button", () => {
-    let prevState = { view: twoButtonView() }
+    let prevState = { view: nButtonView(2) }
     let update = { view: { uiButtons: [{ metadata: { name: "button1" } }] } }
     let result = mergeAppUpdate(prevState as any, update)
     expect(result.view).not.toBe(prevState.view)

--- a/web/src/OverviewActionBar.stories.tsx
+++ b/web/src/OverviewActionBar.stories.tsx
@@ -4,9 +4,7 @@ import { Router } from "react-router"
 import { FilterLevel, FilterSource, useFilterSet } from "./logfilters"
 import OverviewActionBar from "./OverviewActionBar"
 import { StarredResourceMemoryProvider } from "./StarredResourcesContext"
-import { oneResource } from "./testdata"
-
-type UIResource = Proto.v1alpha1UIResource
+import { oneButton, oneResource } from "./testdata"
 
 export default {
   title: "New UI/Log View/OverviewActionBar",
@@ -68,7 +66,10 @@ export const FullBar = () => {
     { url: "http://localhost:4002" },
   ]
   res.status.k8sResourceInfo = { podName: "my-pod-deadbeef" }
-  return <OverviewActionBar resource={res} filterSet={filterSet} />
+  let buttons = [oneButton(1, "vigoda")]
+  return (
+    <OverviewActionBar resource={res} filterSet={filterSet} buttons={buttons} />
+  )
 }
 
 export const EmptyBar = () => {

--- a/web/src/OverviewActionBar.test.tsx
+++ b/web/src/OverviewActionBar.test.tsx
@@ -87,3 +87,16 @@ it("navigates to build warning filter", () => {
   buildItem.simulate("click")
   expect(history.location.search).toEqual("?source=build&level=warn")
 })
+
+it("shows buttons", () => {
+  let root = mount(
+    <MemoryRouter initialEntries={["/"]}>
+      <FullBar />
+    </MemoryRouter>
+  )
+  let topBar = root.find(ActionBarTopRow)
+  expect(topBar).toHaveLength(1)
+
+  let endpoints = topBar.find(Endpoint)
+  expect(endpoints).toHaveLength(2)
+})

--- a/web/src/OverviewResourceDetails.tsx
+++ b/web/src/OverviewResourceDetails.tsx
@@ -8,9 +8,11 @@ import { Color } from "./style-helpers"
 import { ResourceName } from "./types"
 
 type UIResource = Proto.v1alpha1UIResource
+type UIButton = Proto.v1alpha1UIButton
 
 type OverviewResourceDetailsProps = {
   resource?: UIResource
+  buttons?: UIButton[]
   alerts?: Alert[]
   name: string
 }
@@ -34,7 +36,7 @@ let NotFound = styled.div`
 export default function OverviewResourceDetails(
   props: OverviewResourceDetailsProps
 ) {
-  let { name, resource, alerts } = props
+  let { name, resource, alerts, buttons } = props
   let manifestName = resource?.metadata?.name || ""
   let all = name === "" || name === ResourceName.all
   let notFound = !all && !manifestName
@@ -46,6 +48,7 @@ export default function OverviewResourceDetails(
         resource={resource}
         filterSet={filterSet}
         alerts={alerts}
+        buttons={buttons}
       />
       {notFound ? (
         <NotFound>No resource '{name}'</NotFound>

--- a/web/src/OverviewResourcePane.stories.tsx
+++ b/web/src/OverviewResourcePane.stories.tsx
@@ -4,7 +4,12 @@ import LogStore, { LogStoreProvider } from "./LogStore"
 import OverviewResourcePane from "./OverviewResourcePane"
 import { ResourceNavProvider } from "./ResourceNav"
 import { StarredResourceMemoryProvider } from "./StarredResourcesContext"
-import { nResourceView, tenResourceView, twoResourceView } from "./testdata"
+import {
+  nButtonView,
+  nResourceView,
+  tenResourceView,
+  twoResourceView,
+} from "./testdata"
 
 type UIResource = Proto.v1alpha1UIResource
 
@@ -47,6 +52,34 @@ export const TwoResources = () => (
 
 export const TenResources = () => (
   <OverviewResourcePaneHarness name="vigoda_1" view={tenResourceView()} />
+)
+
+export const TwoButtons = () => {
+  const view = nButtonView(2)
+  return <OverviewResourcePaneHarness name="vigoda" view={view} />
+}
+
+export const TwoButtonsWithEndpoint = () => {
+  const view = nButtonView(2)
+  view.uiResources[0].status!.endpointLinks = [{ name: "endpoint", url: "foo" }]
+  return <OverviewResourcePaneHarness name="vigoda" view={view} />
+}
+
+export const TwoButtonsWithPodID = () => {
+  const view = nButtonView(2)
+  view.uiResources[0].status!.k8sResourceInfo = { podName: "abcdefg" }
+  return <OverviewResourcePaneHarness name="vigoda" view={view} />
+}
+
+export const TwoButtonsWithEndpointAndPodID = () => {
+  const view = nButtonView(2)
+  view.uiResources[0].status!.k8sResourceInfo = { podName: "abcdefg" }
+  view.uiResources[0].status!.endpointLinks = [{ name: "endpoint", url: "foo" }]
+  return <OverviewResourcePaneHarness name="vigoda" view={view} />
+}
+
+export const TenButtons = () => (
+  <OverviewResourcePaneHarness name="vigoda" view={nButtonView(10)} />
 )
 
 export const FullResourceBar = () => {

--- a/web/src/OverviewResourcePane.tsx
+++ b/web/src/OverviewResourcePane.tsx
@@ -74,6 +74,12 @@ export default function OverviewResourcePane(props: OverviewResourcePaneProps) {
     resources.forEach((r) => alerts.push(...combinedAlerts(r, logStore)))
   }
 
+  const buttons = props.view.uiButtons?.filter(
+    (b) =>
+      b.spec?.location?.componentType === "resource" &&
+      b.spec.location.componentID === name
+  )
+
   // Hide the HTML element scrollbars, since this pane does all scrolling internally.
   // TODO(nick): Remove this when the old UI is deleted.
   useEffect(() => {
@@ -88,7 +94,12 @@ export default function OverviewResourcePane(props: OverviewResourcePaneProps) {
       />
       <Main>
         <OverviewResourceSidebar {...props} name={name} />
-        <OverviewResourceDetails resource={r} name={name} alerts={alerts} />
+        <OverviewResourceDetails
+          resource={r}
+          name={name}
+          alerts={alerts}
+          buttons={buttons}
+        />
       </Main>
     </OverviewResourcePaneRoot>
   )

--- a/web/src/testdata.tsx
+++ b/web/src/testdata.tsx
@@ -389,22 +389,47 @@ export function nResourceView(n: number): view {
   }
 }
 
-function oneButtonView(): view {
+function oneButton(i: number, resourceName: string): UIButton {
   return {
-    uiResources: [],
-    uiSession: { status: { tiltfileKey: "test", runningTiltBuild } },
-    uiButtons: [{ metadata: { name: "foo" }, spec: { text: "hello" } }],
+    metadata: { name: `button${i + 1}` },
+    spec: {
+      text: `text${i + 1}`,
+      location: {
+        componentID: resourceName,
+        componentType: "resource",
+      },
+    },
   }
 }
 
-function twoButtonView(): view {
+function nButtonView(n: number): view {
+  const ts = new Date(Date.now()).toISOString()
+
   return {
-    uiResources: [],
-    uiSession: { status: { tiltfileKey: "test", runningTiltBuild } },
-    uiButtons: [
-      { metadata: { name: "button1" }, spec: { text: "hello" } },
-      { metadata: { name: "button2" }, spec: { text: "goodbye" } },
+    uiResources: [
+      {
+        metadata: {
+          name: "vigoda",
+        },
+        status: {
+          lastDeployTime: ts,
+          buildHistory: [
+            {
+              finishTime: ts,
+              startTime: ts,
+            },
+          ],
+          pendingBuildSince: ts,
+          currentBuild: {},
+          updateStatus: "ok",
+          endpointLinks: [],
+          runtimeStatus: "ok",
+          specs: vigodaSpecs(),
+        },
+      },
     ],
+    uiSession: { status: { tiltfileKey: "test", runningTiltBuild } },
+    uiButtons: Array.from({ length: n }, (_, i) => oneButton(i, "vigoda")),
   }
 }
 
@@ -4479,8 +4504,8 @@ export {
   oneResourceTest,
   oneResourceTestWithName,
   logList,
-  oneButtonView,
-  twoButtonView,
+  oneButton,
+  nButtonView,
   logPaneDOM,
   unnamedEndpointLink,
   namedEndpointLink,


### PR DESCRIPTION
1. When a UIButton API object exists, it gets rendered in the OverviewActionBar.
2. When the user clicks on the button, it just console.logs that it was clicked. The work to make the click actually do something will be in a future PR. I figure it's fine to merge with partial functionality since users won't see it unless they are really getting into the weeds anyway.

Here are some screenshots of how two buttons ("text1" and "text2") render when other OverviewActionBar components are/are not present:

![image](https://user-images.githubusercontent.com/7453991/121743116-ce691900-cace-11eb-8394-e8d67d251b1b.png)
![image](https://user-images.githubusercontent.com/7453991/121743126-d45efa00-cace-11eb-8616-1b1a6e49a3e1.png)
![image](https://user-images.githubusercontent.com/7453991/121743133-d88b1780-cace-11eb-9678-10a4f336253f.png)
![image](https://user-images.githubusercontent.com/7453991/121743145-dd4fcb80-cace-11eb-8fdc-8c01bc06715b.png)
