### PR TITLE
web: Fix scrolling bug with Table Overview

### DIFF
--- a/web/src/GlobalNav.tsx
+++ b/web/src/GlobalNav.tsx
@@ -30,7 +30,6 @@ export const MenuButtonLabel = styled.div`
   bottom: 0;
   font-size: ${FontSize.smallest};
   color: ${Color.blueDark};
-  width: 200%;
   transition: opacity ${AnimDuration.default} ease;
   opacity: 0;
 `
@@ -193,7 +192,7 @@ export function GlobalNav(props: GlobalNavProps) {
   let snapshotButton = props.snapshot.enabled ? (
     <MenuButton onClick={props.snapshot.openModal}>
       <SnapshotIcon width="24" height="24" />
-      <MenuButtonLabel>Make Snapshot</MenuButtonLabel>
+      <MenuButtonLabel>Snapshot</MenuButtonLabel>
     </MenuButton>
   ) : null
 
@@ -210,7 +209,7 @@ export function GlobalNav(props: GlobalNavProps) {
           className={props.showUpdate ? "is-visible" : ""}
         />
         <MenuButtonLabel>
-          {props.showUpdate ? "Update Available" : "Tilt Version"}
+          {props.showUpdate ? "Update!" : "Version"}
         </MenuButtonLabel>
       </MenuButton>
 

--- a/web/src/GlobalNav.tsx
+++ b/web/src/GlobalNav.tsx
@@ -32,6 +32,7 @@ export const MenuButtonLabel = styled.div`
   color: ${Color.blueDark};
   transition: opacity ${AnimDuration.default} ease;
   opacity: 0;
+  white-space: nowrap;
 `
 export const MenuButtonMixin = `
   ${mixinResetButtonStyle};
@@ -209,7 +210,7 @@ export function GlobalNav(props: GlobalNavProps) {
           className={props.showUpdate ? "is-visible" : ""}
         />
         <MenuButtonLabel>
-          {props.showUpdate ? "Update!" : "Version"}
+          {props.showUpdate ? "Get Update" : "Version"}
         </MenuButtonLabel>
       </MenuButton>
 

--- a/web/src/OverviewResourcePane.tsx
+++ b/web/src/OverviewResourcePane.tsx
@@ -81,12 +81,6 @@ export default function OverviewResourcePane(props: OverviewResourcePaneProps) {
       b.spec.location.componentID === name
   )
 
-  // Hide the HTML element scrollbars, since this pane does all scrolling internally.
-  // TODO(nick): Remove this when the old UI is deleted.
-  useEffect(() => {
-    document.documentElement.style.overflow = "hidden"
-  })
-
   return (
     <OverviewResourcePaneRoot>
       <HeaderBar view={props.view} />

--- a/web/src/index.scss
+++ b/web/src/index.scss
@@ -3,10 +3,6 @@
 html {
   width: 100%;
   height: 100%;
-
-  // Ensure that the scrollbar doesn't appear/disappear
-  // when switching between log panes.
-  overflow-y: scroll;
 }
 body {
   margin: 0;


### PR DESCRIPTION
There was an issue where if you go to the Log view and then back to Table Overview, you could no longer scroll down the page! This is now fixed in this PR.

We had some legacy code that was preventing scrolling, which was supposed to be deleted along with our old UI.

Also, I found that an overly long label in the header was causing the layout to be too wide and create scrollbars!