### PR TITLE
cli: add namespace flag

### DIFF
--- a/integration/namespaceflag/Dockerfile
+++ b/integration/namespaceflag/Dockerfile
@@ -1,0 +1,4 @@
+FROM busybox
+WORKDIR /app
+ADD . .
+ENTRYPOINT busybox httpd -f -p 8000

--- a/integration/namespaceflag/Tiltfile
+++ b/integration/namespaceflag/Tiltfile
@@ -1,0 +1,13 @@
+# -*- mode: Python -*-
+
+include('../Tiltfile')
+
+# If you get push errors, you can change the default_registry.
+# Create tilt_option.json with contents: {"default_registry": "gcr.io/my-personal-project"}
+# (with your registry inserted). tilt_option.json is gitignore'd, unlike Tiltfile
+default_registry(read_json('tilt_option.json', {})
+                 .get('default_registry', 'gcr.io/windmill-test-containers/servantes'))
+
+docker_build('namespaceflag', '.')
+k8s_yaml('namespaceflag.yaml')
+k8s_resource('namespaceflag', port_forwards=8100)

--- a/integration/namespaceflag/index.html
+++ b/integration/namespaceflag/index.html
@@ -1,0 +1,1 @@
+🍄 Namespace flag! 🍄

--- a/integration/namespaceflag/namespaceflag.yaml
+++ b/integration/namespaceflag/namespaceflag.yaml
@@ -1,0 +1,20 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: namespaceflag
+  labels:
+    app: namespaceflag
+spec:
+  selector:
+    matchLabels:
+      app: namespaceflag
+  template:
+    metadata:
+      labels:
+        app: namespaceflag
+    spec:
+      containers:
+      - name: namespaceflag
+        image: namespaceflag
+        ports:
+        - containerPort: 8000

