### PR TITLE
api: make StartAfter optional on Cmd StartOn spec

### DIFF
--- a/pkg/apis/core/v1alpha1/cmd_types.go
+++ b/pkg/apis/core/v1alpha1/cmd_types.go
@@ -229,7 +229,9 @@ type RestartOnSpec struct {
 // StartOnSpec indicates the set of objects that can trigger a start/restart of this object.
 type StartOnSpec struct {
 	// Any events that predate this time will be ignored.
-	StartAfter metav1.Time `json:"startAfter" protobuf:"bytes,1,opt,name=startAfter"`
+	//
+	// +optional
+	StartAfter metav1.Time `json:"startAfter,omitempty" protobuf:"bytes,1,opt,name=startAfter"`
 	// A list of ui buttons that can trigger a run.
 	UIButtons []string `json:"uiButtons" protobuf:"bytes,2,rep,name=uiButtons"`
 }

--- a/pkg/apis/core/v1alpha1/generated.proto
+++ b/pkg/apis/core/v1alpha1/generated.proto
@@ -902,6 +902,8 @@ message SessionStatus {
 // StartOnSpec indicates the set of objects that can trigger a start/restart of this object.
 message StartOnSpec {
   // Any events that predate this time will be ignored.
+  //
+  // +optional
   optional k8s.io.apimachinery.pkg.apis.meta.v1.Time startAfter = 1;
 
   // A list of ui buttons that can trigger a run.

--- a/pkg/openapi/zz_generated.openapi.go
+++ b/pkg/openapi/zz_generated.openapi.go
@@ -2636,7 +2636,7 @@ func schema_pkg_apis_core_v1alpha1_StartOnSpec(ref common.ReferenceCallback) com
 						},
 					},
 				},
-				Required: []string{"startAfter", "uiButtons"},
+				Required: []string{"uiButtons"},
 			},
 		},
 		Dependencies: []string{


### PR DESCRIPTION
For simplicity, it's fine to let this default to `time.Zero`,
which will mean there's no filter to ignore old events (see
`internal/controllers/core/cmd/startmanager.go` for where it's
used).