### PR TITLE
web: add a subscribe link in the update dialog

### DIFF
--- a/web/src/UpdateDialog.tsx
+++ b/web/src/UpdateDialog.tsx
@@ -83,11 +83,18 @@ export default function UpdateDialog(props: props) {
     )
   } else {
     updateEl = (
-      <div key="no-update">Already on the recommended version! Nice work.</div>
+      <div key="no-update">
+        <div>Already on the recommended version!</div>
+        <div>
+          If you're impatient for more,
+          <br />
+          subscribe to <a href="https://tilt.dev/subscribe">Tilt News</a>.
+        </div>
+      </div>
     )
   }
 
-  let title = props.showUpdate ? "Updates Available" : "Tilt Version"
+  let title = props.showUpdate ? "Updates Available" : "Update Status"
   return (
     <FloatDialog id="update" title={title} {...props}>
       {updateEl}


### PR DESCRIPTION
Hello @hyu, @ellenkorbes,

Please review the following commits I made in branch nicks/update2:

03b6cad38b64e1676046d5062662c8cdf316fef1 (2021-06-29 17:50:38 -0400)
web: add a subscribe link in the update dialog
My thinking is that if you're clicking around for updates,
you probably care about tilt news more than most people.

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics