### PR TITLE
kubernetesapply: port the old KubernetesDiscovery code to the KubernetesApply reconciler

### DIFF
--- a/internal/cli/wire_gen.go
+++ b/internal/cli/wire_gen.go
@@ -255,7 +255,7 @@ func wireCmdUp(ctx context.Context, analytics3 *analytics.TiltAnalytics, cmdTags
 	labels := _wireLabelsValue
 	dockerImageBuilder := build.NewDockerImageBuilder(switchCli, labels)
 	dockerBuilder := build.DefaultDockerBuilder(dockerImageBuilder)
-	kubernetesapplyReconciler := kubernetesapply.NewReconciler(deferredClient, client, scheme, dockerBuilder, kubeContext, storeStore)
+	kubernetesapplyReconciler := kubernetesapply.NewReconciler(deferredClient, client, scheme, dockerBuilder, kubeContext, storeStore, namespace)
 	uisessionReconciler := uisession.NewReconciler(deferredClient, websocketList)
 	uiresourceReconciler := uiresource.NewReconciler(deferredClient, websocketList)
 	uibuttonReconciler := uibutton.NewReconciler(deferredClient, websocketList)
@@ -450,7 +450,7 @@ func wireCmdCI(ctx context.Context, analytics3 *analytics.TiltAnalytics, subcomm
 	labels := _wireLabelsValue
 	dockerImageBuilder := build.NewDockerImageBuilder(switchCli, labels)
 	dockerBuilder := build.DefaultDockerBuilder(dockerImageBuilder)
-	kubernetesapplyReconciler := kubernetesapply.NewReconciler(deferredClient, client, scheme, dockerBuilder, kubeContext, storeStore)
+	kubernetesapplyReconciler := kubernetesapply.NewReconciler(deferredClient, client, scheme, dockerBuilder, kubeContext, storeStore, namespace)
 	uisessionReconciler := uisession.NewReconciler(deferredClient, websocketList)
 	uiresourceReconciler := uiresource.NewReconciler(deferredClient, websocketList)
 	uibuttonReconciler := uibutton.NewReconciler(deferredClient, websocketList)
@@ -642,7 +642,7 @@ func wireCmdUpdog(ctx context.Context, analytics3 *analytics.TiltAnalytics, cmdT
 	labels := _wireLabelsValue
 	dockerImageBuilder := build.NewDockerImageBuilder(switchCli, labels)
 	dockerBuilder := build.DefaultDockerBuilder(dockerImageBuilder)
-	kubernetesapplyReconciler := kubernetesapply.NewReconciler(deferredClient, k8sClient, scheme, dockerBuilder, kubeContext, storeStore)
+	kubernetesapplyReconciler := kubernetesapply.NewReconciler(deferredClient, k8sClient, scheme, dockerBuilder, kubeContext, storeStore, namespace)
 	uisessionReconciler := uisession.NewReconciler(deferredClient, websocketList)
 	uiresourceReconciler := uiresource.NewReconciler(deferredClient, websocketList)
 	uibuttonReconciler := uibutton.NewReconciler(deferredClient, websocketList)

--- a/internal/controllers/core/kubernetesapply/disco.go
+++ b/internal/controllers/core/kubernetesapply/disco.go
@@ -1,0 +1,176 @@
+package kubernetesapply
+
+import (
+	"context"
+	"fmt"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	"github.com/tilt-dev/tilt/internal/controllers/apicmp"
+	"github.com/tilt-dev/tilt/internal/k8s"
+	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
+)
+
+// Each KubernetesApply object owns a KubernetesDiscovery object of the same name.
+//
+// After we reconcile a KubernetesApply, update the KubernetesDiscovery objects it owns.
+//
+// If the Apply has been deleted, any corresponding Disco objects should be deleted.
+func (r *Reconciler) manageOwnedKubernetesDiscovery(ctx context.Context, nn types.NamespacedName, ka *v1alpha1.KubernetesApply) error {
+	if !r.enableDiscoForTesting {
+		// TODO(nick): remove this.
+		return nil
+	}
+
+	if ka != nil && (ka.Status.Error != "" || ka.Status.ResultYAML == "") {
+		// If the KubernetesApply is in an error state or hasn't deployed anything, don't
+		// reconcile the discovery object. This prevents the reconcilers
+		// from tearing down all the discovery infra on a transient deploy error.
+		return nil
+	}
+
+	var existingKD v1alpha1.KubernetesDiscovery
+	err := r.ctrlClient.Get(ctx, nn, &existingKD)
+	isNotFound := apierrors.IsNotFound(err)
+	if err != nil && !isNotFound {
+		return fmt.Errorf("failed to fetch managed KubernetesDiscovery objects for KubernetesApply %s: %v",
+			ka.Name, err)
+	}
+
+	kd, err := r.toDesiredKubernetesDiscovery(ka)
+	if err != nil {
+		return fmt.Errorf("generating kubernetesdiscovery: %v", err)
+	}
+
+	if isNotFound {
+		if kd == nil {
+			return nil // Nothing to do.
+		}
+
+		err := r.ctrlClient.Create(ctx, kd)
+		if err != nil {
+			return fmt.Errorf("creating kubernetesdiscovery: %v", err)
+		}
+		return nil
+	}
+
+	if kd == nil {
+		err := r.ctrlClient.Delete(ctx, &existingKD)
+		if err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("deleting kubernetesdiscovery: %v", err)
+		}
+		return nil
+	}
+
+	if !apicmp.DeepEqual(existingKD.Spec, kd.Spec) {
+		existingKD.Spec = kd.Spec
+		err = r.ctrlClient.Update(ctx, &existingKD)
+		if err != nil {
+			return fmt.Errorf("updating kubernetesdiscovery: %v", err)
+		}
+	}
+
+	return nil
+}
+
+// Construct the desired KubernetesDiscovery
+func (r *Reconciler) toDesiredKubernetesDiscovery(ka *v1alpha1.KubernetesApply) (*v1alpha1.KubernetesDiscovery, error) {
+	if ka == nil {
+		return nil, nil
+	}
+
+	watchRefs, err := r.toWatchRefs(ka)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(watchRefs) == 0 {
+		return nil, nil
+	}
+
+	kapp := ka.Spec
+	var extraSelectors []metav1.LabelSelector
+	if kapp.KubernetesDiscoveryTemplateSpec != nil {
+		extraSelectors = kapp.KubernetesDiscoveryTemplateSpec.ExtraSelectors
+	}
+
+	kd := &v1alpha1.KubernetesDiscovery{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: ka.Name,
+			Annotations: map[string]string{
+				v1alpha1.AnnotationManifest: ka.Annotations[v1alpha1.AnnotationManifest],
+				v1alpha1.AnnotationSpanID:   ka.Annotations[v1alpha1.AnnotationSpanID],
+			},
+		},
+		Spec: v1alpha1.KubernetesDiscoverySpec{
+			Watches:                  watchRefs,
+			ExtraSelectors:           extraSelectors,
+			PodLogStreamTemplateSpec: kapp.PodLogStreamTemplateSpec.DeepCopy(),
+			PortForwardTemplateSpec:  kapp.PortForwardTemplateSpec.DeepCopy(),
+		},
+	}
+
+	err = controllerutil.SetControllerReference(ka, kd, r.ctrlClient.Scheme())
+	if err != nil {
+		return nil, err
+	}
+	return kd, nil
+}
+
+// Based on the deployed UIDs, create the list of resources to watch.
+//
+// TODO(nick): This currently does a lot of YAML parsing, just to get a few small
+// metadata fields. We should be able to do better here if it becomes a problem, by either
+// 1) optimizing the parsing, or
+// 2) memoizing the Apply -> Discovery function
+func (r *Reconciler) toWatchRefs(ka *v1alpha1.KubernetesApply) ([]v1alpha1.KubernetesWatchRef, error) {
+	seenNamespaces := make(map[k8s.Namespace]bool)
+	var result []v1alpha1.KubernetesWatchRef
+	if ka.Status.ResultYAML != "" {
+		deployed, err := k8s.ParseYAMLFromString(ka.Status.ResultYAML)
+		if err != nil {
+			return nil, err
+		}
+		deployedRefs := k8s.ToRefList(deployed)
+
+		for _, ref := range deployedRefs {
+			ns := k8s.Namespace(ref.Namespace)
+			if ns == "" {
+				// since this entity is actually deployed, don't fallback to cfgNS
+				ns = k8s.DefaultNamespace
+			}
+			seenNamespaces[ns] = true
+			result = append(result, v1alpha1.KubernetesWatchRef{
+				UID:       string(ref.UID),
+				Namespace: ns.String(),
+				Name:      ref.Name,
+			})
+		}
+	}
+
+	entities, err := k8s.ParseYAMLFromString(ka.Spec.YAML)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, e := range entities {
+		ns := k8s.Namespace(e.Meta().GetNamespace())
+		if ns == "" {
+			ns = r.cfgNS
+		}
+		if ns == "" {
+			ns = k8s.DefaultNamespace
+		}
+		if !seenNamespaces[ns] {
+			seenNamespaces[ns] = true
+			result = append(result, v1alpha1.KubernetesWatchRef{
+				Namespace: ns.String(),
+			})
+		}
+	}
+
+	return result, nil
+}

--- a/internal/controllers/core/kubernetesapply/disco_test.go
+++ b/internal/controllers/core/kubernetesapply/disco_test.go
@@ -1,0 +1,115 @@
+package kubernetesapply
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/tilt-dev/tilt/internal/k8s/testyaml"
+	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
+)
+
+func TestCreateAndUpdateDisco(t *testing.T) {
+	f := newFixture(t)
+	f.r.enableDiscoForTesting = true
+	ka := v1alpha1.KubernetesApply{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "a",
+		},
+		Spec: v1alpha1.KubernetesApplySpec{
+			YAML: testyaml.SanchoYAML,
+		},
+	}
+	f.Create(&ka)
+
+	f.MustReconcile(types.NamespacedName{Name: "a"})
+	f.MustGet(types.NamespacedName{Name: "a"}, &ka)
+
+	var kd v1alpha1.KubernetesDiscovery
+	f.MustGet(types.NamespacedName{Name: "a"}, &kd)
+	assert.Equal(f.T(), 1, len(kd.Spec.Watches))
+
+	// Make sure the UID in the watch ref matches what we deployed.
+	uid1 := kd.Spec.Watches[0].UID
+	assert.Contains(f.T(), ka.Status.ResultYAML, fmt.Sprintf("uid: %s", uid1))
+
+	// Change the yaml and redeploy.
+	ka.Spec = v1alpha1.KubernetesApplySpec{
+		YAML: strings.Replace(testyaml.SanchoYAML, "name: sancho", "name: sancho2", 1),
+	}
+	f.Update(&ka)
+
+	f.MustReconcile(types.NamespacedName{Name: "a"})
+	f.MustGet(types.NamespacedName{Name: "a"}, &ka)
+	f.MustGet(types.NamespacedName{Name: "a"}, &kd)
+
+	// Make sure the UID changed and got updated.
+	assert.Equal(f.T(), 1, len(kd.Spec.Watches))
+	uid2 := kd.Spec.Watches[0].UID
+	assert.NotEqual(f.T(), uid1, uid2)
+	assert.Contains(f.T(), ka.Status.ResultYAML, fmt.Sprintf("uid: %s", uid2))
+}
+
+func TestCreateAndDeleteDisco(t *testing.T) {
+	f := newFixture(t)
+	f.r.enableDiscoForTesting = true
+	ka := v1alpha1.KubernetesApply{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "a",
+		},
+		Spec: v1alpha1.KubernetesApplySpec{
+			YAML: testyaml.SanchoYAML,
+		},
+	}
+	f.Create(&ka)
+
+	f.MustReconcile(types.NamespacedName{Name: "a"})
+	f.MustGet(types.NamespacedName{Name: "a"}, &ka)
+
+	var kd v1alpha1.KubernetesDiscovery
+	assert.True(f.T(), f.Get(types.NamespacedName{Name: "a"}, &kd))
+
+	f.Delete(&ka)
+	f.MustReconcile(types.NamespacedName{Name: "a"})
+	assert.False(f.T(), f.Get(types.NamespacedName{Name: "a"}, &kd))
+}
+
+func TestDoNotReconcileDiscoOnTransientError(t *testing.T) {
+	f := newFixture(t)
+	f.r.enableDiscoForTesting = true
+	ka := v1alpha1.KubernetesApply{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "a",
+		},
+		Spec: v1alpha1.KubernetesApplySpec{
+			YAML: testyaml.SanchoYAML,
+		},
+	}
+	f.Create(&ka)
+
+	f.MustReconcile(types.NamespacedName{Name: "a"})
+	f.MustGet(types.NamespacedName{Name: "a"}, &ka)
+
+	var kd v1alpha1.KubernetesDiscovery
+	assert.True(f.T(), f.Get(types.NamespacedName{Name: "a"}, &kd))
+
+	// Simulate a redeploy that fails.
+	ka.Spec = v1alpha1.KubernetesApplySpec{
+		YAML: strings.Replace(testyaml.SanchoYAML, "name: sancho", "name: sancho2", 1),
+	}
+	f.kClient.UpsertError = fmt.Errorf("Failed to deploy")
+	f.Update(&ka)
+	f.MustReconcile(types.NamespacedName{Name: "a"})
+
+	// Assert the KubernetesDeploy is still running.
+	f.MustGet(types.NamespacedName{Name: "a"}, &kd)
+	assert.Equal(f.T(), 1, len(kd.Spec.Watches))
+
+	// Assert the apply status
+	f.MustGet(types.NamespacedName{Name: "a"}, &ka)
+	assert.Contains(f.T(), ka.Status.Error, "Failed to deploy")
+}

