### PR TITLE
store: add backoff logic to subscribers

### DIFF
--- a/internal/store/helpers_test.go
+++ b/internal/store/helpers_test.go
@@ -31,7 +31,7 @@ func newFakeSubscriber() *fakeSubscriber {
 }
 
 type onChangeCall struct {
-	done    chan bool
+	done    chan error
 	summary ChangeSummary
 }
 
@@ -64,10 +64,9 @@ func (f *fakeSubscriber) assertOnChange(t *testing.T) {
 }
 
 func (f *fakeSubscriber) OnChange(ctx context.Context, st RStore, summary ChangeSummary) error {
-	call := onChangeCall{done: make(chan bool), summary: summary}
+	call := onChangeCall{done: make(chan error), summary: summary}
 	f.onChange <- call
-	<-call.done
-	return nil
+	return <-call.done
 }
 
 func (f *fakeSubscriber) SetUp(ctx context.Context, st RStore) error {

--- a/internal/store/sleep.go
+++ b/internal/store/sleep.go
@@ -1,0 +1,26 @@
+package store
+
+import (
+	"context"
+	"time"
+)
+
+type Sleeper interface {
+	// A cancelable Sleep(). Exits immediately if the context is canceled.
+	Sleep(ctx context.Context, d time.Duration)
+}
+
+type sleeper struct{}
+
+func (s sleeper) Sleep(ctx context.Context, d time.Duration) {
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-t.C:
+	case <-ctx.Done():
+	}
+}
+
+func DefaultSleeper() Sleeper {
+	return sleeper{}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -28,6 +28,7 @@ type RStore interface {
 // https://redux.js.org/introduction/threeprinciples
 // https://redux.js.org/basics
 type Store struct {
+	sleeper     Sleeper
 	state       *EngineState
 	subscribers *subscriberList
 	actionQueue *actionQueue
@@ -43,6 +44,7 @@ type Store struct {
 
 func NewStore(reducer Reducer, logActions LogActionsFlag) *Store {
 	return &Store{
+		sleeper:     DefaultSleeper(),
 		state:       NewState(),
 		reduce:      reducer,
 		actionQueue: &actionQueue{},
@@ -214,7 +216,7 @@ func (s *Store) maybeFinished() (bool, error) {
 }
 
 func (s *Store) drainActions() {
-	time.Sleep(actionBatchWindow)
+	s.sleeper.Sleep(context.Background(), actionBatchWindow)
 
 	// The mutex here ensures that the actions appear on the channel in-order.
 	// Otherwise, two drains can interleave badly.

--- a/internal/store/summary.go
+++ b/internal/store/summary.go
@@ -95,6 +95,9 @@ func (s *ChangeSummary) Add(other ChangeSummary) {
 	s.PortForwards.AddAll(other.PortForwards)
 	s.UISessions.AddAll(other.UISessions)
 	s.UIResources.AddAll(other.UIResources)
+	if other.LastBackoff > s.LastBackoff {
+		s.LastBackoff = other.LastBackoff
+	}
 }
 
 func LegacyChangeSummary() ChangeSummary {


### PR DESCRIPTION
Hello @milas, @landism,

Please review the following commits I made in branch nicks/onchange:

69909e11093c984d6cedf1212148fdc789aedccd (2021-06-21 12:15:25 -0400)
store: add backoff logic to subscribers

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics