### PR TITLE
web: update LastClickedAt on UIButton click

### DIFF
--- a/web/src/OverviewActionBar.tsx
+++ b/web/src/OverviewActionBar.tsx
@@ -3,6 +3,7 @@ import MenuItem from "@material-ui/core/MenuItem"
 import { PopoverOrigin } from "@material-ui/core/Popover"
 import { makeStyles } from "@material-ui/core/styles"
 import ExpandMoreIcon from "@material-ui/icons/ExpandMore"
+import moment from "moment"
 import React, { useRef, useState } from "react"
 import { useHistory } from "react-router"
 import styled from "styled-components"
@@ -438,14 +439,47 @@ function openEndpointUrl(url: string) {
 }
 
 function ApiButton(props: { button: UIButton }) {
-  const onClick = () => {
-    // TODO - actually send the click to the API
-    // https://app.clubhouse.io/windmill/story/12081/clicking-a-uibutton-in-the-web-ui-updates-the-click-state-in-the-api-server
-    console.log(`clicked uibutton ${props.button.metadata?.name}`)
+  const [loading, setLoading] = useState(false)
+  const onClick = async () => {
+    const toUpdate = {
+      metadata: { ...props.button.metadata },
+      status: { ...props.button.status },
+    } as UIButton
+    // apiserver's date format time is _extremely_ strict to the point that it requires the full
+    // six-decimal place microsecond precision, e.g. .000Z will be rejected, it must be .000000Z
+    // so use an explicit RFC3339 moment format to ensure it passes
+    toUpdate.status!.lastClickedAt = moment().format(
+      "YYYY-MM-DDTHH:mm:ss.SSSSSSZ"
+    )
+
+    // TODO(milas): currently the loading state just disables the button for the duration of
+    //  the AJAX request to avoid duplicate clicks - there is no progress tracking at the
+    //  moment, so there's no fancy spinner animation or propagation of result of action(s)
+    //  that occur as a result of click right now
+    setLoading(true)
+    const url = `/proxy/apis/tilt.dev/v1alpha1/uibuttons/${
+      toUpdate.metadata!.name
+    }/status`
+    try {
+      await fetch(url, {
+        method: "PUT",
+        headers: {
+          Accept: "application/json",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(toUpdate),
+      })
+    } finally {
+      setLoading(false)
+    }
   }
   // button text is not included in analytics name since that can be user data
   return (
-    <ButtonRoot analyticsName={"ui.web.uibutton"} onClick={onClick}>
+    <ButtonRoot
+      analyticsName={"ui.web.uibutton"}
+      onClick={onClick}
+      disabled={loading}
+    >
       {props.button.spec?.text ?? "Button"}
     </ButtonRoot>
   )

--- a/web/src/OverviewResourcePane.tsx
+++ b/web/src/OverviewResourcePane.tsx
@@ -76,7 +76,8 @@ export default function OverviewResourcePane(props: OverviewResourcePaneProps) {
 
   const buttons = props.view.uiButtons?.filter(
     (b) =>
-      b.spec?.location?.componentType === "resource" &&
+      b.spec?.location &&
+      (b.spec.location.componentType ?? "").toLowerCase() === "resource" &&
       b.spec.location.componentID === name
   )
 


### PR DESCRIPTION
Use the apiserver proxy to send a `/status` update for a UIButton
when clicked, updating its `LastClickedAt` field value with the
current time.

(See #4640 for the main PR that adds `UIButton` support to the web
interface.)