### PR TITLE
engine: remove some dead code

### DIFF
--- a/internal/engine/k8swatch/actions.go
+++ b/internal/engine/k8swatch/actions.go
@@ -5,50 +5,12 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/tilt-dev/tilt/pkg/apis"
-
 	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
 
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/types"
 
-	"github.com/tilt-dev/tilt/internal/store"
 	"github.com/tilt-dev/tilt/pkg/model"
 )
-
-type KubernetesDiscoveryCreateAction struct {
-	KubernetesDiscovery *v1alpha1.KubernetesDiscovery
-}
-
-func (p KubernetesDiscoveryCreateAction) Action() {}
-
-func (p KubernetesDiscoveryCreateAction) Summarize(s *store.ChangeSummary) {
-	s.KubernetesDiscoveries.Add(types.NamespacedName{
-		Name:      p.KubernetesDiscovery.Name,
-		Namespace: p.KubernetesDiscovery.Namespace,
-	})
-}
-
-func NewKubernetesDiscoveryCreateAction(kd *v1alpha1.KubernetesDiscovery) KubernetesDiscoveryCreateAction {
-	return KubernetesDiscoveryCreateAction{KubernetesDiscovery: kd.DeepCopy()}
-}
-
-type KubernetesDiscoveryUpdateAction struct {
-	KubernetesDiscovery *v1alpha1.KubernetesDiscovery
-}
-
-func (p KubernetesDiscoveryUpdateAction) Action() {}
-
-func (p KubernetesDiscoveryUpdateAction) Summarize(s *store.ChangeSummary) {
-	s.KubernetesDiscoveries.Add(types.NamespacedName{
-		Name:      p.KubernetesDiscovery.Name,
-		Namespace: p.KubernetesDiscovery.Namespace,
-	})
-}
-
-func NewKubernetesDiscoveryUpdateAction(kd *v1alpha1.KubernetesDiscovery) KubernetesDiscoveryUpdateAction {
-	return KubernetesDiscoveryUpdateAction{KubernetesDiscovery: kd.DeepCopy()}
-}
 
 type KubernetesDiscoveryUpdateStatusAction struct {
 	ObjectMeta *metav1.ObjectMeta
@@ -57,29 +19,11 @@ type KubernetesDiscoveryUpdateStatusAction struct {
 
 func (p KubernetesDiscoveryUpdateStatusAction) Action() {}
 
-func (p KubernetesDiscoveryUpdateStatusAction) Summarize(s *store.ChangeSummary) {
-	s.KubernetesDiscoveries.Add(apis.KeyFromMeta(*p.ObjectMeta))
-}
-
 func NewKubernetesDiscoveryUpdateStatusAction(kd *v1alpha1.KubernetesDiscovery) KubernetesDiscoveryUpdateStatusAction {
 	return KubernetesDiscoveryUpdateStatusAction{
 		ObjectMeta: kd.ObjectMeta.DeepCopy(),
 		Status:     kd.Status.DeepCopy(),
 	}
-}
-
-type KubernetesDiscoveryDeleteAction struct {
-	Name types.NamespacedName
-}
-
-func (p KubernetesDiscoveryDeleteAction) Action() {}
-
-func (p KubernetesDiscoveryDeleteAction) Summarize(s *store.ChangeSummary) {
-	s.KubernetesDiscoveries.Add(p.Name)
-}
-
-func NewKubernetesDiscoveryDeleteAction(name types.NamespacedName) KubernetesDiscoveryDeleteAction {
-	return KubernetesDiscoveryDeleteAction{Name: name}
 }
 
 type ServiceChangeAction struct {

--- a/internal/engine/k8swatch/manifest_subscriber.go
+++ b/internal/engine/k8swatch/manifest_subscriber.go
@@ -95,7 +95,6 @@ func (m *ManifestSubscriber) createKubernetesDiscovery(ctx context.Context, st s
 		return fmt.Errorf("failed to create KubernetesDiscovery %q: %v", key, err)
 	}
 	m.lastUpdate[key] = kd.Spec.DeepCopy()
-	st.Dispatch(NewKubernetesDiscoveryCreateAction(kd))
 	return nil
 }
 
@@ -114,7 +113,6 @@ func (m *ManifestSubscriber) updateKubernetesDiscovery(ctx context.Context, st s
 	err = m.client.Update(ctx, kd)
 	if err == nil {
 		m.lastUpdate[key] = kd.Spec.DeepCopy()
-		st.Dispatch(NewKubernetesDiscoveryUpdateAction(kd))
 	} else if !apierrors.IsNotFound(err) && !apierrors.IsConflict(err) {
 		return fmt.Errorf("failed to update KubernetesDiscovery %q: %v", key, err)
 	}
@@ -134,7 +132,6 @@ func (m *ManifestSubscriber) deleteKubernetesDiscovery(ctx context.Context, st s
 	err = m.client.Delete(ctx, kd)
 	if ctrlclient.IgnoreNotFound(err) == nil {
 		delete(m.lastUpdate, key)
-		st.Dispatch(NewKubernetesDiscoveryDeleteAction(key))
 	} else if !apierrors.IsNotFound(err) {
 		return fmt.Errorf("failed to delete KubernetesDiscovery %q: %v", key, err)
 	}

--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -127,14 +127,8 @@ func upperReducerFn(ctx context.Context, state *store.EngineState, action store.
 		handleHudExitAction(state, action)
 	case filewatch.FileWatchUpdateStatusAction:
 		filewatch.HandleFileWatchUpdateStatusEvent(ctx, state, action)
-	case k8swatch.KubernetesDiscoveryCreateAction:
-		k8swatch.HandleKubernetesDiscoveryCreateAction(ctx, state, action)
-	case k8swatch.KubernetesDiscoveryUpdateAction:
-		k8swatch.HandleKubernetesDiscoveryUpdateAction(ctx, state, action)
 	case k8swatch.KubernetesDiscoveryUpdateStatusAction:
 		k8swatch.HandleKubernetesDiscoveryUpdateStatusAction(ctx, state, action)
-	case k8swatch.KubernetesDiscoveryDeleteAction:
-		k8swatch.HandleKubernetesDiscoveryDeleteAction(ctx, state, action)
 	case k8swatch.ServiceChangeAction:
 		handleServiceEvent(ctx, state, action)
 	case store.K8sEventAction:

--- a/internal/store/engine_state.go
+++ b/internal/store/engine_state.go
@@ -13,7 +13,6 @@ import (
 	"github.com/tilt-dev/tilt/internal/store/k8sconv"
 
 	"github.com/tilt-dev/wmclient/pkg/analytics"
-	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/tilt-dev/tilt/internal/k8s"
 	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
@@ -123,8 +122,7 @@ type EngineState struct {
 
 	// API-server-based data models. Stored in EngineState
 	// to assist in migration.
-	Cmds                  map[string]*Cmd                               `json:"-"`
-	KubernetesDiscoveries map[types.NamespacedName]*KubernetesDiscovery `json:"-"`
+	Cmds map[string]*Cmd `json:"-"`
 }
 
 type CloudStatus struct {
@@ -489,7 +487,6 @@ func NewState() *EngineState {
 	}
 
 	ret.Cmds = make(map[string]*Cmd)
-	ret.KubernetesDiscoveries = make(map[types.NamespacedName]*KubernetesDiscovery)
 
 	return ret
 }

--- a/internal/store/summary.go
+++ b/internal/store/summary.go
@@ -57,9 +57,6 @@ type ChangeSummary struct {
 	// Cmds with their specs changed.
 	CmdSpecs ChangeSet
 
-	// KubernetesDiscoveries that have changed.
-	KubernetesDiscoveries ChangeSet
-
 	// Sessions that have changed.
 	Sessions ChangeSet
 
@@ -79,7 +76,6 @@ func (s *ChangeSummary) Add(other ChangeSummary) {
 	s.Legacy = s.Legacy || other.Legacy
 	s.Log = s.Log || other.Log
 	s.CmdSpecs.AddAll(other.CmdSpecs)
-	s.KubernetesDiscoveries.AddAll(other.KubernetesDiscoveries)
 	s.Sessions.AddAll(other.Sessions)
 	s.UISessions.AddAll(other.UISessions)
 	s.UIResources.AddAll(other.UIResources)


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/kdstatus:

b317dede117b793813cd7b1a3ee1b41c38b3f350 (2021-07-13 19:50:09 -0400)
engine: remove some dead code
The store.KubernetesDiscovery map was only being used in tests,
and the actions were only being used for Status updates.

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics