### PR TITLE
(web) Fix a bug where the filter term is not removed during backspace [ch12192]

### DIFF
--- a/web/src/OverviewActionBar.tsx
+++ b/web/src/OverviewActionBar.tsx
@@ -440,16 +440,15 @@ export function FilterTermField(props: { initialTerm: string }) {
    * The term field updates without any debouncing, while the url search params
    * (which actually triggers log filtering) updates with the debounce delay.
    */
-  const setTerm = (term: string) => {
+  const setTerm = (term: string, withDebounceDelay = true) => {
     setFilterTerm(term)
 
     const search = createLogSearch(location.search, { term })
 
-    // Don't use the debounce delay if clearing the filter term
-    if (term === EMPTY_TERM) {
-      history.push({ search: search.toString() })
-    } else {
+    if (withDebounceDelay) {
       debounceFilterLogs(history, search.toString())
+    } else {
+      history.push({ search: search.toString() })
     }
   }
 
@@ -474,7 +473,7 @@ export function FilterTermField(props: { initialTerm: string }) {
       <InputAdornment position="end">
         <ClearFilterTermTextButton
           analyticsName="TODO"
-          onClick={() => setTerm(EMPTY_TERM)}
+          onClick={() => setTerm(EMPTY_TERM, false)}
         >
           <SrOnly>Clear filter term</SrOnly>
           <CloseSvg fill={Color.grayLightest} role="presentation" />


### PR DESCRIPTION
CH12192 Fix a bug where the filter term is not removed during backspace by adding support to explicitly opt out of debouncing

When we update the filter term state, the existing code behaves differently based on whether we're adding/updating a filter term or removing it. The former always has a debouncing delay, while the latter does not have a debouncing delay. The reason behind this is so that we can immediately update the filter state without a delay when a user clears the term field via button. This causes a bug where if a user is backspacing a term they've entered, if they clear it completely, that state update fires immediately, while the previous state update fires after the debouncing delay. 💡