### PR TITLE
tiltfile: add working directory option to local and local_resource

### DIFF
--- a/internal/engine/buildcontrol/local_target_build_and_deployer.go
+++ b/internal/engine/buildcontrol/local_target_build_and_deployer.go
@@ -105,6 +105,7 @@ func (bd *LocalTargetBuildAndDeployer) run(ctx context.Context, c model.Cmd) err
 	cmd := localexec.ExecCmdContext(ctx, c)
 	cmd.Stdout = writer
 	cmd.Stderr = writer
+	cmd.Dir = c.Dir
 
 	ps := build.NewPipelineState(ctx, 1, bd.clock)
 	ps.StartPipelineStep(ctx, "Running command: %v (in %q)", c.Argv, c.Dir)

--- a/internal/tiltfile/docker.go
+++ b/internal/tiltfile/docker.go
@@ -194,7 +194,7 @@ func (s *tiltfileState) dockerBuild(thread *starlark.Thread, fn *starlark.Builti
 		return nil, err
 	}
 
-	entrypointCmd, err := value.ValueToUnixCmd(thread, entrypoint, nil)
+	entrypointCmd, err := value.ValueToUnixCmd(thread, entrypoint, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -312,7 +312,7 @@ func (s *tiltfileState) customBuild(thread *starlark.Thread, fn *starlark.Builti
 		return nil, err
 	}
 
-	entrypointCmd, err := value.ValueToUnixCmd(thread, entrypoint, nil)
+	entrypointCmd, err := value.ValueToUnixCmd(thread, entrypoint, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -330,7 +330,7 @@ func (s *tiltfileState) customBuild(thread *starlark.Thread, fn *starlark.Builti
 		commandBat = commandBatVal
 	}
 
-	command, err := value.ValueGroupToCmdHelper(thread, commandVal, commandBat, nil)
+	command, err := value.ValueGroupToCmdHelper(thread, commandVal, commandBat, nil, nil)
 	if err != nil {
 		return nil, fmt.Errorf("Argument 2 (command): %v", err)
 	} else if command.Empty() {

--- a/internal/tiltfile/files.go
+++ b/internal/tiltfile/files.go
@@ -27,7 +27,7 @@ import (
 const localLogPrefix = " → "
 
 func (s *tiltfileState) local(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-	var commandValue, commandBatValue starlark.Value
+	var commandValue, commandBatValue, commandDirValue starlark.Value
 	var commandEnv value.StringStringMap
 	quiet := false
 	echoOff := false
@@ -37,12 +37,13 @@ func (s *tiltfileState) local(thread *starlark.Thread, fn *starlark.Builtin, arg
 		"command_bat", &commandBatValue,
 		"echo_off", &echoOff,
 		"env", &commandEnv,
+		"dir?", &commandDirValue,
 	)
 	if err != nil {
 		return nil, err
 	}
 
-	cmd, err := value.ValueGroupToCmdHelper(thread, commandValue, commandBatValue, commandEnv)
+	cmd, err := value.ValueGroupToCmdHelper(thread, commandValue, commandBatValue, commandDirValue, commandEnv)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/tiltfile/live_update.go
+++ b/internal/tiltfile/live_update.go
@@ -163,11 +163,13 @@ func (s *tiltfileState) liveUpdateSync(thread *starlark.Thread, fn *starlark.Bui
 func (s *tiltfileState) liveUpdateRun(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	var commandVal starlark.Value
 	var triggers starlark.Value
-	if err := s.unpackArgs(fn.Name(), args, kwargs, "cmd", &commandVal, "trigger?", &triggers); err != nil {
+	if err := s.unpackArgs(fn.Name(), args, kwargs,
+		"cmd", &commandVal,
+		"trigger?", &triggers); err != nil {
 		return nil, err
 	}
 
-	command, err := value.ValueToUnixCmd(thread, commandVal, nil)
+	command, err := value.ValueToUnixCmd(thread, commandVal, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/tiltfile/local_resource.go
+++ b/internal/tiltfile/local_resource.go
@@ -84,8 +84,8 @@ func (s *tiltfileState) localResource(thread *starlark.Thread, fn *starlark.Buil
 		"env?", &updateEnv,
 		"serve_env?", &serveEnv,
 		"readiness_probe?", &readinessProbe,
-		"cmd_dir?", &updateCmdDirVal,
-		"serve_cmd_dir?", &serveCmdDirVal,
+		"dir?", &updateCmdDirVal,
+		"serve_dir?", &serveCmdDirVal,
 	); err != nil {
 		return nil, err
 	}

--- a/internal/tiltfile/local_resource.go
+++ b/internal/tiltfile/local_resource.go
@@ -44,6 +44,7 @@ func (s *tiltfileState) localResource(thread *starlark.Thread, fn *starlark.Buil
 	var updateEnv, serveEnv value.StringStringMap
 	var triggerMode triggerMode
 	var readinessProbe probe.Probe
+	var updateCmdDirVal, serveCmdDirVal starlark.Value
 
 	deps := value.NewLocalPathListUnpacker(thread)
 
@@ -83,6 +84,8 @@ func (s *tiltfileState) localResource(thread *starlark.Thread, fn *starlark.Buil
 		"env?", &updateEnv,
 		"serve_env?", &serveEnv,
 		"readiness_probe?", &readinessProbe,
+		"cmd_dir?", &updateCmdDirVal,
+		"serve_cmd_dir?", &serveCmdDirVal,
 	); err != nil {
 		return nil, err
 	}
@@ -103,11 +106,11 @@ func (s *tiltfileState) localResource(thread *starlark.Thread, fn *starlark.Buil
 		return nil, err
 	}
 
-	updateCmd, err := value.ValueGroupToCmdHelper(thread, updateCmdVal, updateCmdBatVal, updateEnv)
+	updateCmd, err := value.ValueGroupToCmdHelper(thread, updateCmdVal, updateCmdBatVal, updateCmdDirVal, updateEnv)
 	if err != nil {
 		return nil, err
 	}
-	serveCmd, err := value.ValueGroupToCmdHelper(thread, serveCmdVal, serveCmdBatVal, serveEnv)
+	serveCmd, err := value.ValueGroupToCmdHelper(thread, serveCmdVal, serveCmdBatVal, serveCmdDirVal, serveEnv)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/tiltfile/telemetry/telemetry.go
+++ b/internal/tiltfile/telemetry/telemetry.go
@@ -28,17 +28,18 @@ func (Extension) OnStart(env *starkit.Environment) error {
 }
 
 func setTelemetryCmd(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-	var cmdVal, cmdBatVal starlark.Value
+	var cmdVal, cmdBatVal, cmdDirVal starlark.Value
 	var period value.Duration
 	err := starkit.UnpackArgs(thread, fn.Name(), args, kwargs,
 		"cmd", &cmdVal,
 		"cmd_bat?", &cmdBatVal,
-		"period?", &period)
+		"period?", &period,
+		"cmd_dir?", &cmdDirVal)
 	if err != nil {
 		return starlark.None, err
 	}
 
-	cmd, err := value.ValueGroupToCmdHelper(thread, cmdVal, cmdBatVal, nil)
+	cmd, err := value.ValueGroupToCmdHelper(thread, cmdVal, cmdBatVal, cmdDirVal, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/tiltfile/telemetry/telemetry.go
+++ b/internal/tiltfile/telemetry/telemetry.go
@@ -34,7 +34,7 @@ func setTelemetryCmd(thread *starlark.Thread, fn *starlark.Builtin, args starlar
 		"cmd", &cmdVal,
 		"cmd_bat?", &cmdBatVal,
 		"period?", &period,
-		"cmd_dir?", &cmdDirVal)
+		"dir?", &cmdDirVal)
 	if err != nil {
 		return starlark.None, err
 	}

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -4324,6 +4324,70 @@ local_resource("test", "echo hi", serve_cmd="sleep 1000", serve_env={"KEY1": "va
 	))
 }
 
+func TestLocalResourceUpdateCmdDir(t *testing.T) {
+	f := newFixture(t)
+	defer f.TearDown()
+
+	f.file("nested/inside.txt", "inside the nested directory")
+	f.file("Tiltfile", `
+local_resource("test", cmd="cat inside.txt", dir="nested")
+`)
+
+	f.load()
+	f.assertNumManifests(1)
+	f.assertNextManifest("test", localTarget(
+		updateCmd(f.JoinPath(f.Path(), "nested"), "cat inside.txt", nil),
+	))
+}
+
+func TestLocalResourceUpdateCmdDirNone(t *testing.T) {
+	f := newFixture(t)
+	defer f.TearDown()
+
+	f.file("here.txt", "same level")
+	f.file("Tiltfile", `
+local_resource("test", cmd="cat here.txt", dir=None)
+`)
+
+	f.load()
+	f.assertNumManifests(1)
+	f.assertNextManifest("test", localTarget(
+		updateCmd(f.Path(), "cat here.txt", nil),
+	))
+}
+
+func TestLocalResourceServeCmdDir(t *testing.T) {
+	f := newFixture(t)
+	defer f.TearDown()
+
+	f.file("nested/inside.txt", "inside the nested directory")
+	f.file("Tiltfile", `
+local_resource("test", serve_cmd="cat inside.txt", serve_dir="nested")
+`)
+
+	f.load()
+	f.assertNumManifests(1)
+	f.assertNextManifest("test", localTarget(
+		serveCmd(f.JoinPath(f.Path(), "nested"), "cat inside.txt", nil),
+	))
+}
+
+func TestLocalResourceServeCmdDirNone(t *testing.T) {
+	f := newFixture(t)
+	defer f.TearDown()
+
+	f.file("here.txt", "same level")
+	f.file("Tiltfile", `
+local_resource("test", serve_cmd="cat here.txt", serve_dir=None)
+`)
+
+	f.load()
+	f.assertNumManifests(1)
+	f.assertNextManifest("test", localTarget(
+		serveCmd(f.Path(), "cat here.txt", nil),
+	))
+}
+
 func TestCustomBuildStoresTiltfilePath(t *testing.T) {
 	f := newFixture(t)
 	defer f.TearDown()

--- a/internal/tiltfile/value/value.go
+++ b/internal/tiltfile/value/value.go
@@ -141,10 +141,10 @@ func valueToCmdHelper(t *starlark.Thread, cmdVal, cmdDirVal starlark.Value, cmdE
 		dir = starkit.AbsWorkingDir(t)
 	case starlark.NoneType:
 		dir = starkit.AbsWorkingDir(t)
-	case starlark.String:
+	default:
 		dir, dirErr = ValueToAbsPath(t, cmdDirVal)
 		if dirErr != nil {
-			return model.Cmd{}, errors.Wrap(dirErr, "error on directory string")
+			return model.Cmd{}, errors.Wrap(dirErr, "a command directory must be empty or a string")
 		}
 	}
 


### PR DESCRIPTION
Adds a working directory option as specified in #4549.

Documentation change in [tilt.build/#872](https://github.com/tilt-dev/tilt.build/pull/872).

Given the following directory structure: 
```
.
├── Tiltfile
├── site.yaml
├── some_dir
│   └── test-greeting.txt
└── test-greeting.txt
```
And the contents of `Tiltfile`:
```
k8s_yaml('site.yaml')
k8s_resource('site')
local_resource('greeting', cmd='cat test-greeting.txt', dir='some_dir')
```
The "greeting" `local_resource` prints the contents of `some_dir/test-greeting.txt`.

Specifying `dir=None` defaults the working directory to the Tiltfile's directory, meaning the "greeting" resource will print the contents of the Tiltfile-level `test-greeting.txt` instead. This is equivalent to omitting the `dir` operation altogether.

The following will produce errors:
```
# local_resource('greeting', cmd='cat test-greeting.txt', dir=['inside'])         # Tiltfile error
# local_resource('greeting', cmd='cat test-greeting.txt', dir=4)                  # Tiltfile error
# local_resource('greeting', cmd='cat test-greeting.txt', dir='nonexistent_dir')  # resource error
```