--- a/internal/controllers/core/kubernetesapply/reconciler_test.go
+++ b/internal/controllers/core/kubernetesapply/reconciler_test.go
@@ -154,7 +154,7 @@ func newFixture(t *testing.T) *fixture {
 	dockerClient.ImageAlwaysExists = true
 
 	db := build.NewDockerImageBuilder(dockerClient, dockerfile.Labels{})
-	r := NewReconciler(cfb.Client, kClient, v1alpha1.NewScheme(), db, kubeContext, st)
+	r := NewReconciler(cfb.Client, kClient, v1alpha1.NewScheme(), db, kubeContext, st, "default")
 
 	return &fixture{
 		ControllerFixture: cfb.Build(r),

--- a/internal/engine/buildcontrol/wire.go
+++ b/internal/engine/buildcontrol/wire.go
@@ -66,9 +66,14 @@ func ProvideImageBuildAndDeployer(
 		BaseWireSet,
 		wire.Value(UpdateModeFlag(UpdateModeAuto)),
 		kubernetesapply.NewReconciler,
+		provideFakeK8sNamespace,
 	)
 
 	return nil, nil
+}
+
+func provideFakeK8sNamespace() k8s.Namespace {
+	return "default"
 }
 
 func ProvideDockerComposeBuildAndDeployer(

--- a/internal/engine/buildcontrol/wire_gen.go
+++ b/internal/engine/buildcontrol/wire_gen.go
@@ -38,7 +38,8 @@ func ProvideImageBuildAndDeployer(ctx context.Context, docker2 docker.Client, kC
 		return nil, err
 	}
 	scheme := v1alpha1.NewScheme()
-	reconciler := kubernetesapply.NewReconciler(ctrlclient, kClient, scheme, dockerBuilder, kubeContext, st)
+	namespace := provideFakeK8sNamespace()
+	reconciler := kubernetesapply.NewReconciler(ctrlclient, kClient, scheme, dockerBuilder, kubeContext, st, namespace)
 	imageBuildAndDeployer := NewImageBuildAndDeployer(dockerBuilder, execCustomBuilder, kClient, env, kubeContext, analytics2, updateMode, clock, kp, ctrlclient, reconciler)
 	return imageBuildAndDeployer, nil
 }
@@ -90,3 +91,7 @@ var BaseWireSet = wire.NewSet(wire.Value(dockerfile.Labels{}), v1alpha1.NewSchem
 	NewLiveUpdateBuildAndDeployer,
 	NewLocalTargetBuildAndDeployer, containerupdate.NewDockerUpdater, containerupdate.NewExecUpdater, NewImageBuilder, tracer.InitOpenTelemetry, ProvideUpdateMode,
 )
+
+func provideFakeK8sNamespace() k8s.Namespace {
+	return "default"
+}

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -3942,7 +3942,7 @@ func newTestFixture(t *testing.T) *testFixture {
 
 	wsl := server.NewWebsocketList()
 
-	kar := kubernetesapply.NewReconciler(cdc, b.kClient, sch, docker.Env{}, k8s.KubeContext("kind-kind"), st)
+	kar := kubernetesapply.NewReconciler(cdc, b.kClient, sch, docker.Env{}, k8s.KubeContext("kind-kind"), st, "default")
 
 	cb := controllers.NewControllerBuilder(tscm, controllers.ProvideControllers(
 		fwc,

--- a/internal/engine/wire.go
+++ b/internal/engine/wire.go
@@ -63,12 +63,17 @@ func provideFakeBuildAndDeployer(
 		k8s.ProvideContainerRuntime,
 		provideFakeKubeContext,
 		provideFakeDockerClusterEnv,
+		provideFakeK8sNamespace,
 		kubernetesapply.NewReconciler,
 		cmd.WireSet,
 		clockwork.NewRealClock,
 	)
 
 	return nil, nil
+}
+
+func provideFakeK8sNamespace() k8s.Namespace {
+	return "default"
 }
 
 func provideFakeKubeContext(env k8s.Env) k8s.KubeContext {

--- a/internal/engine/wire_gen.go
+++ b/internal/engine/wire_gen.go
@@ -48,7 +48,8 @@ func provideFakeBuildAndDeployer(ctx context.Context, docker2 docker.Client, kCl
 	dockerBuilder := build.DefaultDockerBuilder(dockerImageBuilder)
 	execCustomBuilder := build.NewExecCustomBuilder(docker2, clock)
 	scheme := v1alpha1.NewScheme()
-	reconciler := kubernetesapply.NewReconciler(ctrlClient, kClient, scheme, dockerBuilder, kubeContext, st)
+	namespace := provideFakeK8sNamespace()
+	reconciler := kubernetesapply.NewReconciler(ctrlClient, kClient, scheme, dockerBuilder, kubeContext, st, namespace)
 	imageBuildAndDeployer := buildcontrol.NewImageBuildAndDeployer(dockerBuilder, execCustomBuilder, kClient, env, kubeContext, analytics2, buildcontrolUpdateMode, clock, kp, ctrlClient, reconciler)
 	imageBuilder := buildcontrol.NewImageBuilder(dockerBuilder, execCustomBuilder, buildcontrolUpdateMode)
 	dockerComposeBuildAndDeployer := buildcontrol.NewDockerComposeBuildAndDeployer(dcc, docker2, imageBuilder, clock)
@@ -83,6 +84,10 @@ var DeployerWireSetTest = wire.NewSet(
 var DeployerWireSet = wire.NewSet(
 	DeployerBaseWireSet,
 )
+
+func provideFakeK8sNamespace() k8s.Namespace {
+	return "default"
+}
 
 func provideFakeKubeContext(env k8s.Env) k8s.KubeContext {
 	return k8s.KubeContext(string(env))

--- a/pkg/webview/view.pb.go
+++ b/pkg/webview/view.pb.go
@@ -7,6 +7,7 @@ import (
 	context "context"
 	fmt "fmt"
 	math "math"
+
 	v1alpha1 "github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
 
 	proto "github.com/golang/protobuf/proto"


### PR DESCRIPTION
Hello @landism,

Please review the following commits I made in branch nicks/apply2:

fa68d0fb31ff3c29d4401ca58bdd8e8bef6fbf76 (2021-07-14 15:12:59 -0400)
kubernetesapply: port the old KubernetesDiscovery code to the KubernetesApply reconciler
This is mostly copied and pasted from https://github.com/tilt-dev/tilt/blob/a760f2ebcb8d8346139d3143d8b82baf6183329f/internal/engine/k8swatch/manifest_subscriber.go

That code will be deleted in a subsequent PR

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics