### PR TITLE
controllers: index manually instead of with cache indexers

### DIFF
--- a/internal/controllers/core/kubernetesdiscovery/portforwards.go
+++ b/internal/controllers/core/kubernetesdiscovery/portforwards.go
@@ -9,10 +9,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	errorutil "k8s.io/apimachinery/pkg/util/errors"
-	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"github.com/tilt-dev/tilt/internal/controllers/apicmp"
+	"github.com/tilt-dev/tilt/internal/controllers/indexer"
 	"github.com/tilt-dev/tilt/internal/store"
 	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
 )
@@ -20,8 +20,7 @@ import (
 // Reconcile all the port forwards owned by this KD. The KD may be nil if it's being deleted.
 func (r *Reconciler) manageOwnedPortForwards(ctx context.Context, nn types.NamespacedName, kd *v1alpha1.KubernetesDiscovery) error {
 	var pfList v1alpha1.PortForwardList
-	err := r.ctrlClient.List(ctx, &pfList, ctrlclient.InNamespace(nn.Namespace),
-		ctrlclient.MatchingFields{ownerKey: nn.Name})
+	err := indexer.ListOwnedBy(ctx, r.ctrlClient, &pfList, nn, apiType)
 	if err != nil {
 		return fmt.Errorf("failed to fetch managed PortForward objects for KubernetesDiscovery %s: %v",
 			kd.Name, err)

--- a/internal/controllers/indexer/list.go
+++ b/internal/controllers/indexer/list.go
@@ -1,0 +1,50 @@
+package indexer
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// List all the objects owned by the given object type.
+//
+// This allows us to use owner-based indexing in tests without
+// incurring the overhead of caching.
+//
+// See discussion here:
+// https://github.com/tilt-dev/tilt/issues/4719
+func ListOwnedBy(ctx context.Context, client ctrlclient.Client, list ctrlclient.ObjectList, nn types.NamespacedName, ownerType metav1.TypeMeta) error {
+	err := client.List(ctx, list, ctrlclient.InNamespace(nn.Namespace))
+	if err != nil {
+		return err
+	}
+
+	items, err := meta.ExtractList(list)
+	if err != nil {
+		return err
+	}
+
+	result := []runtime.Object{}
+	for _, item := range items {
+		clientObj, ok := item.(ctrlclient.Object)
+		if !ok {
+			continue
+		}
+		owner := metav1.GetControllerOf(clientObj)
+		if owner == nil {
+			continue
+		}
+		if owner.APIVersion != ownerType.APIVersion || owner.Kind != ownerType.Kind {
+			continue
+		}
+		if owner.Name != nn.Name {
+			continue
+		}
+		result = append(result, item)
+	}
+	return meta.SetList(list, result)
+}

--- a/internal/controllers/indexer/list_test.go
+++ b/internal/controllers/indexer/list_test.go
@@ -1,0 +1,66 @@
+package indexer
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	"github.com/tilt-dev/tilt/internal/controllers/fake"
+	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
+	"github.com/tilt-dev/tilt/pkg/logger"
+)
+
+func TestListOwnedBy(t *testing.T) {
+	c := fake.NewFakeTiltClient()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	ctx = logger.WithLogger(ctx, logger.NewTestLogger(os.Stdout))
+	scheme := v1alpha1.NewScheme()
+
+	// set up the owner objects
+	kd1 := &v1alpha1.KubernetesDiscovery{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "tilt.dev/v1alpha1", Kind: "KubernetesDiscovery"},
+		ObjectMeta: metav1.ObjectMeta{Name: "fe1"},
+	}
+	assert.NoError(t, c.Create(ctx, kd1))
+
+	kd2 := &v1alpha1.KubernetesDiscovery{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "tilt.dev/v1alpha1", Kind: "KubernetesDiscovery"},
+		ObjectMeta: metav1.ObjectMeta{Name: "fe2"},
+	}
+	assert.NoError(t, c.Create(ctx, kd2))
+
+	// set up the child objects.
+	pls1a := &v1alpha1.PodLogStream{
+		ObjectMeta: metav1.ObjectMeta{Name: "pls1a"},
+		Spec:       v1alpha1.PodLogStreamSpec{Pod: "pls1a"},
+	}
+	pls1b := &v1alpha1.PodLogStream{
+		ObjectMeta: metav1.ObjectMeta{Name: "pls1b"},
+		Spec:       v1alpha1.PodLogStreamSpec{Pod: "pls1b"},
+	}
+	pls2a := &v1alpha1.PodLogStream{
+		ObjectMeta: metav1.ObjectMeta{Name: "pls2a"},
+		Spec:       v1alpha1.PodLogStreamSpec{Pod: "pls2a"},
+	}
+
+	assert.NoError(t, controllerutil.SetControllerReference(kd1, pls1a, scheme))
+	assert.NoError(t, controllerutil.SetControllerReference(kd1, pls1b, scheme))
+	assert.NoError(t, controllerutil.SetControllerReference(kd2, pls2a, scheme))
+	assert.NoError(t, c.Create(ctx, pls1a))
+	assert.NoError(t, c.Create(ctx, pls1b))
+	assert.NoError(t, c.Create(ctx, pls2a))
+
+	var plsList1 v1alpha1.PodLogStreamList
+	assert.NoError(t, ListOwnedBy(ctx, c, &plsList1, types.NamespacedName{Name: kd1.Name}, kd1.TypeMeta))
+	assert.ElementsMatch(t, []v1alpha1.PodLogStream{*pls1a, *pls1b}, plsList1.Items)
+
+	var plsList2 v1alpha1.PodLogStreamList
+	assert.NoError(t, ListOwnedBy(ctx, c, &plsList2, types.NamespacedName{Name: kd2.Name}, kd2.TypeMeta))
+	assert.ElementsMatch(t, []v1alpha1.PodLogStream{*pls2a}, plsList2.Items)
+}


### PR DESCRIPTION
Hello @landism,

Please review the following commits I made in branch nicks/indexers:

22f5dfe8a025486050bade7f414ebdaf5c3b42a5 (2021-07-13 18:18:38 -0400)
controllers: index manually instead of with cache indexers
Fixes https://github.com/tilt-dev/tilt/issues/4719

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics