### PR TITLE
kubernetesdiscovery: propagate PodLogStreamTemplate

### DIFF
--- a/pkg/apis/core/v1alpha1/generated.proto
+++ b/pkg/apis/core/v1alpha1/generated.proto
@@ -685,6 +685,9 @@ message KubernetesDiscoverySpec {
   // The KubernetesDiscovery controller will attach PodLogStream objects
   // to all active pods it discovers.
   //
+  // If no template is specified, the controller will stream all
+  // pod logs available from the apiserver.
+  //
   // +optional
   optional PodLogStreamTemplateSpec podLogStreamTemplateSpec = 4;
 }

--- a/pkg/apis/core/v1alpha1/kubernetesdiscovery_types.go
+++ b/pkg/apis/core/v1alpha1/kubernetesdiscovery_types.go
@@ -76,11 +76,15 @@ type KubernetesDiscoverySpec struct {
 	//
 	// +optional
 	PortForwardTemplateSpec *PortForwardTemplateSpec `json:"portForwardTemplateSpec,omitempty" protobuf:"bytes,3,opt,name=portForwardTemplateSpec"`
+
 	// PodLogStreamTemplateSpec describes the data model for PodLogStreams
 	// that KubernetesDiscovery should set up.
 	//
 	// The KubernetesDiscovery controller will attach PodLogStream objects
 	// to all active pods it discovers.
+	//
+	// If no template is specified, the controller will stream all
+	// pod logs available from the apiserver.
 	//
 	// +optional
 	PodLogStreamTemplateSpec *PodLogStreamTemplateSpec `json:"podLogStreamTemplateSpec,omitempty" protobuf:"bytes,4,opt,name=podLogStreamTemplateSpec"`

--- a/pkg/openapi/zz_generated.openapi.go
+++ b/pkg/openapi/zz_generated.openapi.go
@@ -1804,7 +1804,7 @@ func schema_pkg_apis_core_v1alpha1_KubernetesDiscoverySpec(ref common.ReferenceC
 					},
 					"podLogStreamTemplateSpec": {
 						SchemaProps: spec.SchemaProps{
-							Description: "PodLogStreamTemplateSpec describes the data model for PodLogStreams that KubernetesDiscovery should set up.\n\nThe KubernetesDiscovery controller will attach PodLogStream objects to all active pods it discovers.",
+							Description: "PodLogStreamTemplateSpec describes the data model for PodLogStreams that KubernetesDiscovery should set up.\n\nThe KubernetesDiscovery controller will attach PodLogStream objects to all active pods it discovers.\n\nIf no template is specified, the controller will stream all pod logs available from the apiserver.",
 							Ref:         ref("github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1.PodLogStreamTemplateSpec"),
 						},
 					},


### PR DESCRIPTION
Hello @milas,

Please review the following commits I made in branch nicks/pls2:

25351dd0f0122e8a2fa87a37352f22b77ce0a745 (2021-07-02 15:47:36 -0400)
kubernetesdiscovery: propagate PodLogStreamTemplate

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics