### PR TITLE
doctor: log docker server version

### DIFF
--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -92,6 +92,7 @@ func (c *doctorCmd) run(ctx context.Context, args []string) error {
 			printField("Host", host, nil)
 
 			version := localDocker.ServerVersion()
+			printField("Server Version", version.Version, nil)
 			printField("Version", version.APIVersion, nil)
 
 			builderVersion := localDocker.BuilderVersion()

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -70,7 +70,8 @@ func (c *doctorCmd) run(ctx context.Context, args []string) error {
 		printField("Host", host, nil)
 
 		version := clusterDocker.ServerVersion()
-		printField("Version", version.APIVersion, nil)
+		printField("Server Version", version.Version, nil)
+		printField("API Version", version.APIVersion, nil)
 
 		builderVersion := clusterDocker.BuilderVersion()
 		printField("Builder", builderVersion, nil)


### PR DESCRIPTION
Motivated by #4678

```
Docker
- Host: [default]
- Server Version: 20.10.2
- API Version: 1.41
- Builder: 2
```