### PR TITLE
store: add a return value to OnChange, so we can add re-queueing logic

### DIFF
--- a/internal/cli/updog.go
+++ b/internal/cli/updog.go
@@ -164,7 +164,8 @@ func (s *updogSubscriber) SetUp(ctx context.Context, _ store.RStore) error {
 	}
 	return nil
 }
-func (s *updogSubscriber) OnChange(_ context.Context, _ store.RStore, _ store.ChangeSummary) {
+func (s *updogSubscriber) OnChange(_ context.Context, _ store.RStore, _ store.ChangeSummary) error {
+	return nil
 }
 
 func provideUpdogCmdSubscribers(

--- a/internal/cloud/cloud_status_manager.go
+++ b/internal/cloud/cloud_status_manager.go
@@ -170,7 +170,7 @@ func (c *CloudStatusManager) needsLookup(requestKey statusRequestKey) bool {
 		requestKey != c.lastRequestKey
 }
 
-func (c *CloudStatusManager) OnChange(ctx context.Context, st store.RStore, _ store.ChangeSummary) {
+func (c *CloudStatusManager) OnChange(ctx context.Context, st store.RStore, _ store.ChangeSummary) error {
 	state := st.RLockState()
 	defer st.RUnlockState()
 
@@ -183,7 +183,7 @@ func (c *CloudStatusManager) OnChange(ctx context.Context, st store.RStore, _ st
 
 	if state.CloudStatus.WaitingForStatusPostRegistration && !currentlyMakingRequest {
 		go c.CheckStatus(ctx, st, state.CloudAddress, requestKey, true)
-		return
+		return nil
 	}
 
 	// c.currentlyMakingRequest is a bit of a race condition here:
@@ -196,6 +196,7 @@ func (c *CloudStatusManager) OnChange(ctx context.Context, st store.RStore, _ st
 
 	if needsLookup && allowedToPerformLookup {
 		go c.CheckStatus(ctx, st, state.CloudAddress, requestKey, false)
-		return
+		return nil
 	}
+	return nil
 }

--- a/internal/cloud/cloud_status_manager_test.go
+++ b/internal/cloud/cloud_status_manager_test.go
@@ -128,13 +128,13 @@ func TestStatusRefresh(t *testing.T) {
 
 	f.st.ClearActions()
 
-	f.um.OnChange(f.ctx, f.st, store.LegacyChangeSummary())
+	_ = f.um.OnChange(f.ctx, f.st, store.LegacyChangeSummary())
 	store.AssertNoActionOfType(t, reflect.TypeOf(store.TiltCloudStatusReceivedAction{}), f.st.Actions)
 
 	// check that we periodically refresh
 	f.clock.Advance(24 * time.Hour)
 
-	f.um.OnChange(f.ctx, f.st, store.LegacyChangeSummary())
+	_ = f.um.OnChange(f.ctx, f.st, store.LegacyChangeSummary())
 	a = store.WaitForAction(t, reflect.TypeOf(store.TiltCloudStatusReceivedAction{}), f.st.Actions)
 	require.Equal(t, expected, a)
 }
@@ -173,7 +173,7 @@ func (f *cloudStatusManagerTestFixture) Run(mutateState func(state *store.Engine
 	}
 	mutateState(&state)
 	f.st.SetState(state)
-	f.um.OnChange(f.ctx, f.st, store.LegacyChangeSummary())
+	_ = f.um.OnChange(f.ctx, f.st, store.LegacyChangeSummary())
 }
 
 func (f *cloudStatusManagerTestFixture) waitForRequest(expectedURL string) http.Request {

--- a/internal/controllers/builder.go
+++ b/internal/controllers/builder.go
@@ -34,7 +34,9 @@ var _ store.Subscriber = &ControllerBuilder{}
 var _ store.SetUpper = &ControllerBuilder{}
 var _ store.TearDowner = &ControllerBuilder{}
 
-func (c *ControllerBuilder) OnChange(_ context.Context, _ store.RStore, _ store.ChangeSummary) {}
+func (c *ControllerBuilder) OnChange(_ context.Context, _ store.RStore, _ store.ChangeSummary) error {
+	return nil
+}
 
 func (c *ControllerBuilder) SetUp(_ context.Context, _ store.RStore) error {
 	mgr := c.tscm.GetManager()

--- a/internal/controllers/core/cmd/controller_test.go
+++ b/internal/controllers/core/cmd/controller_test.go
@@ -660,7 +660,7 @@ func (f *fixture) resourceFromTarget(name string, target model.TargetSpec, lastD
 
 func (f *fixture) step() {
 	f.st.summary = store.ChangeSummary{}
-	f.sc.OnChange(f.ctx, f.st, store.LegacyChangeSummary())
+	_ = f.sc.OnChange(f.ctx, f.st, store.LegacyChangeSummary())
 	for name := range f.st.summary.CmdSpecs.Changes {
 		_, err := f.c.Reconcile(f.ctx, ctrl.Request{NamespacedName: name})
 		require.NoError(f.t, err)

--- a/internal/controllers/core/podlogstream/podlogstreamcontroller_test.go
+++ b/internal/controllers/core/podlogstream/podlogstreamcontroller_test.go
@@ -486,7 +486,7 @@ func newPLMFixture(t *testing.T) *plmFixture {
 func (f *plmFixture) onChange(mn model.ManifestName, podID k8s.PodID) {
 	podNN := types.NamespacedName{Name: string(podID), Namespace: "default"}
 	kdNN := k8swatch.KeyForManifest(mn)
-	f.plm.OnChange(f.ctx, f.store, store.ChangeSummary{
+	_ = f.plm.OnChange(f.ctx, f.store, store.ChangeSummary{
 		KubernetesDiscoveries: store.NewChangeSet(kdNN),
 	})
 

--- a/internal/controllers/manager.go
+++ b/internal/controllers/manager.go
@@ -123,5 +123,6 @@ func (m *TiltServerControllerManager) TearDown(_ context.Context) {
 }
 
 // OnChange is a no-op but used to get initialized in upper along with the API server
-func (m *TiltServerControllerManager) OnChange(_ context.Context, _ store.RStore, _ store.ChangeSummary) {
+func (m *TiltServerControllerManager) OnChange(_ context.Context, _ store.RStore, _ store.ChangeSummary) error {
+	return nil
 }

--- a/internal/engine/analytics/analytics_reporter.go
+++ b/internal/engine/analytics/analytics_reporter.go
@@ -21,9 +21,9 @@ type AnalyticsReporter struct {
 	started bool
 }
 
-func (ar *AnalyticsReporter) OnChange(ctx context.Context, st store.RStore, _ store.ChangeSummary) {
+func (ar *AnalyticsReporter) OnChange(ctx context.Context, st store.RStore, _ store.ChangeSummary) error {
 	if ar.started {
-		return
+		return nil
 	}
 
 	state := st.RLockState()
@@ -51,6 +51,8 @@ func (ar *AnalyticsReporter) OnChange(ctx context.Context, st store.RStore, _ st
 			}
 		}()
 	}
+
+	return nil
 }
 
 var _ store.Subscriber = &AnalyticsReporter{}

--- a/internal/engine/analytics/analytics_updater.go
+++ b/internal/engine/analytics/analytics_updater.go
@@ -30,7 +30,7 @@ func NewAnalyticsUpdater(ta *analytics.TiltAnalytics, cmdTags CmdTags) *Analytic
 	}
 }
 
-func (sub *AnalyticsUpdater) OnChange(ctx context.Context, st store.RStore, _ store.ChangeSummary) {
+func (sub *AnalyticsUpdater) OnChange(ctx context.Context, st store.RStore, _ store.ChangeSummary) error {
 	state := st.RLockState()
 	defer st.RUnlockState()
 
@@ -50,6 +50,8 @@ func (sub *AnalyticsUpdater) OnChange(ctx context.Context, st store.RStore, _ st
 
 		sub.ta.Incr(cmd, sub.cmdTags.AsMap())
 	}
+
+	return nil
 }
 
 var _ store.Subscriber = &AnalyticsUpdater{}

--- a/internal/engine/analytics/analytics_updater_test.go
+++ b/internal/engine/analytics/analytics_updater_test.go
@@ -20,7 +20,7 @@ func TestOnChange(t *testing.T) {
 	au := NewAnalyticsUpdater(a, cmdUpTags)
 	st := store.NewTestingStore()
 	setUserOpt(st, analytics.OptOut)
-	au.OnChange(context.Background(), st, store.LegacyChangeSummary())
+	_ = au.OnChange(context.Background(), st, store.LegacyChangeSummary())
 
 	assert.Equal(t, []analytics.Opt{analytics.OptOut}, to.Calls())
 }
@@ -35,7 +35,7 @@ func TestReportOnOptIn(t *testing.T) {
 	au := NewAnalyticsUpdater(a, cmdUpTags)
 	st := store.NewTestingStore()
 	setUserOpt(st, analytics.OptIn)
-	au.OnChange(context.Background(), st, store.LegacyChangeSummary())
+	_ = au.OnChange(context.Background(), st, store.LegacyChangeSummary())
 
 	assert.Equal(t, []analytics.Opt{analytics.OptOut, analytics.OptIn}, to.Calls())
 	if assert.Equal(t, 1, len(mem.Counts)) {
@@ -45,10 +45,10 @@ func TestReportOnOptIn(t *testing.T) {
 
 	// opt-out then back in again, and make sure it doesn't get re-reported.
 	setUserOpt(st, analytics.OptOut)
-	au.OnChange(context.Background(), st, store.LegacyChangeSummary())
+	_ = au.OnChange(context.Background(), st, store.LegacyChangeSummary())
 
 	setUserOpt(st, analytics.OptIn)
-	au.OnChange(context.Background(), st, store.LegacyChangeSummary())
+	_ = au.OnChange(context.Background(), st, store.LegacyChangeSummary())
 	assert.Equal(t, 1, len(mem.Counts))
 }
 

--- a/internal/engine/buildcontroller.go
+++ b/internal/engine/buildcontroller.go
@@ -80,13 +80,13 @@ func (c *BuildController) DisableForTesting() {
 	c.disabledForTesting = true
 }
 
-func (c *BuildController) OnChange(ctx context.Context, st store.RStore, _ store.ChangeSummary) {
+func (c *BuildController) OnChange(ctx context.Context, st store.RStore, _ store.ChangeSummary) error {
 	if c.disabledForTesting {
-		return
+		return nil
 	}
 	entry, ok := c.needsBuild(ctx, st)
 	if !ok {
-		return
+		return nil
 	}
 
 	st.Dispatch(buildcontrol.BuildStartedAction{
@@ -112,6 +112,8 @@ func (c *BuildController) OnChange(ctx context.Context, st store.RStore, _ store
 		result, err := c.buildAndDeploy(ctx, st, entry)
 		st.Dispatch(buildcontrol.NewBuildCompleteAction(entry.name, entry.spanID, result, err))
 	}()
+
+	return nil
 }
 
 func (c *BuildController) buildAndDeploy(ctx context.Context, st store.RStore, entry buildEntry) (store.BuildResultSet, error) {

--- a/internal/engine/configs/configs_controller.go
+++ b/internal/engine/configs/configs_controller.go
@@ -183,17 +183,18 @@ func (cc *ConfigsController) loadTiltfile(ctx context.Context, st store.RStore, 
 	})
 }
 
-func (cc *ConfigsController) OnChange(ctx context.Context, st store.RStore, _ store.ChangeSummary) {
+func (cc *ConfigsController) OnChange(ctx context.Context, st store.RStore, _ store.ChangeSummary) error {
 	if cc.disabledForTesting {
-		return
+		return nil
 	}
 
 	entry, ok := cc.needsBuild(ctx, st)
 	if !ok {
-		return
+		return nil
 	}
 
 	cc.loadTiltfile(ctx, st, entry)
+	return nil
 }
 
 func requiresDocker(tlr tiltfile.TiltfileLoadResult) bool {

--- a/internal/engine/configs/configs_controller_test.go
+++ b/internal/engine/configs/configs_controller_test.go
@@ -34,7 +34,7 @@ func TestConfigsController(t *testing.T) {
 
 	bar := manifestbuilder.New(f, "bar").WithK8sYAML(testyaml.SanchoYAML).Build()
 	f.setManifestResult(bar)
-	f.cc.OnChange(f.ctx, f.st, store.LegacyChangeSummary())
+	_ = f.cc.OnChange(f.ctx, f.st, store.LegacyChangeSummary())
 
 	expected := &ConfigsReloadedAction{
 		Manifests:  []model.Manifest{bar},
@@ -58,7 +58,7 @@ func TestConfigsControllerDockerNotConnected(t *testing.T) {
 		WithImageTarget(NewSanchoDockerBuildImageTarget(f)).
 		Build()
 	f.setManifestResult(bar)
-	f.cc.OnChange(f.ctx, f.st, store.LegacyChangeSummary())
+	_ = f.cc.OnChange(f.ctx, f.st, store.LegacyChangeSummary())
 
 	if assert.Error(t, f.st.end.Err) {
 		assert.Equal(t, "Failed to connect to Docker: connection-error", f.st.end.Err.Error())
@@ -77,7 +77,7 @@ func TestConfigsControllerDockerNotConnectedButNotRequired(t *testing.T) {
 		WithK8sYAML(testyaml.SanchoYAML).
 		Build()
 	f.setManifestResult(bar)
-	f.cc.OnChange(f.ctx, f.st, store.LegacyChangeSummary())
+	_ = f.cc.OnChange(f.ctx, f.st, store.LegacyChangeSummary())
 
 	assert.NoError(t, f.st.end.Err)
 }
@@ -94,7 +94,7 @@ func TestBuildReasonTrigger(t *testing.T) {
 	f.st.UnlockMutableState()
 
 	f.setManifestResult(bar)
-	f.cc.OnChange(f.ctx, f.st, store.LegacyChangeSummary())
+	_ = f.cc.OnChange(f.ctx, f.st, store.LegacyChangeSummary())
 
 	assert.True(t, f.st.start.Reason.Has(model.BuildReasonFlagTriggerWeb),
 		"expected build reason has flag: TriggerWeb")
@@ -105,7 +105,7 @@ func TestErrorLog(t *testing.T) {
 	defer f.TearDown()
 
 	f.tfl.Result = tiltfile.TiltfileLoadResult{Error: fmt.Errorf("The goggles do nothing!")}
-	f.cc.OnChange(f.ctx, f.st, store.LegacyChangeSummary())
+	_ = f.cc.OnChange(f.ctx, f.st, store.LegacyChangeSummary())
 
 	assert.Contains(f.T(), f.st.out.String(), "ERROR LEVEL: The goggles do nothing!")
 }

--- a/internal/engine/dcwatch/event_watcher.go
+++ b/internal/engine/dcwatch/event_watcher.go
@@ -26,9 +26,9 @@ func NewEventWatcher(dcc dockercompose.DockerComposeClient, docker docker.LocalC
 	}
 }
 
-func (w *EventWatcher) OnChange(ctx context.Context, st store.RStore, _ store.ChangeSummary) {
+func (w *EventWatcher) OnChange(ctx context.Context, st store.RStore, _ store.ChangeSummary) error {
 	if !w.watching {
-		return
+		return nil
 	}
 
 	// TODO(nick): This should respond dynamically if the path changes.
@@ -38,7 +38,7 @@ func (w *EventWatcher) OnChange(ctx context.Context, st store.RStore, _ store.Ch
 
 	if len(configPaths) == 0 {
 		// No DC manifests to watch
-		return
+		return nil
 	}
 
 	w.watching = true
@@ -46,10 +46,12 @@ func (w *EventWatcher) OnChange(ctx context.Context, st store.RStore, _ store.Ch
 	if err != nil {
 		err = errors.Wrap(err, "Subscribing to docker-compose events")
 		st.Dispatch(store.NewErrorAction(err))
-		return
+		return nil
 	}
 
 	go w.dispatchEventLoop(ctx, ch, st)
+
+	return nil
 }
 
 func (w *EventWatcher) startWatch(ctx context.Context, configPath []string) (<-chan string, error) {

--- a/internal/engine/dockerprune/docker_pruner_test.go
+++ b/internal/engine/dockerprune/docker_pruner_test.go
@@ -227,7 +227,7 @@ func TestDockerPrunerSinceNBuilds(t *testing.T) {
 	f.dp.lastPruneBuildCount = 5
 	f.dp.lastPruneTime = twoHrsAgo()
 
-	f.dp.OnChange(f.ctx, f.st, store.LegacyChangeSummary())
+	_ = f.dp.OnChange(f.ctx, f.st, store.LegacyChangeSummary())
 
 	f.assertPrune()
 }
@@ -240,7 +240,7 @@ func TestDockerPrunerNotEnoughBuilds(t *testing.T) {
 	f.dp.lastPruneBuildCount = 5
 	f.dp.lastPruneTime = twoHrsAgo()
 
-	f.dp.OnChange(f.ctx, f.st, store.LegacyChangeSummary())
+	_ = f.dp.OnChange(f.ctx, f.st, store.LegacyChangeSummary())
 
 	f.assertNoPrune()
 }
@@ -251,7 +251,7 @@ func TestDockerPrunerSinceInterval(t *testing.T) {
 	f.withDockerPruneSettings(true, 0, 0, 30*time.Minute)
 	f.dp.lastPruneTime = twoHrsAgo()
 
-	f.dp.OnChange(f.ctx, f.st, store.LegacyChangeSummary())
+	_ = f.dp.OnChange(f.ctx, f.st, store.LegacyChangeSummary())
 
 	f.assertPrune()
 }
@@ -262,7 +262,7 @@ func TestDockerPrunerSinceDefaultInterval(t *testing.T) {
 	f.withDockerPruneSettings(true, 0, 0, 0)
 	f.dp.lastPruneTime = time.Now().Add(-1 * (model.DockerPruneDefaultInterval + time.Minute))
 
-	f.dp.OnChange(f.ctx, f.st, store.LegacyChangeSummary())
+	_ = f.dp.OnChange(f.ctx, f.st, store.LegacyChangeSummary())
 
 	f.assertPrune()
 }
@@ -273,7 +273,7 @@ func TestDockerPrunerNotEnoughTimeElapsed(t *testing.T) {
 	f.withDockerPruneSettings(true, 0, 0, 3*time.Hour)
 	f.dp.lastPruneTime = twoHrsAgo()
 
-	f.dp.OnChange(f.ctx, f.st, store.LegacyChangeSummary())
+	_ = f.dp.OnChange(f.ctx, f.st, store.LegacyChangeSummary())
 
 	f.assertNoPrune()
 }
@@ -284,7 +284,7 @@ func TestDockerPrunerSinceDefaultIntervalNotEnoughTime(t *testing.T) {
 	f.withDockerPruneSettings(true, 0, 0, 0)
 	f.dp.lastPruneTime = time.Now().Add(-1 * model.DockerPruneDefaultInterval).Add(20 * time.Minute)
 
-	f.dp.OnChange(f.ctx, f.st, store.LegacyChangeSummary())
+	_ = f.dp.OnChange(f.ctx, f.st, store.LegacyChangeSummary())
 
 	f.assertNoPrune()
 }
@@ -295,7 +295,7 @@ func TestDockerPrunerFirstRun(t *testing.T) {
 	f.withBuildCount(5)
 	f.withDockerPruneSettings(true, 0, 10, 0)
 
-	f.dp.OnChange(f.ctx, f.st, store.LegacyChangeSummary())
+	_ = f.dp.OnChange(f.ctx, f.st, store.LegacyChangeSummary())
 
 	f.assertPrune()
 }
@@ -306,7 +306,7 @@ func TestDockerPrunerFirstRunButNoCompletedBuilds(t *testing.T) {
 	f.withBuildCount(0)
 	f.withDockerPruneSettings(true, 0, 10, 0)
 
-	f.dp.OnChange(f.ctx, f.st, store.LegacyChangeSummary())
+	_ = f.dp.OnChange(f.ctx, f.st, store.LegacyChangeSummary())
 
 	f.assertNoPrune()
 }
@@ -317,7 +317,7 @@ func TestDockerPrunerNoDockerManifests(t *testing.T) {
 	f.withBuildCount(11)
 	f.withDockerPruneSettings(true, 0, 5, 0)
 
-	f.dp.OnChange(f.ctx, f.st, store.LegacyChangeSummary())
+	_ = f.dp.OnChange(f.ctx, f.st, store.LegacyChangeSummary())
 
 	f.assertNoPrune()
 }
@@ -327,7 +327,7 @@ func TestDockerPrunerDisabled(t *testing.T) {
 	f.withDockerManifestAlreadyBuilt()
 	f.withDockerPruneSettings(false, 0, 0, 0)
 
-	f.dp.OnChange(f.ctx, f.st, store.LegacyChangeSummary())
+	_ = f.dp.OnChange(f.ctx, f.st, store.LegacyChangeSummary())
 
 	f.assertNoPrune()
 }
@@ -339,7 +339,7 @@ func TestDockerPrunerCurrentlyBuilding(t *testing.T) {
 	f.withDockerPruneSettings(true, 0, 0, time.Hour)
 	f.dp.lastPruneTime = twoHrsAgo()
 
-	f.dp.OnChange(f.ctx, f.st, store.LegacyChangeSummary())
+	_ = f.dp.OnChange(f.ctx, f.st, store.LegacyChangeSummary())
 
 	f.assertNoPrune()
 }
@@ -350,7 +350,7 @@ func TestDockerPrunerPendingBuild(t *testing.T) {
 	f.withDockerPruneSettings(true, 0, 0, time.Hour)
 	f.dp.lastPruneTime = twoHrsAgo()
 
-	f.dp.OnChange(f.ctx, f.st, store.LegacyChangeSummary())
+	_ = f.dp.OnChange(f.ctx, f.st, store.LegacyChangeSummary())
 
 	f.assertNoPrune()
 }
@@ -362,7 +362,7 @@ func TestDockerPrunerMaxAgeFromSettings(t *testing.T) {
 	maxAge := time.Hour
 	f.withDockerPruneSettings(true, maxAge, 10, 0)
 
-	f.dp.OnChange(f.ctx, f.st, store.LegacyChangeSummary())
+	_ = f.dp.OnChange(f.ctx, f.st, store.LegacyChangeSummary())
 
 	f.assertPrune()
 	untilVals := f.dCli.ContainersPruneFilters.Get("until")

--- a/internal/engine/fswatch/manifest_subscriber_test.go
+++ b/internal/engine/fswatch/manifest_subscriber_test.go
@@ -79,7 +79,7 @@ func TestWatchManager_disabledOnCIMode(t *testing.T) {
 	ms := NewManifestSubscriber(cli)
 
 	ctx, _, _ := testutils.CtxAndAnalyticsForTest()
-	ms.OnChange(ctx, testingStore, store.LegacyChangeSummary())
+	_ = ms.OnChange(ctx, testingStore, store.LegacyChangeSummary())
 
 	assert.Empty(t, testingStore.Actions())
 }

--- a/internal/engine/k8srollout/podmonitor.go
+++ b/internal/engine/k8srollout/podmonitor.go
@@ -70,7 +70,7 @@ func (m *PodMonitor) diff(st store.RStore) []podStatus {
 	return updates
 }
 
-func (m *PodMonitor) OnChange(ctx context.Context, st store.RStore, _ store.ChangeSummary) {
+func (m *PodMonitor) OnChange(ctx context.Context, st store.RStore, _ store.ChangeSummary) error {
 	updates := m.diff(st)
 	for _, update := range updates {
 		ctx := logger.CtxWithLogHandler(ctx, podStatusWriter{
@@ -80,6 +80,8 @@ func (m *PodMonitor) OnChange(ctx context.Context, st store.RStore, _ store.Chan
 		})
 		m.print(ctx, update)
 	}
+
+	return nil
 }
 
 func (m *PodMonitor) print(ctx context.Context, update podStatus) {

--- a/internal/engine/k8srollout/podmonitor_test.go
+++ b/internal/engine/k8srollout/podmonitor_test.go
@@ -60,7 +60,7 @@ func TestMonitorReady(t *testing.T) {
 		model.Manifest{Name: "server"}, p))
 	f.store.SetState(*state)
 
-	f.pm.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
+	_ = f.pm.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
 
 	assertSnapshot(t, f.out.String())
 }

--- a/internal/engine/k8swatch/event_watch_manager.go
+++ b/internal/engine/k8swatch/event_watch_manager.go
@@ -71,7 +71,7 @@ func (m *EventWatchManager) diff(st store.RStore) eventWatchTaskList {
 	}
 }
 
-func (m *EventWatchManager) OnChange(ctx context.Context, st store.RStore, _ store.ChangeSummary) {
+func (m *EventWatchManager) OnChange(ctx context.Context, st store.RStore, _ store.ChangeSummary) error {
 	taskList := m.diff(st)
 
 	m.mu.Lock()
@@ -92,6 +92,7 @@ func (m *EventWatchManager) OnChange(ctx context.Context, st store.RStore, _ sto
 	if len(taskList.newUIDs) > 0 {
 		m.setupNewUIDs(ctx, st, taskList.newUIDs)
 	}
+	return nil
 }
 
 func (m *EventWatchManager) setupWatch(ctx context.Context, st store.RStore, ns k8s.Namespace, tiltStartTime time.Time) {

--- a/internal/engine/k8swatch/event_watch_manager_test.go
+++ b/internal/engine/k8swatch/event_watch_manager_test.go
@@ -40,7 +40,7 @@ func TestEventWatchManager_dispatchesEvent(t *testing.T) {
 
 	evt := f.makeEvent(k8s.NewK8sEntity(pb.Build()))
 
-	f.ewm.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
+	_ = f.ewm.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
 	f.kClient.UpsertEvent(evt)
 	expected := store.K8sEventAction{Event: evt, ManifestName: mn}
 	f.assertActions(expected)
@@ -64,7 +64,7 @@ func TestEventWatchManager_dispatchesNamespaceEvent(t *testing.T) {
 
 	evt2 := f.makeEvent(k8s.NewK8sEntity(pb.Build()))
 
-	f.ewm.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
+	_ = f.ewm.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
 	f.kClient.UpsertEvent(evt1)
 	f.kClient.UpsertEvent(evt2)
 
@@ -91,8 +91,8 @@ func TestEventWatchManager_duplicateDeployIDs(t *testing.T) {
 	evt := f.makeEvent(k8s.NewK8sEntity(pb.Build()))
 
 	f.kClient.UpsertEvent(evt)
-	f.ewm.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
-	f.ewm.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
+	_ = f.ewm.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
+	_ = f.ewm.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
 	expected := store.K8sEventAction{Event: evt, ManifestName: fe1}
 	f.assertActions(expected)
 }
@@ -129,7 +129,7 @@ func TestEventWatchManagerDifferentEvents(t *testing.T) {
 			evt.Reason = c.Reason
 			evt.Type = c.Type
 
-			f.ewm.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
+			_ = f.ewm.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
 			f.kClient.UpsertEvent(evt)
 			if c.Expected {
 				expected := store.K8sEventAction{Event: evt, ManifestName: mn}
@@ -146,10 +146,10 @@ func TestEventWatchManager_listensOnce(t *testing.T) {
 	defer f.TearDown()
 
 	f.addManifest("fe")
-	f.ewm.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
+	_ = f.ewm.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
 
 	f.kClient.EventsWatchErr = fmt.Errorf("Multiple watches forbidden")
-	f.ewm.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
+	_ = f.ewm.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
 	f.assertActions()
 }
 
@@ -161,7 +161,7 @@ func TestEventWatchManager_watchError(t *testing.T) {
 	f.kClient.EventsWatchErr = err
 	f.addManifest("someK8sManifest")
 
-	f.ewm.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
+	_ = f.ewm.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
 
 	expectedErr := errors.Wrap(err, "Error watching events. Are you connected to kubernetes?\nTry running `kubectl get events -n \"default\"`")
 	expected := store.ErrorAction{Error: expectedErr}
@@ -177,7 +177,7 @@ func TestEventWatchManager_eventBeforeUID(t *testing.T) {
 
 	// Seed the k8s client with a pod and its owner tree
 	manifest := f.addManifest(mn)
-	f.ewm.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
+	_ = f.ewm.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
 
 	pb := podbuilder.New(t, manifest)
 	entities := pb.ObjectTreeEntities()
@@ -298,7 +298,9 @@ func (f *ewmFixture) addManifest(manifestName model.ManifestName) model.Manifest
 }
 
 func (f *ewmFixture) addDeployedEntity(m model.Manifest, entity k8s.K8sEntity) {
-	defer f.ewm.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
+	defer func() {
+		_ = f.ewm.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
+	}()
 
 	state := f.store.LockMutableStateForTesting()
 	defer f.store.UnlockMutableState()

--- a/internal/engine/k8swatch/manifest_subscriber_test.go
+++ b/internal/engine/k8swatch/manifest_subscriber_test.go
@@ -54,7 +54,7 @@ func TestManifestsWithNoWatches(t *testing.T) {
 
 	f.store.UnlockMutableState()
 
-	f.ms.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
+	_ = f.ms.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
 
 	require.Never(t, func() bool {
 		state := f.store.RLockState()
@@ -235,7 +235,7 @@ func (f *msFixture) upsertManifest(mn model.ManifestName, yaml string, ls ...lab
 	state.UpsertManifestTarget(mt)
 	f.store.UnlockMutableState()
 
-	f.ms.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
+	_ = f.ms.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
 	// verify that a change summary was properly generated
 	f.cs.waitForChangeAndReset(KeyForManifest(mn))
 
@@ -256,7 +256,7 @@ func (f *msFixture) addDeployedEntity(m model.Manifest, entity k8s.K8sEntity) {
 	mState.RuntimeState = runtimeState
 	f.store.UnlockMutableState()
 
-	f.ms.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
+	_ = f.ms.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
 }
 
 func (f *msFixture) requireDiscoveryState(mn model.ManifestName, cond func(kd *v1alpha1.KubernetesDiscovery) bool, msg string, args ...interface{}) {
@@ -379,10 +379,11 @@ func (c *changeSubscriber) waitForChangeAndReset(key types.NamespacedName) {
 	}, stdTimeout, 20*time.Millisecond, "Change for key[%s] was never seen", key.String())
 }
 
-func (c *changeSubscriber) OnChange(_ context.Context, _ store.RStore, summary store.ChangeSummary) {
+func (c *changeSubscriber) OnChange(_ context.Context, _ store.RStore, summary store.ChangeSummary) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	for key := range summary.KubernetesDiscoveries.Changes {
 		c.changes.Add(key)
 	}
+	return nil
 }

--- a/internal/engine/k8swatch/service_watch.go
+++ b/internal/engine/k8swatch/service_watch.go
@@ -42,7 +42,7 @@ func (w *ServiceWatcher) diff(st store.RStore) watcherTaskList {
 	return w.watcherKnownState.createTaskList(state)
 }
 
-func (w *ServiceWatcher) OnChange(ctx context.Context, st store.RStore, _ store.ChangeSummary) {
+func (w *ServiceWatcher) OnChange(ctx context.Context, st store.RStore, _ store.ChangeSummary) error {
 	taskList := w.diff(st)
 
 	w.mu.Lock()
@@ -63,6 +63,8 @@ func (w *ServiceWatcher) OnChange(ctx context.Context, st store.RStore, _ store.
 	if len(taskList.newUIDs) > 0 {
 		w.setupNewUIDs(ctx, st, taskList.newUIDs)
 	}
+
+	return nil
 }
 
 func (w *ServiceWatcher) setupWatch(ctx context.Context, st store.RStore, ns k8s.Namespace) {

--- a/internal/engine/k8swatch/service_watch_test.go
+++ b/internal/engine/k8swatch/service_watch_test.go
@@ -64,7 +64,7 @@ func TestServiceWatchUIDDelayed(t *testing.T) {
 	uid := types.UID("fake-uid")
 	manifest := f.addManifest("server")
 
-	f.sw.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
+	_ = f.sw.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
 
 	s := servicebuilder.New(f.t, manifest).
 		WithUID(uid).
@@ -93,7 +93,9 @@ func (f *swFixture) addManifest(manifestName model.ManifestName) model.Manifest 
 }
 
 func (f *swFixture) addDeployedService(m model.Manifest, svc *v1.Service) {
-	defer f.sw.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
+	defer func() {
+		_ = f.sw.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
+	}()
 
 	state := f.store.LockMutableStateForTesting()
 	defer f.store.UnlockMutableState()

--- a/internal/engine/local/servercontroller.go
+++ b/internal/engine/local/servercontroller.go
@@ -50,9 +50,9 @@ func NewServerController(client ctrlclient.Client) *ServerController {
 	}
 }
 
-func (c *ServerController) OnChange(ctx context.Context, st store.RStore, summary store.ChangeSummary) {
+func (c *ServerController) OnChange(ctx context.Context, st store.RStore, summary store.ChangeSummary) error {
 	if summary.IsLogOnly() {
-		return
+		return nil
 	}
 
 	servers, owned, orphans := c.determineServers(ctx, st)
@@ -64,6 +64,7 @@ func (c *ServerController) OnChange(ctx context.Context, st store.RStore, summar
 	for _, orphan := range orphans {
 		c.deleteOrphanedCmd(ctx, st, orphan)
 	}
+	return nil
 }
 
 // Returns a list of server objects and the Cmd they own (if any).

--- a/internal/engine/metrics/controller.go
+++ b/internal/engine/metrics/controller.go
@@ -62,11 +62,11 @@ func (c *Controller) newMetricsState(rStore store.RStore) MetricsState {
 	}
 }
 
-func (c *Controller) OnChange(ctx context.Context, rStore store.RStore, _ store.ChangeSummary) {
+func (c *Controller) OnChange(ctx context.Context, rStore store.RStore, _ store.ChangeSummary) error {
 	newMetricsState := c.newMetricsState(rStore)
 	oldMetricsState := c.metrics
 	if newMetricsState == oldMetricsState {
-		return
+		return nil
 	}
 
 	c.metrics = newMetricsState
@@ -96,7 +96,7 @@ func (c *Controller) OnChange(ctx context.Context, rStore store.RStore, _ store.
 		oce, err := ocagent.NewExporter(options...)
 		if err != nil {
 			logger.Get(ctx).Debugf("Creating metrics exporter: %v", err)
-			return
+			return nil
 		}
 
 		err = c.exporter.SetRemote(oce)
@@ -109,6 +109,8 @@ func (c *Controller) OnChange(ctx context.Context, rStore store.RStore, _ store.
 		// If we're exporting for the first time, flush now.
 		c.exporter.Flush()
 	}
+
+	return nil
 }
 
 func (c *Controller) makeResourceDetector(state MetricsState) func(ctx context.Context) (*resource.Resource, error) {

--- a/internal/engine/metrics/controller_test.go
+++ b/internal/engine/metrics/controller_test.go
@@ -22,24 +22,24 @@ func TestEnableMetrics(t *testing.T) {
 	ms := model.DefaultMetricsSettings()
 	ms.Enabled = true
 	f.st.SetState(newLoggedInEngineState(ms))
-	f.mc.OnChange(f.ctx, f.st, store.LegacyChangeSummary())
+	_ = f.mc.OnChange(f.ctx, f.st, store.LegacyChangeSummary())
 
 	remote := f.exp.remote
 	assert.NotNil(t, remote)
 
-	f.mc.OnChange(f.ctx, f.st, store.LegacyChangeSummary())
+	_ = f.mc.OnChange(f.ctx, f.st, store.LegacyChangeSummary())
 	assert.Same(t, remote, f.exp.remote)
 
 	// Verify that changing the metrics settings creates a new remote exporter.
 	ms.Insecure = true
 	f.st.SetState(newLoggedInEngineState(ms))
-	f.mc.OnChange(f.ctx, f.st, store.LegacyChangeSummary())
+	_ = f.mc.OnChange(f.ctx, f.st, store.LegacyChangeSummary())
 	assert.NotSame(t, remote, f.exp.remote)
 
 	// Verify that disabling the metrics settings nulls out the remote exporter.
 	ms.Enabled = false
 	f.st.SetState(newLoggedInEngineState(ms))
-	f.mc.OnChange(f.ctx, f.st, store.LegacyChangeSummary())
+	_ = f.mc.OnChange(f.ctx, f.st, store.LegacyChangeSummary())
 	assert.Nil(t, f.exp.remote)
 }
 

--- a/internal/engine/portforward/subscriber.go
+++ b/internal/engine/portforward/subscriber.go
@@ -122,9 +122,9 @@ func (s *Subscriber) diff(st store.RStore) (toStart, toShutdown []*PortForward) 
 	return toStart, toShutdown
 }
 
-func (s *Subscriber) OnChange(ctx context.Context, st store.RStore, summary store.ChangeSummary) {
+func (s *Subscriber) OnChange(ctx context.Context, st store.RStore, summary store.ChangeSummary) error {
 	if summary.IsLogOnly() {
-		return
+		return nil
 	}
 	toStart, toShutdown := s.diff(st)
 	for _, pf := range toShutdown {
@@ -134,6 +134,8 @@ func (s *Subscriber) OnChange(ctx context.Context, st store.RStore, summary stor
 	for _, pf := range toStart {
 		s.upsertPF(ctx, st, pf)
 	}
+
+	return nil
 }
 
 var _ store.Subscriber = &Subscriber{}

--- a/internal/engine/portforward/subscriber_test.go
+++ b/internal/engine/portforward/subscriber_test.go
@@ -396,7 +396,7 @@ func newPFSFixture(t *testing.T) *pfsFixture {
 }
 
 func (f *pfsFixture) onChange() {
-	f.s.OnChange(f.ctx, f.st, store.LegacyChangeSummary())
+	_ = f.s.OnChange(f.ctx, f.st, store.LegacyChangeSummary())
 	time.Sleep(10 * time.Millisecond)
 }
 

--- a/internal/engine/runtimelog/docker_compose_log_manager.go
+++ b/internal/engine/runtimelog/docker_compose_log_manager.go
@@ -91,7 +91,7 @@ func (m *DockerComposeLogManager) diff(ctx context.Context, st store.RStore) (se
 	return setup, teardown
 }
 
-func (m *DockerComposeLogManager) OnChange(ctx context.Context, st store.RStore, _ store.ChangeSummary) {
+func (m *DockerComposeLogManager) OnChange(ctx context.Context, st store.RStore, _ store.ChangeSummary) error {
 	setup, teardown := m.diff(ctx, st)
 	for _, watch := range teardown {
 		watch.cancel()
@@ -100,6 +100,7 @@ func (m *DockerComposeLogManager) OnChange(ctx context.Context, st store.RStore,
 	for _, watch := range setup {
 		go m.consumeLogs(watch, st)
 	}
+	return nil
 }
 
 func (m *DockerComposeLogManager) consumeLogs(watch dockerComposeLogWatch, st store.RStore) {

--- a/internal/engine/runtimelog/podlogmanager.go
+++ b/internal/engine/runtimelog/podlogmanager.go
@@ -97,9 +97,9 @@ func (m *PodLogManager) diff(ctx context.Context, st store.RStore) (setup []*Pod
 	return setup, teardown
 }
 
-func (m *PodLogManager) OnChange(ctx context.Context, st store.RStore, summary store.ChangeSummary) {
+func (m *PodLogManager) OnChange(ctx context.Context, st store.RStore, summary store.ChangeSummary) error {
 	if len(summary.KubernetesDiscoveries.Changes) == 0 {
-		return
+		return nil
 	}
 
 	setup, teardown := m.diff(ctx, st)
@@ -110,6 +110,7 @@ func (m *PodLogManager) OnChange(ctx context.Context, st store.RStore, summary s
 	for _, pls := range setup {
 		m.createPls(ctx, st, pls)
 	}
+	return nil
 }
 
 // Delete the PodLogStream API object. Should be idempotent.

--- a/internal/engine/session/controller_test.go
+++ b/internal/engine/session/controller_test.go
@@ -40,7 +40,7 @@ func TestExitControlCI_TiltfileFailure(t *testing.T) {
 		})
 	})
 
-	f.c.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
+	_ = f.c.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
 	f.store.requireExitSignalWithError("fake Tiltfile error")
 }
 
@@ -48,11 +48,11 @@ func TestExitControlIdempotent(t *testing.T) {
 	f := newFixture(t, store.EngineModeCI)
 	defer f.TearDown()
 
-	f.c.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
+	_ = f.c.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
 	assert.NotNil(t, f.store.LastAction())
 
 	f.store.ClearLastAction()
-	f.c.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
+	_ = f.c.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
 	assert.Nil(t, f.store.LastAction())
 }
 
@@ -68,7 +68,7 @@ func TestExitControlCI_FirstBuildFailure(t *testing.T) {
 		state.UpsertManifestTarget(store.NewManifestTarget(m2))
 	})
 
-	f.c.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
+	_ = f.c.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
 	f.store.requireNoExitSignal()
 
 	f.store.WithState(func(state *store.EngineState) {
@@ -79,7 +79,7 @@ func TestExitControlCI_FirstBuildFailure(t *testing.T) {
 		})
 	})
 
-	f.c.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
+	_ = f.c.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
 	f.store.requireExitSignalWithError("does not compile")
 }
 
@@ -104,7 +104,7 @@ func TestExitControlCI_FirstRuntimeFailure(t *testing.T) {
 		})
 	})
 
-	f.c.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
+	_ = f.c.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
 	f.store.requireNoExitSignal()
 
 	f.store.WithState(func(state *store.EngineState) {
@@ -128,7 +128,7 @@ func TestExitControlCI_FirstRuntimeFailure(t *testing.T) {
 		})
 	})
 
-	f.c.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
+	_ = f.c.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
 	f.store.requireExitSignalWithError("Pod pod-a in error state due to container c1: ErrImagePull")
 }
 
@@ -146,7 +146,7 @@ func TestExitControlCI_PodRunningContainerError(t *testing.T) {
 		})
 	})
 
-	f.c.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
+	_ = f.c.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
 	f.store.requireNoExitSignal()
 
 	f.store.WithState(func(state *store.EngineState) {
@@ -179,7 +179,7 @@ func TestExitControlCI_PodRunningContainerError(t *testing.T) {
 		})
 	})
 
-	f.c.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
+	_ = f.c.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
 	// even though one of the containers is in an error state, CI shouldn't exit - expectation is that the target for
 	// the pod is in Waiting state
 	f.store.requireNoExitSignal()
@@ -196,7 +196,7 @@ func TestExitControlCI_PodRunningContainerError(t *testing.T) {
 		pod.Containers[0] = c1
 	})
 
-	f.c.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
+	_ = f.c.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
 	f.store.requireExitSignalWithNoError()
 }
 
@@ -229,7 +229,7 @@ func TestExitControlCI_Success(t *testing.T) {
 		state.ManifestTargets["fe"].State.RuntimeState = store.NewK8sRuntimeStateWithPods(m, pod("pod-a", true))
 	})
 
-	f.c.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
+	_ = f.c.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
 	f.store.requireNoExitSignal()
 
 	// pod-a: ready / pod-b: ready
@@ -238,7 +238,7 @@ func TestExitControlCI_Success(t *testing.T) {
 		mt.State.RuntimeState = store.NewK8sRuntimeStateWithPods(mt.Manifest, pod("pod-b", true))
 	})
 
-	f.c.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
+	_ = f.c.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
 	f.store.requireExitSignalWithNoError()
 }
 
@@ -262,7 +262,7 @@ func TestExitControlCI_PodReadinessMode_Wait(t *testing.T) {
 			pod("pod-a", false))
 	})
 
-	f.c.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
+	_ = f.c.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
 	f.store.requireNoExitSignal()
 
 	f.store.WithState(func(state *store.EngineState) {
@@ -272,7 +272,7 @@ func TestExitControlCI_PodReadinessMode_Wait(t *testing.T) {
 		)
 	})
 
-	f.c.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
+	_ = f.c.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
 	f.store.requireExitSignalWithNoError()
 }
 
@@ -297,7 +297,7 @@ func TestExitControlCI_PodReadinessMode_Ignore_Pods(t *testing.T) {
 		state.ManifestTargets["fe"].State.RuntimeState = store.NewK8sRuntimeState(m)
 	})
 
-	f.c.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
+	_ = f.c.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
 	f.store.requireNoExitSignal()
 
 	f.store.WithState(func(state *store.EngineState) {
@@ -306,7 +306,7 @@ func TestExitControlCI_PodReadinessMode_Ignore_Pods(t *testing.T) {
 		mt.State.RuntimeState = store.NewK8sRuntimeStateWithPods(mt.Manifest, pod("pod-a", false))
 	})
 
-	f.c.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
+	_ = f.c.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
 	f.store.requireExitSignalWithNoError()
 }
 
@@ -331,7 +331,7 @@ func TestExitControlCI_PodReadinessMode_Ignore_NoPods(t *testing.T) {
 		state.ManifestTargets["fe"].State.RuntimeState = store.NewK8sRuntimeState(m)
 	})
 
-	f.c.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
+	_ = f.c.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
 	f.store.requireNoExitSignal()
 
 	f.store.WithState(func(state *store.EngineState) {
@@ -342,7 +342,7 @@ func TestExitControlCI_PodReadinessMode_Ignore_NoPods(t *testing.T) {
 		mt.State.RuntimeState = krs
 	})
 
-	f.c.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
+	_ = f.c.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
 	f.store.requireExitSignalWithNoError()
 }
 
@@ -361,7 +361,7 @@ func TestExitControlCI_JobSuccess(t *testing.T) {
 		state.ManifestTargets["fe"].State.RuntimeState = store.NewK8sRuntimeStateWithPods(m, pod("pod-a", true))
 	})
 
-	f.c.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
+	_ = f.c.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
 	f.store.requireNoExitSignal()
 
 	f.store.WithState(func(state *store.EngineState) {
@@ -369,7 +369,7 @@ func TestExitControlCI_JobSuccess(t *testing.T) {
 		mt.State.RuntimeState = store.NewK8sRuntimeStateWithPods(mt.Manifest, successPod("pod-a"))
 	})
 
-	f.c.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
+	_ = f.c.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
 	f.store.requireExitSignalWithNoError()
 }
 
@@ -413,7 +413,7 @@ func TestExitControlCI_TriggerMode_Local(t *testing.T) {
 			if tc.triggerMode.AutoInitial() {
 				// because this resource SHOULD start automatically, no exit signal should be received before
 				// a build has completed
-				f.c.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
+				_ = f.c.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
 				f.store.requireNoExitSignal()
 
 				// N.B. a build is triggered regardless of if there is an update_cmd! it's a fake build produced
@@ -429,7 +429,7 @@ func TestExitControlCI_TriggerMode_Local(t *testing.T) {
 				if tc.serveCmd {
 					// the serve_cmd hasn't started yet, so no exit signal should be received still even though
 					// a build occurred
-					f.c.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
+					_ = f.c.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
 					f.store.requireNoExitSignal()
 
 					// only mimic a runtime state if there is a serve_cmd since this won't be populated
@@ -450,7 +450,7 @@ func TestExitControlCI_TriggerMode_Local(t *testing.T) {
 
 			// for auto_init=True, it's now ready, so can exit
 			// for auto_init=False, it should NOT block on it, so can exit
-			f.c.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
+			_ = f.c.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
 			f.store.requireExitSignalWithNoError()
 		})
 	}
@@ -472,7 +472,7 @@ func TestExitControlCI_TriggerMode_K8s(t *testing.T) {
 
 			if triggerMode.AutoInitial() {
 				// because this resource SHOULD start automatically, no exit signal should be received until it's ready
-				f.c.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
+				_ = f.c.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
 				f.store.requireNoExitSignal()
 
 				f.store.WithState(func(state *store.EngineState) {
@@ -487,7 +487,7 @@ func TestExitControlCI_TriggerMode_K8s(t *testing.T) {
 
 			// for auto_init=True, it's now ready, so can exit
 			// for auto_init=False, it should NOT block on it, so can exit
-			f.c.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
+			_ = f.c.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
 			f.store.requireExitSignalWithNoError()
 		})
 	}

--- a/internal/engine/telemetry/controller_test.go
+++ b/internal/engine/telemetry/controller_test.go
@@ -191,7 +191,7 @@ func (tcf *tcFixture) run() {
 	tc := NewController(tcf.clock, tcf.sc)
 	tc.lastRunAt = tcf.lastRun
 	tcf.controller = tc
-	tc.OnChange(tcf.ctx, tcf.st, store.LegacyChangeSummary())
+	_ = tc.OnChange(tcf.ctx, tcf.st, store.LegacyChangeSummary())
 }
 
 func (tcf *tcFixture) assertNoLogs() {

--- a/internal/engine/telemetry/start_tracker.go
+++ b/internal/engine/telemetry/start_tracker.go
@@ -18,9 +18,9 @@ func NewStartTracker(tracer trace.Tracer) *StartTracker {
 	return &StartTracker{tracer: tracer, startFinished: false}
 }
 
-func (c *StartTracker) OnChange(ctx context.Context, st store.RStore, _ store.ChangeSummary) {
+func (c *StartTracker) OnChange(ctx context.Context, st store.RStore, _ store.ChangeSummary) error {
 	if c.startFinished {
-		return
+		return nil
 	}
 
 	state := st.RLockState()
@@ -35,4 +35,6 @@ func (c *StartTracker) OnChange(ctx context.Context, st store.RStore, _ store.Ch
 		c.span.End()
 		c.startFinished = true
 	}
+
+	return nil
 }

--- a/internal/engine/telemetry/start_tracker_test.go
+++ b/internal/engine/telemetry/start_tracker_test.go
@@ -27,7 +27,7 @@ func TestStart(t *testing.T) {
 		model.ManifestName("test"): mt,
 	}}
 	st.SetState(engineState)
-	cst.OnChange(ctx, st, store.LegacyChangeSummary())
+	_ = cst.OnChange(ctx, st, store.LegacyChangeSummary())
 
 	// first run span should be started
 	span, exists := ft.spans["first_run"]
@@ -35,7 +35,7 @@ func TestStart(t *testing.T) {
 	assert.False(t, span.ended)
 
 	// first run span should still not be ended
-	cst.OnChange(ctx, st, store.LegacyChangeSummary())
+	_ = cst.OnChange(ctx, st, store.LegacyChangeSummary())
 	span, exists = ft.spans["first_run"]
 	require.True(t, exists)
 	assert.False(t, span.ended)
@@ -43,14 +43,14 @@ func TestStart(t *testing.T) {
 	engineState.CompletedBuildCount = 1
 	engineState.ManifestTargets[manifest.ManifestName()].State.BuildHistory = append(engineState.ManifestTargets[manifest.ManifestName()].State.BuildHistory, model.BuildRecord{StartTime: time.Now()})
 	st.SetState(engineState)
-	cst.OnChange(ctx, st, store.LegacyChangeSummary())
+	_ = cst.OnChange(ctx, st, store.LegacyChangeSummary())
 
 	// first run span should be ended
 	span, exists = ft.spans["first_run"]
 	require.True(t, exists)
 	assert.True(t, span.ended)
 
-	cst.OnChange(ctx, st, store.LegacyChangeSummary())
+	_ = cst.OnChange(ctx, st, store.LegacyChangeSummary())
 
 	// first run span should still be ended
 	span, exists = ft.spans["first_run"]

--- a/internal/engine/uiresource/subscriber_test.go
+++ b/internal/engine/uiresource/subscriber_test.go
@@ -23,14 +23,14 @@ func TestCreate(t *testing.T) {
 	f := newFixture(t)
 	defer f.TearDown()
 
-	f.sub.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
+	_ = f.sub.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
 
 	r := f.resource("(Tiltfile)")
 	require.NotNil(t, r)
 	assert.Equal(t, "(Tiltfile)", r.ObjectMeta.Name)
 	assert.Equal(t, "1", r.ObjectMeta.ResourceVersion)
 
-	f.sub.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
+	_ = f.sub.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
 	r = f.resource("(Tiltfile)")
 	assert.Equal(t, "1", r.ObjectMeta.ResourceVersion)
 }
@@ -39,7 +39,7 @@ func TestUpdateTiltfile(t *testing.T) {
 	f := newFixture(t)
 	defer f.TearDown()
 
-	f.sub.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
+	_ = f.sub.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
 	r := f.resource("(Tiltfile)")
 	require.NotNil(t, r)
 	assert.Equal(t, "(Tiltfile)", r.ObjectMeta.Name)
@@ -49,7 +49,7 @@ func TestUpdateTiltfile(t *testing.T) {
 		es.TiltfileState.CurrentBuild.StartTime = time.Now()
 	})
 
-	f.sub.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
+	_ = f.sub.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
 
 	r = f.resource("(Tiltfile)")
 	require.NotNil(t, r)
@@ -67,7 +67,7 @@ func TestDeleteManifest(t *testing.T) {
 		state.UpsertManifestTarget(store.NewManifestTarget(m))
 	})
 
-	f.sub.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
+	_ = f.sub.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
 	assert.Equal(t, "(Tiltfile)", f.resource("(Tiltfile)").ObjectMeta.Name)
 	assert.Equal(t, "fe", f.resource("fe").ObjectMeta.Name)
 
@@ -75,7 +75,7 @@ func TestDeleteManifest(t *testing.T) {
 		state.RemoveManifestTarget("fe")
 	})
 
-	f.sub.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
+	_ = f.sub.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
 	assert.Nil(t, f.resource("fe"))
 }
 

--- a/internal/engine/uisession/subscriber.go
+++ b/internal/engine/uisession/subscriber.go
@@ -22,9 +22,9 @@ func NewSubscriber(client ctrlclient.Client) *Subscriber {
 	return &Subscriber{client: client}
 }
 
-func (s *Subscriber) OnChange(ctx context.Context, st store.RStore, summary store.ChangeSummary) {
+func (s *Subscriber) OnChange(ctx context.Context, st store.RStore, summary store.ChangeSummary) error {
 	if summary.IsLogOnly() {
-		return
+		return nil
 	}
 
 	state := st.RLockState()
@@ -38,12 +38,12 @@ func (s *Subscriber) OnChange(ctx context.Context, st store.RStore, summary stor
 		err := s.client.Create(ctx, session)
 		if err != nil {
 			logger.Get(ctx).Infof("creating uisession: %v", err)
-			return
+			return nil
 		}
-		return
+		return nil
 	} else if err != nil {
 		logger.Get(ctx).Infof("fetching uisession: %v", err)
-		return
+		return nil
 	}
 
 	if !apicmp.DeepEqual(session.Status, stored.Status) {
@@ -56,9 +56,11 @@ func (s *Subscriber) OnChange(ctx context.Context, st store.RStore, summary stor
 		err = s.client.Status().Update(ctx, update)
 		if err != nil {
 			logger.Get(ctx).Infof("updating uisession: %v", err)
-			return
+			return nil
 		}
 	}
+
+	return nil
 }
 
 var _ store.Subscriber = &Subscriber{}

--- a/internal/engine/uisession/subscriber_test.go
+++ b/internal/engine/uisession/subscriber_test.go
@@ -18,21 +18,21 @@ import (
 func TestCreate(t *testing.T) {
 	f := newFixture(t)
 
-	f.sub.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
+	_ = f.sub.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
 
 	r := f.session("Tiltfile")
 	require.NotNil(t, r)
 	assert.Equal(t, "Tiltfile", r.ObjectMeta.Name)
 	assert.Equal(t, "1", r.ObjectMeta.ResourceVersion)
 
-	f.sub.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
+	_ = f.sub.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
 	r = f.session("Tiltfile")
 	assert.Equal(t, "1", r.ObjectMeta.ResourceVersion)
 }
 
 func TestUpdate(t *testing.T) {
 	f := newFixture(t)
-	f.sub.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
+	_ = f.sub.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
 
 	r := f.session("Tiltfile")
 	require.NotNil(t, r)
@@ -43,7 +43,7 @@ func TestUpdate(t *testing.T) {
 		es.CloudStatus.Username = "sparkle"
 	})
 
-	f.sub.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
+	_ = f.sub.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
 
 	r = f.session("Tiltfile")
 	require.NotNil(t, r)

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -4604,8 +4604,9 @@ type fixtureSub struct {
 	ch chan bool
 }
 
-func (s fixtureSub) OnChange(ctx context.Context, st store.RStore, _ store.ChangeSummary) {
+func (s fixtureSub) OnChange(ctx context.Context, st store.RStore, _ store.ChangeSummary) error {
 	s.ch <- true
+	return nil
 }
 
 func (f *testFixture) dispatchDCEvent(m model.Manifest, action dockercompose.Action, containerState dockertypes.ContainerState) {

--- a/internal/hud/fake_hud.go
+++ b/internal/hud/fake_hud.go
@@ -39,7 +39,7 @@ func (h *FakeHud) Run(ctx context.Context, dispatch func(action store.Action), r
 	return ctx.Err()
 }
 
-func (h *FakeHud) OnChange(ctx context.Context, st store.RStore, _ store.ChangeSummary) {
+func (h *FakeHud) OnChange(ctx context.Context, st store.RStore, _ store.ChangeSummary) error {
 	state := st.RLockState()
 	view := store.StateToView(state, st.StateMutex())
 	st.RUnlockState()
@@ -48,6 +48,8 @@ func (h *FakeHud) OnChange(ctx context.Context, st store.RStore, _ store.ChangeS
 	if err != nil {
 		logger.Get(ctx).Infof("Error updating HUD: %v", err)
 	}
+
+	return nil
 }
 
 func (h *FakeHud) update(v view.View, vs view.ViewState) error {

--- a/internal/hud/hud.go
+++ b/internal/hud/hud.go
@@ -262,9 +262,9 @@ func (h *Hud) isEnabled(st store.RStore) bool {
 	return state.TerminalMode == store.TerminalModeHUD
 }
 
-func (h *Hud) OnChange(ctx context.Context, st store.RStore, _ store.ChangeSummary) {
+func (h *Hud) OnChange(ctx context.Context, st store.RStore, _ store.ChangeSummary) error {
 	if !h.isEnabled(st) {
-		return
+		return nil
 	}
 
 	if !h.isStarted {
@@ -301,6 +301,7 @@ func (h *Hud) OnChange(ctx context.Context, st store.RStore, _ store.ChangeSumma
 	}
 	h.currentView = view
 	h.refreshSelectedIndex()
+	return nil
 }
 
 func (h *Hud) Refresh(ctx context.Context) {

--- a/internal/hud/prompt/prompt.go
+++ b/internal/hud/prompt/prompt.go
@@ -98,13 +98,13 @@ func (p *TerminalPrompt) TearDown(ctx context.Context) {
 	}
 }
 
-func (p *TerminalPrompt) OnChange(ctx context.Context, st store.RStore, _ store.ChangeSummary) {
+func (p *TerminalPrompt) OnChange(ctx context.Context, st store.RStore, _ store.ChangeSummary) error {
 	if !p.isEnabled(st) {
-		return
+		return nil
 	}
 
 	if p.printed {
-		return
+		return nil
 	}
 
 	build := p.tiltBuild(st)
@@ -142,7 +142,7 @@ func (p *TerminalPrompt) OnChange(ctx context.Context, st store.RStore, _ store.
 	t, err := p.openInput()
 	if err != nil {
 		st.Dispatch(store.ErrorAction{Error: err})
-		return
+		return nil
 	}
 	p.term = t
 
@@ -218,6 +218,8 @@ func (p *TerminalPrompt) OnChange(ctx context.Context, st store.RStore, _ store.
 			}
 		}
 	}()
+
+	return nil
 }
 
 type runeMessage struct {

--- a/internal/hud/prompt/prompt_test.go
+++ b/internal/hud/prompt/prompt_test.go
@@ -23,7 +23,7 @@ func TestOpenBrowser(t *testing.T) {
 	f := newFixture()
 	defer f.TearDown()
 
-	f.prompt.OnChange(f.ctx, f.st, store.LegacyChangeSummary())
+	_ = f.prompt.OnChange(f.ctx, f.st, store.LegacyChangeSummary())
 
 	assert.Contains(t, f.out.String(), "(space) to open the browser")
 
@@ -35,7 +35,7 @@ func TestOpenStream(t *testing.T) {
 	f := newFixture()
 	defer f.TearDown()
 
-	f.prompt.OnChange(f.ctx, f.st, store.LegacyChangeSummary())
+	_ = f.prompt.OnChange(f.ctx, f.st, store.LegacyChangeSummary())
 
 	assert.Contains(t, f.out.String(), "(s) to stream logs")
 
@@ -49,7 +49,7 @@ func TestOpenHUD(t *testing.T) {
 	f := newFixture()
 	defer f.TearDown()
 
-	f.prompt.OnChange(f.ctx, f.st, store.LegacyChangeSummary())
+	_ = f.prompt.OnChange(f.ctx, f.st, store.LegacyChangeSummary())
 
 	assert.Contains(t, f.out.String(), "(t) to open legacy terminal mode")
 
@@ -64,7 +64,7 @@ func TestInitOutput(t *testing.T) {
 	defer f.TearDown()
 
 	f.prompt.SetInitOutput(bytes.NewBuffer([]byte("this is a warning\n")))
-	f.prompt.OnChange(f.ctx, f.st, store.LegacyChangeSummary())
+	_ = f.prompt.OnChange(f.ctx, f.st, store.LegacyChangeSummary())
 
 	assert.Contains(t, f.out.String(), `this is a warning
 

--- a/internal/hud/server/controller.go
+++ b/internal/hud/server/controller.go
@@ -84,7 +84,8 @@ func (s *HeadsUpServerController) TearDown(ctx context.Context) {
 	_ = s.removeFromAPIServerConfig()
 }
 
-func (s *HeadsUpServerController) OnChange(ctx context.Context, st store.RStore, _ store.ChangeSummary) {
+func (s *HeadsUpServerController) OnChange(ctx context.Context, st store.RStore, _ store.ChangeSummary) error {
+	return nil
 }
 
 // Merge the APIServer and the Tilt Web server into a single handler,

--- a/internal/hud/server/websocket.go
+++ b/internal/hud/server/websocket.go
@@ -116,25 +116,25 @@ func (ws *WebsocketSubscriber) waitForInitOrClose(ctx context.Context) bool {
 	}
 }
 
-func (ws *WebsocketSubscriber) OnChange(ctx context.Context, s store.RStore, summary store.ChangeSummary) {
+func (ws *WebsocketSubscriber) OnChange(ctx context.Context, s store.RStore, summary store.ChangeSummary) error {
 	// Currently, we only broadcast log changes from this OnChange handler.
 	// Everything else should be handled by reconcilers from the apiserver
 	if !summary.Log {
-		return
+		return nil
 	}
 
 	if !ws.waitForInitOrClose(ctx) {
-		return
+		return nil
 	}
 
 	view, err := webview.LogUpdate(s, ws.clientCheckpoint)
 	if err != nil {
-		return // Not much we can do on error right now.
+		return nil // Not much we can do on error right now.
 	}
 
 	// [-1,-1) means there are no logs
 	if view.LogList.ToCheckpoint == -1 && view.LogList.FromCheckpoint == -1 {
-		return
+		return nil
 	}
 
 	ws.sendView(ctx, view)
@@ -149,6 +149,7 @@ func (ws *WebsocketSubscriber) OnChange(ctx context.Context, s store.RStore, sum
 	//     JSON marshaling with jsoniter (though changing json marshalers is
 	//     always fraught with peril).
 	time.Sleep(time.Millisecond * 100)
+	return nil
 }
 
 // Sends a UISession update on the websocket.

--- a/internal/hud/server/websocket_test.go
+++ b/internal/hud/server/websocket_test.go
@@ -139,7 +139,7 @@ func TestWebsocketIgnoreEmptyLogList(t *testing.T) {
 
 	conn.AssertNextWriteMsg(t).Ack()
 
-	ws.OnChange(ctx, st, store.ChangeSummary{Log: true})
+	_ = ws.OnChange(ctx, st, store.ChangeSummary{Log: true})
 	require.NotEqual(t, -1, ws.clientCheckpoint)
 }
 

--- a/internal/hud/terminal_stream.go
+++ b/internal/hud/terminal_stream.go
@@ -24,7 +24,7 @@ func (h *TerminalStream) TearDown(ctx context.Context) {
 		return
 	}
 
-	h.OnChange(ctx, h.store, store.LegacyChangeSummary())
+	_ = h.OnChange(ctx, h.store, store.LegacyChangeSummary())
 
 	state := h.store.RLockState()
 	uncompleted := state.LogStore.IsLastSegmentUncompleted()
@@ -41,9 +41,9 @@ func (h *TerminalStream) isEnabled(st store.RStore) bool {
 	return state.TerminalMode == store.TerminalModeStream
 }
 
-func (h *TerminalStream) OnChange(ctx context.Context, st store.RStore, _ store.ChangeSummary) {
+func (h *TerminalStream) OnChange(ctx context.Context, st store.RStore, _ store.ChangeSummary) error {
 	if !h.isEnabled(st) {
-		return
+		return nil
 	}
 
 	state := st.RLockState()
@@ -53,6 +53,7 @@ func (h *TerminalStream) OnChange(ctx context.Context, st store.RStore, _ store.
 
 	h.printer.Print(lines)
 	h.ProcessedLogs = checkpoint
+	return nil
 }
 
 var _ store.TearDowner = &TerminalStream{}

--- a/internal/store/helpers_test.go
+++ b/internal/store/helpers_test.go
@@ -63,10 +63,11 @@ func (f *fakeSubscriber) assertOnChange(t *testing.T) {
 	}
 }
 
-func (f *fakeSubscriber) OnChange(ctx context.Context, st RStore, summary ChangeSummary) {
+func (f *fakeSubscriber) OnChange(ctx context.Context, st RStore, summary ChangeSummary) error {
 	call := onChangeCall{done: make(chan bool), summary: summary}
 	f.onChange <- call
 	<-call.done
+	return nil
 }
 
 func (f *fakeSubscriber) SetUp(ctx context.Context, st RStore) error {

--- a/internal/store/summary.go
+++ b/internal/store/summary.go
@@ -1,6 +1,8 @@
 package store
 
 import (
+	"time"
+
 	"github.com/google/go-cmp/cmp"
 	"k8s.io/apimachinery/pkg/types"
 )
@@ -72,6 +74,10 @@ type ChangeSummary struct {
 
 	UISessions  ChangeSet
 	UIResources ChangeSet
+
+	// If non-zero, that means we tried to apply this change and got
+	// an error.
+	LastBackoff time.Duration
 }
 
 func (s ChangeSummary) IsLogOnly() bool {


### PR DESCRIPTION
Hello @milas,

Please review the following commits I made in branch nicks/onchange2:

ee5c3892e71b4a725234854d972cc335320fd423 (2021-06-15 13:44:10 -0400)
store: add a return value to OnChange, so we can add re-queueing logic

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics