### PR TITLE
cmd: support self-modifying cmds

### DIFF
--- a/internal/controllers/apicmp/delta.go
+++ b/internal/controllers/apicmp/delta.go
@@ -10,26 +10,30 @@ import (
 	"github.com/tilt-dev/tilt/internal/timecmp"
 )
 
+func Comparators() []interface{} {
+	return []interface{}{
+		func(a, b resource.Quantity) bool {
+			return a.Cmp(b) == 0
+		},
+		func(a, b metav1.MicroTime) bool {
+			return timecmp.Equal(a, b)
+		},
+		func(a, b metav1.Time) bool {
+			return timecmp.Equal(a, b)
+		},
+		func(a, b labels.Selector) bool {
+			return a.String() == b.String()
+		},
+		func(a, b fields.Selector) bool {
+			return a.String() == b.String()
+		},
+	}
+}
+
 // A deep equality check to see if a client object and
 // a server object are different, such that the server object
 // needs to be updated.
-var delta = conversion.EqualitiesOrDie(
-	func(a, b resource.Quantity) bool {
-		return a.Cmp(b) == 0
-	},
-	func(a, b metav1.MicroTime) bool {
-		return timecmp.Equal(a, b)
-	},
-	func(a, b metav1.Time) bool {
-		return timecmp.Equal(a, b)
-	},
-	func(a, b labels.Selector) bool {
-		return a.String() == b.String()
-	},
-	func(a, b fields.Selector) bool {
-		return a.String() == b.String()
-	},
-)
+var delta = conversion.EqualitiesOrDie(Comparators()...)
 
 func DeepEqual(a, b interface{}) bool {
 	return delta.DeepEqual(a, b)

--- a/internal/controllers/core/cmd/cmp.go
+++ b/internal/controllers/core/cmd/cmp.go
@@ -1,0 +1,26 @@
+package cmd
+
+import (
+	"k8s.io/apimachinery/pkg/conversion"
+
+	"github.com/tilt-dev/tilt/internal/controllers/apicmp"
+	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
+)
+
+// Compares the exec-only fields of a CmdSpec.
+// Ignores fields that specify dependency info (StartOn, RestartOn)
+func cmdExecEqual(a, b v1alpha1.CmdSpec) bool {
+	return execDelta.DeepEqual(a, b)
+}
+
+var execDelta = conversion.EqualitiesOrDie(
+	append(
+		[]interface{}{
+			func(a, b *v1alpha1.StartOnSpec) bool { // ignore
+				return true
+			},
+			func(a, b *v1alpha1.RestartOnSpec) bool { // ignore
+				return true
+			},
+		},
+		apicmp.Comparators()...)...)

--- a/internal/controllers/core/cmd/cmp_test.go
+++ b/internal/controllers/core/cmd/cmp_test.go
@@ -1,0 +1,28 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
+)
+
+func TestCmdExecEqual(t *testing.T) {
+	assert.True(t,
+		cmdExecEqual(
+			v1alpha1.CmdSpec{Args: []string{"cat"}},
+			v1alpha1.CmdSpec{Args: []string{"cat"}}))
+	assert.False(t,
+		cmdExecEqual(
+			v1alpha1.CmdSpec{Args: []string{"cat"}},
+			v1alpha1.CmdSpec{Args: []string{"dog"}}))
+	assert.True(t,
+		cmdExecEqual(
+			v1alpha1.CmdSpec{Args: []string{"cat"}},
+			v1alpha1.CmdSpec{
+				Args:      []string{"cat"},
+				StartOn:   &v1alpha1.StartOnSpec{UIButtons: []string{"x"}},
+				RestartOn: &v1alpha1.RestartOnSpec{FileWatches: []string{"x"}},
+			}))
+}

