### PR TITLE
web: tweak styles for filter term input field to align better with design

### DIFF
--- a/web/src/OverviewActionBar.tsx
+++ b/web/src/OverviewActionBar.tsx
@@ -274,11 +274,10 @@ const FilterTermTextField = styled(TextField)`
     &:hover:not(.Mui-focused, .Mui-error) fieldset {
       border: 1px solid ${Color.blue};
     }
-    & .Mui-focused fieldset {
-      border: 1px solid ${Color.grayLighter};
-      outline: none;
+    &.Mui-focused fieldset {
+      border: 1px solid ${Color.grayLightest};
     }
-    & .Mui-error fieldset {
+    &.Mui-error fieldset {
       border: 1px solid ${Color.red};
     }
     & .MuiOutlinedInput-input {
@@ -297,6 +296,7 @@ const FieldErrorTooltip = styled.span`
   align-items: center;
   background-color: ${Color.grayDark};
   box-sizing: border-box;
+  color: ${Color.red};
   display: flex;
   font-family: ${Font.monospace};
   font-size: ${FontSize.smallest};
@@ -319,10 +319,6 @@ const FieldErrorTooltip = styled.span`
     position: absolute;
     top: -8px;
     width: 0;
-  }
-
-  .Mui-error {
-    color: ${Color.red};
   }
 `
 


### PR DESCRIPTION
This PR fixes an issue with the `fieldset` border width + color and error color styles not applying correctly.

Active border is now 1px (instead of 2px) and matches the buttons:
![Screen Shot 2021-06-22 at 12 50 13 PM](https://user-images.githubusercontent.com/23283986/122967437-76e16d80-d358-11eb-9e2c-234f67add835.png)

Active border is now 1px (instead of 2px) and reds are the correct red:
![Screen Shot 2021-06-22 at 12 50 05 PM](https://user-images.githubusercontent.com/23283986/122967443-777a0400-d358-11eb-93e1-c2c45429fa19.png)
