### PR TITLE
cmd: fix flaky grandkid test

### DIFF
--- a/internal/controllers/core/cmd/execer_unix_test.go
+++ b/internal/controllers/core/cmd/execer_unix_test.go
@@ -27,6 +27,29 @@ echo BACKGROUND $!
 '`)
 	f.waitForStatus(Done)
 
+	// Since execer uses cmd.Process.Wait instead of cmd.Wait, it doesn't block until the writers have finished.
+	// (https://github.com/tilt-dev/tilt/blob/7dad0c01169c7e7825268eff27e96068288280b7/internal/controllers/core/cmd/execer.go#L184)
+	// This is probably not currently really a problem for Tilt since the underlying goroutine will still write to the
+	// logger's Writer after Wait has returned, but it's the kind of thing that could lead to surprises in the future.
+	// (e.g., tests like this, or if we use Cmd to power `local` in the Tiltfile)
+	var grandkidPid int
+	timeout := time.After(time.Second)
+	interval := 5 * time.Millisecond
+	for {
+		lines := strings.Split(f.testWriter.String(), "\n")
+		if strings.Contains(lines[1], "BACKGROUND") {
+			var err error
+			grandkidPid, err = strconv.Atoi(strings.TrimSpace(strings.TrimPrefix(lines[1], "BACKGROUND")))
+			require.NoError(t, err)
+			break
+		}
+		select {
+		case <-time.After(interval):
+		case <-timeout:
+			t.Fatalf("timed out after %s waiting for grandkid pid. current output: %q", timeout, f.testWriter.String())
+		}
+	}
+
 	lines := strings.Split(f.testWriter.String(), "\n")
 	assert.Contains(t, lines[1], "BACKGROUND")
 	grandkidPid, err := strconv.Atoi(strings.TrimSpace(strings.TrimPrefix(lines[1], "BACKGROUND")))


### PR DESCRIPTION
This test failed for me in CI.

I'm not sure a test change is the right path forward, but it's not immediately clear to me how to fix the underlying code in a way that's copacetic with #4456, so I figured I'd throw up a PR to discuss the issue.

(FWIW, I added logging to the `io.Writer` passed as stdout and confirmed its `Write` was being called with `BACKGROUND $!` after `c.Process.Wait()` had returned)