### PR TITLE
k8s: update PortForwardStatus after initializing forwards

### DIFF
--- a/internal/controllers/core/portforward/reconciler.go
+++ b/internal/controllers/core/portforward/reconciler.go
@@ -2,7 +2,13 @@ package portforward
 
 import (
 	"context"
+	"sort"
+	"sync"
 	"time"
+
+	"github.com/tilt-dev/tilt/internal/timecmp"
+	"github.com/tilt-dev/tilt/pkg/apis"
+	"github.com/tilt-dev/tilt/pkg/logger"
 
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -17,7 +23,6 @@ import (
 
 	"github.com/tilt-dev/tilt/internal/k8s"
 	"github.com/tilt-dev/tilt/internal/store"
-	"github.com/tilt-dev/tilt/pkg/logger"
 )
 
 type Reconciler struct {
@@ -26,7 +31,7 @@ type Reconciler struct {
 	ctrlClient ctrlclient.Client
 
 	// map of PortForward object name --> running forward(s)
-	activeForwards map[types.NamespacedName]portForwardEntry
+	activeForwards map[types.NamespacedName]*portForwardEntry
 }
 
 var _ store.TearDowner = &Reconciler{}
@@ -36,7 +41,7 @@ func NewReconciler(store store.RStore, kClient k8s.Client) *Reconciler {
 	return &Reconciler{
 		store:          store,
 		kClient:        kClient,
-		activeForwards: make(map[types.NamespacedName]portForwardEntry),
+		activeForwards: make(map[types.NamespacedName]*portForwardEntry),
 	}
 }
 
@@ -84,15 +89,13 @@ func (r *Reconciler) reconcile(ctx context.Context, name types.NamespacedName) e
 	ctx = store.MustObjectLogHandler(entry.ctx, r.store, entry.PortForward)
 
 	for _, forward := range entry.Spec.Forwards {
-		entry := entry
-		forward := forward
-		go r.startPortForwardLoop(ctx, entry, forward)
+		go r.portForwardLoop(ctx, entry, forward)
 	}
 
 	return nil
 }
 
-func (r *Reconciler) startPortForwardLoop(ctx context.Context, entry portForwardEntry, forward Forward) {
+func (r *Reconciler) portForwardLoop(ctx context.Context, entry *portForwardEntry, forward Forward) {
 	originalBackoff := wait.Backoff{
 		Steps:    1000,
 		Duration: 50 * time.Millisecond,
@@ -104,18 +107,13 @@ func (r *Reconciler) startPortForwardLoop(ctx context.Context, entry portForward
 
 	for {
 		start := time.Now()
-		err := r.onePortForward(ctx, entry, forward)
+		r.onePortForward(ctx, entry, forward)
 		if ctx.Err() != nil {
-			// If the context was canceled, we're satisfied.
-			// Ignore any errors.
+			// If the context was canceled, there's nothing more to do;
+			// we cannot even update the status because we no longer have
+			// a valid context, but that's fine because that means this
+			// PortForward is being deleted.
 			return
-		}
-
-		// Otherwise, repeat the loop, maybe logging the error
-		if err != nil {
-			logger.Get(ctx).Infof("Reconnecting... Error port-forwarding %s (%d -> %d): %v",
-				entry.ObjectMeta.Annotations[v1alpha1.AnnotationManifest],
-				forward.LocalPort, forward.ContainerPort, err)
 		}
 
 		// If this failed in less than a second, then we should advance the backoff.
@@ -128,23 +126,92 @@ func (r *Reconciler) startPortForwardLoop(ctx context.Context, entry portForward
 	}
 }
 
-func (r *Reconciler) onePortForward(ctx context.Context, entry portForwardEntry, forward Forward) error {
-	ns := k8s.Namespace(entry.Spec.Namespace)
-	podID := k8s.PodID(entry.Spec.PodName)
-
-	pf, err := r.kClient.CreatePortForwarder(ctx, ns, podID, int(forward.LocalPort), int(forward.ContainerPort), forward.Host)
-	if err != nil {
-		return err
+func (r *Reconciler) updateForwardStatus(ctx context.Context, entry *portForwardEntry) {
+	var pf v1alpha1.PortForward
+	key := apis.Key(entry.PortForward)
+	if err := r.ctrlClient.Get(ctx, key, &pf); err != nil {
+		if !apierrors.IsNotFound(err) {
+			// short of dispatching a fatal error, there's nothing that can really be done here, so just log it
+			// for debugging purposes
+			logger.Get(ctx).Debugf("Failed to fetch PortForward %q for status update: %v", entry.Name, err)
+		}
+		return
 	}
 
-	err = pf.ForwardPorts()
-	if err != nil {
-		return err
+	newStatuses := entry.statuses()
+	if equality.Semantic.DeepEqual(pf.Status.ForwardStatuses, newStatuses) {
+		// the forwards didn't actually change, so skip the update
+		return
 	}
-	return nil
+
+	pf.Status.ForwardStatuses = newStatuses
+	if err := r.ctrlClient.Status().Update(ctx, &pf); err != nil {
+		if !apierrors.IsNotFound(err) && !apierrors.IsConflict(err) {
+			logger.Get(ctx).Debugf("Failed to update status for PortForward %q: %v", entry.Name, err)
+		}
+	}
 }
 
-func (r *Reconciler) TearDown(ctx context.Context) {
+func (r *Reconciler) onePortForward(ctx context.Context, entry *portForwardEntry, forward Forward) {
+	pf, err := r.kClient.CreatePortForwarder(
+		ctx,
+		k8s.Namespace(entry.Spec.Namespace),
+		k8s.PodID(entry.Spec.PodName),
+		int(forward.LocalPort),
+		int(forward.ContainerPort),
+		forward.Host)
+	if err != nil {
+		shouldUpdate := entry.setStatus(forward, ForwardStatus{
+			LocalPort:     forward.LocalPort,
+			ContainerPort: forward.ContainerPort,
+			Error:         err.Error(),
+		})
+		if shouldUpdate {
+			r.updateForwardStatus(ctx, entry)
+		}
+		return
+	}
+
+	// wait in the background for the port forwarder to signal that it's ready to update the status
+	// the doneCh ensures we don't leak the goroutine if ForwardPorts() errors out early without
+	// ever becoming ready
+	doneCh := make(chan struct{}, 1)
+	go func() {
+		readyCh := pf.ReadyCh()
+		if readyCh == nil {
+			return
+		}
+		select {
+		case <-doneCh:
+			return
+		case <-readyCh:
+			entry.setStatus(forward, ForwardStatus{
+				LocalPort:     int32(pf.LocalPort()),
+				ContainerPort: forward.ContainerPort,
+				Addresses:     pf.Addresses(),
+				StartedAt:     apis.NowMicro(),
+			})
+			r.updateForwardStatus(ctx, entry)
+		}
+	}()
+
+	err = pf.ForwardPorts()
+	close(doneCh)
+	if err != nil {
+		shouldUpdate := entry.setStatus(forward, ForwardStatus{
+			LocalPort:     int32(pf.LocalPort()),
+			ContainerPort: forward.ContainerPort,
+			Addresses:     pf.Addresses(),
+			Error:         err.Error(),
+		})
+		if shouldUpdate {
+			r.updateForwardStatus(ctx, entry)
+		}
+		return
+	}
+}
+
+func (r *Reconciler) TearDown(_ context.Context) {
 	for name := range r.activeForwards {
 		r.stop(name)
 	}
@@ -163,13 +230,66 @@ type portForwardEntry struct {
 	*PortForward
 	ctx    context.Context
 	cancel func()
+
+	mu     sync.Mutex
+	status map[Forward]statusMeta
 }
 
-func newEntry(ctx context.Context, pf *PortForward) portForwardEntry {
+func newEntry(ctx context.Context, pf *PortForward) *portForwardEntry {
 	ctx, cancel := context.WithCancel(ctx)
-	return portForwardEntry{
+	return &portForwardEntry{
 		PortForward: pf,
 		ctx:         ctx,
 		cancel:      cancel,
+		status:      make(map[Forward]statusMeta),
 	}
+}
+
+type statusMeta struct {
+	status    ForwardStatus
+	lastError time.Time
+}
+
+// setStatus tracks the latest status for this Forward and returns a bool indicating whether
+// an API update should be performed.
+func (e *portForwardEntry) setStatus(spec Forward, status ForwardStatus) (shouldUpdate bool) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	var lastError time.Time
+	if status.Error != "" {
+		lastError = time.Now()
+		// if this port forward last failed more than a second ago (or had lastError reset
+		// by having gone into a success status), do an update
+		shouldUpdate = e.status[spec].lastError.Before(time.Now().Add(-time.Second))
+	} else {
+		// always update on success
+		shouldUpdate = true
+	}
+
+	e.status[spec] = statusMeta{
+		status:    status,
+		lastError: lastError,
+	}
+	return shouldUpdate
+}
+
+func (e *portForwardEntry) statuses() []ForwardStatus {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	var statuses []ForwardStatus
+	for _, s := range e.status {
+		statuses = append(statuses, *s.status.DeepCopy())
+	}
+	sort.SliceStable(statuses, func(i, j int) bool {
+		if statuses[i].ContainerPort < statuses[j].ContainerPort {
+			return true
+		}
+		if statuses[i].LocalPort < statuses[j].LocalPort {
+			return true
+		}
+		return timecmp.BeforeOrEqual(statuses[i].StartedAt, statuses[j].StartedAt)
+	})
+	return statuses
 }

--- a/internal/controllers/core/portforward/reconciler.go
+++ b/internal/controllers/core/portforward/reconciler.go
@@ -189,7 +189,11 @@ func (r *Reconciler) onePortForward(ctx context.Context, entry *portForwardEntry
 			return
 		}
 		select {
+		case <-ctx.Done():
+			// context canceled before forward was every ready
+			return
 		case <-doneCh:
+			// forward initialization errored at start before ready
 			return
 		case <-readyCh:
 			entry.setStatus(forward, ForwardStatus{

--- a/internal/controllers/core/portforward/types.go
+++ b/internal/controllers/core/portforward/types.go
@@ -11,3 +11,4 @@ type PortForwardSpec = v1alpha1.PortForwardSpec
 type PortForwardStatus = v1alpha1.PortForwardStatus
 type ObjectMeta = metav1.ObjectMeta
 type Forward = v1alpha1.Forward
+type ForwardStatus = v1alpha1.ForwardStatus

--- a/internal/controllers/fake/fixture.go
+++ b/internal/controllers/fake/fixture.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"os"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -74,14 +73,8 @@ func (f ControllerFixture) Cancel() {
 	f.cancel()
 }
 
-func (f *ControllerFixture) RootContext() context.Context {
+func (f *ControllerFixture) Context() context.Context {
 	return f.ctx
-}
-
-func (f *ControllerFixture) TimeoutContext() context.Context {
-	ctx, cancel := context.WithTimeout(f.ctx, 5*time.Second)
-	f.t.Cleanup(cancel)
-	return ctx
 }
 
 func (f *ControllerFixture) KeyForObject(o object) types.NamespacedName {
@@ -90,7 +83,7 @@ func (f *ControllerFixture) KeyForObject(o object) types.NamespacedName {
 
 func (f *ControllerFixture) MustReconcile(key types.NamespacedName) ctrl.Result {
 	f.t.Helper()
-	res, err := f.controller.Reconcile(f.TimeoutContext(), ctrl.Request{NamespacedName: key})
+	res, err := f.controller.Reconcile(f.ctx, ctrl.Request{NamespacedName: key})
 	require.NoError(f.t, err)
 	return res
 }

--- a/internal/k8s/client_test.go
+++ b/internal/k8s/client_test.go
@@ -281,7 +281,7 @@ func newClientTestFixture(t *testing.T) *clientTestFixture {
 	ret.client = K8sClient{
 		env:               EnvUnknown,
 		core:              core,
-		portForwardClient: NewFakePortfowardClient(),
+		portForwardClient: NewFakePortForwardClient(),
 		dynamic:           dc,
 		runtimeAsync:      runtimeAsync,
 		registryAsync:     registryAsync,

--- a/internal/k8s/portforward/portforward.go
+++ b/internal/k8s/portforward/portforward.go
@@ -181,6 +181,14 @@ func NewOnAddresses(ctx context.Context, dialer httpstream.Dialer, addresses []s
 	}, nil
 }
 
+func (pf *PortForwarder) Addresses() []string {
+	var addresses []string
+	for _, la := range pf.addresses {
+		addresses = append(addresses, la.address)
+	}
+	return addresses
+}
+
 // ForwardPorts formats and executes a port forwarding request. The connection will remain
 // open until stopChan is closed.
 func (pf *PortForwarder) ForwardPorts() error {


### PR DESCRIPTION
There are 3 cases where status gets updated for a forward:
 * Forward started successfully (StartedAt set as well as local
   port, which is useful if a randomized one was requested)
 * Forwarder instance can't be created (bad config)
 * Forwarder returns an error after start

To simplify error handling and keep the status update logic
as centralized as possible, the actual initialization changed
slightly to happen in a single method.

There is some very basic logic to avoid spamming the API
server with updates on errors: it will only attempt to do
an update once a second if continuously failing. (Even then,
it will attempt to avoid a no-op update if the error hasn't
actually changed.)

(This is based off Maia's original stub PR: #4621)