### PR TITLE
watch: upgrade fsnotify to fix spurious file changed on Windows

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -65,7 +65,7 @@ require (
 	github.com/theupdateframework/notary v0.6.1 // indirect
 	github.com/tilt-dev/dockerignore v0.0.0-20200910202654-0d8c17a73277
 	github.com/tilt-dev/fsevents v0.0.0-20200515134857-2efe37af20de
-	github.com/tilt-dev/fsnotify v1.4.8-0.20210420175148-fb09a0d02ca7
+	github.com/tilt-dev/fsnotify v1.4.8-0.20210701141043-dd524499d3fe
 	github.com/tilt-dev/go-get v0.0.0-20200911222649-1acd29546527
 	github.com/tilt-dev/localregistry-go v0.0.0-20200615231835-07e386f4ebd7
 	github.com/tilt-dev/probe v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -1080,6 +1080,8 @@ github.com/tilt-dev/fsevents v0.0.0-20200515134857-2efe37af20de h1:tG+nJMUUxV7MJ
 github.com/tilt-dev/fsevents v0.0.0-20200515134857-2efe37af20de/go.mod h1:1jUbPVh7Ani2CSublmvP7+zqTgR06A8Y0MKU9Xr2L5s=
 github.com/tilt-dev/fsnotify v1.4.8-0.20210420175148-fb09a0d02ca7 h1:TQIuhMvYgU9wE6fVzo/m+zIYPfyxFATeMXGYHderFmM=
 github.com/tilt-dev/fsnotify v1.4.8-0.20210420175148-fb09a0d02ca7/go.mod h1:9wJjkpCk7ADlLOAl+yIXbHwnMoV9i0+uLr9CG3D5434=
+github.com/tilt-dev/fsnotify v1.4.8-0.20210701141043-dd524499d3fe h1:dULiU6eWdUfLAO0URJz+k1zEN5B3rPS5Iupr4Srd/yk=
+github.com/tilt-dev/fsnotify v1.4.8-0.20210701141043-dd524499d3fe/go.mod h1:9wJjkpCk7ADlLOAl+yIXbHwnMoV9i0+uLr9CG3D5434=
 github.com/tilt-dev/go-get v0.0.0-20200911222649-1acd29546527 h1:Vs10qGgqW8K/2+mOlYmZIDrpKL30jAoDNHN4kSkbi+8=
 github.com/tilt-dev/go-get v0.0.0-20200911222649-1acd29546527/go.mod h1:sqJ1OH6ggqbd2+J5TFsDGP/CXeRAXBxR52m5FtL0+xo=
 github.com/tilt-dev/json-patch/v4 v4.8.1 h1:AbrhK3NMDfk/+/oMXz3NcKaCNwHYdhUJMDjBHNOHF5o=

--- a/vendor/github.com/tilt-dev/fsnotify/README.md
+++ b/vendor/github.com/tilt-dev/fsnotify/README.md
@@ -6,6 +6,16 @@ Fork of https://github.com/fsnotify/fsnotify
 
 Contains patches for Tilt Dev.
 
+### Notable Changes
+* [macOS] Fix for panic when debugging ([fsnotify/fsnotify#212](https://github.com/fsnotify/fsnotify/issues/212))
+* [Windows] Recursive watch support
+* [Windows] Customizable buffer size
+* [Windows] File attribute changes are ignored
+  * No `Chmod` operations will be detected or returned on Windows because the underlying Windows API does not support
+    distinguishing these from `Write` operations
+  * Some software (likely AV/security) can cause excessive attribute changes resulting in many spurious write events
+    for otherwise unchanged files
+
 ## Original Readme
 
 [![GoDoc](https://godoc.org/github.com/fsnotify/fsnotify?status.svg)](https://godoc.org/github.com/fsnotify/fsnotify) [![Go Report Card](https://goreportcard.com/badge/github.com/fsnotify/fsnotify)](https://goreportcard.com/report/github.com/fsnotify/fsnotify)
@@ -135,4 +145,3 @@ fsnotify requires support from underlying OS to work. The current NFS protocol d
 
 * [notify](https://github.com/rjeczalik/notify)
 * [fsevents](https://github.com/fsnotify/fsevents)
-

--- a/vendor/github.com/tilt-dev/fsnotify/windows.go
+++ b/vendor/github.com/tilt-dev/fsnotify/windows.go
@@ -92,10 +92,33 @@ func (w *Watcher) Add(name string) error {
 	if w.isClosed {
 		return errors.New("watcher already closed")
 	}
+
+	// When reporting file notifications, FILE_ACTION_MODIFIED includes changes to file attributes;
+	// so attribute handling is broken for Windows (op.Chmod will NEVER get used in practice).
+	//
+	// To prevent events for attribute changes erroneously showing up as file modifications,
+	// FILE_NOTIFY_CHANGE_ATTRIBUTES (sysFSATTRIB) is excluded from the notify filter.
+	//
+	// This means attribute changes will NOT be detected on Windows, as this has been deemed
+	// better than misreporting them as file modifications.
+	//
+	// For most purposes, especially since there is no execute bit in Windows/NTFS, these events
+	// are uninteresting, but it appears some security/AV/backup software can trigger excessive
+	// attribute changes resulting in lots of events for otherwise unchanged files.
+	//
+	// To accurately get Chmod events, a substantial refactor would be needed to set up two
+	// underlying watchers - one with a FILE_NOTIFY_CHANGE_ATTRIBUTES filter and another with
+	// the remaining filters, so that attribute changes can be reliably detected.
+	//
+	// See also:
+	// 	* ReadDirectoryChangesW flags: https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-readdirectorychangesw
+	// 	* FILE_NOTIFY_INFORMATION: https://docs.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-file_notify_information
+	flags := sysFSCREATE | sysFSDELETE | sysFSDELETESELF | sysFSMODIFY | sysFSMOVEDFROM | sysFSMOVEDTO | sysFSMOVESELF
+
 	in := &input{
 		op:    opAddWatch,
 		path:  filepath.Clean(name),
-		flags: sysFSALLEVENTS,
+		flags: uint32(flags),
 		reply: make(chan error),
 	}
 	w.input <- in

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -510,7 +510,7 @@ github.com/tilt-dev/dockerignore
 # github.com/tilt-dev/fsevents v0.0.0-20200515134857-2efe37af20de
 ## explicit
 github.com/tilt-dev/fsevents
-# github.com/tilt-dev/fsnotify v1.4.8-0.20210420175148-fb09a0d02ca7
+# github.com/tilt-dev/fsnotify v1.4.8-0.20210701141043-dd524499d3fe
 ## explicit
 github.com/tilt-dev/fsnotify
 # github.com/tilt-dev/go-get v0.0.0-20200911222649-1acd29546527


### PR DESCRIPTION
Ignore file attribute changes on Windows.

See https://github.com/tilt-dev/fsnotify/pull/8 for details.

Fixes #4706.