### PR TITLE
web: type the label data better to handle the generic generated type

### DIFF
--- a/web/src/OverviewResourceSidebar.stories.tsx
+++ b/web/src/OverviewResourceSidebar.stories.tsx
@@ -63,15 +63,19 @@ export const OneHundredResources = () => (
 export const ResourcesWithLabels = () => {
   const view = nResourceView(10)
   for (let i = 0; i < 10; i++) {
-    const resourceMetadata: Proto.v1ObjectMeta = { name: `resource_${i}` }
-    view.uiResources[i].metadata = resourceMetadata
-    resourceMetadata.labels = {}
+    const labels: { [key: string]: string } = {}
     if (i < 5) {
-      resourceMetadata.labels["frontend"] = "frontend"
+      labels["frontend"] = "frontend"
     }
     if (i % 2) {
-      resourceMetadata.labels["test"] = "test"
+      labels["test"] = "test"
     }
+
+    const resourceMetadata: Proto.v1ObjectMeta = {
+      name: `resource_${i}`,
+      labels,
+    }
+    view.uiResources[i].metadata = resourceMetadata
   }
 
   // Non-happy path resources

--- a/web/src/SidebarItem.tsx
+++ b/web/src/SidebarItem.tsx
@@ -1,6 +1,6 @@
 import moment from "moment"
 import { buildAlerts, runtimeAlerts } from "./alerts"
-import { getUiLabels } from "./labels"
+import { asUILabels, getUiLabels } from "./labels"
 import { buildStatus, runtimeStatus } from "./status"
 import { timeDiff } from "./time"
 import { ResourceName, ResourceStatus, TriggerMode } from "./types"
@@ -35,6 +35,7 @@ class SidebarItem {
     let status = (res.status || {}) as UIResourceStatus
     let buildHistory = status.buildHistory || []
     let lastBuild = buildHistory.length > 0 ? buildHistory[0] : null
+    const labels = asUILabels({ labels: res.metadata?.labels })
     this.name = res.metadata?.name ?? ""
     this.isTiltfile = this.name === ResourceName.tiltfile
     this.isTest = !!status.localResourceInfo?.isTest
@@ -43,7 +44,7 @@ class SidebarItem {
     this.runtimeStatus = runtimeStatus(res)
     this.runtimeAlertCount = runtimeAlerts(res, null).length
     this.hasEndpoints = (status.endpointLinks || []).length > 0
-    this.labels = getUiLabels({ labels: res.metadata?.labels })
+    this.labels = getUiLabels(labels)
     this.lastBuildDur =
       lastBuild && lastBuild.startTime && lastBuild.finishTime
         ? timeDiff(lastBuild.startTime, lastBuild.finishTime)

--- a/web/src/labels.ts
+++ b/web/src/labels.ts
@@ -1,10 +1,35 @@
 // Helper functions for working with labels
 
-type UILabels = Pick<Proto.v1ObjectMeta, "labels">
+// The generated type for labels is a generic object,
+// when in reality, it is an object with string keys and values,
+// so we can use a predicate function to type the labels object
+// more precisely
+type UILabelsGenerated = Pick<Proto.v1ObjectMeta, "labels">
+interface UILabels extends UILabelsGenerated {
+  labels: { [key: string]: string } | undefined
+}
 
-// TODO (LT): Add a lil' explanation here about k8s use of labels
-// and why we filter out labels with prefixes
-export function getUiLabels({ labels }: UILabels) {
+function isUILabels(
+  labelsWrapper: UILabelsGenerated
+): labelsWrapper is UILabels {
+  return (
+    labelsWrapper.labels === undefined ||
+    typeof labelsWrapper.labels === "object"
+  )
+}
+
+export function asUILabels(labels: UILabelsGenerated): UILabels {
+  if (isUILabels(labels)) {
+    return labels
+  }
+
+  return { labels: undefined } as UILabels
+}
+
+// Following k8s practices, we treat labels with prefixes as
+// added by external tooling and not relevant to the user
+// k8s practices outline that automated tooling prefix
+export function getUiLabels({ labels }: UILabels): string[] {
   if (!labels) {
     return []
   }

--- a/web/src/view.d.ts
+++ b/web/src/view.d.ts
@@ -293,7 +293,7 @@ declare namespace Proto {
      */
     deletionTimestamp?: string;
     deletionGracePeriodSeconds?: string;
-    labels?: {[key: string]: string};
+    labels?: object;
     annotations?: object;
     ownerReferences?: v1OwnerReference[];
     finalizers?: string[];


### PR DESCRIPTION
These are some slight Typescript gymnastics to cast the generic `object` to `{ [key: string]: string }` for label data. 🙃 I'm not sure this is phenomenally better than using `any` types for labels, but it does let us keep stricter type information.