### PR TITLE
web: Add basic display of labeled resources in Storybook behind feature flag

### DIFF
--- a/internal/feature/flags.go
+++ b/internal/feature/flags.go
@@ -23,6 +23,7 @@ const Events = "events"
 const Snapshots = "snapshots"
 const UpdateHistory = "update_history"
 const Facets = "facets"
+const Labels = "labels"
 
 // The Value a flag can have. Status should never be changed.
 type Value struct {
@@ -55,6 +56,10 @@ var MainDefaults = Defaults{
 	Facets: Value{
 		Enabled: true,
 		Status:  Obsolete,
+	},
+	Labels: Value{
+		Enabled: false,
+		Status:  Active,
 	},
 }
 

--- a/web/src/HUD.tsx
+++ b/web/src/HUD.tsx
@@ -9,7 +9,7 @@ import AnalyticsNudge from "./AnalyticsNudge"
 import AppController from "./AppController"
 import ErrorModal from "./ErrorModal"
 import FatalErrorModal from "./FatalErrorModal"
-import Features, { FeaturesProvider } from "./feature"
+import Features, { FeaturesProvider, Flag } from "./feature"
 import HeroScreen from "./HeroScreen"
 import "./HUD.scss"
 import HudState from "./HudState"
@@ -235,7 +235,7 @@ export default class HUD extends Component<HudProps, HudState> {
   renderOverviewSwitch() {
     const features = this.getFeatures()
     let showSnapshot =
-      features.isEnabled("snapshots") && !this.pathBuilder.isSnapshot()
+      features.isEnabled(Flag.Snapshots) && !this.pathBuilder.isSnapshot()
     let snapshotAction = {
       enabled: showSnapshot,
       openModal: this.handleOpenModal,

--- a/web/src/OverviewResourceSidebar.stories.tsx
+++ b/web/src/OverviewResourceSidebar.stories.tsx
@@ -1,10 +1,13 @@
 import React from "react"
 import { MemoryRouter } from "react-router"
+import Features, { FeaturesProvider, Flag } from "./feature"
 import OverviewResourceSidebar from "./OverviewResourceSidebar"
 import PathBuilder from "./PathBuilder"
 import {
   nResourceView,
   oneResource,
+  oneResourceCrashedOnStart,
+  oneResourceFailedToBuild,
   oneResourceNoAlerts,
   oneResourceTest,
   tenResourceView,
@@ -19,14 +22,30 @@ let pathBuilder = PathBuilder.forTesting("localhost", "/")
 export default {
   title: "New UI/Log View/OverviewResourceSidebar",
   decorators: [
-    (Story: any) => (
-      <MemoryRouter initialEntries={["/"]}>
-        <div style={{ margin: "-1rem", height: "80vh" }}>
-          <Story />
-        </div>
-      </MemoryRouter>
-    ),
+    (Story: any, context: any) => {
+      const features = new Features({
+        [Flag.Labels]: context?.args?.labelsEnabled ?? true,
+      })
+      return (
+        <MemoryRouter initialEntries={["/"]}>
+          <FeaturesProvider value={features}>
+            <div style={{ margin: "-1rem", height: "80vh" }}>
+              <Story />
+            </div>
+          </FeaturesProvider>
+        </MemoryRouter>
+      )
+    },
   ],
+  argTypes: {
+    labelsEnabled: {
+      name: "Group resources by label enabled",
+      control: {
+        type: "boolean",
+      },
+      defaultValue: true,
+    },
+  },
 }
 
 export const TwoResources = () => (
@@ -40,6 +59,40 @@ export const TenResources = () => (
 export const OneHundredResources = () => (
   <OverviewResourceSidebar name={"vigoda_1"} view={nResourceView(100)} />
 )
+
+export const ResourcesWithLabels = () => {
+  const view = nResourceView(10)
+  for (let i = 0; i < 10; i++) {
+    const resourceMetadata: Proto.v1ObjectMeta = { name: `resource_${i}` }
+    view.uiResources[i].metadata = resourceMetadata
+    resourceMetadata.labels = {}
+    if (i < 5) {
+      resourceMetadata.labels["frontend"] = "frontend"
+    }
+    if (i % 2) {
+      resourceMetadata.labels["test"] = "test"
+    }
+  }
+
+  // Non-happy path resources
+  const [failedBuild] = oneResourceFailedToBuild()
+  failedBuild.metadata!.labels = {
+    test: "test",
+    backend: "backend",
+  }
+  failedBuild.metadata!.name = "resource_11"
+  view.uiResources.push(failedBuild)
+
+  const [crashedStart] = oneResourceCrashedOnStart()
+  crashedStart.metadata!.labels = {
+    javascript: "javascript",
+    backend: "frontend",
+  }
+  crashedStart.metadata!.name = "resource_12"
+  view.uiResources.push(crashedStart)
+
+  return <OverviewResourceSidebar name={"vigoda_1"} view={view} />
+}
 
 export function TwoResourcesTwoTests() {
   let all: UIResource[] = [

--- a/web/src/SidebarItem.tsx
+++ b/web/src/SidebarItem.tsx
@@ -1,5 +1,6 @@
 import moment from "moment"
 import { buildAlerts, runtimeAlerts } from "./alerts"
+import { getUiLabels } from "./labels"
 import { buildStatus, runtimeStatus } from "./status"
 import { timeDiff } from "./time"
 import { ResourceName, ResourceStatus, TriggerMode } from "./types"
@@ -17,6 +18,7 @@ class SidebarItem {
   runtimeStatus: ResourceStatus
   runtimeAlertCount: number
   hasEndpoints: boolean
+  labels: string[]
   lastBuildDur: moment.Duration | null
   lastDeployTime: string
   pendingBuildSince: string
@@ -33,7 +35,6 @@ class SidebarItem {
     let status = (res.status || {}) as UIResourceStatus
     let buildHistory = status.buildHistory || []
     let lastBuild = buildHistory.length > 0 ? buildHistory[0] : null
-
     this.name = res.metadata?.name ?? ""
     this.isTiltfile = this.name === ResourceName.tiltfile
     this.isTest = !!status.localResourceInfo?.isTest
@@ -42,6 +43,7 @@ class SidebarItem {
     this.runtimeStatus = runtimeStatus(res)
     this.runtimeAlertCount = runtimeAlerts(res, null).length
     this.hasEndpoints = (status.endpointLinks || []).length > 0
+    this.labels = getUiLabels({ labels: res.metadata?.labels })
     this.lastBuildDur =
       lastBuild && lastBuild.startTime && lastBuild.finishTime
         ? timeDiff(lastBuild.startTime, lastBuild.finishTime)

--- a/web/src/feature.test.ts
+++ b/web/src/feature.test.ts
@@ -1,23 +1,23 @@
-import Features from "./feature"
+import Features, { Flag } from "./feature"
 
 describe("feature", () => {
   it("returns false if the feature does not exist", () => {
     let features = new Features({})
-    expect(features.isEnabled("foo")).toBe(false)
+    expect(features.isEnabled("foo" as Flag)).toBe(false)
   })
 
   it("returns false if the feature does exist and is false", () => {
     let features = new Features({ foo: false })
-    expect(features.isEnabled("foo")).toBe(false)
+    expect(features.isEnabled("foo" as Flag)).toBe(false)
   })
 
   it("returns true if the feature does exist and is true", () => {
     let features = new Features({ foo: true })
-    expect(features.isEnabled("foo")).toBe(true)
+    expect(features.isEnabled("foo" as Flag)).toBe(true)
   })
 
   it("still works if null is passed in", () => {
     let features = new Features(null)
-    expect(features.isEnabled("foo")).toBe(false)
+    expect(features.isEnabled("foo" as Flag)).toBe(false)
   })
 })

--- a/web/src/feature.ts
+++ b/web/src/feature.ts
@@ -5,7 +5,18 @@
 // until the first engine state comes in over the Websocket.
 import { createContext, useContext } from "react"
 
-type featureFlags = { [featureFlag: string]: boolean }
+type featureFlags = { [featureFlag in Flag]?: boolean }
+
+// Flag names are defined in internal/feature/flags.go
+export enum Flag {
+  MultipleContainersPerPod = "multiple_containers_per_pod",
+  Events = "events",
+  Snapshots = "snapshots",
+  UpdateHistory = "update_history",
+  Facets = "facets",
+  Labels = "labels",
+}
+
 export default class Features {
   private flags: featureFlags
 
@@ -17,9 +28,9 @@ export default class Features {
     }
   }
 
-  public isEnabled(flag: string): boolean {
+  public isEnabled(flag: Flag): boolean {
     if (this.flags.hasOwnProperty(flag)) {
-      return this.flags[flag]
+      return this.flags[flag] as boolean
     }
     return false
   }

--- a/web/src/labels.ts
+++ b/web/src/labels.ts
@@ -1,0 +1,23 @@
+// Helper functions for working with labels
+
+type UILabels = Pick<Proto.v1ObjectMeta, "labels">
+
+// TODO (LT): Add a lil' explanation here about k8s use of labels
+// and why we filter out labels with prefixes
+export function getUiLabels({ labels }: UILabels) {
+  if (!labels) {
+    return []
+  }
+
+  return Object.keys(labels)
+    .filter((labelKey) => {
+      const labelHasPrefix = labelKey.includes("/")
+      return !labelHasPrefix
+    })
+    .map((labelKey) => labels[labelKey])
+}
+
+// Order labels alphabetically A - Z
+export function orderLabels(labels: string[]) {
+  return [...labels].sort((a, b) => a.localeCompare(b))
+}

--- a/web/src/view.d.ts
+++ b/web/src/view.d.ts
@@ -293,7 +293,7 @@ declare namespace Proto {
      */
     deletionTimestamp?: string;
     deletionGracePeriodSeconds?: string;
-    labels?: object;
+    labels?: {[key: string]: string};
     annotations?: object;
     ownerReferences?: v1OwnerReference[];
     finalizers?: string[];

--- a/web/storybook.tiltfile
+++ b/web/storybook.tiltfile
@@ -33,3 +33,5 @@ local_resource(
   'CI=true yarn test -u',
   auto_init=False,
   trigger_mode=TRIGGER_MODE_MANUAL)
+
+enable_feature("labels")


### PR DESCRIPTION
This PR adds basic resource grouping by label using mocked data in Storybook and the `labels` feature flag (which can be toggled in Storybook) for [ch12250](https://app.clubhouse.io/windmill/story/12250/display-label-headings-and-resource-groups-behind-feature-flag). I haven't added any label-specific styles yet, since I want to use the MaterialUI [accordion](https://material-ui.com/components/accordion/#accordion) component and thought that would make this PR too large. (I'll tackle the styles and accordion functionality next for [ch12252](https://app.clubhouse.io/windmill/story/12252/add-expand-collapse-functionality-for-label-groups)).

With feature flag off, everything should remain the same:
![Screen Shot 2021-07-08 at 6 10 57 PM](https://user-images.githubusercontent.com/23283986/124997763-356be600-e019-11eb-89f6-e17d2db2574f.png)

With feature flag on, resources appear under each label they have, with unlabeled resources at the bottom:
![Screen Shot 2021-07-08 at 6 11 12 PM](https://user-images.githubusercontent.com/23283986/124997765-356be600-e019-11eb-858e-546cb6fcfd06.png)

![2021-07-08 18 23 06](https://user-images.githubusercontent.com/23283986/124998132-e1153600-e019-11eb-9567-af02c174dac0.gif)