### PR TITLE
integration: change string match to regexp to allow for either IfNotPresent or Never imagePullPolicy

### DIFF
--- a/integration/crd_test.go
+++ b/integration/crd_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"io/ioutil"
 	"path/filepath"
+	"regexp"
 	"testing"
 	"time"
 
@@ -36,7 +37,7 @@ func TestCRD(t *testing.T) {
 	assert.Contains(t, contents, "name: bobo\n")
 	assert.Contains(t, contents, "nonImage: bobo\n")
 	assert.NotContains(t, contents, "image: bobo\n")
-	assert.Contains(t, contents, "imagePullPolicy: IfNotPresent\n")
+	assert.Regexp(t, regexp.MustCompile("imagePullPolicy: (IfNotPresent|Never)\n"), contents)
 }
 
 // Make sure that running 'tilt down' with no resources installed


### PR DESCRIPTION
## Background
The Custom Resource Definition (CRD) test has a check to ensure that images only get pulled when necessary.

In k8s on Docker for Mac, Tilt uses an extra optimization to share the Docker image cache, which allows it to use `imagePullPolicy: Never` by default. Currently, the CRD test fails in this setup because it only accepts `imagePullPolicy: IfNotPresent`. 

## Changes 
This change allows the Custom Resource Definition test to take the Mac setting into account by replacing the single string to match with a regular expression that accepts both `IfNotPresent` and `Never` image pull policies.