### PR TITLE
hud: improve 'entity too large' errors and raise limit

### DIFF
--- a/internal/engine/configs/api.go
+++ b/internal/engine/configs/api.go
@@ -27,6 +27,7 @@ var ownerSelector = labels.SelectorFromSet(labels.Set{LabelOwnerKind: LabelOwner
 type object interface {
 	ctrlclient.Object
 	GetSpec() interface{}
+	GetGroupVersionResource() schema.GroupVersionResource
 }
 
 type objectSet map[schema.GroupVersionResource]typedObjectSet
@@ -196,7 +197,7 @@ func updateObjects(ctx context.Context, client ctrlclient.Client, newObjects, ol
 			if old == nil {
 				err := client.Create(ctx, obj)
 				if err != nil {
-					errs = append(errs, err)
+					errs = append(errs, fmt.Errorf("create %s/%s: %v", obj.GetGroupVersionResource().Resource, obj.GetName(), err))
 				}
 				continue
 			}
@@ -208,7 +209,7 @@ func updateObjects(ctx context.Context, client ctrlclient.Client, newObjects, ol
 				obj.SetResourceVersion(old.GetResourceVersion())
 				err := client.Update(ctx, obj)
 				if err != nil {
-					errs = append(errs, err)
+					errs = append(errs, fmt.Errorf("update %s/%s: %v", obj.GetGroupVersionResource().Resource, obj.GetName(), err))
 				}
 				continue
 			}
@@ -228,7 +229,7 @@ func updateObjects(ctx context.Context, client ctrlclient.Client, newObjects, ol
 
 			err := client.Delete(ctx, obj)
 			if err != nil {
-				errs = append(errs, err)
+				errs = append(errs, fmt.Errorf("delete %s/%s: %v", obj.GetGroupVersionResource().Resource, obj.GetName(), err))
 			}
 		}
 	}


### PR DESCRIPTION
Hello @milas,

Please review the following commits I made in branch nicks/entity-too-large:

27a5b010d06f87c384c9769bc36b677b9a5c4a29 (2021-06-28 19:54:20 -0400)
hud: improve 'entity too large' errors and raise limit

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics