### PR TITLE
tiltfile: add `module`

### DIFF
--- a/internal/tiltfile/starlarkstruct/struct.go
+++ b/internal/tiltfile/starlarkstruct/struct.go
@@ -14,5 +14,15 @@ func NewExtension() Extension {
 }
 
 func (e Extension) OnStart(env *starkit.Environment) error {
-	return env.AddBuiltin("struct", starlarkstruct.Make)
+	err := env.AddBuiltin("struct", starlarkstruct.Make)
+	if err != nil {
+		return err
+	}
+
+	err = env.AddBuiltin("module", starlarkstruct.MakeModule)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/internal/tiltfile/starlarkstruct/struct_test.go
+++ b/internal/tiltfile/starlarkstruct/struct_test.go
@@ -21,6 +21,21 @@ print("b",x.b)
 	require.Contains(t, f.PrintOutput(), "b 2")
 }
 
+func TestModule(t *testing.T) {
+	f := NewFixture(t)
+	f.File("Tiltfile", `
+x = module("test_module", a = "foo", b = 2)
+print("a",x.a)
+print("b",x.b)
+print("x",x)
+`)
+	_, err := f.ExecFile("Tiltfile")
+	require.NoError(t, err)
+	require.Contains(t, f.PrintOutput(), "a foo")
+	require.Contains(t, f.PrintOutput(), "b 2")
+	require.Contains(t, f.PrintOutput(), "x <module \"test_module\">")
+}
+
 func NewFixture(tb testing.TB) *starkit.Fixture {
 	return starkit.NewFixture(tb, NewExtension())
 }


### PR DESCRIPTION
from (starlark-go)[https://github.com/google/starlark-go/blob/master/starlarkstruct/module.go#L9-L13]:
```
// A Module is a named collection of values,
// typically a suite of functions imported by a load statement.
//
// It differs from Struct primarily in that its string representation
// does not enumerate its fields.
```

This can be handy for Tiltfile extensions where you want multiple symbols, to allow, e.g., `load('ext://myextension', 'myextension')` and then `myextension.foo(myextension.bar)`