### PR TITLE
engine: don't block tilt ci for local_resource with auto_init=False

### DIFF
--- a/internal/engine/session/conv.go
+++ b/internal/engine/session/conv.go
@@ -116,7 +116,8 @@ func k8sRuntimeTarget(mt *store.ManifestTarget) *session.Target {
 
 func localServeTarget(mt *store.ManifestTarget, holds buildcontrol.HoldSet) *session.Target {
 	if mt.Manifest.LocalTarget().ServeCmd.Empty() {
-		// there is no runtime target
+		// there is no serve_cmd, so don't return a runtime target at all
+		// (there will still be a build target from the update cmd)
 		return nil
 	}
 
@@ -138,7 +139,15 @@ func localServeTarget(mt *store.ManifestTarget, holds buildcontrol.HoldSet) *ses
 			StartTime: apis.NewMicroTime(lrs.StartTime),
 			Ready:     lrs.Ready,
 		}
-	} else {
+	} else if mt.Manifest.TriggerMode.AutoInitial() || mt.State.StartedFirstBuild() {
+		// default to waiting unless this resource has auto_init=False and has never
+		// had a build triggered for other reasons (e.g. trigger_mode=TRIGGER_MODE_AUTO and
+		// a relevant file change or being manually invoked via UI)
+		// the latter case ensures there's no race condition between a build being
+		// triggered and the local process actually being launched
+		//
+		// otherwise, Terminated/Active/Waiting will all be nil, which indicates that
+		// the target is currently inactive
 		target.State.Waiting = waitingFromHolds(mt.Manifest.Name, holds)
 	}
 


### PR DESCRIPTION
If a `local_resource` has `auto_init=False` and a `serve_cmd`,
the target in `Session` (used for `tilt ci`) would erroneously
be assigned a waiting state (with an unknown reason since it
wasn't _really_ waiting).

Now the waiting fallback is only used if the resource has
`auto_init=True` (default) OR has ever had a build triggered
for any reason (e.g. `TRIGGER_MODE_AUTO` + file change or via
UI). The latter avoids a potential race condition between the
build being invoked and the serve_cmd actually getting launched.

Fixes #4637.