### PR TITLE
docker-compose: do not force recreate on up

### DIFF
--- a/internal/dockercompose/client.go
+++ b/internal/dockercompose/client.go
@@ -77,14 +77,6 @@ func (c *cmdDCClient) Up(ctx context.Context, configPaths []string, serviceName 
 	runArgs := append([]string{}, genArgs...)
 	runArgs = append(runArgs, "up", "--no-deps", "--no-build", "-d")
 
-	if !shouldBuild {
-		// !shouldBuild implies that Tilt will take care of building, which implies that
-		// we should recreate container so that we pull the new image
-		// NOTE(maia): this is maybe the WRONG thing to do if we're deploying a service
-		// but none of the code changed (i.e. it was just a dockercompose.yml change)?
-		runArgs = append(runArgs, "--force-recreate")
-	}
-
 	runArgs = append(runArgs, serviceName.String())
 	cmd := c.dcCommand(ctx, runArgs)
 	cmd.Stdout = stdout


### PR DESCRIPTION
From the Docker Compose[1] docs:
```
--force-recreate    Recreate containers even if their configuration
                    and image haven't changed.
```

We are currently always passing this flag when Tilt is handling the
build (vs `docker-compose build`). However, Docker Compose already
checks if the image it's using is outdated; if it is, it will stop
the existing container and create a new one with the updated image
(and/or config). If the image and config are the same, it will not
replace them.

It looks like the flag has been in place since the original
implementation of Docker Compose code in Tilt, so wasn't a reaction
to any other sort of regression.

In general, it doesn't matter because Tilt only calls
`docker-compose up` after it has done a build. However, when
re-launching Tilt where an already running `docker-compose` session
is active and changes haven't been made, this means after the (fully
cached) image rebuild happens, we'll force the containers to get
recreated, which slows things down.

[1]: https://docs.docker.com/compose/reference/up/