### PR TITLE
k8s: don't emit a PortForwardTemplate on 0 port-forwards

### DIFF
--- a/internal/k8s/target.go
+++ b/internal/k8s/target.go
@@ -79,9 +79,7 @@ func NewTarget(
 				string(container.IstioSidecarContainerName),
 			},
 		},
-		PortForwardTemplateSpec: &v1alpha1.PortForwardTemplateSpec{
-			Forwards: modelForwardsToApiForwards(portForwards),
-		},
+		PortForwardTemplateSpec: toPortForwardTemplateSpec(portForwards),
 	}
 
 	return model.K8sTarget{
@@ -141,7 +139,12 @@ func ParseImageLocators(locators []v1alpha1.KubernetesImageLocator) ([]ImageLoca
 	return result, nil
 }
 
-func modelForwardsToApiForwards(forwards []model.PortForward) []v1alpha1.Forward {
+// Creates a port-forward template if necessary. Returns nil if no port-forwards.
+func toPortForwardTemplateSpec(forwards []model.PortForward) *v1alpha1.PortForwardTemplateSpec {
+	if len(forwards) == 0 {
+		return nil
+	}
+
 	res := make([]v1alpha1.Forward, len(forwards))
 	for i, fwd := range forwards {
 		res[i] = v1alpha1.Forward{
@@ -150,7 +153,9 @@ func modelForwardsToApiForwards(forwards []model.PortForward) []v1alpha1.Forward
 			Host:          fwd.Host,
 		}
 	}
-	return res
+	return &v1alpha1.PortForwardTemplateSpec{
+		Forwards: res,
+	}
 }
 
 func SetsAsLabelSelectors(sets []labels.Set) []metav1.LabelSelector {

--- a/internal/tiltfile/k8s.go
+++ b/internal/tiltfile/k8s.go
@@ -659,6 +659,9 @@ func convertPortForwards(val starlark.Value) ([]model.PortForward, error) {
 		return nil, nil
 	}
 	switch val := val.(type) {
+	case starlark.NoneType:
+		return nil, nil
+
 	case starlark.Int:
 		pf, err := intToPortForward(val)
 		if err != nil {

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -698,6 +698,10 @@ func TestPortForward(t *testing.T) {
 			expected: []model.PortForward{{LocalPort: 8000, Host: "0.0.0.0"}}},
 		portForwardCase{name: "override_web_host", expr: "'tilt.dev:10000:8000'", webHost: "0.0.0.0",
 			expected: []model.PortForward{{LocalPort: 10000, ContainerPort: 8000, Host: "tilt.dev"}}},
+
+		// None
+		newPortForwardSuccessCase("none", "None", []model.PortForward{}),
+		newPortForwardSuccessCase("empty_array", "[]", []model.PortForward{}),
 	}
 
 	for _, c := range portForwardCases {
@@ -5977,6 +5981,11 @@ func (f *fixture) assertNextManifest(name model.ManifestName, opts ...interface{
 
 		case []model.PortForward:
 			assert.Equal(f.t, opt, m.K8sTarget().PortForwards)
+			if len(opt) == 0 {
+				assert.Nil(f.t, m.K8sTarget().KubernetesApplySpec.PortForwardTemplateSpec)
+			} else {
+				assert.Equal(f.t, len(opt), len(m.K8sTarget().KubernetesApplySpec.PortForwardTemplateSpec.Forwards))
+			}
 		case dcResourceLinks:
 			f.assertLinks(opt, m.DockerComposeTarget().Links)
 		case localResourceLinks:


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/portforwardreconciler:

2d371e2ac0995b5f1d302acb2066eaeeeb01a670 (2021-07-09 19:24:38 -0400)
k8s: don't emit a PortForwardTemplate on 0 port-forwards

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics