### PR TITLE
test: add integration test for `tilt ci`

### DIFF
--- a/integration/crash_test.go
+++ b/integration/crash_test.go
@@ -21,7 +21,7 @@ func TestCrash(t *testing.T) {
 	out := bytes.NewBuffer(nil)
 	// fixture assigns a random unused port when created, which is used for all Tilt commands, so this
 	// will collide with the previous invocation
-	res, err := f.tilt.Up(out)
+	res, err := f.tilt.Up(f.ctx, out)
 	assert.NoError(t, err)
 	<-res.Done()
 	assert.Contains(t, out.String(), "Tilt cannot start")

--- a/integration/crd_test.go
+++ b/integration/crd_test.go
@@ -45,7 +45,7 @@ func TestCRDNotFound(t *testing.T) {
 	f := newK8sFixture(t, "crd")
 	defer f.TearDown()
 
-	err := f.tilt.Down(ioutil.Discard)
+	err := f.tilt.Down(f.ctx, ioutil.Discard)
 	require.NoError(t, err)
 }
 
@@ -62,7 +62,7 @@ func TestCRDPartialNotFound(t *testing.T) {
 	_, err = f.runCommand("kubectl", "get", "crd", "uselessmachines.tilt.dev")
 	assert.NoError(t, err)
 
-	err = f.tilt.Down(ioutil.Discard)
+	err = f.tilt.Down(f.ctx, ioutil.Discard)
 	require.NoError(t, err)
 
 	// Make sure the crds were deleted.

--- a/integration/oneup_test.go
+++ b/integration/oneup_test.go
@@ -35,5 +35,5 @@ func TestOneUp(t *testing.T) {
 	// minimal sanity check that the engine dump works - this really just ensures that there's no egregious
 	// serialization issues
 	var b bytes.Buffer
-	assert.NoErrorf(t, f.tilt.DumpEngine(&b), "Failed to dump engine state, command output:\n%s", b.String())
+	assert.NoErrorf(t, f.tilt.DumpEngine(f.ctx, &b), "Failed to dump engine state, command output:\n%s", b.String())
 }

--- a/integration/tilt.go
+++ b/integration/tilt.go
@@ -3,6 +3,7 @@ package integration
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"fmt"
 	"go/build"
 	"io"
@@ -46,12 +47,12 @@ func NewTiltDriver(t testing.TB, options ...TiltDriverOption) *TiltDriver {
 	return td
 }
 
-func (d *TiltDriver) cmd(args []string, out io.Writer) *exec.Cmd {
+func (d *TiltDriver) cmd(ctx context.Context, args []string, out io.Writer) *exec.Cmd {
 	// rely on the Tilt binary in GOPATH that should have been created by `go install` from the
 	// fixture to avoid accidentally picking up a system install of tilt with higher precedence
 	// on system PATH
 	tiltBin := filepath.Join(build.Default.GOPATH, "bin", "tilt")
-	cmd := exec.Command(tiltBin, args...)
+	cmd := exec.CommandContext(ctx, tiltBin, args...)
 	cmd.Stdout = out
 	cmd.Stderr = out
 	cmd.Env = os.Environ()
@@ -72,18 +73,18 @@ func (d *TiltDriver) cmd(args []string, out io.Writer) *exec.Cmd {
 	return cmd
 }
 
-func (d *TiltDriver) DumpEngine(out io.Writer) error {
-	cmd := d.cmd([]string{"dump", "engine"}, out)
+func (d *TiltDriver) DumpEngine(ctx context.Context, out io.Writer) error {
+	cmd := d.cmd(ctx, []string{"dump", "engine"}, out)
 	return cmd.Run()
 }
 
-func (d *TiltDriver) Down(out io.Writer) error {
-	cmd := d.cmd([]string{"down"}, out)
+func (d *TiltDriver) Down(ctx context.Context, out io.Writer) error {
+	cmd := d.cmd(ctx, []string{"down"}, out)
 	return cmd.Run()
 }
 
-func (d *TiltDriver) CI(out io.Writer, args ...string) error {
-	cmd := d.cmd(append([]string{
+func (d *TiltDriver) CI(ctx context.Context, out io.Writer, args ...string) error {
+	cmd := d.cmd(ctx, append([]string{
 		"ci",
 
 		// Debug logging for integration tests
@@ -96,7 +97,7 @@ func (d *TiltDriver) CI(out io.Writer, args ...string) error {
 	return cmd.Run()
 }
 
-func (d *TiltDriver) Up(out io.Writer, args ...string) (*TiltUpResponse, error) {
+func (d *TiltDriver) Up(ctx context.Context, out io.Writer, args ...string) (*TiltUpResponse, error) {
 	mandatoryArgs := []string{"up",
 		// Can't attach a HUD or install browsers in headless mode
 		"--hud=false",
@@ -109,7 +110,7 @@ func (d *TiltDriver) Up(out io.Writer, args ...string) (*TiltUpResponse, error) 
 		"--web-mode=prod",
 	}
 
-	cmd := d.cmd(append(mandatoryArgs, args...), out)
+	cmd := d.cmd(ctx, append(mandatoryArgs, args...), out)
 	err := cmd.Start()
 	if err != nil {
 		return nil, err
@@ -132,14 +133,14 @@ func (d *TiltDriver) Up(out io.Writer, args ...string) (*TiltUpResponse, error) 
 	return response, nil
 }
 
-func (d *TiltDriver) Args(args []string, out io.Writer) error {
-	cmd := d.cmd(append([]string{"args"}, args...), out)
+func (d *TiltDriver) Args(ctx context.Context, args []string, out io.Writer) error {
+	cmd := d.cmd(ctx, append([]string{"args"}, args...), out)
 	return cmd.Run()
 }
 
-func (d *TiltDriver) APIResources() ([]string, error) {
+func (d *TiltDriver) APIResources(ctx context.Context) ([]string, error) {
 	var out bytes.Buffer
-	cmd := d.cmd([]string{"api-resources", "-o=name"}, &out)
+	cmd := d.cmd(ctx, []string{"api-resources", "-o=name"}, &out)
 	err := cmd.Run()
 	if err != nil {
 		return nil, err
@@ -152,10 +153,10 @@ func (d *TiltDriver) APIResources() ([]string, error) {
 	return resources, nil
 }
 
-func (d *TiltDriver) Get(apiType string, names ...string) ([]byte, error) {
+func (d *TiltDriver) Get(ctx context.Context, apiType string, names ...string) ([]byte, error) {
 	var out bytes.Buffer
 	args := append([]string{"get", "-o=json", apiType}, names...)
-	cmd := d.cmd(args, &out)
+	cmd := d.cmd(ctx, args, &out)
 	err := cmd.Run()
 	return out.Bytes(), err
 }

--- a/integration/tilt_args_test.go
+++ b/integration/tilt_args_test.go
@@ -21,7 +21,7 @@ func TestTiltArgs(t *testing.T) {
 
 	f.logs.Reset()
 
-	err = f.tilt.Args([]string{"bar"}, f.LogWriter())
+	err = f.tilt.Args(f.ctx, []string{"bar"}, f.LogWriter())
 	if err != nil {
 		// Currently, Tilt starts printing logs before the webserver has bound to a port.
 		// If this happens, just sleep for a second and try again.
@@ -29,7 +29,7 @@ func TestTiltArgs(t *testing.T) {
 		fmt.Printf("Error setting args. Sleeping (%s): %v\n", duration, err)
 
 		time.Sleep(duration)
-		err = f.tilt.Args([]string{"bar"}, f.LogWriter())
+		err = f.tilt.Args(f.ctx, []string{"bar"}, f.LogWriter())
 		require.NoError(t, err)
 	}
 

--- a/integration/tilt_ci/Tiltfile
+++ b/integration/tilt_ci/Tiltfile
@@ -1,0 +1,7 @@
+load_dynamic('./Tiltfile.generated')
+
+k8s_yaml('k8s.yaml')
+k8s_resource('k8s-server-enabled', port_forwards='8000')
+
+k8s_resource('k8s-server-disabled', auto_init=False)
+k8s_resource('k8s-job-disabled', auto_init=False)

--- a/integration/tilt_ci/Tiltfile.generated
+++ b/integration/tilt_ci/Tiltfile.generated
@@ -1,0 +1,15 @@
+# AUTOMATICALLY GENERATED - DO NOT EDIT
+# Run TestTiltCI to re-generate
+
+local_resource(name="local-no_auto_init-serve_cmd", auto_init=False, trigger_mode=TRIGGER_MODE_AUTO, serve_cmd="while true; do echo \"serve for local-no_auto_init-serve_cmd\"; sleep 5000; done")
+local_resource(name="local-no_auto_init-update_cmd", auto_init=False, trigger_mode=TRIGGER_MODE_AUTO, cmd="echo \"update for local-no_auto_init-update_cmd\"")
+local_resource(name="local-no_auto_init-update_cmd-serve_cmd", auto_init=False, trigger_mode=TRIGGER_MODE_AUTO, cmd="echo \"update for local-no_auto_init-update_cmd-serve_cmd\"", serve_cmd="while true; do echo \"serve for local-no_auto_init-update_cmd-serve_cmd\"; sleep 5000; done")
+local_resource(name="local-serve_cmd", auto_init=True, trigger_mode=TRIGGER_MODE_AUTO, serve_cmd="while true; do echo \"serve for local-serve_cmd\"; sleep 5000; done")
+local_resource(name="local-update_cmd", auto_init=True, trigger_mode=TRIGGER_MODE_AUTO, cmd="echo \"update for local-update_cmd\"")
+local_resource(name="local-update_cmd-serve_cmd", auto_init=True, trigger_mode=TRIGGER_MODE_AUTO, cmd="echo \"update for local-update_cmd-serve_cmd\"", serve_cmd="while true; do echo \"serve for local-update_cmd-serve_cmd\"; sleep 5000; done")
+local_resource(name="local-trigger_manual-no_auto_init-serve_cmd", auto_init=False, trigger_mode=TRIGGER_MODE_MANUAL, serve_cmd="while true; do echo \"serve for local-trigger_manual-no_auto_init-serve_cmd\"; sleep 5000; done")
+local_resource(name="local-trigger_manual-no_auto_init-update_cmd", auto_init=False, trigger_mode=TRIGGER_MODE_MANUAL, cmd="echo \"update for local-trigger_manual-no_auto_init-update_cmd\"")
+local_resource(name="local-trigger_manual-no_auto_init-update_cmd-serve_cmd", auto_init=False, trigger_mode=TRIGGER_MODE_MANUAL, cmd="echo \"update for local-trigger_manual-no_auto_init-update_cmd-serve_cmd\"", serve_cmd="while true; do echo \"serve for local-trigger_manual-no_auto_init-update_cmd-serve_cmd\"; sleep 5000; done")
+local_resource(name="local-trigger_manual-serve_cmd", auto_init=True, trigger_mode=TRIGGER_MODE_MANUAL, serve_cmd="while true; do echo \"serve for local-trigger_manual-serve_cmd\"; sleep 5000; done")
+local_resource(name="local-trigger_manual-update_cmd", auto_init=True, trigger_mode=TRIGGER_MODE_MANUAL, cmd="echo \"update for local-trigger_manual-update_cmd\"")
+local_resource(name="local-trigger_manual-update_cmd-serve_cmd", auto_init=True, trigger_mode=TRIGGER_MODE_MANUAL, cmd="echo \"update for local-trigger_manual-update_cmd-serve_cmd\"", serve_cmd="while true; do echo \"serve for local-trigger_manual-update_cmd-serve_cmd\"; sleep 5000; done")

--- a/integration/tilt_ci/k8s.yaml
+++ b/integration/tilt_ci/k8s.yaml
@@ -1,0 +1,77 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: k8s-server-enabled
+  namespace: tilt-integration
+  labels:
+    app: k8s-server-enabled
+spec:
+  selector:
+    matchLabels:
+      app: k8s-server-enabled
+  template:
+    metadata:
+      labels:
+        app: k8s-server-enabled
+    spec:
+      containers:
+        - name: k8s-server-enabled
+          image: busybox
+          command: ["sh", "-c", "while true; do echo 'k8s-server-enabled running'; sleep 5; done"]
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: k8s-server-disabled
+  namespace: tilt-integration
+  labels:
+    app: k8s-server-disabled
+spec:
+  selector:
+    matchLabels:
+      app: k8s-server-disabled
+  template:
+    metadata:
+      labels:
+        app: k8s-server-disabled
+    spec:
+      containers:
+        - name: k8s-server-disabled
+          image: busybox
+          command: ["sh", "-c", "while true; do echo 'k8s-server-disabled running'; sleep 5; done"]
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: k8s-job-enabled
+  labels:
+    app: k8s-job-enabled
+spec:
+  template:
+    metadata:
+      labels:
+        app: k8s-job-enabled
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: k8s-job-enabled
+          image: busybox
+          command: ["sh", "-c", "echo 'k8s-job-enabled started'; sleep 5; echo 'k8s-job-enabled finished'"]
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: k8s-job-disabled
+  labels:
+    app: k8s-job-disabled
+spec:
+  template:
+    metadata:
+      labels:
+        app: k8s-job-disabled
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: k8s-job-disabled
+          image: busybox
+          command: ["sh", "-c", "echo 'k8s-job-disabled started'; sleep 5; echo 'k8s-job-disabled finished'"]

--- a/integration/tilt_ci_test.go
+++ b/integration/tilt_ci_test.go
@@ -1,0 +1,163 @@
+//+build integration
+
+package integration
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type localResource struct {
+	name        string
+	triggerMode string
+	autoInit    bool
+	updateCmd   string
+	serveCmd    string
+}
+
+// TestTiltCI covers a variety of different permutations for local_resource + k8s_resource, in particular around
+// auto_init and absence/presence of update cmd/serve_cmd (for local_resource).
+//
+// Critically, it ensures that `tilt ci` does not block indefinitely; there have been several regressions around
+// this due to the subtlety in various states.
+func TestTiltCI(t *testing.T) {
+	f := newK8sFixture(t, "tilt_ci")
+	defer f.TearDown()
+	f.SetRestrictedCredentials()
+
+	// dynamically generate a bunch of combinations of local_resource args and write out to
+	// `Tiltfile.generated` which is loaded in by the main/static Tiltfile (which contains
+	// hardcoded K8s definitions as there's fewer combinations there)
+	localResources := generateLocalResources()
+	generateTiltfile(f.fixture, localResources)
+
+	f.TiltCI()
+
+	// NOTE: the assertions don't use assert.Contains because on failure it'll re-print all the logs
+	// 	which have already been printed and make reading the test failure very difficult
+	logs := f.logs.String()
+	for _, lr := range localResources {
+		if !lr.autoInit {
+			assert.Falsef(t, strings.Contains(logs, lr.name),
+				"Resource %q had auto_init=False and should not have been seen", lr.name)
+			continue
+		}
+
+		if lr.updateCmd != "" {
+			assert.Truef(t, strings.Contains(logs, fmt.Sprintf("update for %s", lr.name)),
+				"Resource %q did not log via update_cmd", lr.name)
+		}
+
+		if lr.serveCmd != "" {
+			assert.Truef(t, strings.Contains(logs, fmt.Sprintf("serve for %s", lr.name)),
+				"Resource %q did not log via serve_cmd", lr.name)
+		}
+	}
+
+	for _, name := range []string{"k8s-server-disabled", "k8s-job-disabled"} {
+		assert.Falsef(t, strings.Contains(logs, fmt.Sprintf("Initial Build • %s", name)),
+			"Resource %q had auto_init=False and should not have been deployed", name)
+	}
+
+	for _, name := range []string{"k8s-server-enabled", "k8s-job-enabled"} {
+		assert.Truef(t, strings.Contains(logs, fmt.Sprintf("Initial Build • %s", name)),
+			"Resource %q did not deploy", name)
+	}
+
+	assert.True(t, strings.Contains(logs, "k8s-job-enabled finished"),
+		`Resource "k8s-job-enabled" did not log via container`)
+
+	assert.True(t, strings.Contains(logs, "k8s-server-enabled running"),
+		`Resource "k8s-server-enabled" did not log via container`)
+}
+
+func generateTiltfile(f *fixture, localResources []localResource) {
+	var out bytes.Buffer
+	out.WriteString("# AUTOMATICALLY GENERATED - DO NOT EDIT\n")
+	out.WriteString("# Run TestTiltCI to re-generate\n\n")
+
+	for _, lr := range localResources {
+		out.WriteString(lr.String())
+		out.WriteString("\n")
+	}
+
+	err := os.WriteFile(f.testDirPath("Tiltfile.generated"), out.Bytes(), os.FileMode(0777))
+	require.NoError(f.t, err, "Failed to write Tiltfile.generated")
+}
+
+func generateLocalResources() []localResource {
+	var localResources []localResource
+	for _, tm := range []string{"TRIGGER_MODE_AUTO", "TRIGGER_MODE_MANUAL"} {
+		for _, autoInit := range []bool{false, true} {
+			for _, hasUpdateCmd := range []bool{false, true} {
+				for _, hasServeCmd := range []bool{false, true} {
+					if !hasUpdateCmd && !hasServeCmd {
+						continue
+					}
+					lr := localResource{triggerMode: tm, autoInit: autoInit}
+					lr.name = "local"
+					if lr.triggerMode == "TRIGGER_MODE_MANUAL" {
+						lr.name += "-trigger_manual"
+					}
+					if !autoInit {
+						lr.name += "-no_auto_init"
+					}
+					if hasUpdateCmd {
+						lr.name += "-update_cmd"
+					}
+					if hasServeCmd {
+						lr.name += "-serve_cmd"
+					}
+
+					// we use the names in the commands so need to finish building the name before setting them
+					if hasUpdateCmd {
+						lr.updateCmd = fmt.Sprintf(`echo "update for %s"`, lr.name)
+					}
+					if hasServeCmd {
+						lr.serveCmd = fmt.Sprintf(`while true; do echo "serve for %s"; sleep 5000; done`, lr.name)
+					}
+
+					localResources = append(localResources, lr)
+				}
+			}
+		}
+	}
+	return localResources
+}
+
+func (lr localResource) String() string {
+	//args := make(map[string]string)
+	var args []string
+	args = append(args, fmt.Sprintf("name=%q", lr.name))
+	var autoInitArgVal string
+	if lr.autoInit {
+		autoInitArgVal = "True"
+	} else {
+		autoInitArgVal = "False"
+	}
+	args = append(args, fmt.Sprintf("auto_init=%s", autoInitArgVal))
+	args = append(args, fmt.Sprintf("trigger_mode=%s", lr.triggerMode))
+	if lr.updateCmd != "" {
+		args = append(args, fmt.Sprintf("cmd=%q", lr.updateCmd))
+	}
+	if lr.serveCmd != "" {
+		args = append(args, fmt.Sprintf("serve_cmd=%q", lr.serveCmd))
+	}
+
+	var out strings.Builder
+	out.WriteString(`local_resource(`)
+	for i, arg := range args {
+		out.WriteString(arg)
+		if i != len(args)-1 {
+			out.WriteString(", ")
+		}
+	}
+	out.WriteString(")")
+	return out.String()
+}


### PR DESCRIPTION
We've had several regressions here recently, particularly due to
nuances in `local_resource` between `auto_init` / `trigger_mode`
and presence/absence of an update `cmd` / `serve_cmd`.

This test has some static K8s resources (2x Deployment + 2x Job,
one of each `auto_init=True` and one of each `auto_init=False`) as
well as code to dynamically generate permutations of local resources
per the above.

Additionally, the Tilt driver now uses a context when creating
commands and the fixture gives a 3 minute timeout context. This is
particularly useful for this new test to ensure if there's a
regression it doesn't hang indefinitely until the test runner
timeout, but it also generally useful for the other integration
tests in the event they have an issue.