--- a/internal/controllers/core/cmd/controller.go
+++ b/internal/controllers/core/cmd/controller.go
@@ -14,7 +14,6 @@ import (
 	"github.com/jonboulle/clockwork"
 	"github.com/tilt-dev/probe/pkg/probe"
 	"github.com/tilt-dev/probe/pkg/prober"
-	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -25,6 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
+	"github.com/tilt-dev/tilt/internal/controllers/apicmp"
 	"github.com/tilt-dev/tilt/internal/controllers/indexer"
 	"github.com/tilt-dev/tilt/internal/engine/local"
 	"github.com/tilt-dev/tilt/internal/store"
@@ -213,31 +213,39 @@ func (c *Controller) reconcile(ctx context.Context, name types.NamespacedName) e
 	lastRestartEventTime := c.lastRestartEventTime(cmd.Spec.RestartOn, fileWatches)
 	lastStartEventTime := c.lastStartEventTime(cmd.Spec.StartOn, buttons)
 
-	proc, ok := c.procs[name]
-	// there is already a proc (which may or may not be running) for this cmd
-	if ok {
+	startOn := cmd.Spec.StartOn
+	waitsOnStartOn := startOn != nil && len(startOn.UIButtons) > 0
 
-		// any change to the spec means we should restart the process to pick up the changes
-		specChanged := !equality.Semantic.DeepEqual(proc.spec, cmd.Spec)
-		// a new restart event happened
-		restartOnTriggered := lastRestartEventTime.After(proc.lastRestartOnEventTime)
-		// a new start event happened
-		startOnTriggered := lastStartEventTime.After(proc.lastStartOnEventTime)
-		needsRestart := specChanged || restartOnTriggered || startOnTriggered
-		if !needsRestart {
-			return nil
-		}
-	} else {
-		startOn := cmd.Spec.StartOn
-		startOnSpecIsEmpty := startOn == nil || len(startOn.UIButtons) == 0
+	proc, hasExistingProc := c.procs[name]
 
-		// cmds with non-empty StartOn specs don't start until triggered
-		if !startOnSpecIsEmpty && lastStartEventTime.IsZero() {
-			c.setStatusWaitingOnStartOn(cmd)
-			return nil
-		}
+	lastSpec := v1alpha1.CmdSpec{}
+	lastRestartOnEventTime := time.Time{}
+	lastStartOnEventTime := time.Time{}
+	if hasExistingProc {
+		lastSpec = proc.spec
+		lastRestartOnEventTime = proc.lastRestartOnEventTime
+		lastStartOnEventTime = proc.lastStartOnEventTime
 	}
-	_ = c.runInternal(ctx, cmd, buttons, fileWatches)
+
+	restartOnTriggered := lastRestartEventTime.After(lastRestartOnEventTime)
+	startOnTriggered := lastStartEventTime.After(lastStartOnEventTime)
+	specChanged := !apicmp.DeepEqual(lastSpec, cmd.Spec)
+
+	// any change to the spec means we should stop the command immediately
+	if specChanged {
+		c.stop(name)
+	}
+
+	if specChanged && waitsOnStartOn && !startOnTriggered {
+		// If the cmd spec has changed since the last run,
+		// and StartOn hasn't triggered yet, set the status to waiting.
+		c.setStatusWaitingOnStartOn(name, cmd)
+	} else if specChanged || restartOnTriggered || startOnTriggered {
+		// Otherwise, any change, new start event, or new restart event
+		// should restart the process to pick up changes.
+		_ = c.runInternal(ctx, cmd, buttons, fileWatches)
+	}
+
 	return nil
 }
 
@@ -298,9 +306,10 @@ func (c *Controller) runInternal(ctx context.Context,
 	proc.lastStartOnEventTime = c.lastStartEventTime(cmd.Spec.StartOn, buttons)
 	ctx, proc.cancelFunc = context.WithCancel(ctx)
 
-	c.resetStatus(name, cmd)
-
 	stillHasSameProcNum := proc.stillHasSameProcNum()
+	c.updateStatus(name, func(status *CmdStatus) {
+		*status = CmdStatus{Waiting: &CmdStateWaiting{}}
+	}, stillHasSameProcNum)
 
 	ctx = store.MustObjectLogHandler(ctx, c.st, cmd)
 	spec := cmd.Spec
@@ -403,25 +412,6 @@ func processReadinessProbeResultLogger(ctx context.Context, stillHasSameProcNum 
 	}
 }
 
-func (c *Controller) resetStatus(name types.NamespacedName, cmd *Cmd) {
-	c.updateMu.Lock()
-	defer c.updateMu.Unlock()
-
-	updated := cmd.DeepCopy()
-	updated.Status = CmdStatus{
-		Waiting: &CmdStateWaiting{},
-	}
-	c.updateCmds[name] = updated
-
-	err := c.client.Status().Update(c.globalCtx, updated)
-	if err != nil && !apierrors.IsNotFound(err) {
-		c.st.Dispatch(store.NewErrorAction(fmt.Errorf("syncing to apiserver: %v", err)))
-		return
-	}
-
-	c.st.Dispatch(local.NewCmdUpdateStatusAction(updated))
-}
-
 // Update the stored status.
 //
 // In a real K8s controller, this would be a queue to make sure we don't miss updates.
@@ -435,43 +425,41 @@ func (c *Controller) updateStatus(name types.NamespacedName, update func(status 
 		return
 	}
 
-	cmd, ok := c.updateCmds[name]
-	if !ok {
+	var cmd v1alpha1.Cmd
+	err := c.client.Get(c.globalCtx, name, &cmd)
+	if err != nil {
 		return
 	}
 
+	lastCmd, ok := c.updateCmds[name]
+	if ok {
+		cmd.Status = lastCmd.Status
+	}
 	update(&cmd.Status)
+	c.updateCmds[name] = cmd.DeepCopy()
 
-	err := c.client.Status().Update(c.globalCtx, cmd)
+	err = c.client.Status().Update(c.globalCtx, &cmd)
 	if err != nil && !apierrors.IsNotFound(err) {
 		c.st.Dispatch(store.NewErrorAction(fmt.Errorf("syncing to apiserver: %v", err)))
 		return
 	}
 
-	c.st.Dispatch(local.NewCmdUpdateStatusAction(cmd))
+	c.st.Dispatch(local.NewCmdUpdateStatusAction(&cmd))
 }
 
 const waitingOnStartOnReason = "cmd StartOn has not been triggered"
 
-func (c *Controller) setStatusWaitingOnStartOn(cmd *Cmd) {
+func (c *Controller) setStatusWaitingOnStartOn(name types.NamespacedName, cmd *Cmd) {
 	if cmd.Status.Waiting != nil && cmd.Status.Waiting.Reason == waitingOnStartOnReason {
 		return
 	}
-
-	updated := cmd.DeepCopy()
-	updated.Status = CmdStatus{
-		Waiting: &CmdStateWaiting{
-			Reason: waitingOnStartOnReason,
-		},
-	}
-
-	err := c.client.Status().Update(c.globalCtx, updated)
-	if err != nil && !apierrors.IsNotFound(err) {
-		c.st.Dispatch(store.NewErrorAction(fmt.Errorf("syncing to apiserver: %v", err)))
-		return
-	}
-
-	c.st.Dispatch(local.NewCmdUpdateStatusAction(updated))
+	c.updateStatus(name, func(status *CmdStatus) {
+		*status = CmdStatus{
+			Waiting: &CmdStateWaiting{
+				Reason: waitingOnStartOnReason,
+			},
+		}
+	}, func() bool { return true })
 }
 
 func (c *Controller) processStatuses(

--- a/internal/controllers/core/cmd/controller_test.go
+++ b/internal/controllers/core/cmd/controller_test.go
@@ -243,14 +243,10 @@ func TestRestartOnFileWatch(t *testing.T) {
 	require.NoError(t, err)
 
 	f.clock.Advance(time.Second)
-	f.setRestartOn("cmd-serve-1", &RestartOnSpec{
-		FileWatches: []string{"fw-1"},
-	})
-	f.reconcileCmd("cmd-serve-1")
-
-	secondStart := f.assertCmdMatches("cmd-serve-1", func(cmd *Cmd) bool {
-		running := cmd.Status.Running
-		return running != nil && running.StartedAt.Time.After(firstStart.Status.Running.StartedAt.Time)
+	f.updateSpec("cmd-serve-1", func(spec *v1alpha1.CmdSpec) {
+		spec.RestartOn = &RestartOnSpec{
+			FileWatches: []string{"fw-1"},
+		}
 	})
 
 	f.clock.Advance(time.Second)
@@ -259,7 +255,7 @@ func TestRestartOnFileWatch(t *testing.T) {
 
 	f.assertCmdMatches("cmd-serve-1", func(cmd *Cmd) bool {
 		running := cmd.Status.Running
-		return running != nil && running.StartedAt.Time.After(secondStart.Status.Running.StartedAt.Time)
+		return running != nil && running.StartedAt.Time.After(firstStart.Status.Running.StartedAt.Time)
 	})
 
 	// Our fixture doesn't test reconcile.Request triage,
@@ -511,7 +507,9 @@ func TestSelfModifyingCmd(t *testing.T) {
 		return cmd.Status.Running != nil
 	})
 
-	f.setArgs("testcmd", []string{"yourserver"})
+	f.updateSpec("testcmd", func(spec *v1alpha1.CmdSpec) {
+		spec.Args = []string{"yourserver"}
+	})
 	f.reconcileCmd("testcmd")
 	f.assertCmdMatchesInAPI("testcmd", func(cmd *Cmd) bool {
 		return cmd.Status.Waiting != nil && cmd.Status.Waiting.Reason == waitingOnStartOnReason
@@ -525,6 +523,48 @@ func TestSelfModifyingCmd(t *testing.T) {
 
 	f.assertCmdMatchesInAPI("testcmd", func(cmd *Cmd) bool {
 		return cmd.Status.Running != nil
+	})
+}
+
+// Ensure that changes to the StartOn or RestartOn fields
+// don't restart the command.
+func TestDependencyChangesDoNotCauseRestart(t *testing.T) {
+	f := newFixture(t)
+	defer f.teardown()
+
+	setupStartOnTest(t, f)
+	f.triggerButton("b-1", f.clock.Now())
+	f.clock.Advance(time.Second)
+	f.reconcileCmd("testcmd")
+
+	firstStart := f.assertCmdMatchesInAPI("testcmd", func(cmd *Cmd) bool {
+		return cmd.Status.Running != nil
+	})
+
+	err := f.client.Create(f.ctx, &v1alpha1.UIButton{ObjectMeta: metav1.ObjectMeta{Name: "new-button"}})
+	require.NoError(t, err)
+
+	err = f.client.Create(f.ctx, &v1alpha1.FileWatch{
+		ObjectMeta: metav1.ObjectMeta{Name: "new-filewatch"},
+		Spec: FileWatchSpec{
+			WatchedPaths: []string{f.JoinPath("new-path")},
+		},
+	})
+	require.NoError(t, err)
+
+	f.updateSpec("testcmd", func(spec *v1alpha1.CmdSpec) {
+		spec.StartOn = &v1alpha1.StartOnSpec{
+			UIButtons: []string{"new-button"},
+		}
+		spec.RestartOn = &v1alpha1.RestartOnSpec{
+			FileWatches: []string{"new-filewatch"},
+		}
+	})
+	f.reconcileCmd("testcmd")
+
+	f.assertCmdMatchesInAPI("testcmd", func(cmd *Cmd) bool {
+		running := cmd.Status.Running
+		return running != nil && running.StartedAt.Time.Equal(firstStart.Status.Running.StartedAt.Time)
 	})
 }
 
@@ -662,22 +702,12 @@ func (f *fixture) reconcileCmd(name string) {
 	require.NoError(f.T(), err)
 }
 
-func (f *fixture) setRestartOn(name string, restartOn *RestartOnSpec) {
+func (f *fixture) updateSpec(name string, update func(spec *v1alpha1.CmdSpec)) {
 	cmd := &Cmd{}
 	err := f.client.Get(f.ctx, types.NamespacedName{Name: name}, cmd)
 	require.NoError(f.T(), err)
 
-	cmd.Spec.RestartOn = restartOn
-	err = f.client.Update(f.ctx, cmd)
-	require.NoError(f.T(), err)
-}
-
-func (f *fixture) setArgs(name string, args []string) {
-	cmd := &Cmd{}
-	err := f.client.Get(f.ctx, types.NamespacedName{Name: name}, cmd)
-	require.NoError(f.T(), err)
-
-	cmd.Spec.Args = args
+	update(&(cmd.Spec))
 	err = f.client.Update(f.ctx, cmd)
 	require.NoError(f.T(), err)
 }


### PR DESCRIPTION
Hello @landism,

Please review the following commits I made in branch nicks/ext202:

1b6311a3036b223f3286a20812e00ff7445f7ef7 (2021-07-12 13:47:07 -0400)
cmd: support self-modifying cmds
fixes https://github.com/tilt-dev/tilt-extensions/issues/202

334b676b0d49f627234a335270e146e21df91bfe (2021-07-09 19:38:30 -0400)
controller: improve apiserver logging

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics