### PR TITLE
web: add support for filtering logs by regular expression

### DIFF
--- a/web/src/OverviewActionBar.tsx
+++ b/web/src/OverviewActionBar.tsx
@@ -24,7 +24,13 @@ import { ReactComponent as LinkSvg } from "./assets/svg/link.svg"
 import { InstrumentedButton } from "./instrumentedComponents"
 import { displayURL } from "./links"
 import LogActions from "./LogActions"
-import { EMPTY_TERM, FilterLevel, FilterSet, FilterSource } from "./logfilters"
+import {
+  EMPTY_TERM,
+  FilterLevel,
+  FilterSet,
+  FilterSource,
+  TermState,
+} from "./logfilters"
 import { useLogStore } from "./LogStore"
 import OverviewActionBarKeyboardShortcuts from "./OverviewActionBarKeyboardShortcuts"
 import { usePathBuilder } from "./PathBuilder"

--- a/web/src/OverviewActionBar.tsx
+++ b/web/src/OverviewActionBar.tsx
@@ -24,13 +24,7 @@ import { ReactComponent as LinkSvg } from "./assets/svg/link.svg"
 import { InstrumentedButton } from "./instrumentedComponents"
 import { displayURL } from "./links"
 import LogActions from "./LogActions"
-import {
-  EMPTY_TERM,
-  FilterLevel,
-  FilterSet,
-  FilterSource,
-  TermState,
-} from "./logfilters"
+import { EMPTY_TERM, FilterLevel, FilterSet, FilterSource } from "./logfilters"
 import { useLogStore } from "./LogStore"
 import OverviewActionBarKeyboardShortcuts from "./OverviewActionBarKeyboardShortcuts"
 import { usePathBuilder } from "./PathBuilder"

--- a/web/src/assets/svg/alert.svg
+++ b/web/src/assets/svg/alert.svg
@@ -1,0 +1,5 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M11 7C11 6.44772 11.4477 6 12 6C12.5523 6 13 6.44772 13 7V14C13 14.5523 12.5523 15 12 15C11.4477 15 11 14.5523 11 14V7Z" fill="#F6685C"/>
+<circle cx="12" cy="17" r="1" fill="#F6685C"/>
+<circle cx="12" cy="12" r="9.5" stroke="#F6685C"/>
+</svg>

--- a/web/src/logfilters.test.ts
+++ b/web/src/logfilters.test.ts
@@ -31,14 +31,29 @@ describe("Log filters", () => {
       })
 
       it("gets set with a parsed state if a valid term is present", () => {
-        const location = { search: "term=docker+build" } as Location
-        const parsedTerm = filterSetFromLocation(location).term
-        expect(parsedTerm.state).toEqual(TermState.Parsed)
-        expect(parsedTerm.input).toEqual("docker build")
-        expect(parsedTerm.hasOwnProperty("regexp")).toBe(true)
+        const textLocation = { search: "term=docker+build" } as Location
+        const textParsedTerm = filterSetFromLocation(textLocation).term
+        expect(textParsedTerm.state).toEqual(TermState.Parsed)
+        expect(textParsedTerm.input).toEqual("docker build")
+        expect(textParsedTerm.hasOwnProperty("regexp")).toBe(true)
+        expect(textParsedTerm.hasOwnProperty("error")).toBe(false)
+
+        const regexpLocation = { search: "term=%2Fdocker%2F" } as Location
+        const regexpParsedTerm = filterSetFromLocation(regexpLocation).term
+        expect(regexpParsedTerm.state).toEqual(TermState.Parsed)
+        expect(regexpParsedTerm.input).toEqual("/docker/")
+        expect(regexpParsedTerm.hasOwnProperty("regexp")).toBe(true)
+        expect(regexpParsedTerm.hasOwnProperty("error")).toBe(false)
       })
 
-      // TODO(LT): when regex input is supported in term filter field, add a test for error case
+      it("gets set with an error state if an invalid input is present", () => {
+        const location = { search: "term=%2Fdock(er%3F%2F" } as Location
+        const parsedTerm = filterSetFromLocation(location).term
+        expect(parsedTerm.state).toEqual(TermState.Error)
+        expect(parsedTerm.input).toEqual("/dock(er?/")
+        expect(parsedTerm.hasOwnProperty("regexp")).toBe(false)
+        expect(parsedTerm.hasOwnProperty("error")).toBe(true)
+      })
     })
 
     describe("term parsing", () => {
@@ -84,6 +99,39 @@ describe("Log filters", () => {
           ).toBe(false)
           expect(parseTermInput("[1/5]").test(TestStrings.BuildInfoLine)).toBe(
             true
+          )
+        })
+      })
+
+      describe("for regular expressions", () => {
+        it("only parses strings surrounded by forward slashes as regexp", () => {
+          expect(
+            parseTermInput("/docker/").test(TestStrings.BuildInfoLine)
+          ).toBe(true)
+          expect(
+            parseTermInput("/docker").test(TestStrings.BuildInfoLine)
+          ).toBe(false)
+        })
+
+        it("matches on the expected text", () => {
+          expect(parseTermInput("/ab?c/").test(TestStrings.Basic)).toBe(true)
+          expect(
+            parseTermInput("/error.+main/").test(TestStrings.BuildErrorInFile)
+          ).toBe(true)
+          expect(parseTermInput("/d+/").test(TestStrings.Basic)).toBe(false)
+          expect(parseTermInput("/d+/").test(TestStrings.BuildInfoLine)).toBe(
+            true
+          )
+          expect(
+            parseTermInput("/failed:/").test(TestStrings.BuildError404)
+          ).toBe(true)
+        })
+
+        it("throws an error when input text is invalid regex", () => {
+          expect(() =>
+            parseTermInput("/(missing)? parenthesis)/")
+          ).toThrowError(
+            "Invalid regular expression: /(missing)? parenthesis)/: Unmatched ')'"
           )
         })
       })


### PR DESCRIPTION
This PR:
*  Fix a bug where navigating to an individual resource from sidebar view would clear the filter term in the url, but not the filter input field
*  Add support for using regular expressions to filter log spans
*  Display an error state with helpful text if parsing regexp errors, using Material UI's `FormHelperText` component

Fyi, the final style implementation does look different than the Figma files. While pairing with Han, we decided that displaying the error message styled as tooltip would be the easiest approach, and Surbhi approved.

Basic functionality:
![2021-06-17 14 38 07](https://user-images.githubusercontent.com/23283986/122455509-7886ec00-cf7a-11eb-8b05-bc898a35a520.gif)

Final styles:
![Screen Shot 2021-06-21 at 12 13 57 PM](https://user-images.githubusercontent.com/23283986/122795932-d45bb880-d28b-11eb-9279-273918d4d895.png)

Closes ch12047