### PR TITLE
cmd: remove redundant fields

### DIFF
--- a/internal/controllers/core/cmd/execer_test.go
+++ b/internal/controllers/core/cmd/execer_test.go
@@ -216,7 +216,6 @@ func newProcessExecFixture(t *testing.T) *processExecFixture {
 	testWriter := bufsync.NewThreadSafeBuffer()
 	ctx, _, _ := testutils.ForkedCtxAndAnalyticsForTest(testWriter)
 	ctx, cancel := context.WithCancel(ctx)
-	statusCh := make(chan statusAndMetadata)
 
 	return &processExecFixture{
 		t:          t,
@@ -224,7 +223,6 @@ func newProcessExecFixture(t *testing.T) *processExecFixture {
 		cancel:     cancel,
 		execer:     execer,
 		testWriter: testWriter,
-		statusCh:   statusCh,
 	}
 }
 
@@ -234,13 +232,13 @@ func (f *processExecFixture) tearDown() {
 
 func (f *processExecFixture) startMalformedCommand() {
 	c := model.Cmd{Argv: []string{"\""}, Dir: "."}
-	f.execer.Start(f.ctx, c, f.testWriter, f.statusCh, model.LogSpanID("rt1"))
+	f.statusCh = f.execer.Start(f.ctx, c, f.testWriter)
 }
 
 func (f *processExecFixture) startWithWorkdir(cmd string, workdir string) {
 	c := model.ToHostCmd(cmd)
 	c.Dir = workdir
-	f.execer.Start(f.ctx, c, f.testWriter, f.statusCh, model.LogSpanID("rt1"))
+	f.statusCh = f.execer.Start(f.ctx, c, f.testWriter)
 }
 
 func (f *processExecFixture) start(cmd string) {


### PR DESCRIPTION
Hello @landism, @milas,

Please review the following commits I made in branch nicks/cmd2:

15142a7bd29f5191230674b83ba903b548d8e256 (2021-06-30 18:10:54 -0400)
cmd: remove redundant fields
- the spanID field was never used
- statusCh and doneCh had the same close() semantics, so we can make one depend on the other

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics