### PR TITLE
ci: use pinned tilt-extensions-ci image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,7 +102,7 @@ jobs:
 
   test-extensions:
     docker:
-      - image: tiltdev/tilt-extensions-ci:latest
+      - image: tiltdev/tilt-extensions-ci@sha256:e1990914dbfdd357ef880110faeb1eaa68bd85b7668a54f9b7aed8e098f83c0c
     steps:
       - checkout
       - run: echo 'export PATH=/go/bin:$PATH' >> $BASH_ENV


### PR DESCRIPTION
Avoid breakage from changes to the extensions CI runner image
by pinning to a specific version (ideally kept in sync with
`tilt-extensions` as much as possible).