--- a/integration/namespaceflag_test.go
+++ b/integration/namespaceflag_test.go
@@ -1,0 +1,41 @@
+//+build integration
+
+package integration
+
+import (
+	"bytes"
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNamespaceFlag(t *testing.T) {
+	f := newK8sFixture(t, "namespaceflag")
+	defer f.TearDown()
+	f.SetRestrictedCredentials()
+
+	// Specify the namespace in the Tilt Up invocation,
+	// but don't put in in the YAML file.
+	f.TiltUp("namespaceflag", "--namespace=tilt-integration")
+
+	// ForwardPort will fail if all the pods are not ready.
+	//
+	// We can't use the normal Tilt-managed forwards here because
+	// Tilt doesn't setup forwards when --watch=false.
+	ctx, cancel := context.WithTimeout(f.ctx, time.Minute)
+	defer cancel()
+	f.WaitForAllPodsReady(ctx, "app=namespaceflag")
+
+	f.ForwardPort("deployment/namespaceflag", "31234:8000")
+
+	ctx, cancel = context.WithTimeout(f.ctx, time.Minute)
+	defer cancel()
+	f.CurlUntil(ctx, "http://localhost:31234", "🍄 Namespace flag! 🍄")
+
+	// minimal sanity check that the engine dump works - this really just ensures that there's no egregious
+	// serialization issues
+	var b bytes.Buffer
+	assert.NoErrorf(t, f.tilt.DumpEngine(f.ctx, &b), "Failed to dump engine state, command output:\n%s", b.String())
+}

--- a/internal/cli/flags.go
+++ b/internal/cli/flags.go
@@ -14,8 +14,10 @@ import (
 
 var defaultWebHost = "localhost"
 var defaultWebPort = model.DefaultWebPort
+var defaultNamespace = ""
 var webHostFlag = ""
 var webPortFlag = 0
+var namespaceFlag = ""
 
 func readEnvDefaults() error {
 	envPort := os.Getenv("TILT_PORT")
@@ -62,8 +64,16 @@ func addDevServerFlags(cmd *cobra.Command) {
 	cmd.Flags().Var(&webModeFlag, "web-mode", "Values: local, prod. Controls whether to use prod assets or a local dev server. (If flag not specified: if Tilt was built from source, it will use a local asset server; otherwise, prod assets.)")
 }
 
+func addNamespaceFlag(cmd *cobra.Command) {
+	cmd.Flags().StringVar(&namespaceFlag, "namespace", defaultNamespace, "Namespace for the resources Tilt brings up.")
+}
+
 var kubeContextOverride string
 
 func ProvideKubeContextOverride() k8s.KubeContextOverride {
 	return k8s.KubeContextOverride(kubeContextOverride)
+}
+
+func ProvideNamespaceFlag() k8s.NamespaceFlag {
+	return k8s.NamespaceFlag(namespaceFlag)
 }

--- a/internal/cli/flags.go
+++ b/internal/cli/flags.go
@@ -17,7 +17,7 @@ var defaultWebPort = model.DefaultWebPort
 var defaultNamespace = ""
 var webHostFlag = ""
 var webPortFlag = 0
-var namespaceFlag = ""
+var namespaceOverride = ""
 
 func readEnvDefaults() error {
 	envPort := os.Getenv("TILT_PORT")
@@ -65,7 +65,7 @@ func addDevServerFlags(cmd *cobra.Command) {
 }
 
 func addNamespaceFlag(cmd *cobra.Command) {
-	cmd.Flags().StringVar(&namespaceFlag, "namespace", defaultNamespace, "Namespace for the resources Tilt brings up.")
+	cmd.Flags().StringVar(&namespaceOverride, "namespace", defaultNamespace, "Default namespace for Kubernetes resources (overrides default namespace from active context in kubeconfig)")
 }
 
 var kubeContextOverride string
@@ -74,6 +74,6 @@ func ProvideKubeContextOverride() k8s.KubeContextOverride {
 	return k8s.KubeContextOverride(kubeContextOverride)
 }
 
-func ProvideNamespaceFlag() k8s.NamespaceFlag {
-	return k8s.NamespaceFlag(namespaceFlag)
+func ProvideNamespaceOverride() k8s.NamespaceOverride {
+	return k8s.NamespaceOverride(namespaceOverride)
 }

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -80,6 +80,7 @@ local resources--i.e. those using serve_cmd--are terminated when you exit Tilt.
 	addDevServerFlags(cmd)
 	addTiltfileFlag(cmd, &c.fileName)
 	addKubeContextFlag(cmd)
+	addNamespaceFlag(cmd)
 	cmd.Flags().Lookup("logactions").Hidden = true
 	cmd.Flags().StringVar(&c.outputSnapshotOnExit, "output-snapshot-on-exit", "", "If specified, Tilt will dump a snapshot of its state to the specified path when it exits")
 

--- a/internal/cli/wire.go
+++ b/internal/cli/wire.go
@@ -76,7 +76,8 @@ var K8sWireSet = wire.NewSet(
 	k8s.ProvideServerVersion,
 	k8s.ProvideK8sClient,
 	k8s.ProvideOwnerFetcher,
-	ProvideKubeContextOverride)
+	ProvideKubeContextOverride,
+	ProvideNamespaceFlag)
 
 var BaseWireSet = wire.NewSet(
 	K8sWireSet,

--- a/internal/cli/wire.go
+++ b/internal/cli/wire.go
@@ -77,7 +77,7 @@ var K8sWireSet = wire.NewSet(
 	k8s.ProvideK8sClient,
 	k8s.ProvideOwnerFetcher,
 	ProvideKubeContextOverride,
-	ProvideNamespaceFlag)
+	ProvideNamespaceOverride)
 
 var BaseWireSet = wire.NewSet(
 	K8sWireSet,

--- a/internal/cli/wire_gen.go
+++ b/internal/cli/wire_gen.go
@@ -79,7 +79,8 @@ import (
 
 func wireTiltfileResult(ctx context.Context, analytics2 *analytics.TiltAnalytics, subcommand model.TiltSubcommand) (cmdTiltfileResultDeps, error) {
 	k8sKubeContextOverride := ProvideKubeContextOverride()
-	clientConfig := k8s.ProvideClientConfig(k8sKubeContextOverride)
+	k8sNamespaceFlag := ProvideNamespaceFlag()
+	clientConfig := k8s.ProvideClientConfig(k8sKubeContextOverride, k8sNamespaceFlag)
 	apiConfig, err := k8s.ProvideKubeConfig(clientConfig, k8sKubeContextOverride)
 	if err != nil {
 		return cmdTiltfileResultDeps{}, err
@@ -88,8 +89,7 @@ func wireTiltfileResult(ctx context.Context, analytics2 *analytics.TiltAnalytics
 	restConfigOrError := k8s.ProvideRESTConfig(clientConfig)
 	clientsetOrError := k8s.ProvideClientset(restConfigOrError)
 	portForwardClient := k8s.ProvidePortForwardClient(restConfigOrError, clientsetOrError)
-	k8sNamespaceFlag := ProvideNamespaceFlag()
-	namespace := k8s.ProvideConfigNamespace(clientConfig, k8sNamespaceFlag)
+	namespace := k8s.ProvideConfigNamespace(clientConfig)
 	kubeContext, err := k8s.ProvideKubeContext(apiConfig)
 	if err != nil {
 		return cmdTiltfileResultDeps{}, err
@@ -117,7 +117,8 @@ var (
 
 func wireDockerPrune(ctx context.Context, analytics2 *analytics.TiltAnalytics, subcommand model.TiltSubcommand) (dpDeps, error) {
 	k8sKubeContextOverride := ProvideKubeContextOverride()
-	clientConfig := k8s.ProvideClientConfig(k8sKubeContextOverride)
+	k8sNamespaceFlag := ProvideNamespaceFlag()
+	clientConfig := k8s.ProvideClientConfig(k8sKubeContextOverride, k8sNamespaceFlag)
 	apiConfig, err := k8s.ProvideKubeConfig(clientConfig, k8sKubeContextOverride)
 	if err != nil {
 		return dpDeps{}, err
@@ -130,8 +131,7 @@ func wireDockerPrune(ctx context.Context, analytics2 *analytics.TiltAnalytics, s
 	restConfigOrError := k8s.ProvideRESTConfig(clientConfig)
 	clientsetOrError := k8s.ProvideClientset(restConfigOrError)
 	portForwardClient := k8s.ProvidePortForwardClient(restConfigOrError, clientsetOrError)
-	k8sNamespaceFlag := ProvideNamespaceFlag()
-	namespace := k8s.ProvideConfigNamespace(clientConfig, k8sNamespaceFlag)
+	namespace := k8s.ProvideConfigNamespace(clientConfig)
 	minikubeClient := k8s.ProvideMinikubeClient(kubeContext)
 	client := k8s.ProvideK8sClient(ctx, env, restConfigOrError, clientsetOrError, portForwardClient, namespace, minikubeClient, clientConfig)
 	runtime := k8s.ProvideContainerRuntime(ctx, client)
@@ -223,7 +223,8 @@ func wireCmdUp(ctx context.Context, analytics3 *analytics.TiltAnalytics, cmdTags
 	clock := clockwork.NewRealClock()
 	cmdController := cmd.NewController(ctx, execer, proberManager, deferredClient, storeStore, clock, scheme)
 	k8sKubeContextOverride := ProvideKubeContextOverride()
-	clientConfig := k8s.ProvideClientConfig(k8sKubeContextOverride)
+	k8sNamespaceFlag := ProvideNamespaceFlag()
+	clientConfig := k8s.ProvideClientConfig(k8sKubeContextOverride, k8sNamespaceFlag)
 	apiConfig, err := k8s.ProvideKubeConfig(clientConfig, k8sKubeContextOverride)
 	if err != nil {
 		return CmdUpDeps{}, err
@@ -232,8 +233,7 @@ func wireCmdUp(ctx context.Context, analytics3 *analytics.TiltAnalytics, cmdTags
 	restConfigOrError := k8s.ProvideRESTConfig(clientConfig)
 	clientsetOrError := k8s.ProvideClientset(restConfigOrError)
 	portForwardClient := k8s.ProvidePortForwardClient(restConfigOrError, clientsetOrError)
-	k8sNamespaceFlag := ProvideNamespaceFlag()
-	namespace := k8s.ProvideConfigNamespace(clientConfig, k8sNamespaceFlag)
+	namespace := k8s.ProvideConfigNamespace(clientConfig)
 	kubeContext, err := k8s.ProvideKubeContext(apiConfig)
 	if err != nil {
 		return CmdUpDeps{}, err
@@ -421,7 +421,8 @@ func wireCmdCI(ctx context.Context, analytics3 *analytics.TiltAnalytics, subcomm
 	clock := clockwork.NewRealClock()
 	cmdController := cmd.NewController(ctx, execer, proberManager, deferredClient, storeStore, clock, scheme)
 	k8sKubeContextOverride := ProvideKubeContextOverride()
-	clientConfig := k8s.ProvideClientConfig(k8sKubeContextOverride)
+	k8sNamespaceFlag := ProvideNamespaceFlag()
+	clientConfig := k8s.ProvideClientConfig(k8sKubeContextOverride, k8sNamespaceFlag)
 	apiConfig, err := k8s.ProvideKubeConfig(clientConfig, k8sKubeContextOverride)
 	if err != nil {
 		return CmdCIDeps{}, err
@@ -430,8 +431,7 @@ func wireCmdCI(ctx context.Context, analytics3 *analytics.TiltAnalytics, subcomm
 	restConfigOrError := k8s.ProvideRESTConfig(clientConfig)
 	clientsetOrError := k8s.ProvideClientset(restConfigOrError)
 	portForwardClient := k8s.ProvidePortForwardClient(restConfigOrError, clientsetOrError)
-	k8sNamespaceFlag := ProvideNamespaceFlag()
-	namespace := k8s.ProvideConfigNamespace(clientConfig, k8sNamespaceFlag)
+	namespace := k8s.ProvideConfigNamespace(clientConfig)
 	kubeContext, err := k8s.ProvideKubeContext(apiConfig)
 	if err != nil {
 		return CmdCIDeps{}, err
@@ -616,7 +616,8 @@ func wireCmdUpdog(ctx context.Context, analytics3 *analytics.TiltAnalytics, cmdT
 	clock := clockwork.NewRealClock()
 	cmdController := cmd.NewController(ctx, execer, proberManager, deferredClient, storeStore, clock, scheme)
 	k8sKubeContextOverride := ProvideKubeContextOverride()
-	clientConfig := k8s.ProvideClientConfig(k8sKubeContextOverride)
+	k8sNamespaceFlag := ProvideNamespaceFlag()
+	clientConfig := k8s.ProvideClientConfig(k8sKubeContextOverride, k8sNamespaceFlag)
 	apiConfig, err := k8s.ProvideKubeConfig(clientConfig, k8sKubeContextOverride)
 	if err != nil {
 		return CmdUpdogDeps{}, err
@@ -625,8 +626,7 @@ func wireCmdUpdog(ctx context.Context, analytics3 *analytics.TiltAnalytics, cmdT
 	restConfigOrError := k8s.ProvideRESTConfig(clientConfig)
 	clientsetOrError := k8s.ProvideClientset(restConfigOrError)
 	portForwardClient := k8s.ProvidePortForwardClient(restConfigOrError, clientsetOrError)
-	k8sNamespaceFlag := ProvideNamespaceFlag()
-	namespace := k8s.ProvideConfigNamespace(clientConfig, k8sNamespaceFlag)
+	namespace := k8s.ProvideConfigNamespace(clientConfig)
 	kubeContext, err := k8s.ProvideKubeContext(apiConfig)
 	if err != nil {
 		return CmdUpdogDeps{}, err
@@ -670,7 +670,8 @@ func wireCmdUpdog(ctx context.Context, analytics3 *analytics.TiltAnalytics, cmdT
 
 func wireKubeContext(ctx context.Context) (k8s.KubeContext, error) {
 	k8sKubeContextOverride := ProvideKubeContextOverride()
-	clientConfig := k8s.ProvideClientConfig(k8sKubeContextOverride)
+	k8sNamespaceFlag := ProvideNamespaceFlag()
+	clientConfig := k8s.ProvideClientConfig(k8sKubeContextOverride, k8sNamespaceFlag)
 	apiConfig, err := k8s.ProvideKubeConfig(clientConfig, k8sKubeContextOverride)
 	if err != nil {
 		return "", err
@@ -684,7 +685,8 @@ func wireKubeContext(ctx context.Context) (k8s.KubeContext, error) {
 
 func wireKubeConfig(ctx context.Context) (*api.Config, error) {
 	k8sKubeContextOverride := ProvideKubeContextOverride()
-	clientConfig := k8s.ProvideClientConfig(k8sKubeContextOverride)
+	k8sNamespaceFlag := ProvideNamespaceFlag()
+	clientConfig := k8s.ProvideClientConfig(k8sKubeContextOverride, k8sNamespaceFlag)
 	apiConfig, err := k8s.ProvideKubeConfig(clientConfig, k8sKubeContextOverride)
 	if err != nil {
 		return nil, err
@@ -694,7 +696,8 @@ func wireKubeConfig(ctx context.Context) (*api.Config, error) {
 
 func wireEnv(ctx context.Context) (k8s.Env, error) {
 	k8sKubeContextOverride := ProvideKubeContextOverride()
-	clientConfig := k8s.ProvideClientConfig(k8sKubeContextOverride)
+	k8sNamespaceFlag := ProvideNamespaceFlag()
+	clientConfig := k8s.ProvideClientConfig(k8sKubeContextOverride, k8sNamespaceFlag)
 	apiConfig, err := k8s.ProvideKubeConfig(clientConfig, k8sKubeContextOverride)
 	if err != nil {
 		return "", err
@@ -705,15 +708,16 @@ func wireEnv(ctx context.Context) (k8s.Env, error) {
 
 func wireNamespace(ctx context.Context) (k8s.Namespace, error) {
 	k8sKubeContextOverride := ProvideKubeContextOverride()
-	clientConfig := k8s.ProvideClientConfig(k8sKubeContextOverride)
 	k8sNamespaceFlag := ProvideNamespaceFlag()
-	namespace := k8s.ProvideConfigNamespace(clientConfig, k8sNamespaceFlag)
+	clientConfig := k8s.ProvideClientConfig(k8sKubeContextOverride, k8sNamespaceFlag)
+	namespace := k8s.ProvideConfigNamespace(clientConfig)
 	return namespace, nil
 }
 
 func wireClusterName(ctx context.Context) (k8s.ClusterName, error) {
 	k8sKubeContextOverride := ProvideKubeContextOverride()
-	clientConfig := k8s.ProvideClientConfig(k8sKubeContextOverride)
+	k8sNamespaceFlag := ProvideNamespaceFlag()
+	clientConfig := k8s.ProvideClientConfig(k8sKubeContextOverride, k8sNamespaceFlag)
 	apiConfig, err := k8s.ProvideKubeConfig(clientConfig, k8sKubeContextOverride)
 	if err != nil {
 		return "", err
@@ -724,7 +728,8 @@ func wireClusterName(ctx context.Context) (k8s.ClusterName, error) {
 
 func wireRuntime(ctx context.Context) (container.Runtime, error) {
 	k8sKubeContextOverride := ProvideKubeContextOverride()
-	clientConfig := k8s.ProvideClientConfig(k8sKubeContextOverride)
+	k8sNamespaceFlag := ProvideNamespaceFlag()
+	clientConfig := k8s.ProvideClientConfig(k8sKubeContextOverride, k8sNamespaceFlag)
 	apiConfig, err := k8s.ProvideKubeConfig(clientConfig, k8sKubeContextOverride)
 	if err != nil {
 		return "", err
@@ -733,8 +738,7 @@ func wireRuntime(ctx context.Context) (container.Runtime, error) {
 	restConfigOrError := k8s.ProvideRESTConfig(clientConfig)
 	clientsetOrError := k8s.ProvideClientset(restConfigOrError)
 	portForwardClient := k8s.ProvidePortForwardClient(restConfigOrError, clientsetOrError)
-	k8sNamespaceFlag := ProvideNamespaceFlag()
-	namespace := k8s.ProvideConfigNamespace(clientConfig, k8sNamespaceFlag)
+	namespace := k8s.ProvideConfigNamespace(clientConfig)
 	kubeContext, err := k8s.ProvideKubeContext(apiConfig)
 	if err != nil {
 		return "", err
@@ -747,7 +751,8 @@ func wireRuntime(ctx context.Context) (container.Runtime, error) {
 
 func wireK8sClient(ctx context.Context) (k8s.Client, error) {
 	k8sKubeContextOverride := ProvideKubeContextOverride()
-	clientConfig := k8s.ProvideClientConfig(k8sKubeContextOverride)
+	k8sNamespaceFlag := ProvideNamespaceFlag()
+	clientConfig := k8s.ProvideClientConfig(k8sKubeContextOverride, k8sNamespaceFlag)
 	apiConfig, err := k8s.ProvideKubeConfig(clientConfig, k8sKubeContextOverride)
 	if err != nil {
 		return nil, err
@@ -756,8 +761,7 @@ func wireK8sClient(ctx context.Context) (k8s.Client, error) {
 	restConfigOrError := k8s.ProvideRESTConfig(clientConfig)
 	clientsetOrError := k8s.ProvideClientset(restConfigOrError)
 	portForwardClient := k8s.ProvidePortForwardClient(restConfigOrError, clientsetOrError)
-	k8sNamespaceFlag := ProvideNamespaceFlag()
-	namespace := k8s.ProvideConfigNamespace(clientConfig, k8sNamespaceFlag)
+	namespace := k8s.ProvideConfigNamespace(clientConfig)
 	kubeContext, err := k8s.ProvideKubeContext(apiConfig)
 	if err != nil {
 		return nil, err
@@ -769,7 +773,8 @@ func wireK8sClient(ctx context.Context) (k8s.Client, error) {
 
 func wireK8sVersion(ctx context.Context) (*version2.Info, error) {
 	k8sKubeContextOverride := ProvideKubeContextOverride()
-	clientConfig := k8s.ProvideClientConfig(k8sKubeContextOverride)
+	k8sNamespaceFlag := ProvideNamespaceFlag()
+	clientConfig := k8s.ProvideClientConfig(k8sKubeContextOverride, k8sNamespaceFlag)
 	restConfigOrError := k8s.ProvideRESTConfig(clientConfig)
 	clientsetOrError := k8s.ProvideClientset(restConfigOrError)
 	info, err := k8s.ProvideServerVersion(clientsetOrError)
@@ -781,7 +786,8 @@ func wireK8sVersion(ctx context.Context) (*version2.Info, error) {
 
 func wireDockerClusterClient(ctx context.Context) (docker.ClusterClient, error) {
 	k8sKubeContextOverride := ProvideKubeContextOverride()
-	clientConfig := k8s.ProvideClientConfig(k8sKubeContextOverride)
+	k8sNamespaceFlag := ProvideNamespaceFlag()
+	clientConfig := k8s.ProvideClientConfig(k8sKubeContextOverride, k8sNamespaceFlag)
 	apiConfig, err := k8s.ProvideKubeConfig(clientConfig, k8sKubeContextOverride)
 	if err != nil {
 		return nil, err
@@ -794,8 +800,7 @@ func wireDockerClusterClient(ctx context.Context) (docker.ClusterClient, error) 
 	restConfigOrError := k8s.ProvideRESTConfig(clientConfig)
 	clientsetOrError := k8s.ProvideClientset(restConfigOrError)
 	portForwardClient := k8s.ProvidePortForwardClient(restConfigOrError, clientsetOrError)
-	k8sNamespaceFlag := ProvideNamespaceFlag()
-	namespace := k8s.ProvideConfigNamespace(clientConfig, k8sNamespaceFlag)
+	namespace := k8s.ProvideConfigNamespace(clientConfig)
 	minikubeClient := k8s.ProvideMinikubeClient(kubeContext)
 	k8sClient := k8s.ProvideK8sClient(ctx, env, restConfigOrError, clientsetOrError, portForwardClient, namespace, minikubeClient, clientConfig)
 	runtime := k8s.ProvideContainerRuntime(ctx, k8sClient)
@@ -811,7 +816,8 @@ func wireDockerClusterClient(ctx context.Context) (docker.ClusterClient, error) 
 
 func wireDockerLocalClient(ctx context.Context) (docker.LocalClient, error) {
 	k8sKubeContextOverride := ProvideKubeContextOverride()
-	clientConfig := k8s.ProvideClientConfig(k8sKubeContextOverride)
+	k8sNamespaceFlag := ProvideNamespaceFlag()
+	clientConfig := k8s.ProvideClientConfig(k8sKubeContextOverride, k8sNamespaceFlag)
 	apiConfig, err := k8s.ProvideKubeConfig(clientConfig, k8sKubeContextOverride)
 	if err != nil {
 		return nil, err
@@ -824,8 +830,7 @@ func wireDockerLocalClient(ctx context.Context) (docker.LocalClient, error) {
 	restConfigOrError := k8s.ProvideRESTConfig(clientConfig)
 	clientsetOrError := k8s.ProvideClientset(restConfigOrError)
 	portForwardClient := k8s.ProvidePortForwardClient(restConfigOrError, clientsetOrError)
-	k8sNamespaceFlag := ProvideNamespaceFlag()
-	namespace := k8s.ProvideConfigNamespace(clientConfig, k8sNamespaceFlag)
+	namespace := k8s.ProvideConfigNamespace(clientConfig)
 	minikubeClient := k8s.ProvideMinikubeClient(kubeContext)
 	k8sClient := k8s.ProvideK8sClient(ctx, env, restConfigOrError, clientsetOrError, portForwardClient, namespace, minikubeClient, clientConfig)
 	runtime := k8s.ProvideContainerRuntime(ctx, k8sClient)
@@ -837,7 +842,8 @@ func wireDockerLocalClient(ctx context.Context) (docker.LocalClient, error) {
 
 func wireDownDeps(ctx context.Context, tiltAnalytics *analytics.TiltAnalytics, subcommand model.TiltSubcommand) (DownDeps, error) {
 	k8sKubeContextOverride := ProvideKubeContextOverride()
-	clientConfig := k8s.ProvideClientConfig(k8sKubeContextOverride)
+	k8sNamespaceFlag := ProvideNamespaceFlag()
+	clientConfig := k8s.ProvideClientConfig(k8sKubeContextOverride, k8sNamespaceFlag)
 	apiConfig, err := k8s.ProvideKubeConfig(clientConfig, k8sKubeContextOverride)
 	if err != nil {
 		return DownDeps{}, err
@@ -846,8 +852,7 @@ func wireDownDeps(ctx context.Context, tiltAnalytics *analytics.TiltAnalytics, s
 	restConfigOrError := k8s.ProvideRESTConfig(clientConfig)
 	clientsetOrError := k8s.ProvideClientset(restConfigOrError)
 	portForwardClient := k8s.ProvidePortForwardClient(restConfigOrError, clientsetOrError)
-	k8sNamespaceFlag := ProvideNamespaceFlag()
-	namespace := k8s.ProvideConfigNamespace(clientConfig, k8sNamespaceFlag)
+	namespace := k8s.ProvideConfigNamespace(clientConfig)
 	kubeContext, err := k8s.ProvideKubeContext(apiConfig)
 	if err != nil {
 		return DownDeps{}, err
@@ -884,7 +889,8 @@ func wireLogsDeps(ctx context.Context, tiltAnalytics *analytics.TiltAnalytics, s
 
 func wireDumpImageDeployRefDeps(ctx context.Context) (DumpImageDeployRefDeps, error) {
 	k8sKubeContextOverride := ProvideKubeContextOverride()
-	clientConfig := k8s.ProvideClientConfig(k8sKubeContextOverride)
+	k8sNamespaceFlag := ProvideNamespaceFlag()
+	clientConfig := k8s.ProvideClientConfig(k8sKubeContextOverride, k8sNamespaceFlag)
 	apiConfig, err := k8s.ProvideKubeConfig(clientConfig, k8sKubeContextOverride)
 	if err != nil {
 		return DumpImageDeployRefDeps{}, err
@@ -897,8 +903,7 @@ func wireDumpImageDeployRefDeps(ctx context.Context) (DumpImageDeployRefDeps, er
 	restConfigOrError := k8s.ProvideRESTConfig(clientConfig)
 	clientsetOrError := k8s.ProvideClientset(restConfigOrError)
 	portForwardClient := k8s.ProvidePortForwardClient(restConfigOrError, clientsetOrError)
-	k8sNamespaceFlag := ProvideNamespaceFlag()
-	namespace := k8s.ProvideConfigNamespace(clientConfig, k8sNamespaceFlag)
+	namespace := k8s.ProvideConfigNamespace(clientConfig)
 	minikubeClient := k8s.ProvideMinikubeClient(kubeContext)
 	k8sClient := k8s.ProvideK8sClient(ctx, env, restConfigOrError, clientsetOrError, portForwardClient, namespace, minikubeClient, clientConfig)
 	runtime := k8s.ProvideContainerRuntime(ctx, k8sClient)

--- a/internal/cli/wire_gen.go
+++ b/internal/cli/wire_gen.go
@@ -88,7 +88,8 @@ func wireTiltfileResult(ctx context.Context, analytics2 *analytics.TiltAnalytics
 	restConfigOrError := k8s.ProvideRESTConfig(clientConfig)
 	clientsetOrError := k8s.ProvideClientset(restConfigOrError)
 	portForwardClient := k8s.ProvidePortForwardClient(restConfigOrError, clientsetOrError)
-	namespace := k8s.ProvideConfigNamespace(clientConfig)
+	k8sNamespaceFlag := ProvideNamespaceFlag()
+	namespace := k8s.ProvideConfigNamespace(clientConfig, k8sNamespaceFlag)
 	kubeContext, err := k8s.ProvideKubeContext(apiConfig)
 	if err != nil {
 		return cmdTiltfileResultDeps{}, err
@@ -129,7 +130,8 @@ func wireDockerPrune(ctx context.Context, analytics2 *analytics.TiltAnalytics, s
 	restConfigOrError := k8s.ProvideRESTConfig(clientConfig)
 	clientsetOrError := k8s.ProvideClientset(restConfigOrError)
 	portForwardClient := k8s.ProvidePortForwardClient(restConfigOrError, clientsetOrError)
-	namespace := k8s.ProvideConfigNamespace(clientConfig)
+	k8sNamespaceFlag := ProvideNamespaceFlag()
+	namespace := k8s.ProvideConfigNamespace(clientConfig, k8sNamespaceFlag)
 	minikubeClient := k8s.ProvideMinikubeClient(kubeContext)
 	client := k8s.ProvideK8sClient(ctx, env, restConfigOrError, clientsetOrError, portForwardClient, namespace, minikubeClient, clientConfig)
 	runtime := k8s.ProvideContainerRuntime(ctx, client)
@@ -230,7 +232,8 @@ func wireCmdUp(ctx context.Context, analytics3 *analytics.TiltAnalytics, cmdTags
 	restConfigOrError := k8s.ProvideRESTConfig(clientConfig)
 	clientsetOrError := k8s.ProvideClientset(restConfigOrError)
 	portForwardClient := k8s.ProvidePortForwardClient(restConfigOrError, clientsetOrError)
-	namespace := k8s.ProvideConfigNamespace(clientConfig)
+	k8sNamespaceFlag := ProvideNamespaceFlag()
+	namespace := k8s.ProvideConfigNamespace(clientConfig, k8sNamespaceFlag)
 	kubeContext, err := k8s.ProvideKubeContext(apiConfig)
 	if err != nil {
 		return CmdUpDeps{}, err
@@ -427,7 +430,8 @@ func wireCmdCI(ctx context.Context, analytics3 *analytics.TiltAnalytics, subcomm
 	restConfigOrError := k8s.ProvideRESTConfig(clientConfig)
 	clientsetOrError := k8s.ProvideClientset(restConfigOrError)
 	portForwardClient := k8s.ProvidePortForwardClient(restConfigOrError, clientsetOrError)
-	namespace := k8s.ProvideConfigNamespace(clientConfig)
+	k8sNamespaceFlag := ProvideNamespaceFlag()
+	namespace := k8s.ProvideConfigNamespace(clientConfig, k8sNamespaceFlag)
 	kubeContext, err := k8s.ProvideKubeContext(apiConfig)
 	if err != nil {
 		return CmdCIDeps{}, err
@@ -621,7 +625,8 @@ func wireCmdUpdog(ctx context.Context, analytics3 *analytics.TiltAnalytics, cmdT
 	restConfigOrError := k8s.ProvideRESTConfig(clientConfig)
 	clientsetOrError := k8s.ProvideClientset(restConfigOrError)
 	portForwardClient := k8s.ProvidePortForwardClient(restConfigOrError, clientsetOrError)
-	namespace := k8s.ProvideConfigNamespace(clientConfig)
+	k8sNamespaceFlag := ProvideNamespaceFlag()
+	namespace := k8s.ProvideConfigNamespace(clientConfig, k8sNamespaceFlag)
 	kubeContext, err := k8s.ProvideKubeContext(apiConfig)
 	if err != nil {
 		return CmdUpdogDeps{}, err
@@ -701,7 +706,8 @@ func wireEnv(ctx context.Context) (k8s.Env, error) {
 func wireNamespace(ctx context.Context) (k8s.Namespace, error) {
 	k8sKubeContextOverride := ProvideKubeContextOverride()
 	clientConfig := k8s.ProvideClientConfig(k8sKubeContextOverride)
-	namespace := k8s.ProvideConfigNamespace(clientConfig)
+	k8sNamespaceFlag := ProvideNamespaceFlag()
+	namespace := k8s.ProvideConfigNamespace(clientConfig, k8sNamespaceFlag)
 	return namespace, nil
 }
 
@@ -727,7 +733,8 @@ func wireRuntime(ctx context.Context) (container.Runtime, error) {
 	restConfigOrError := k8s.ProvideRESTConfig(clientConfig)
 	clientsetOrError := k8s.ProvideClientset(restConfigOrError)
 	portForwardClient := k8s.ProvidePortForwardClient(restConfigOrError, clientsetOrError)
-	namespace := k8s.ProvideConfigNamespace(clientConfig)
+	k8sNamespaceFlag := ProvideNamespaceFlag()
+	namespace := k8s.ProvideConfigNamespace(clientConfig, k8sNamespaceFlag)
 	kubeContext, err := k8s.ProvideKubeContext(apiConfig)
 	if err != nil {
 		return "", err
@@ -749,7 +756,8 @@ func wireK8sClient(ctx context.Context) (k8s.Client, error) {
 	restConfigOrError := k8s.ProvideRESTConfig(clientConfig)
 	clientsetOrError := k8s.ProvideClientset(restConfigOrError)
 	portForwardClient := k8s.ProvidePortForwardClient(restConfigOrError, clientsetOrError)
-	namespace := k8s.ProvideConfigNamespace(clientConfig)
+	k8sNamespaceFlag := ProvideNamespaceFlag()
+	namespace := k8s.ProvideConfigNamespace(clientConfig, k8sNamespaceFlag)
 	kubeContext, err := k8s.ProvideKubeContext(apiConfig)
 	if err != nil {
 		return nil, err
@@ -786,7 +794,8 @@ func wireDockerClusterClient(ctx context.Context) (docker.ClusterClient, error) 
 	restConfigOrError := k8s.ProvideRESTConfig(clientConfig)
 	clientsetOrError := k8s.ProvideClientset(restConfigOrError)
 	portForwardClient := k8s.ProvidePortForwardClient(restConfigOrError, clientsetOrError)
-	namespace := k8s.ProvideConfigNamespace(clientConfig)
+	k8sNamespaceFlag := ProvideNamespaceFlag()
+	namespace := k8s.ProvideConfigNamespace(clientConfig, k8sNamespaceFlag)
 	minikubeClient := k8s.ProvideMinikubeClient(kubeContext)
 	k8sClient := k8s.ProvideK8sClient(ctx, env, restConfigOrError, clientsetOrError, portForwardClient, namespace, minikubeClient, clientConfig)
 	runtime := k8s.ProvideContainerRuntime(ctx, k8sClient)
@@ -815,7 +824,8 @@ func wireDockerLocalClient(ctx context.Context) (docker.LocalClient, error) {
 	restConfigOrError := k8s.ProvideRESTConfig(clientConfig)
 	clientsetOrError := k8s.ProvideClientset(restConfigOrError)
 	portForwardClient := k8s.ProvidePortForwardClient(restConfigOrError, clientsetOrError)
-	namespace := k8s.ProvideConfigNamespace(clientConfig)
+	k8sNamespaceFlag := ProvideNamespaceFlag()
+	namespace := k8s.ProvideConfigNamespace(clientConfig, k8sNamespaceFlag)
 	minikubeClient := k8s.ProvideMinikubeClient(kubeContext)
 	k8sClient := k8s.ProvideK8sClient(ctx, env, restConfigOrError, clientsetOrError, portForwardClient, namespace, minikubeClient, clientConfig)
 	runtime := k8s.ProvideContainerRuntime(ctx, k8sClient)
@@ -836,7 +846,8 @@ func wireDownDeps(ctx context.Context, tiltAnalytics *analytics.TiltAnalytics, s
 	restConfigOrError := k8s.ProvideRESTConfig(clientConfig)
 	clientsetOrError := k8s.ProvideClientset(restConfigOrError)
 	portForwardClient := k8s.ProvidePortForwardClient(restConfigOrError, clientsetOrError)
-	namespace := k8s.ProvideConfigNamespace(clientConfig)
+	k8sNamespaceFlag := ProvideNamespaceFlag()
+	namespace := k8s.ProvideConfigNamespace(clientConfig, k8sNamespaceFlag)
 	kubeContext, err := k8s.ProvideKubeContext(apiConfig)
 	if err != nil {
 		return DownDeps{}, err
@@ -886,7 +897,8 @@ func wireDumpImageDeployRefDeps(ctx context.Context) (DumpImageDeployRefDeps, er
 	restConfigOrError := k8s.ProvideRESTConfig(clientConfig)
 	clientsetOrError := k8s.ProvideClientset(restConfigOrError)
 	portForwardClient := k8s.ProvidePortForwardClient(restConfigOrError, clientsetOrError)
-	namespace := k8s.ProvideConfigNamespace(clientConfig)
+	k8sNamespaceFlag := ProvideNamespaceFlag()
+	namespace := k8s.ProvideConfigNamespace(clientConfig, k8sNamespaceFlag)
 	minikubeClient := k8s.ProvideMinikubeClient(kubeContext)
 	k8sClient := k8s.ProvideK8sClient(ctx, env, restConfigOrError, clientsetOrError, portForwardClient, namespace, minikubeClient, clientConfig)
 	runtime := k8s.ProvideContainerRuntime(ctx, k8sClient)
@@ -936,7 +948,8 @@ func wireClientGetter(ctx context.Context) (*client2.Getter, error) {
 
 // wire.go:
 
-var K8sWireSet = wire.NewSet(k8s.ProvideEnv, k8s.ProvideClusterName, k8s.ProvideKubeContext, k8s.ProvideKubeConfig, k8s.ProvideClientConfig, k8s.ProvideClientset, k8s.ProvideRESTConfig, k8s.ProvidePortForwardClient, k8s.ProvideConfigNamespace, k8s.ProvideContainerRuntime, k8s.ProvideServerVersion, k8s.ProvideK8sClient, k8s.ProvideOwnerFetcher, ProvideKubeContextOverride)
+var K8sWireSet = wire.NewSet(k8s.ProvideEnv, k8s.ProvideClusterName, k8s.ProvideKubeContext, k8s.ProvideKubeConfig, k8s.ProvideClientConfig, k8s.ProvideClientset, k8s.ProvideRESTConfig, k8s.ProvidePortForwardClient, k8s.ProvideConfigNamespace, k8s.ProvideContainerRuntime, k8s.ProvideServerVersion, k8s.ProvideK8sClient, k8s.ProvideOwnerFetcher, ProvideKubeContextOverride,
+	ProvideNamespaceFlag)
 
 var BaseWireSet = wire.NewSet(
 	K8sWireSet, tiltfile.WireSet, git.ProvideGitRemote, docker.SwitchWireSet, ProvideDeferredExporter, metrics.WireSet, user.WireSet, dockercompose.NewDockerComposeClient, clockwork.NewRealClock, engine.DeployerWireSet, runtimelog.NewPodLogManager, portforward2.NewSubscriber, engine.NewBuildController, local.NewServerController, kubernetesdiscovery.NewContainerRestartDetector, k8swatch.NewManifestSubscriber, k8swatch.NewServiceWatcher, k8swatch.NewEventWatchManager, uisession2.NewSubscriber, uiresource2.NewSubscriber, configs.NewConfigsController, telemetry.NewController, dcwatch.NewEventWatcher, runtimelog.NewDockerComposeLogManager, cloud.WireSet, cloudurl.ProvideAddress, k8srollout.NewPodMonitor, telemetry.NewStartTracker, session.NewController, build.ProvideClock, provideClock, hud.WireSet, prompt.WireSet, wire.Value(openurl.OpenURL(openurl.BrowserOpen)), provideLogActions, store.NewStore, wire.Bind(new(store.RStore), new(*store.Store)), dockerprune.NewDockerPruner, provideTiltInfo, engine.NewUpper, analytics2.NewAnalyticsUpdater, analytics2.ProvideAnalyticsReporter, provideUpdateModeFlag, fswatch.NewManifestSubscriber, fsevent.ProvideWatcherMaker, fsevent.ProvideTimerMaker, controllers.WireSet, provideWebVersion,

--- a/internal/cli/wire_gen.go
+++ b/internal/cli/wire_gen.go
@@ -79,8 +79,8 @@ import (
 
 func wireTiltfileResult(ctx context.Context, analytics2 *analytics.TiltAnalytics, subcommand model.TiltSubcommand) (cmdTiltfileResultDeps, error) {
 	k8sKubeContextOverride := ProvideKubeContextOverride()
-	k8sNamespaceFlag := ProvideNamespaceFlag()
-	clientConfig := k8s.ProvideClientConfig(k8sKubeContextOverride, k8sNamespaceFlag)
+	k8sNamespaceOverride := ProvideNamespaceOverride()
+	clientConfig := k8s.ProvideClientConfig(k8sKubeContextOverride, k8sNamespaceOverride)
 	apiConfig, err := k8s.ProvideKubeConfig(clientConfig, k8sKubeContextOverride)
 	if err != nil {
 		return cmdTiltfileResultDeps{}, err
@@ -117,8 +117,8 @@ var (
 
 func wireDockerPrune(ctx context.Context, analytics2 *analytics.TiltAnalytics, subcommand model.TiltSubcommand) (dpDeps, error) {
 	k8sKubeContextOverride := ProvideKubeContextOverride()
-	k8sNamespaceFlag := ProvideNamespaceFlag()
-	clientConfig := k8s.ProvideClientConfig(k8sKubeContextOverride, k8sNamespaceFlag)
+	k8sNamespaceOverride := ProvideNamespaceOverride()
+	clientConfig := k8s.ProvideClientConfig(k8sKubeContextOverride, k8sNamespaceOverride)
 	apiConfig, err := k8s.ProvideKubeConfig(clientConfig, k8sKubeContextOverride)
 	if err != nil {
 		return dpDeps{}, err
@@ -223,8 +223,8 @@ func wireCmdUp(ctx context.Context, analytics3 *analytics.TiltAnalytics, cmdTags
 	clock := clockwork.NewRealClock()
 	cmdController := cmd.NewController(ctx, execer, proberManager, deferredClient, storeStore, clock, scheme)
 	k8sKubeContextOverride := ProvideKubeContextOverride()
-	k8sNamespaceFlag := ProvideNamespaceFlag()
-	clientConfig := k8s.ProvideClientConfig(k8sKubeContextOverride, k8sNamespaceFlag)
+	k8sNamespaceOverride := ProvideNamespaceOverride()
+	clientConfig := k8s.ProvideClientConfig(k8sKubeContextOverride, k8sNamespaceOverride)
 	apiConfig, err := k8s.ProvideKubeConfig(clientConfig, k8sKubeContextOverride)
 	if err != nil {
 		return CmdUpDeps{}, err
@@ -421,8 +421,8 @@ func wireCmdCI(ctx context.Context, analytics3 *analytics.TiltAnalytics, subcomm
 	clock := clockwork.NewRealClock()
 	cmdController := cmd.NewController(ctx, execer, proberManager, deferredClient, storeStore, clock, scheme)
 	k8sKubeContextOverride := ProvideKubeContextOverride()
-	k8sNamespaceFlag := ProvideNamespaceFlag()
-	clientConfig := k8s.ProvideClientConfig(k8sKubeContextOverride, k8sNamespaceFlag)
+	k8sNamespaceOverride := ProvideNamespaceOverride()
+	clientConfig := k8s.ProvideClientConfig(k8sKubeContextOverride, k8sNamespaceOverride)
 	apiConfig, err := k8s.ProvideKubeConfig(clientConfig, k8sKubeContextOverride)
 	if err != nil {
 		return CmdCIDeps{}, err
@@ -616,8 +616,8 @@ func wireCmdUpdog(ctx context.Context, analytics3 *analytics.TiltAnalytics, cmdT
 	clock := clockwork.NewRealClock()
 	cmdController := cmd.NewController(ctx, execer, proberManager, deferredClient, storeStore, clock, scheme)
 	k8sKubeContextOverride := ProvideKubeContextOverride()
-	k8sNamespaceFlag := ProvideNamespaceFlag()
-	clientConfig := k8s.ProvideClientConfig(k8sKubeContextOverride, k8sNamespaceFlag)
+	k8sNamespaceOverride := ProvideNamespaceOverride()
+	clientConfig := k8s.ProvideClientConfig(k8sKubeContextOverride, k8sNamespaceOverride)
 	apiConfig, err := k8s.ProvideKubeConfig(clientConfig, k8sKubeContextOverride)
 	if err != nil {
 		return CmdUpdogDeps{}, err
@@ -670,8 +670,8 @@ func wireCmdUpdog(ctx context.Context, analytics3 *analytics.TiltAnalytics, cmdT
 
 func wireKubeContext(ctx context.Context) (k8s.KubeContext, error) {
 	k8sKubeContextOverride := ProvideKubeContextOverride()
-	k8sNamespaceFlag := ProvideNamespaceFlag()
-	clientConfig := k8s.ProvideClientConfig(k8sKubeContextOverride, k8sNamespaceFlag)
+	k8sNamespaceOverride := ProvideNamespaceOverride()
+	clientConfig := k8s.ProvideClientConfig(k8sKubeContextOverride, k8sNamespaceOverride)
 	apiConfig, err := k8s.ProvideKubeConfig(clientConfig, k8sKubeContextOverride)
 	if err != nil {
 		return "", err
@@ -685,8 +685,8 @@ func wireKubeContext(ctx context.Context) (k8s.KubeContext, error) {
 
 func wireKubeConfig(ctx context.Context) (*api.Config, error) {
 	k8sKubeContextOverride := ProvideKubeContextOverride()
-	k8sNamespaceFlag := ProvideNamespaceFlag()
-	clientConfig := k8s.ProvideClientConfig(k8sKubeContextOverride, k8sNamespaceFlag)
+	k8sNamespaceOverride := ProvideNamespaceOverride()
+	clientConfig := k8s.ProvideClientConfig(k8sKubeContextOverride, k8sNamespaceOverride)
 	apiConfig, err := k8s.ProvideKubeConfig(clientConfig, k8sKubeContextOverride)
 	if err != nil {
 		return nil, err
@@ -696,8 +696,8 @@ func wireKubeConfig(ctx context.Context) (*api.Config, error) {
 
 func wireEnv(ctx context.Context) (k8s.Env, error) {
 	k8sKubeContextOverride := ProvideKubeContextOverride()
-	k8sNamespaceFlag := ProvideNamespaceFlag()
-	clientConfig := k8s.ProvideClientConfig(k8sKubeContextOverride, k8sNamespaceFlag)
+	k8sNamespaceOverride := ProvideNamespaceOverride()
+	clientConfig := k8s.ProvideClientConfig(k8sKubeContextOverride, k8sNamespaceOverride)
 	apiConfig, err := k8s.ProvideKubeConfig(clientConfig, k8sKubeContextOverride)
 	if err != nil {
 		return "", err
@@ -708,16 +708,16 @@ func wireEnv(ctx context.Context) (k8s.Env, error) {
 
 func wireNamespace(ctx context.Context) (k8s.Namespace, error) {
 	k8sKubeContextOverride := ProvideKubeContextOverride()
-	k8sNamespaceFlag := ProvideNamespaceFlag()
-	clientConfig := k8s.ProvideClientConfig(k8sKubeContextOverride, k8sNamespaceFlag)
+	k8sNamespaceOverride := ProvideNamespaceOverride()
+	clientConfig := k8s.ProvideClientConfig(k8sKubeContextOverride, k8sNamespaceOverride)
 	namespace := k8s.ProvideConfigNamespace(clientConfig)
 	return namespace, nil
 }
 
 func wireClusterName(ctx context.Context) (k8s.ClusterName, error) {
 	k8sKubeContextOverride := ProvideKubeContextOverride()
-	k8sNamespaceFlag := ProvideNamespaceFlag()
-	clientConfig := k8s.ProvideClientConfig(k8sKubeContextOverride, k8sNamespaceFlag)
+	k8sNamespaceOverride := ProvideNamespaceOverride()
+	clientConfig := k8s.ProvideClientConfig(k8sKubeContextOverride, k8sNamespaceOverride)
 	apiConfig, err := k8s.ProvideKubeConfig(clientConfig, k8sKubeContextOverride)
 	if err != nil {
 		return "", err
@@ -728,8 +728,8 @@ func wireClusterName(ctx context.Context) (k8s.ClusterName, error) {
 
 func wireRuntime(ctx context.Context) (container.Runtime, error) {
 	k8sKubeContextOverride := ProvideKubeContextOverride()
-	k8sNamespaceFlag := ProvideNamespaceFlag()
-	clientConfig := k8s.ProvideClientConfig(k8sKubeContextOverride, k8sNamespaceFlag)
+	k8sNamespaceOverride := ProvideNamespaceOverride()
+	clientConfig := k8s.ProvideClientConfig(k8sKubeContextOverride, k8sNamespaceOverride)
 	apiConfig, err := k8s.ProvideKubeConfig(clientConfig, k8sKubeContextOverride)
 	if err != nil {
 		return "", err
@@ -751,8 +751,8 @@ func wireRuntime(ctx context.Context) (container.Runtime, error) {
 
 func wireK8sClient(ctx context.Context) (k8s.Client, error) {
 	k8sKubeContextOverride := ProvideKubeContextOverride()
-	k8sNamespaceFlag := ProvideNamespaceFlag()
-	clientConfig := k8s.ProvideClientConfig(k8sKubeContextOverride, k8sNamespaceFlag)
+	k8sNamespaceOverride := ProvideNamespaceOverride()
+	clientConfig := k8s.ProvideClientConfig(k8sKubeContextOverride, k8sNamespaceOverride)
 	apiConfig, err := k8s.ProvideKubeConfig(clientConfig, k8sKubeContextOverride)
 	if err != nil {
 		return nil, err
@@ -773,8 +773,8 @@ func wireK8sClient(ctx context.Context) (k8s.Client, error) {
 
 func wireK8sVersion(ctx context.Context) (*version2.Info, error) {
 	k8sKubeContextOverride := ProvideKubeContextOverride()
-	k8sNamespaceFlag := ProvideNamespaceFlag()
-	clientConfig := k8s.ProvideClientConfig(k8sKubeContextOverride, k8sNamespaceFlag)
+	k8sNamespaceOverride := ProvideNamespaceOverride()
+	clientConfig := k8s.ProvideClientConfig(k8sKubeContextOverride, k8sNamespaceOverride)
 	restConfigOrError := k8s.ProvideRESTConfig(clientConfig)
 	clientsetOrError := k8s.ProvideClientset(restConfigOrError)
 	info, err := k8s.ProvideServerVersion(clientsetOrError)
@@ -786,8 +786,8 @@ func wireK8sVersion(ctx context.Context) (*version2.Info, error) {
 
 func wireDockerClusterClient(ctx context.Context) (docker.ClusterClient, error) {
 	k8sKubeContextOverride := ProvideKubeContextOverride()
-	k8sNamespaceFlag := ProvideNamespaceFlag()
-	clientConfig := k8s.ProvideClientConfig(k8sKubeContextOverride, k8sNamespaceFlag)
+	k8sNamespaceOverride := ProvideNamespaceOverride()
+	clientConfig := k8s.ProvideClientConfig(k8sKubeContextOverride, k8sNamespaceOverride)
 	apiConfig, err := k8s.ProvideKubeConfig(clientConfig, k8sKubeContextOverride)
 	if err != nil {
 		return nil, err
@@ -816,8 +816,8 @@ func wireDockerClusterClient(ctx context.Context) (docker.ClusterClient, error) 
 
 func wireDockerLocalClient(ctx context.Context) (docker.LocalClient, error) {
 	k8sKubeContextOverride := ProvideKubeContextOverride()
-	k8sNamespaceFlag := ProvideNamespaceFlag()
-	clientConfig := k8s.ProvideClientConfig(k8sKubeContextOverride, k8sNamespaceFlag)
+	k8sNamespaceOverride := ProvideNamespaceOverride()
+	clientConfig := k8s.ProvideClientConfig(k8sKubeContextOverride, k8sNamespaceOverride)
 	apiConfig, err := k8s.ProvideKubeConfig(clientConfig, k8sKubeContextOverride)
 	if err != nil {
 		return nil, err
@@ -842,8 +842,8 @@ func wireDockerLocalClient(ctx context.Context) (docker.LocalClient, error) {
 
 func wireDownDeps(ctx context.Context, tiltAnalytics *analytics.TiltAnalytics, subcommand model.TiltSubcommand) (DownDeps, error) {
 	k8sKubeContextOverride := ProvideKubeContextOverride()
-	k8sNamespaceFlag := ProvideNamespaceFlag()
-	clientConfig := k8s.ProvideClientConfig(k8sKubeContextOverride, k8sNamespaceFlag)
+	k8sNamespaceOverride := ProvideNamespaceOverride()
+	clientConfig := k8s.ProvideClientConfig(k8sKubeContextOverride, k8sNamespaceOverride)
 	apiConfig, err := k8s.ProvideKubeConfig(clientConfig, k8sKubeContextOverride)
 	if err != nil {
 		return DownDeps{}, err
@@ -889,8 +889,8 @@ func wireLogsDeps(ctx context.Context, tiltAnalytics *analytics.TiltAnalytics, s
 
 func wireDumpImageDeployRefDeps(ctx context.Context) (DumpImageDeployRefDeps, error) {
 	k8sKubeContextOverride := ProvideKubeContextOverride()
-	k8sNamespaceFlag := ProvideNamespaceFlag()
-	clientConfig := k8s.ProvideClientConfig(k8sKubeContextOverride, k8sNamespaceFlag)
+	k8sNamespaceOverride := ProvideNamespaceOverride()
+	clientConfig := k8s.ProvideClientConfig(k8sKubeContextOverride, k8sNamespaceOverride)
 	apiConfig, err := k8s.ProvideKubeConfig(clientConfig, k8sKubeContextOverride)
 	if err != nil {
 		return DumpImageDeployRefDeps{}, err
@@ -954,7 +954,7 @@ func wireClientGetter(ctx context.Context) (*client2.Getter, error) {
 // wire.go:
 
 var K8sWireSet = wire.NewSet(k8s.ProvideEnv, k8s.ProvideClusterName, k8s.ProvideKubeContext, k8s.ProvideKubeConfig, k8s.ProvideClientConfig, k8s.ProvideClientset, k8s.ProvideRESTConfig, k8s.ProvidePortForwardClient, k8s.ProvideConfigNamespace, k8s.ProvideContainerRuntime, k8s.ProvideServerVersion, k8s.ProvideK8sClient, k8s.ProvideOwnerFetcher, ProvideKubeContextOverride,
-	ProvideNamespaceFlag)
+	ProvideNamespaceOverride)
 
 var BaseWireSet = wire.NewSet(
 	K8sWireSet, tiltfile.WireSet, git.ProvideGitRemote, docker.SwitchWireSet, ProvideDeferredExporter, metrics.WireSet, user.WireSet, dockercompose.NewDockerComposeClient, clockwork.NewRealClock, engine.DeployerWireSet, runtimelog.NewPodLogManager, portforward2.NewSubscriber, engine.NewBuildController, local.NewServerController, kubernetesdiscovery.NewContainerRestartDetector, k8swatch.NewManifestSubscriber, k8swatch.NewServiceWatcher, k8swatch.NewEventWatchManager, uisession2.NewSubscriber, uiresource2.NewSubscriber, configs.NewConfigsController, telemetry.NewController, dcwatch.NewEventWatcher, runtimelog.NewDockerComposeLogManager, cloud.WireSet, cloudurl.ProvideAddress, k8srollout.NewPodMonitor, telemetry.NewStartTracker, session.NewController, build.ProvideClock, provideClock, hud.WireSet, prompt.WireSet, wire.Value(openurl.OpenURL(openurl.BrowserOpen)), provideLogActions, store.NewStore, wire.Bind(new(store.RStore), new(*store.Store)), dockerprune.NewDockerPruner, provideTiltInfo, engine.NewUpper, analytics2.NewAnalyticsUpdater, analytics2.ProvideAnalyticsReporter, provideUpdateModeFlag, fswatch.NewManifestSubscriber, fsevent.ProvideWatcherMaker, fsevent.ProvideTimerMaker, controllers.WireSet, provideWebVersion,

--- a/internal/engine/buildcontrol/wire.go
+++ b/internal/engine/buildcontrol/wire.go
@@ -75,7 +75,7 @@ func ProvideDockerComposeBuildAndDeployer(
 
 		// EnvNone ensures that we get an exploding k8s client.
 		wire.Value(k8s.KubeContextOverride("")),
-		wire.Value(k8s.NamespaceFlag("")),
+		wire.Value(k8s.NamespaceOverride("")),
 		k8s.ProvideClientConfig,
 		k8s.ProvideKubeContext,
 		k8s.ProvideKubeConfig,

--- a/internal/engine/buildcontrol/wire.go
+++ b/internal/engine/buildcontrol/wire.go
@@ -75,6 +75,7 @@ func ProvideDockerComposeBuildAndDeployer(
 
 		// EnvNone ensures that we get an exploding k8s client.
 		wire.Value(k8s.KubeContextOverride("")),
+		wire.Value(k8s.NamespaceFlag("")),
 		k8s.ProvideClientConfig,
 		k8s.ProvideKubeContext,
 		k8s.ProvideKubeConfig,

--- a/internal/engine/buildcontrol/wire_gen.go
+++ b/internal/engine/buildcontrol/wire_gen.go
@@ -50,7 +50,8 @@ func ProvideDockerComposeBuildAndDeployer(ctx context.Context, dcCli dockercompo
 	execCustomBuilder := build.NewExecCustomBuilder(dCli, clock)
 	updateModeFlag := _wireBuildcontrolUpdateModeFlagValue
 	kubeContextOverride := _wireKubeContextOverrideValue
-	clientConfig := k8s.ProvideClientConfig(kubeContextOverride)
+	namespaceFlag := _wireNamespaceFlagValue
+	clientConfig := k8s.ProvideClientConfig(kubeContextOverride, namespaceFlag)
 	config, err := k8s.ProvideKubeConfig(clientConfig, kubeContextOverride)
 	if err != nil {
 		return nil, err
@@ -72,6 +73,7 @@ func ProvideDockerComposeBuildAndDeployer(ctx context.Context, dcCli dockercompo
 var (
 	_wireBuildcontrolUpdateModeFlagValue = UpdateModeFlag(UpdateModeAuto)
 	_wireKubeContextOverrideValue        = k8s.KubeContextOverride("")
+	_wireNamespaceFlagValue              = k8s.NamespaceFlag("")
 	_wireClusterEnvValue                 = docker.ClusterEnv(docker.Env{})
 )
 

--- a/internal/engine/buildcontrol/wire_gen.go
+++ b/internal/engine/buildcontrol/wire_gen.go
@@ -50,8 +50,8 @@ func ProvideDockerComposeBuildAndDeployer(ctx context.Context, dcCli dockercompo
 	execCustomBuilder := build.NewExecCustomBuilder(dCli, clock)
 	updateModeFlag := _wireBuildcontrolUpdateModeFlagValue
 	kubeContextOverride := _wireKubeContextOverrideValue
-	namespaceFlag := _wireNamespaceFlagValue
-	clientConfig := k8s.ProvideClientConfig(kubeContextOverride, namespaceFlag)
+	namespaceOverride := _wireNamespaceOverrideValue
+	clientConfig := k8s.ProvideClientConfig(kubeContextOverride, namespaceOverride)
 	config, err := k8s.ProvideKubeConfig(clientConfig, kubeContextOverride)
 	if err != nil {
 		return nil, err
@@ -73,7 +73,7 @@ func ProvideDockerComposeBuildAndDeployer(ctx context.Context, dcCli dockercompo
 var (
 	_wireBuildcontrolUpdateModeFlagValue = UpdateModeFlag(UpdateModeAuto)
 	_wireKubeContextOverrideValue        = k8s.KubeContextOverride("")
-	_wireNamespaceFlagValue              = k8s.NamespaceFlag("")
+	_wireNamespaceOverrideValue          = k8s.NamespaceOverride("")
 	_wireClusterEnvValue                 = docker.ClusterEnv(docker.Env{})
 )
 

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -42,7 +42,7 @@ import (
 )
 
 type Namespace string
-type NamespaceFlag string
+type NamespaceOverride string
 type PodID string
 type NodeID string
 type ServiceName string
@@ -636,7 +636,7 @@ func ProvideClientset(cfg RESTConfigOrError) ClientsetOrError {
 	return ClientsetOrError{Clientset: clientset, Error: err}
 }
 
-func ProvideClientConfig(contextOverride KubeContextOverride, nsFlag NamespaceFlag) clientcmd.ClientConfig {
+func ProvideClientConfig(contextOverride KubeContextOverride, nsFlag NamespaceOverride) clientcmd.ClientConfig {
 	rules := clientcmd.NewDefaultClientConfigLoadingRules()
 	rules.DefaultClientConfig = &clientcmd.DefaultClientConfig
 

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/restmapper"
 	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	"k8s.io/kubectl/pkg/cmd/wait"
 
 	// Client auth plugins! They will auto-init if we import them.
@@ -635,12 +636,15 @@ func ProvideClientset(cfg RESTConfigOrError) ClientsetOrError {
 	return ClientsetOrError{Clientset: clientset, Error: err}
 }
 
-func ProvideClientConfig(contextOverride KubeContextOverride) clientcmd.ClientConfig {
+func ProvideClientConfig(contextOverride KubeContextOverride, nsFlag NamespaceFlag) clientcmd.ClientConfig {
 	rules := clientcmd.NewDefaultClientConfigLoadingRules()
 	rules.DefaultClientConfig = &clientcmd.DefaultClientConfig
 
 	overrides := &clientcmd.ConfigOverrides{
 		CurrentContext: string(contextOverride),
+		Context: clientcmdapi.Context{
+			Namespace: string(nsFlag),
+		},
 	}
 	return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
 		rules,
@@ -650,12 +654,12 @@ func ProvideClientConfig(contextOverride KubeContextOverride) clientcmd.ClientCo
 // The namespace in the kubeconfig.
 // Used as a default namespace in some (but not all) client commands.
 // https://godoc.org/k8s.io/client-go/tools/clientcmd/api/v1#Context
-func ProvideConfigNamespace(clientLoader clientcmd.ClientConfig, nsFlag NamespaceFlag) Namespace {
+func ProvideConfigNamespace(clientLoader clientcmd.ClientConfig) Namespace {
 	namespace, explicit, err := clientLoader.Namespace()
 	if err != nil {
 		// If we can't get a namespace from the config, just fail gracefully to the default.
 		// If this error indicates a more serious problem, it will get handled downstream.
-		return Namespace(nsFlag)
+		return ""
 	}
 
 	// TODO(nick): Right now, tilt doesn't provide a namespace flag. If we ever did,

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -41,6 +41,7 @@ import (
 )
 
 type Namespace string
+type NamespaceFlag string
 type PodID string
 type NodeID string
 type ServiceName string
@@ -649,12 +650,12 @@ func ProvideClientConfig(contextOverride KubeContextOverride) clientcmd.ClientCo
 // The namespace in the kubeconfig.
 // Used as a default namespace in some (but not all) client commands.
 // https://godoc.org/k8s.io/client-go/tools/clientcmd/api/v1#Context
-func ProvideConfigNamespace(clientLoader clientcmd.ClientConfig) Namespace {
+func ProvideConfigNamespace(clientLoader clientcmd.ClientConfig, nsFlag NamespaceFlag) Namespace {
 	namespace, explicit, err := clientLoader.Namespace()
 	if err != nil {
 		// If we can't get a namespace from the config, just fail gracefully to the default.
 		// If this error indicates a more serious problem, it will get handled downstream.
-		return ""
+		return Namespace(nsFlag)
 	}
 
 	// TODO(nick): Right now, tilt doesn't provide a namespace flag. If we ever did,


### PR DESCRIPTION
A very basic default namespace flag, inspired by the change suggested in #1113. 
```
tilt up --namespace=my-namespace
```
Documentation change in [tilt.build #876](https://github.com/tilt-dev/tilt.build/pull/876).