### PR TITLE
test: refactor PodLogStream reconciler tests

### DIFF
--- a/internal/controllers/core/podlogstream/podlogstreamcontroller_test.go
+++ b/internal/controllers/core/podlogstream/podlogstreamcontroller_test.go
@@ -5,20 +5,20 @@ import (
 	"fmt"
 	"io"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 
-	"github.com/tilt-dev/tilt/internal/engine/k8swatch"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tilt-dev/tilt/internal/timecmp"
+	"github.com/tilt-dev/tilt/pkg/apis"
 
 	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/tilt-dev/tilt/internal/container"
@@ -29,8 +29,6 @@ import (
 	"github.com/tilt-dev/tilt/internal/store"
 	"github.com/tilt-dev/tilt/internal/store/k8sconv"
 	"github.com/tilt-dev/tilt/internal/testutils/bufsync"
-	"github.com/tilt-dev/tilt/internal/testutils/manifestutils"
-	"github.com/tilt-dev/tilt/internal/testutils/tempdir"
 	"github.com/tilt-dev/tilt/pkg/logger"
 	"github.com/tilt-dev/tilt/pkg/model"
 )
@@ -41,22 +39,18 @@ var cID = container.ID("cid")
 
 func TestLogs(t *testing.T) {
 	f := newPLMFixture(t)
-	defer f.TearDown()
 
 	f.kClient.SetLogsForPodContainer(podID, cName, "hello world!")
 
 	start := time.Now()
-	state := f.store.LockMutableStateForTesting()
-	state.TiltStartTime = start
 
 	pb := newPodBuilder(podID).addRunningContainer(cName, cID)
 	f.kClient.UpsertPod(pb.toPod())
 
-	state.UpsertManifestTarget(manifestutils.NewManifestTargetWithPod(
-		model.Manifest{Name: "server"}, pb.toStorePod(f.ctx)))
-	f.store.UnlockMutableState()
+	pls := plsFromPod("server", pb, start)
+	f.Create(pls)
 
-	f.onChange("server", podID)
+	f.triggerPodEvent(podID)
 	f.AssertOutputContains("hello world!")
 	f.AssertLogStartTime(start)
 
@@ -64,52 +58,43 @@ func TestLogs(t *testing.T) {
 	podNN := types.NamespacedName{Name: string(podID), Namespace: "default"}
 	streamNN := types.NamespacedName{Name: fmt.Sprintf("default-%s", podID)}
 	assert.Equal(t, []reconcile.Request{
-		reconcile.Request{NamespacedName: streamNN},
+		{NamespacedName: streamNN},
 	}, f.plsc.podSource.indexer.EnqueueKey(indexer.Key{Name: podNN, GVK: podGVK}))
 }
 
 func TestLogActions(t *testing.T) {
 	f := newPLMFixture(t)
-	defer f.TearDown()
 
 	f.kClient.SetLogsForPodContainer(podID, cName, "hello world!\ngoodbye world!\n")
-
-	state := f.store.LockMutableStateForTesting()
 
 	pb := newPodBuilder(podID).addRunningContainer(cName, cID)
 	f.kClient.UpsertPod(pb.toPod())
 
-	state.UpsertManifestTarget(manifestutils.NewManifestTargetWithPod(
-		model.Manifest{Name: "server"}, pb.toStorePod(f.ctx)))
-	f.store.UnlockMutableState()
+	f.Create(plsFromPod("server", pb, time.Time{}))
 
-	f.onChange("server", podID)
+	f.triggerPodEvent(podID)
 	f.ConsumeLogActionsUntil("hello world!")
 }
 
 func TestLogsFailed(t *testing.T) {
 	f := newPLMFixture(t)
-	defer f.TearDown()
 
 	f.kClient.ContainerLogsError = fmt.Errorf("my-error")
 
-	state := f.store.LockMutableStateForTesting()
-
 	pb := newPodBuilder(podID).addRunningContainer(cName, cID)
 	f.kClient.UpsertPod(pb.toPod())
-	state.UpsertManifestTarget(manifestutils.NewManifestTargetWithPod(
-		model.Manifest{Name: "server"}, pb.toStorePod(f.ctx)))
-	f.store.UnlockMutableState()
 
-	f.onChange("server", podID)
+	pls := plsFromPod("server", pb, time.Time{})
+	f.Create(pls)
+
 	f.AssertOutputContains("Error streaming pod-id logs")
 	assert.Contains(t, f.out.String(), "my-error")
 
 	// Check to make sure the status has an error.
-	stream := f.getPodLogStream(podID)
-	assert.Equal(t, stream.Status, PodLogStreamStatus{
+	f.MustGet(f.KeyForObject(pls), pls)
+	assert.Equal(t, pls.Status, PodLogStreamStatus{
 		ContainerStatuses: []ContainerLogStreamStatus{
-			ContainerLogStreamStatus{
+			{
 				Name:  "cname",
 				Error: "my-error",
 			},
@@ -119,25 +104,20 @@ func TestLogsFailed(t *testing.T) {
 
 func TestLogsCanceledUnexpectedly(t *testing.T) {
 	f := newPLMFixture(t)
-	defer f.TearDown()
 
 	f.kClient.SetLogsForPodContainer(podID, cName, "hello world!\n")
 
-	state := f.store.LockMutableStateForTesting()
-
 	pb := newPodBuilder(podID).addRunningContainer(cName, cID)
 	f.kClient.UpsertPod(pb.toPod())
-	state.UpsertManifestTarget(manifestutils.NewManifestTargetWithPod(
-		model.Manifest{Name: "server"}, pb.toStorePod(f.ctx)))
-	f.store.UnlockMutableState()
+	pls := plsFromPod("server", pb, time.Time{})
+	f.Create(pls)
 
-	f.onChange("server", podID)
 	f.AssertOutputContains("hello world!\n")
 
 	// Wait until the previous log stream finishes.
-	assert.Eventually(f.T(), func() bool {
-		stream := f.getPodLogStream(podID)
-		statuses := stream.Status.ContainerStatuses
+	assert.Eventually(f.t, func() bool {
+		f.MustGet(f.KeyForObject(pls), pls)
+		statuses := pls.Status.ContainerStatuses
 		if len(statuses) != 1 {
 			return false
 		}
@@ -146,35 +126,28 @@ func TestLogsCanceledUnexpectedly(t *testing.T) {
 
 	// Set new logs, as if the pod restarted.
 	f.kClient.SetLogsForPodContainer(podID, cName, "goodbye world!\n")
-	f.onChange("server", podID)
+	f.triggerPodEvent(podID)
 	f.AssertOutputContains("goodbye world!\n")
 }
 
 func TestMultiContainerLogs(t *testing.T) {
 	f := newPLMFixture(t)
-	defer f.TearDown()
 
 	f.kClient.SetLogsForPodContainer(podID, "cont1", "hello world!")
 	f.kClient.SetLogsForPodContainer(podID, "cont2", "goodbye world!")
-
-	state := f.store.LockMutableStateForTesting()
 
 	pb := newPodBuilder(podID).
 		addRunningContainer("cont1", "cid1").
 		addRunningContainer("cont2", "cid2")
 	f.kClient.UpsertPod(pb.toPod())
-	state.UpsertManifestTarget(manifestutils.NewManifestTargetWithPod(
-		model.Manifest{Name: "server"}, pb.toStorePod(f.ctx)))
-	f.store.UnlockMutableState()
+	f.Create(plsFromPod("server", pb, time.Time{}))
 
-	f.onChange("server", podID)
 	f.AssertOutputContains("hello world!")
 	f.AssertOutputContains("goodbye world!")
 }
 
 func TestContainerPrefixes(t *testing.T) {
 	f := newPLMFixture(t)
-	defer f.TearDown()
 
 	pID1 := k8s.PodID("pod1")
 	cNamePrefix1 := container.Name("yes-prefix-1")
@@ -186,29 +159,20 @@ func TestContainerPrefixes(t *testing.T) {
 	cNameNoPrefix := container.Name("no-prefix")
 	f.kClient.SetLogsForPodContainer(pID2, cNameNoPrefix, "hello jupiter!")
 
-	state := f.store.LockMutableStateForTesting()
-
 	pbMultiC := newPodBuilder(pID1).
 		// Pod with multiple containers -- logs should be prefixed with container name
 		addRunningContainer(cNamePrefix1, "cid1").
 		addRunningContainer(cNamePrefix2, "cid2")
 	f.kClient.UpsertPod(pbMultiC.toPod())
 
-	state.UpsertManifestTarget(manifestutils.NewManifestTargetWithPod(
-		model.Manifest{Name: "multiContainer"}, pbMultiC.toStorePod(f.ctx)))
+	f.Create(plsFromPod("multiContainer", pbMultiC, time.Time{}))
 
 	pbSingleC := newPodBuilder(pID2).
 		// Pod with just one container -- logs should NOT be prefixed with container name
 		addRunningContainer(cNameNoPrefix, "cid3")
 	f.kClient.UpsertPod(pbSingleC.toPod())
 
-	state.UpsertManifestTarget(manifestutils.NewManifestTargetWithPod(
-		model.Manifest{Name: "singleContainer"},
-		pbSingleC.toStorePod(f.ctx)))
-	f.store.UnlockMutableState()
-
-	f.onChange("singleContainer", pID1)
-	f.onChange("singleContainer", pID2)
+	f.Create(plsFromPod("singleContainer", pbSingleC, time.Time{}))
 
 	// Make sure we have expected logs
 	f.AssertOutputContains("hello world!")
@@ -223,23 +187,19 @@ func TestContainerPrefixes(t *testing.T) {
 
 func TestTerminatedContainerLogs(t *testing.T) {
 	f := newPLMFixture(t)
-	defer f.TearDown()
-
-	state := f.store.LockMutableStateForTesting()
 
 	cName := container.Name("cName")
 	pb := newPodBuilder(podID).addTerminatedContainer(cName, "cID")
 	f.kClient.UpsertPod(pb.toPod())
-	state.UpsertManifestTarget(manifestutils.NewManifestTargetWithPod(
-		model.Manifest{Name: "server"}, pb.toStorePod(f.ctx)))
-	f.store.UnlockMutableState()
 
 	f.kClient.SetLogsForPodContainer(podID, cName, "hello world!")
 
+	f.Create(plsFromPod("server", pb, time.Time{}))
+
 	// Fire OnChange twice, because we used to have a bug where
 	// we'd immediately teardown the log watch on the terminated container.
-	f.onChange("server", podID)
-	f.onChange("server", podID)
+	f.triggerPodEvent(podID)
+	f.triggerPodEvent(podID)
 
 	f.AssertOutputContains("hello world!")
 
@@ -247,7 +207,7 @@ func TestTerminatedContainerLogs(t *testing.T) {
 	// closes the log stream.
 	f.kClient.SetLogsForPodContainer(podID, cName, "hello world!\ngoodbye world!\n")
 
-	f.onChange("server", podID)
+	f.triggerPodEvent(podID)
 	f.AssertOutputContains("hello world!")
 	f.AssertOutputDoesNotContain("goodbye world!")
 }
@@ -255,19 +215,14 @@ func TestTerminatedContainerLogs(t *testing.T) {
 // https://github.com/tilt-dev/tilt/issues/3908
 func TestLogReconnection(t *testing.T) {
 	f := newPLMFixture(t)
-	defer f.TearDown()
-
-	state := f.store.LockMutableStateForTesting()
-
 	cName := container.Name("cName")
 	pb := newPodBuilder(podID).addRunningContainer(cName, "cID")
 	f.kClient.UpsertPod(pb.toPod())
-	state.UpsertManifestTarget(manifestutils.NewManifestTargetWithPod(
-		model.Manifest{Name: "server"}, pb.toStorePod(f.ctx)))
-	f.store.UnlockMutableState()
 
 	reader, writer := io.Pipe()
-	defer writer.Close()
+	defer func() {
+		require.NoError(t, writer.Close())
+	}()
 	f.kClient.SetLogReaderForPodContainer(podID, cName, reader)
 
 	// Set up fake time
@@ -279,13 +234,10 @@ func TestLogReconnection(t *testing.T) {
 	f.plsc.since = func(t time.Time) time.Duration { return currentTime.Sub(t) }
 	f.plsc.newTicker = func(d time.Duration) *time.Ticker { return &ticker }
 
-	f.store.WithState(func(state *store.EngineState) {
-		state.TiltStartTime = startTime
-	})
+	f.Create(plsFromPod("server", pb, startTime))
 
-	f.onChange("server", podID)
-
-	_, _ = writer.Write([]byte("hello world!"))
+	_, err := writer.Write([]byte("hello world!"))
+	require.NoError(t, err)
 	f.AssertOutputContains("hello world!")
 	f.AssertLogStartTime(startTime)
 
@@ -296,7 +248,9 @@ func TestLogReconnection(t *testing.T) {
 
 	// Simulate Kubernetes rotating the logs by creating a new pipe.
 	reader2, writer2 := io.Pipe()
-	defer writer2.Close()
+	defer func() {
+		require.NoError(t, writer2.Close())
+	}()
 	f.kClient.SetLogReaderForPodContainer(podID, cName, reader2)
 	go func() {
 		_, _ = writer2.Write([]byte("goodbye world!"))
@@ -317,7 +271,7 @@ func TestLogReconnection(t *testing.T) {
 	timeCh <- currentTime
 	time.Sleep(20 * time.Millisecond)
 	assert.Error(t, f.kClient.LastPodLogContext.Err())
-	writer.Close()
+	require.NoError(t, writer.Close())
 
 	f.AssertOutputContains("goodbye world!")
 
@@ -327,11 +281,8 @@ func TestLogReconnection(t *testing.T) {
 
 func TestInitContainerLogs(t *testing.T) {
 	f := newPLMFixture(t)
-	defer f.TearDown()
 
 	f.kClient.SetLogsForPodContainer(podID, "cont1", "hello world!")
-
-	state := f.store.LockMutableStateForTesting()
 
 	cNameInit := container.Name("cNameInit")
 	cNameNormal := container.Name("cNameNormal")
@@ -340,14 +291,10 @@ func TestInitContainerLogs(t *testing.T) {
 		addRunningContainer(cNameNormal, "cID-normal")
 	f.kClient.UpsertPod(pb.toPod())
 
-	state.UpsertManifestTarget(manifestutils.NewManifestTargetWithPod(
-		model.Manifest{Name: "server"}, pb.toStorePod(f.ctx)))
-	f.store.UnlockMutableState()
-
 	f.kClient.SetLogsForPodContainer(podID, cNameInit, "init world!")
 	f.kClient.SetLogsForPodContainer(podID, cNameNormal, "hello world!")
 
-	f.onChange("server", podID)
+	f.Create(plsFromPod("server", pb, time.Time{}))
 
 	f.AssertOutputContains(cNameInit.String())
 	f.AssertOutputContains("init world!")
@@ -355,13 +302,10 @@ func TestInitContainerLogs(t *testing.T) {
 	f.AssertOutputContains("hello world!")
 }
 
-func TestIstioContainerLogs(t *testing.T) {
+func TestIgnoredContainerLogs(t *testing.T) {
 	f := newPLMFixture(t)
-	defer f.TearDown()
 
 	f.kClient.SetLogsForPodContainer(podID, "cont1", "hello world!")
-
-	state := f.store.LockMutableStateForTesting()
 
 	istioInit := runtimelog.IstioInitContainerName
 	istioSidecar := runtimelog.IstioSidecarContainerName
@@ -372,69 +316,33 @@ func TestIstioContainerLogs(t *testing.T) {
 		addRunningContainer(cNormal, "cID-normal")
 	f.kClient.UpsertPod(pb.toPod())
 
-	state.UpsertManifestTarget(manifestutils.NewManifestTargetWithPod(
-		model.Manifest{Name: "server"}, pb.toStorePod(f.ctx)))
-	f.store.UnlockMutableState()
-
 	f.kClient.SetLogsForPodContainer(podID, istioInit, "init istio!")
 	f.kClient.SetLogsForPodContainer(podID, istioSidecar, "hello istio!")
 	f.kClient.SetLogsForPodContainer(podID, cNormal, "hello world!")
 
-	f.onChange("server", podID)
+	pls := plsFromPod("server", pb, time.Time{})
+	pls.Spec.IgnoreContainers = []string{string(istioInit), string(istioSidecar)}
+	f.Create(pls)
 
 	f.AssertOutputDoesNotContain("istio")
 	f.AssertOutputContains("hello world!")
 }
 
 type plmStore struct {
-	t *testing.T
+	t testing.TB
 	*store.TestingStore
 	out *bufsync.ThreadSafeBuffer
-
-	mu      sync.Mutex
-	streams map[string]*PodLogStream
-	summary store.ChangeSummary
 }
 
-func newPLMStore(t *testing.T, out *bufsync.ThreadSafeBuffer) *plmStore {
+func newPLMStore(t testing.TB, out *bufsync.ThreadSafeBuffer) *plmStore {
 	return &plmStore{
 		t:            t,
 		TestingStore: store.NewTestingStore(),
 		out:          out,
-		streams:      make(map[string]*PodLogStream),
 	}
-}
-
-func (s *plmStore) getSummary() store.ChangeSummary {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return s.summary
-}
-
-func (s *plmStore) clearSummary() {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.summary = store.ChangeSummary{}
 }
 
 func (s *plmStore) Dispatch(action store.Action) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	state := s.LockMutableStateForTesting()
-	defer s.UnlockMutableState()
-
-	switch action := action.(type) {
-	case runtimelog.PodLogStreamCreateAction:
-		state.PodLogStreams[action.PodLogStream.Name] = action.PodLogStream
-		action.Summarize(&s.summary)
-		return
-	case runtimelog.PodLogStreamDeleteAction:
-		delete(state.PodLogStreams, action.Name)
-		action.Summarize(&s.summary)
-		return
-	}
-
 	event, ok := action.(store.LogAction)
 	if !ok {
 		s.t.Errorf("Expected action type LogAction. Actual: %T", action)
@@ -447,73 +355,51 @@ func (s *plmStore) Dispatch(action store.Action) {
 }
 
 type plmFixture struct {
-	*tempdir.TempDirFixture
+	*fake.ControllerFixture
+	t       testing.TB
 	ctx     context.Context
-	client  ctrlclient.Client
 	kClient *k8s.FakeK8sClient
 	plm     *runtimelog.PodLogManager
 	plsc    *Controller
-	cancel  func()
 	out     *bufsync.ThreadSafeBuffer
 	store   *plmStore
 }
 
-func newPLMFixture(t *testing.T) *plmFixture {
-	f := tempdir.NewTempDirFixture(t)
+func newPLMFixture(t testing.TB) *plmFixture {
 	kClient := k8s.NewFakeK8sClient(t)
+	t.Cleanup(kClient.TearDown)
 
 	out := bufsync.NewThreadSafeBuffer()
 	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
 	ctx = logger.WithLogger(ctx, logger.NewTestLogger(out))
 
+	cfb := fake.NewControllerFixtureBuilder(t)
+
 	st := newPLMStore(t, out)
-	fc := fake.NewFakeTiltClient()
-	plm := runtimelog.NewPodLogManager(fc)
-	podSource := NewPodSource(ctx, kClient, v1alpha1.NewScheme())
-	plsc := NewController(ctx, fc, st, kClient, podSource)
+	plm := runtimelog.NewPodLogManager(cfb.Client)
+	podSource := NewPodSource(ctx, kClient, cfb.Client.Scheme())
+	plsc := NewController(ctx, cfb.Client, st, kClient, podSource)
 
 	return &plmFixture{
-		TempDirFixture: f,
-		kClient:        kClient,
-		client:         fc,
-		plm:            plm,
-		plsc:           plsc,
-		ctx:            ctx,
-		cancel:         cancel,
-		out:            out,
-		store:          st,
+		t:                 t,
+		ControllerFixture: cfb.Build(plsc),
+		kClient:           kClient,
+		plm:               plm,
+		plsc:              plsc,
+		ctx:               ctx,
+		out:               out,
+		store:             st,
 	}
 }
 
-func (f *plmFixture) onChange(mn model.ManifestName, podID k8s.PodID) {
+func (f *plmFixture) triggerPodEvent(podID k8s.PodID) {
 	podNN := types.NamespacedName{Name: string(podID), Namespace: "default"}
-	kdNN := k8swatch.KeyForManifest(mn)
-	_ = f.plm.OnChange(f.ctx, f.store, store.ChangeSummary{
-		KubernetesDiscoveries: store.NewChangeSet(kdNN),
-	})
-
-	// Reconcile any PodLogStreams
-	summary := f.store.getSummary()
-	for streamName := range summary.PodLogStreams.Changes {
-		_, err := f.plsc.Reconcile(f.ctx, reconcile.Request{NamespacedName: streamName})
-		assert.NoError(f.T(), err)
-	}
-
 	reqs := f.plsc.podSource.indexer.EnqueueKey(indexer.Key{Name: podNN, GVK: podGVK})
 	for _, req := range reqs {
 		_, err := f.plsc.Reconcile(f.ctx, req)
-		assert.NoError(f.T(), err)
+		assert.NoError(f.t, err)
 	}
-
-	f.store.clearSummary()
-}
-
-func (f *plmFixture) getPodLogStream(id k8s.PodID) *PodLogStream {
-	stream := &PodLogStream{}
-	streamNN := types.NamespacedName{Name: fmt.Sprintf("default-%s", id)}
-	err := f.client.Get(f.ctx, streamNN, stream)
-	require.NoError(f.T(), err)
-	return stream
 }
 
 func (f *plmFixture) ConsumeLogActionsUntil(expected string) {
@@ -530,33 +416,27 @@ func (f *plmFixture) ConsumeLogActionsUntil(expected string) {
 		time.Sleep(10 * time.Millisecond)
 	}
 
-	f.T().Fatalf("Timeout. Collected output: %s", f.out.String())
-}
-
-func (f *plmFixture) TearDown() {
-	f.cancel()
-	f.kClient.TearDown()
-	f.TempDirFixture.TearDown()
+	f.t.Fatalf("Timeout. Collected output: %s", f.out.String())
 }
 
 func (f *plmFixture) AssertOutputContains(s string) {
-	f.T().Helper()
+	f.t.Helper()
 	err := f.out.WaitUntilContains(s, time.Second)
 	if err != nil {
-		f.T().Fatal(err)
+		f.t.Fatal(err)
 	}
 }
 
 func (f *plmFixture) AssertOutputDoesNotContain(s string) {
 	time.Sleep(10 * time.Millisecond)
-	assert.NotContains(f.T(), f.out.String(), s)
+	assert.NotContains(f.t, f.out.String(), s)
 }
 
 func (f *plmFixture) AssertLogStartTime(t time.Time) {
-	f.T().Helper()
+	f.t.Helper()
 
 	// Truncate the time to match the behavior of metav1.Time
-	assert.Equal(f.T(), t.Truncate(time.Second), f.kClient.LastPodLogStartTime)
+	timecmp.AssertTimeEqual(f.t, t.Truncate(time.Second), f.kClient.LastPodLogStartTime)
 }
 
 type podBuilder v1.Pod
@@ -632,12 +512,24 @@ func (pb *podBuilder) toPod() *v1.Pod {
 	return (*v1.Pod)(pb)
 }
 
-func (pb *podBuilder) toStorePod(ctx context.Context) v1alpha1.Pod {
-	pod := (*v1.Pod)(pb)
-	return v1alpha1.Pod{
-		Name:           pb.Name,
-		Namespace:      pb.Namespace,
-		InitContainers: k8sconv.PodContainers(ctx, pod, pod.Status.InitContainerStatuses),
-		Containers:     k8sconv.PodContainers(ctx, pod, pod.Status.ContainerStatuses),
+func plsFromPod(mn model.ManifestName, pb *podBuilder, start time.Time) *v1alpha1.PodLogStream {
+	var sinceTime *metav1.Time
+	if !start.IsZero() {
+		t := apis.NewTime(start)
+		sinceTime = &t
+	}
+	return &v1alpha1.PodLogStream{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: fmt.Sprintf("%s-%s", pb.Namespace, pb.Name),
+			Annotations: map[string]string{
+				v1alpha1.AnnotationManifest: string(mn),
+				v1alpha1.AnnotationSpanID:   string(k8sconv.SpanIDForPod(mn, k8s.PodID(pb.Name))),
+			},
+		},
+		Spec: PodLogStreamSpec{
+			Namespace: pb.Namespace,
+			Pod:       pb.Name,
+			SinceTime: sinceTime,
+		},
 	}
 }

--- a/internal/k8s/fake_client.go
+++ b/internal/k8s/fake_client.go
@@ -444,6 +444,7 @@ func (c *FakeK8sClient) ListMeta(_ context.Context, gvk schema.GroupVersionKind,
 }
 
 func (c *FakeK8sClient) SetLogsForPodContainer(pID PodID, cName container.Name, logs string) {
+
 	c.SetLogReaderForPodContainer(pID, cName, strings.NewReader(logs))
 }
 


### PR DESCRIPTION
Eliminate the store part of the tests (besides using it to extract
logs).

This makes these tests purely about actual reconciler behavior and
not about implicit object creation from manifests; this will
temporarily reduce the test coverage, but will be reinstated by
tests for the `kubernetesdiscovery.Reconciler` to ensure that it
creates `PodLogStream` objects (instead of `runtimelog.PodLogManager`
which will go away). This is just split out because the scope of
changes required for these tests was sufficient on its own.