### PR TITLE
api: validation for PortForward objects

### DIFF
--- a/internal/hud/server/apiserver_test.go
+++ b/internal/hud/server/apiserver_test.go
@@ -62,6 +62,15 @@ func TestAPIServerDynamicClient(t *testing.T) {
 				"componentID":   "my-resource",
 			},
 		},
+		"PortForward": map[string]interface{}{
+			"podName": "my-pod",
+			"forwards": []interface{}{
+				map[string]interface{}{
+					"localPort":     8080,
+					"containerPort": 8000,
+				},
+			},
+		},
 	}
 
 	for _, obj := range v1alpha1.AllResourceObjects() {


### PR DESCRIPTION
* PodName cannot be empty
* At least one Forward must be defined
* LocalPort must be [0, 65535] (0 == randomized)
* ContainerPort must be (0, 65535]
* LocalPorts cannot repeat (though likely not common, ContainerPort
  can be forwarded multiple times, so duplicates are fine there)