### PR TITLE
ci: add retry for Windows tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ ifneq ($(CIRCLECI),true)
 	gotestsum -- -mod vendor -p $(GO_PARALLEL_JOBS) -tags skipcontainertests,skiplargetiltfiletests -timeout 100s ./...
 else
 	mkdir -p test-results
-	gotestsum --format standard-quiet --junitfile test-results/unit-tests.xml -- ./... -mod vendor -count 1 -p $(GO_PARALLEL_JOBS) -tags skipcontainertests,skiplargetiltfiletests -timeout 100s
+	gotestsum --format standard-quiet --junitfile test-results/unit-tests.xml --rerun-fails=2 --rerun-fails-max-failures=10 -- ./... -mod vendor -count 1 -p $(GO_PARALLEL_JOBS) -tags skipcontainertests,skiplargetiltfiletests -timeout 100s
 endif
 
 integration:

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ ifneq ($(CIRCLECI),true)
 	gotestsum -- -mod vendor -p $(GO_PARALLEL_JOBS) -tags skipcontainertests,skiplargetiltfiletests -timeout 100s ./...
 else
 	mkdir -p test-results
-	gotestsum --format standard-quiet --junitfile test-results/unit-tests.xml --rerun-fails=2 --rerun-fails-max-failures=10 -- ./... -mod vendor -count 1 -p $(GO_PARALLEL_JOBS) -tags skipcontainertests,skiplargetiltfiletests -timeout 100s
+	gotestsum --format standard-quiet --junitfile test-results/unit-tests.xml --rerun-fails=2 --rerun-fails-max-failures=10 --packages="./..." -- -mod vendor -count 1 -p $(GO_PARALLEL_JOBS) -tags skipcontainertests,skiplargetiltfiletests -timeout 100s
 endif
 
 integration:


### PR DESCRIPTION
Use some `gotestsum` flags to automatically retry a failed test.
If there's >10 failures that require retry, the tests will still
fail.

This only applies to the `shorttestsum` make task and more
specifically when run under CircleCI, which ONLY applies to
Windows.