### PR TITLE
k8s: remove our homegrown meta Accessor in favor of apimachinery's

### DIFF
--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -408,7 +408,7 @@ func (b *fakeBuildAndDeployer) nextK8sDeployResult(kTarg model.K8sTarget) store.
 				uid = b.nextDeployedUID
 				b.nextDeployedUID = ""
 			}
-			k8s.SetUIDForTest(b.t, &deployed[i], string(uid))
+			deployed[i].SetUID(string(uid))
 		}
 
 		templateSpecHashes = podTemplateSpecHashesForTarg(b.t, kTarg)

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -86,8 +86,8 @@ type Client interface {
 	// behavior for our use cases.
 	Delete(ctx context.Context, entities []K8sEntity) error
 
-	GetMetaByReference(ctx context.Context, ref v1.ObjectReference) (ObjectMeta, error)
-	ListMeta(ctx context.Context, gvk schema.GroupVersionKind, ns Namespace) ([]ObjectMeta, error)
+	GetMetaByReference(ctx context.Context, ref v1.ObjectReference) (metav1.Object, error)
+	ListMeta(ctx context.Context, gvk schema.GroupVersionKind, ns Namespace) ([]metav1.Object, error)
 
 	// Streams the container logs
 	ContainerLogs(ctx context.Context, podID PodID, cName container.Name, n Namespace, startTime time.Time) (io.ReadCloser, error)
@@ -95,7 +95,7 @@ type Client interface {
 	// Opens a tunnel to the specified pod+port. Returns the tunnel's local port and a function that closes the tunnel
 	CreatePortForwarder(ctx context.Context, namespace Namespace, podID PodID, optionalLocalPort, remotePort int, host string) (PortForwarder, error)
 
-	WatchMeta(ctx context.Context, gvk schema.GroupVersionKind, ns Namespace) (<-chan ObjectMeta, error)
+	WatchMeta(ctx context.Context, gvk schema.GroupVersionKind, ns Namespace) (<-chan metav1.Object, error)
 
 	ContainerRuntime(ctx context.Context) container.Runtime
 
@@ -546,7 +546,7 @@ func (k *K8sClient) forceDiscovery(ctx context.Context, gvk schema.GroupVersionK
 	return rm.Resource, nil
 }
 
-func (k *K8sClient) ListMeta(ctx context.Context, gvk schema.GroupVersionKind, ns Namespace) ([]ObjectMeta, error) {
+func (k *K8sClient) ListMeta(ctx context.Context, gvk schema.GroupVersionKind, ns Namespace) ([]metav1.Object, error) {
 	gvr, err := k.forceDiscovery(ctx, gvk)
 	if err != nil {
 		return nil, err
@@ -558,7 +558,7 @@ func (k *K8sClient) ListMeta(ctx context.Context, gvk schema.GroupVersionKind, n
 	}
 
 	// type conversion
-	result := make([]ObjectMeta, len(metaList.Items))
+	result := make([]metav1.Object, len(metaList.Items))
 	for i, meta := range metaList.Items {
 		m := meta.ObjectMeta
 		result[i] = &m
@@ -566,7 +566,7 @@ func (k *K8sClient) ListMeta(ctx context.Context, gvk schema.GroupVersionKind, n
 	return result, nil
 }
 
-func (k *K8sClient) GetMetaByReference(ctx context.Context, ref v1.ObjectReference) (ObjectMeta, error) {
+func (k *K8sClient) GetMetaByReference(ctx context.Context, ref v1.ObjectReference) (metav1.Object, error) {
 	gvk := ReferenceGVK(ref)
 	gvr, err := k.forceDiscovery(ctx, gvk)
 	if err != nil {

--- a/internal/k8s/exploding_client.go
+++ b/internal/k8s/exploding_client.go
@@ -8,6 +8,7 @@ import (
 	"github.com/docker/distribution/reference"
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -29,11 +30,11 @@ func (ec *explodingClient) Delete(ctx context.Context, entities []K8sEntity) err
 	return errors.Wrap(ec.err, "could not set up k8s client")
 }
 
-func (ec *explodingClient) GetMetaByReference(ctx context.Context, ref v1.ObjectReference) (ObjectMeta, error) {
+func (ec *explodingClient) GetMetaByReference(ctx context.Context, ref v1.ObjectReference) (metav1.Object, error) {
 	return nil, errors.Wrap(ec.err, "could not set up k8s client")
 }
 
-func (ec *explodingClient) ListMeta(ctx context.Context, gvk schema.GroupVersionKind, ns Namespace) ([]ObjectMeta, error) {
+func (ec *explodingClient) ListMeta(ctx context.Context, gvk schema.GroupVersionKind, ns Namespace) ([]metav1.Object, error) {
 	return nil, errors.Wrap(ec.err, "could not set up k8s client")
 }
 
@@ -69,7 +70,7 @@ func (ec *explodingClient) WatchEvents(ctx context.Context, ns Namespace) (<-cha
 	return nil, errors.Wrap(ec.err, "could not set up k8s client")
 }
 
-func (ec *explodingClient) WatchMeta(ctx context.Context, gvk schema.GroupVersionKind, ns Namespace) (<-chan ObjectMeta, error) {
+func (ec *explodingClient) WatchMeta(ctx context.Context, gvk schema.GroupVersionKind, ns Namespace) (<-chan metav1.Object, error) {
 	return nil, errors.Wrap(ec.err, "could not set up k8s client")
 }
 

--- a/internal/k8s/fake_client.go
+++ b/internal/k8s/fake_client.go
@@ -15,6 +15,7 @@ import (
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -251,8 +252,8 @@ func (c *FakeK8sClient) WatchEvents(ctx context.Context, ns Namespace) (<-chan *
 	return ch, nil
 }
 
-func (c *FakeK8sClient) WatchMeta(ctx context.Context, gvk schema.GroupVersionKind, ns Namespace) (<-chan ObjectMeta, error) {
-	return make(chan ObjectMeta), nil
+func (c *FakeK8sClient) WatchMeta(ctx context.Context, gvk schema.GroupVersionKind, ns Namespace) (<-chan metav1.Object, error) {
+	return make(chan metav1.Object), nil
 }
 
 func (c *FakeK8sClient) EmitPodDelete(p *v1.Pod) {
@@ -360,10 +361,7 @@ func (c *FakeK8sClient) Upsert(ctx context.Context, entities []K8sEntity, timeou
 
 	for _, e := range entities {
 		clone := e.DeepCopy()
-		err = SetUID(&clone, uuid.New().String())
-		if err != nil {
-			return nil, errors.Wrap(err, "Upsert: generating UUID")
-		}
+		clone.SetUID(uuid.New().String())
 		result = append(result, clone)
 	}
 
@@ -407,7 +405,7 @@ func (c *FakeK8sClient) Inject(entities ...K8sEntity) {
 	}
 }
 
-func (c *FakeK8sClient) GetMetaByReference(ctx context.Context, ref v1.ObjectReference) (ObjectMeta, error) {
+func (c *FakeK8sClient) GetMetaByReference(ctx context.Context, ref v1.ObjectReference) (metav1.Object, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -417,10 +415,10 @@ func (c *FakeK8sClient) GetMetaByReference(ctx context.Context, ref v1.ObjectRef
 		logger.Get(ctx).Infof("FakeK8sClient.GetMetaByReference: resource not found: %s", ref.Name)
 		return nil, apierrors.NewNotFound(v1.Resource(ref.Kind), ref.Name)
 	}
-	return resp.meta(), nil
+	return resp.Meta(), nil
 }
 
-func (c *FakeK8sClient) ListMeta(_ context.Context, gvk schema.GroupVersionKind, ns Namespace) ([]ObjectMeta, error) {
+func (c *FakeK8sClient) ListMeta(_ context.Context, gvk schema.GroupVersionKind, ns Namespace) ([]metav1.Object, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -429,7 +427,7 @@ func (c *FakeK8sClient) ListMeta(_ context.Context, gvk schema.GroupVersionKind,
 		return nil, nil
 	}
 
-	result := make([]ObjectMeta, 0)
+	result := make([]metav1.Object, 0)
 	for _, uid := range c.currentVersions {
 		entity := c.entities[uid]
 		if entity.Namespace() != ns {
@@ -438,7 +436,7 @@ func (c *FakeK8sClient) ListMeta(_ context.Context, gvk schema.GroupVersionKind,
 		if entity.GVK() != gvk {
 			continue
 		}
-		result = append(result, entity.meta())
+		result = append(result, entity.Meta())
 	}
 	return result, nil
 }

--- a/internal/k8s/locator_test.go
+++ b/internal/k8s/locator_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/tilt-dev/tilt/internal/container"
 	"github.com/tilt-dev/tilt/internal/k8s/testyaml"
@@ -51,7 +52,7 @@ func TestCRDPullPolicyInjection(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, modified)
 
-	spec := e.maybeUnstructuredMeta().Object["spec"].(map[string]interface{})
+	spec := e.Obj.(*unstructured.Unstructured).Object["spec"].(map[string]interface{})
 	c := spec["containers"].([]interface{})[0].(map[string]interface{})
 	require.Equal(t, "frontend:tilt-123", c["image"])
 	require.Equal(t, "Never", c["imagePullPolicy"].(string))

--- a/internal/k8s/owner_fetcher.go
+++ b/internal/k8s/owner_fetcher.go
@@ -58,7 +58,7 @@ type OwnerFetcher struct {
 	cache     map[types.UID]*objectTreePromise
 	mu        *sync.Mutex
 
-	metaCache       map[types.UID]ObjectMeta
+	metaCache       map[types.UID]metav1.Object
 	resourceFetches map[resourceNamespace]*sync.Once
 }
 
@@ -69,7 +69,7 @@ func ProvideOwnerFetcher(ctx context.Context, kCli Client) OwnerFetcher {
 		cache:     make(map[types.UID]*objectTreePromise),
 		mu:        &sync.Mutex{},
 
-		metaCache:       make(map[types.UID]ObjectMeta),
+		metaCache:       make(map[types.UID]metav1.Object),
 		resourceFetches: make(map[resourceNamespace]*sync.Once),
 	}
 }
@@ -168,7 +168,7 @@ func (v OwnerFetcher) OwnerTreeOfRef(ctx context.Context, ref v1.ObjectReference
 	return v.ownerTreeOfHelper(ctx, ref, meta)
 }
 
-func (v OwnerFetcher) getMetaByReference(ctx context.Context, ref v1.ObjectReference) (ObjectMeta, error) {
+func (v OwnerFetcher) getMetaByReference(ctx context.Context, ref v1.ObjectReference) (metav1.Object, error) {
 	gvk := ReferenceGVK(ref)
 	v.ensureResourceFetched(gvk, Namespace(ref.Namespace))
 
@@ -184,7 +184,7 @@ func (v OwnerFetcher) getMetaByReference(ctx context.Context, ref v1.ObjectRefer
 }
 
 func (v OwnerFetcher) OwnerTreeOf(ctx context.Context, entity K8sEntity) (result ObjectRefTree, err error) {
-	meta := entity.meta()
+	meta := entity.Meta()
 	uid := meta.GetUID()
 	if uid == "" {
 		return ObjectRefTree{}, fmt.Errorf("Can only get owners of deployed entities")
@@ -207,7 +207,7 @@ func (v OwnerFetcher) OwnerTreeOf(ctx context.Context, entity K8sEntity) (result
 	return v.ownerTreeOfHelper(ctx, ref, meta)
 }
 
-func (v OwnerFetcher) ownerTreeOfHelper(ctx context.Context, ref v1.ObjectReference, meta ObjectMeta) (ObjectRefTree, error) {
+func (v OwnerFetcher) ownerTreeOfHelper(ctx context.Context, ref v1.ObjectReference, meta metav1.Object) (ObjectRefTree, error) {
 	tree := ObjectRefTree{Ref: ref}
 	owners := meta.GetOwnerReferences()
 	for _, owner := range owners {

--- a/internal/k8s/owner_fetcher_test.go
+++ b/internal/k8s/owner_fetcher_test.go
@@ -18,7 +18,7 @@ func TestVisitOneParent(t *testing.T) {
 	pod, rs := fakeOneParentChain()
 	kCli.Inject(NewK8sEntity(rs))
 
-	tree, err := ov.OwnerTreeOf(context.Background(), K8sEntity{Obj: pod})
+	tree, err := ov.OwnerTreeOf(context.Background(), NewK8sEntity(pod))
 	assert.NoError(t, err)
 	assert.Equal(t, `Pod:pod-a
   ReplicaSet:rs-a`, tree.String())
@@ -31,7 +31,7 @@ func TestVisitTwoParentsEnsureListCaching(t *testing.T) {
 	pod, rs, dep := fakeTwoParentChain()
 	kCli.Inject(NewK8sEntity(rs), NewK8sEntity(dep))
 
-	tree, err := ov.OwnerTreeOf(context.Background(), K8sEntity{Obj: pod})
+	tree, err := ov.OwnerTreeOf(context.Background(), NewK8sEntity(pod))
 	assert.NoError(t, err)
 	assert.Equal(t, `Pod:pod-a
   ReplicaSet:rs-a
@@ -48,7 +48,7 @@ func TestVisitTwoParentsNoList(t *testing.T) {
 	pod, rs, dep := fakeTwoParentChain()
 	kCli.Inject(NewK8sEntity(rs), NewK8sEntity(dep))
 
-	tree, err := ov.OwnerTreeOf(context.Background(), K8sEntity{Obj: pod})
+	tree, err := ov.OwnerTreeOf(context.Background(), NewK8sEntity(pod))
 	assert.NoError(t, err)
 	assert.Equal(t, `Pod:pod-a
   ReplicaSet:rs-a

--- a/internal/k8s/watch_test.go
+++ b/internal/k8s/watch_test.go
@@ -329,7 +329,7 @@ func TestK8sClient_WatchMeta(t *testing.T) {
 		&metav1.PartialObjectMetadata{TypeMeta: pod2.TypeMeta, ObjectMeta: pod2.ObjectMeta},
 		metav1.CreateOptions{})
 
-	expected := []*metav1.ObjectMeta{&pod1.ObjectMeta, &pod2.ObjectMeta}
+	expected := []metav1.Object{&pod1.ObjectMeta, &pod2.ObjectMeta}
 	tf.assertMeta(expected, ch)
 }
 
@@ -345,7 +345,7 @@ func TestK8sClient_WatchMetaBackfillK8s14(t *testing.T) {
 
 	tf.addObjects(pod1, pod2)
 
-	expected := []*metav1.ObjectMeta{&pod1.ObjectMeta, &pod2.ObjectMeta}
+	expected := []metav1.Object{pod1, pod2}
 	tf.assertMeta(expected, ch)
 }
 
@@ -509,7 +509,7 @@ func (tf *watchTestFixture) watchEvents() <-chan *v1.Event {
 	return ch
 }
 
-func (tf *watchTestFixture) watchMeta(gvr schema.GroupVersionKind) <-chan ObjectMeta {
+func (tf *watchTestFixture) watchMeta(gvr schema.GroupVersionKind) <-chan metav1.Object {
 	ch, err := tf.kCli.WatchMeta(tf.ctx, gvr, tf.kCli.configNamespace)
 	if err != nil {
 		tf.t.Fatalf("watchMeta: %v", err)
@@ -615,8 +615,8 @@ func (tf *watchTestFixture) assertEvents(expectedOutput []runtime.Object, ch <-c
 	assert.ElementsMatch(tf.t, expectedOutput, observedEvents)
 }
 
-func (tf *watchTestFixture) assertMeta(expected []*metav1.ObjectMeta, ch <-chan ObjectMeta) {
-	var observed []*metav1.ObjectMeta
+func (tf *watchTestFixture) assertMeta(expected []metav1.Object, ch <-chan metav1.Object) {
+	var observed []metav1.Object
 
 	done := false
 	for !done {
@@ -625,7 +625,7 @@ func (tf *watchTestFixture) assertMeta(expected []*metav1.ObjectMeta, ch <-chan 
 			if !ok {
 				done = true
 			} else {
-				observed = append(observed, m.(*metav1.ObjectMeta))
+				observed = append(observed, m)
 			}
 		case <-time.After(200 * time.Millisecond):
 			// if we haven't seen any events for 10ms, assume we're done


### PR DESCRIPTION
Hello @landism, @milas,

Please review the following commits I made in branch nicks/entity:

60b63fcbc1a670905f4653adff5846eb3a4f4248 (2021-06-28 19:00:43 -0400)
k8s: remove our homegrown meta Accessor in favor of apimachinery's

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics