### PR TITLE
web: add accordion functionality for resources grouped by labels

### DIFF
--- a/web/src/OverviewResourceSidebar.stories.tsx
+++ b/web/src/OverviewResourceSidebar.stories.tsx
@@ -64,7 +64,8 @@ export const ResourcesWithLabels = () => {
   const view = nResourceView(10)
   for (let i = 0; i < 10; i++) {
     const labels: { [key: string]: string } = {}
-    if (i < 5) {
+    // The first item is a Tiltfile, so don't apply a label to it
+    if (i > 0 && i < 5) {
       labels["frontend"] = "frontend"
     }
     if (i % 2) {
@@ -72,15 +73,10 @@ export const ResourcesWithLabels = () => {
     }
 
     if (i === 3) {
-      labels["some_really_really_really_long_label_name"] =
-        "some_really_really_really_long_label_name"
+      labels["very_long_long_long_label"] = "very_long_long_long_label"
     }
 
-    const resourceMetadata: Proto.v1ObjectMeta = {
-      name: `resource_${i}`,
-      labels,
-    }
-    view.uiResources[i].metadata = resourceMetadata
+    view.uiResources[i].metadata!.labels = labels
   }
 
   // Non-happy path resources
@@ -99,6 +95,8 @@ export const ResourcesWithLabels = () => {
   }
   crashedStart.metadata!.name = "resource_12"
   view.uiResources.push(crashedStart)
+
+  // TODO: Add a Tiltfile resource
 
   return <OverviewResourceSidebar name={"vigoda_1"} view={view} />
 }

--- a/web/src/OverviewResourceSidebar.stories.tsx
+++ b/web/src/OverviewResourceSidebar.stories.tsx
@@ -96,8 +96,6 @@ export const ResourcesWithLabels = () => {
   crashedStart.metadata!.name = "resource_12"
   view.uiResources.push(crashedStart)
 
-  // TODO: Add a Tiltfile resource
-
   return <OverviewResourceSidebar name={"vigoda_1"} view={view} />
 }
 

--- a/web/src/OverviewResourceSidebar.stories.tsx
+++ b/web/src/OverviewResourceSidebar.stories.tsx
@@ -71,6 +71,11 @@ export const ResourcesWithLabels = () => {
       labels["test"] = "test"
     }
 
+    if (i === 3) {
+      labels["some_really_really_really_long_label_name"] =
+        "some_really_really_really_long_label_name"
+    }
+
     const resourceMetadata: Proto.v1ObjectMeta = {
       name: `resource_${i}`,
       labels,

--- a/web/src/OverviewSidebarOptions.test.tsx
+++ b/web/src/OverviewSidebarOptions.test.tsx
@@ -46,7 +46,7 @@ export function assertSidebarItemsAndOptions(
 
   // only check items in the "all resources" section, i.e. don't look at starred things
   // or we'll have duplicates
-  let all = sidebar.find(SidebarListSection).find({ name: "resources" })
+  let all = sidebar.find(SidebarListSection)
   let items = all.find(SidebarItemView)
   const observedNames = items.map((i) => i.props().item.name)
   expect(observedNames).toEqual(names)
@@ -217,10 +217,7 @@ describe("overview sidebar options", () => {
       </MemoryRouter>
     )
 
-    const resourceSectionItems = root
-      .find(SidebarListSection)
-      .find({ name: "resources" })
-      .find("li")
+    const resourceSectionItems = root.find(SidebarListSection).find("li")
     expect(resourceSectionItems.map((n) => n.text())).toEqual([
       "No matching resources",
     ])

--- a/web/src/ResourceStatusSummary.tsx
+++ b/web/src/ResourceStatusSummary.tsx
@@ -8,7 +8,7 @@ import { ReactComponent as WarningSvg } from "./assets/svg/warning.svg"
 import { FilterLevel } from "./logfilters"
 import { usePathBuilder } from "./PathBuilder"
 import SidebarItem from "./SidebarItem"
-import { summaryStatus, summaryStatusFromAllStatuses } from "./status"
+import { buildStatus, combinedStatus, runtimeStatus } from "./status"
 import {
   Color,
   Font,
@@ -287,18 +287,14 @@ export function ResourceStatusSummary(props: ResourceStatusSummaryProps) {
   let resources = props.view.uiResources || []
   const allStatuses: ResourceStatus[] = []
 
-  let testResources = new Array<UIResource>()
   const testStatuses: ResourceStatus[] = []
-  let otherResources = new Array<UIResource>()
   const otherStatuses: ResourceStatus[] = []
   resources.forEach((r) => {
-    const status = summaryStatus(r)
+    const status = combinedStatus(buildStatus(r), runtimeStatus(r))
     allStatuses.push(status)
     if (r.status?.localResourceInfo?.isTest) {
-      testResources.push(r)
       testStatuses.push(status)
     } else {
-      otherResources.push(r)
       otherStatuses.push(status)
     }
   })
@@ -335,10 +331,7 @@ export function ResourceSidebarStatusSummary(
   // Because SidebarItems have already-calculated statuses,
   // pass those directly to determine their summary status
   const statuses: ResourceStatus[] = props.items.map((item) =>
-    summaryStatusFromAllStatuses({
-      buildStatus: item.buildStatus,
-      runtimeStatus: item.runtimeStatus,
-    })
+    combinedStatus(item.buildStatus, item.runtimeStatus)
   )
 
   return (

--- a/web/src/ResourceStatusSummary.tsx
+++ b/web/src/ResourceStatusSummary.tsx
@@ -7,7 +7,8 @@ import { ReactComponent as PendingSvg } from "./assets/svg/pending.svg"
 import { ReactComponent as WarningSvg } from "./assets/svg/warning.svg"
 import { FilterLevel } from "./logfilters"
 import { usePathBuilder } from "./PathBuilder"
-import { combinedStatus } from "./status"
+import SidebarItem from "./SidebarItem"
+import { summaryStatus, summaryStatusFromAllStatuses } from "./status"
 import {
   Color,
   Font,
@@ -214,8 +215,7 @@ export type StatusCounts = {
   warning: number
 }
 
-function statusCounts(resources: UIResource[]): StatusCounts {
-  let statuses = resources.map((res) => combinedStatus(res))
+function statusCounts(statuses: ResourceStatus[]): StatusCounts {
   let allStatusCount = 0
   let healthyStatusCount = 0
   let unhealthyStatusCount = 0
@@ -283,34 +283,71 @@ type ResourceStatusSummaryProps = {
 }
 
 export function ResourceStatusSummary(props: ResourceStatusSummaryProps) {
-  // Count the statuses.
+  // Count and calculate the combined statuses.
   let resources = props.view.uiResources || []
+  const allStatuses: ResourceStatus[] = []
 
   let testResources = new Array<UIResource>()
+  const testStatuses: ResourceStatus[] = []
   let otherResources = new Array<UIResource>()
+  const otherStatuses: ResourceStatus[] = []
   resources.forEach((r) => {
+    const status = summaryStatus(r)
+    allStatuses.push(status)
     if (r.status?.localResourceInfo?.isTest) {
       testResources.push(r)
+      testStatuses.push(status)
     } else {
       otherResources.push(r)
+      otherStatuses.push(status)
     }
   })
 
   return (
     <ResourceStatusSummaryRoot>
-      <ResourceMetadata counts={statusCounts(resources)} />
+      <ResourceMetadata counts={statusCounts(allStatuses)} />
       <ResourceGroupStatus
-        counts={statusCounts(otherResources)}
+        counts={statusCounts(otherStatuses)}
         label={"Resources"}
         healthyLabel={"healthy"}
         unhealthyLabel={"err"}
         warningLabel={"warn"}
       />
       <ResourceGroupStatus
-        counts={statusCounts(testResources)}
+        counts={statusCounts(testStatuses)}
         label={"Tests"}
         healthyLabel={"pass"}
         unhealthyLabel={"fail"}
+        warningLabel={"warn"}
+      />
+    </ResourceStatusSummaryRoot>
+  )
+}
+
+type ResourceSidebarStatusSummaryProps = {
+  items: SidebarItem[]
+  label?: string
+}
+
+export function ResourceSidebarStatusSummary(
+  props: ResourceSidebarStatusSummaryProps
+) {
+  // Because SidebarItems have already-calculated statuses,
+  // pass those directly to determine their summary status
+  const statuses: ResourceStatus[] = props.items.map((item) =>
+    summaryStatusFromAllStatuses({
+      buildStatus: item.buildStatus,
+      runtimeStatus: item.runtimeStatus,
+    })
+  )
+
+  return (
+    <ResourceStatusSummaryRoot>
+      <ResourceGroupStatus
+        counts={statusCounts(statuses)}
+        label={props.label ?? ""}
+        healthyLabel={"healthy"}
+        unhealthyLabel={"err"}
         warningLabel={"warn"}
       />
     </ResourceStatusSummaryRoot>

--- a/web/src/SidebarItemView.tsx
+++ b/web/src/SidebarItemView.tsx
@@ -38,6 +38,11 @@ export const SidebarItemRoot = styled.li`
   ${StarResourceButtonRoot} {
     margin-right: ${SizeUnit(1.0 / 12)};
   }
+
+  /* groupIndent is used for un-grouped items in the grouped sidebar view */
+  &.groupIndent {
+    margin-left: ${SizeUnit(2 / 3)};
+  }
 `
 
 export let SidebarItemBox = styled.div`
@@ -194,6 +199,7 @@ export type SidebarItemViewProps = {
   selected: boolean
   resourceView: ResourceView
   pathBuilder: PathBuilder
+  inGroup?: boolean
 }
 
 function buildStatusText(item: SidebarItem): string {
@@ -266,11 +272,12 @@ export default function SidebarItemView(props: SidebarItemViewProps) {
   let isBuildingClass = building ? "isBuilding" : ""
   let onTrigger = triggerUpdate.bind(null, item.name)
   let onModeToggle = toggleTriggerMode.bind(null, item.name)
+  const groupIndentClass = props.inGroup ? "groupIndent" : ""
 
   return (
     <SidebarItemRoot
       key={item.name}
-      className={`u-showStarOnHover u-showTriggerModeOnHover ${isSelectedClass} ${isBuildingClass}`}
+      className={`u-showStarOnHover u-showTriggerModeOnHover ${isSelectedClass} ${isBuildingClass} ${groupIndentClass}`}
     >
       <StarResourceButton
         resourceName={item.name}

--- a/web/src/SidebarItemView.tsx
+++ b/web/src/SidebarItemView.tsx
@@ -39,8 +39,8 @@ export const SidebarItemRoot = styled.li`
     margin-right: ${SizeUnit(1.0 / 12)};
   }
 
-  /* groupIndent is used for un-grouped items in the grouped sidebar view */
-  &.groupIndent {
+  /* groupViewIndent is used to indent un-grouped items so they align with grouped items */
+  &.groupViewIndent {
     margin-left: ${SizeUnit(2 / 3)};
   }
 `
@@ -199,7 +199,7 @@ export type SidebarItemViewProps = {
   selected: boolean
   resourceView: ResourceView
   pathBuilder: PathBuilder
-  inGroup?: boolean
+  groupView?: boolean
 }
 
 function buildStatusText(item: SidebarItem): string {
@@ -272,12 +272,12 @@ export default function SidebarItemView(props: SidebarItemViewProps) {
   let isBuildingClass = building ? "isBuilding" : ""
   let onTrigger = triggerUpdate.bind(null, item.name)
   let onModeToggle = toggleTriggerMode.bind(null, item.name)
-  const groupIndentClass = props.inGroup ? "groupIndent" : ""
+  const groupViewIndentClass = props.groupView ? "groupViewIndent" : ""
 
   return (
     <SidebarItemRoot
       key={item.name}
-      className={`u-showStarOnHover u-showTriggerModeOnHover ${isSelectedClass} ${isBuildingClass} ${groupIndentClass}`}
+      className={`u-showStarOnHover u-showTriggerModeOnHover ${isSelectedClass} ${isBuildingClass} ${groupViewIndentClass}`}
     >
       <StarResourceButton
         resourceName={item.name}

--- a/web/src/SidebarResources.tsx
+++ b/web/src/SidebarResources.tsx
@@ -1,12 +1,22 @@
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+} from "@material-ui/core"
 import React, { Dispatch, PropsWithChildren, SetStateAction } from "react"
 import styled from "styled-components"
+import { ReactComponent as CaretSvg } from "./assets/svg/caret.svg"
 import Features, { FeaturesContext, Flag } from "./feature"
 import { orderLabels } from "./labels"
 import { PersistentStateProvider } from "./LocalStorage"
 import { OverviewSidebarOptions } from "./OverviewSidebarOptions"
 import PathBuilder from "./PathBuilder"
+import { ResourceSidebarStatusSummary } from "./ResourceStatusSummary"
 import SidebarItem from "./SidebarItem"
-import SidebarItemView, { triggerUpdate } from "./SidebarItemView"
+import SidebarItemView, {
+  SidebarItemRoot,
+  triggerUpdate,
+} from "./SidebarItemView"
 import SidebarKeyboardShortcuts from "./SidebarKeyboardShortcuts"
 import { Color, FontSize, SizeUnit } from "./style-helpers"
 import { ResourceView, SidebarOptions } from "./types"
@@ -37,6 +47,69 @@ const SidebarListSectionItems = styled.ul`
 const NoMatchesFound = styled.li`
   margin-left: ${SizeUnit(0.5)};
   color: ${Color.grayLightest};
+`
+
+const SidebarLabelSection = styled(Accordion)`
+  &.MuiPaper-root {
+    background-color: unset;
+  }
+
+  &.MuiAccordion-root,
+  &.MuiAccordion-root.Mui-expanded {
+    margin: ${SizeUnit(1 / 3)} 0;
+  }
+`
+
+const SummaryIcon = styled(CaretSvg)`
+  padding: ${SizeUnit(1 / 4)};
+  transition: all 300ms cubic-bezier(0.4, 0, 0.2, 1) 0ms; /* Copied from MUI accordion */
+`
+
+const SidebarGroupSummary = styled(AccordionSummary)`
+  &.MuiAccordionSummary-root,
+  &.MuiAccordionSummary-root.Mui-expanded {
+    min-height: unset;
+    padding: unset;
+  }
+
+  .MuiAccordionSummary-content {
+    align-items: center;
+    background-color: ${Color.grayLighter};
+    border: 1px solid ${Color.grayLight};
+    border-radius: ${SizeUnit(1 / 8)};
+    box-sizing: border-box;
+    color: ${Color.white};
+    display: flex;
+    font-size: ${FontSize.small};
+    margin: 0;
+    max-width: 336px;
+    padding: ${SizeUnit(1 / 8)};
+
+    &.Mui-expanded {
+      margin: 0;
+
+      ${SummaryIcon} {
+        transform: rotate(90deg);
+      }
+    }
+  }
+`
+
+const SidebarGroupName = styled.span`
+  margin-right: auto;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`
+
+const SidebarGroupDetails = styled(AccordionDetails)`
+  &.MuiAccordionDetails-root {
+    display: unset;
+    padding: unset;
+
+    ${SidebarItemRoot} {
+      margin-right: unset;
+    }
+  }
 `
 
 export function SidebarListSection(
@@ -71,13 +144,28 @@ function SidebarLabelListSection(props: { label: string } & SidebarProps) {
     return null
   }
 
+  // TODO: Investigate accessibility implications and add focus styles
+  // There's probably a layer of a11y markup we need to add
   return (
-    <>
-      <SidebarListSectionName>{props.label}</SidebarListSectionName>
-      <SidebarListSectionItems>
-        <SidebarItemsView {...props} />
-      </SidebarListSectionItems>
-    </>
+    <SidebarLabelSection
+      defaultExpanded={true}
+      key={`sidebarItem-${props.label}`}
+    >
+      <SidebarGroupSummary>
+        <SummaryIcon width={10} height={10} role="presentation" />
+        <SidebarGroupName>
+          {/* TODO: Make 'unlabeled' label italics */}
+          {props.label}
+        </SidebarGroupName>
+        <ResourceSidebarStatusSummary items={props.items} />
+      </SidebarGroupSummary>
+      <SidebarGroupDetails>
+        <SidebarListSectionItems>
+          <SidebarItemsView {...props} />
+        </SidebarListSectionItems>
+      </SidebarGroupDetails>
+      {/* TODO: Handle Tiltfile display separately */}
+    </SidebarLabelSection>
   )
 }
 

--- a/web/src/StarredResourceBar.tsx
+++ b/web/src/StarredResourceBar.tsx
@@ -6,7 +6,7 @@ import { InstrumentedButton } from "./instrumentedComponents"
 import { usePathBuilder } from "./PathBuilder"
 import { ClassNameFromResourceStatus } from "./ResourceStatus"
 import { useStarredResources } from "./StarredResourcesContext"
-import { combinedStatus } from "./status"
+import { summaryStatus } from "./status"
 import {
   AnimDuration,
   barberpole,
@@ -221,7 +221,7 @@ export function starredResourcePropsFromView(
   const namesAndStatuses = (view?.uiResources || []).flatMap((r) => {
     let name = r.metadata?.name
     if (name && starContext.starredResources.includes(name)) {
-      return [{ name: name, status: combinedStatus(r) }]
+      return [{ name: name, status: summaryStatus(r) }]
     } else {
       return []
     }

--- a/web/src/StarredResourceBar.tsx
+++ b/web/src/StarredResourceBar.tsx
@@ -6,7 +6,7 @@ import { InstrumentedButton } from "./instrumentedComponents"
 import { usePathBuilder } from "./PathBuilder"
 import { ClassNameFromResourceStatus } from "./ResourceStatus"
 import { useStarredResources } from "./StarredResourcesContext"
-import { summaryStatus } from "./status"
+import { buildStatus, combinedStatus, runtimeStatus } from "./status"
 import {
   AnimDuration,
   barberpole,
@@ -221,7 +221,12 @@ export function starredResourcePropsFromView(
   const namesAndStatuses = (view?.uiResources || []).flatMap((r) => {
     let name = r.metadata?.name
     if (name && starContext.starredResources.includes(name)) {
-      return [{ name: name, status: summaryStatus(r) }]
+      return [
+        {
+          name: name,
+          status: combinedStatus(buildStatus(r), runtimeStatus(r)),
+        },
+      ]
     } else {
       return []
     }

--- a/web/src/assets/svg/caret.svg
+++ b/web/src/assets/svg/caret.svg
@@ -1,3 +1,3 @@
 <svg width="9" height="9" viewBox="0 0 9 9" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M0 0L0 9L9 4.5L0 0Z" fill="#586E75"/>
+  <path d="M0 0L0 9L9 4.5L0 0Z" class="fillStd" fill="#586E75"/>
 </svg>

--- a/web/src/assets/svg/caret.svg
+++ b/web/src/assets/svg/caret.svg
@@ -1,0 +1,3 @@
+<svg width="9" height="9" viewBox="0 0 9 9" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M0 0L0 9L9 4.5L0 0Z" fill="#586E75"/>
+</svg>

--- a/web/src/status.test.tsx
+++ b/web/src/status.test.tsx
@@ -1,4 +1,4 @@
-import { summaryStatus, warnings } from "./status"
+import { buildStatus, combinedStatus, runtimeStatus, warnings } from "./status"
 import { oneResource } from "./testdata"
 import { zeroTime } from "./time"
 import { ResourceStatus, RuntimeStatus, UpdateStatus } from "./types"
@@ -13,10 +13,12 @@ function emptyResource() {
   return res
 }
 
-describe("summaryStatus", () => {
+describe("combinedStatus", () => {
   it("pending when no build info", () => {
     let res = emptyResource()
-    expect(summaryStatus(res)).toBe(ResourceStatus.Pending)
+    expect(combinedStatus(buildStatus(res), runtimeStatus(res))).toBe(
+      ResourceStatus.Pending
+    )
   })
 
   it("building when current build", () => {
@@ -24,7 +26,9 @@ describe("summaryStatus", () => {
     let res = emptyResource()
     res.status!.updateStatus = UpdateStatus.InProgress
     res.status!.runtimeStatus = RuntimeStatus.Ok
-    expect(summaryStatus(res)).toBe(ResourceStatus.Building)
+    expect(combinedStatus(buildStatus(res), runtimeStatus(res))).toBe(
+      ResourceStatus.Building
+    )
   })
 
   it("healthy when runtime ok", () => {
@@ -32,7 +36,9 @@ describe("summaryStatus", () => {
     let res = emptyResource()
     res.status!.updateStatus = UpdateStatus.Ok
     res.status!.runtimeStatus = RuntimeStatus.Ok
-    expect(summaryStatus(res)).toBe(ResourceStatus.Healthy)
+    expect(combinedStatus(buildStatus(res), runtimeStatus(res))).toBe(
+      ResourceStatus.Healthy
+    )
   })
 
   it("unhealthy when runtime error", () => {
@@ -40,7 +46,9 @@ describe("summaryStatus", () => {
     let res = emptyResource()
     res.status!.updateStatus = UpdateStatus.Ok
     res.status!.runtimeStatus = RuntimeStatus.Error
-    expect(summaryStatus(res)).toBe(ResourceStatus.Unhealthy)
+    expect(combinedStatus(buildStatus(res), runtimeStatus(res))).toBe(
+      ResourceStatus.Unhealthy
+    )
   })
 
   it("unhealthy when last build error", () => {
@@ -48,7 +56,9 @@ describe("summaryStatus", () => {
     let res = emptyResource()
     res.status!.updateStatus = UpdateStatus.Error
     res.status!.runtimeStatus = RuntimeStatus.Ok
-    expect(summaryStatus(res)).toBe(ResourceStatus.Unhealthy)
+    expect(combinedStatus(buildStatus(res), runtimeStatus(res))).toBe(
+      ResourceStatus.Unhealthy
+    )
   })
 
   it("building when runtime status error, but also building", () => {
@@ -56,7 +66,9 @@ describe("summaryStatus", () => {
     let res = emptyResource()
     res.status!.updateStatus = UpdateStatus.InProgress
     res.status!.runtimeStatus = RuntimeStatus.Error
-    expect(summaryStatus(res)).toBe(ResourceStatus.Building)
+    expect(combinedStatus(buildStatus(res), runtimeStatus(res))).toBe(
+      ResourceStatus.Building
+    )
   })
 
   it("unhealthy when warning and runtime error", () => {
@@ -64,7 +76,9 @@ describe("summaryStatus", () => {
     res.status!.runtimeStatus = RuntimeStatus.Error
     if (!res.status!.k8sResourceInfo) throw new Error("missing k8s info")
     res.status!.k8sResourceInfo.podRestarts = 1
-    expect(summaryStatus(res)).toBe(ResourceStatus.Unhealthy)
+    expect(combinedStatus(buildStatus(res), runtimeStatus(res))).toBe(
+      ResourceStatus.Unhealthy
+    )
   })
 
   it("warning when container restarts", () => {
@@ -74,7 +88,9 @@ describe("summaryStatus", () => {
     res.status!.runtimeStatus = RuntimeStatus.Ok
     if (!res.status!.k8sResourceInfo) throw new Error("missing k8s info")
     res.status!.k8sResourceInfo.podRestarts = 1
-    expect(summaryStatus(res)).toBe(ResourceStatus.Warning)
+    expect(combinedStatus(buildStatus(res), runtimeStatus(res))).toBe(
+      ResourceStatus.Warning
+    )
     expect(warnings(res)).toEqual(["Container restarted"])
   })
 
@@ -82,7 +98,9 @@ describe("summaryStatus", () => {
     let res = emptyResource()
     res.status!.updateStatus = UpdateStatus.None
     res.status!.runtimeStatus = RuntimeStatus.NotApplicable
-    expect(summaryStatus(res)).toBe(ResourceStatus.None)
+    expect(combinedStatus(buildStatus(res), runtimeStatus(res))).toBe(
+      ResourceStatus.None
+    )
   })
 
   it("healthy when n/a runtime status and last build succeeded", () => {
@@ -90,7 +108,9 @@ describe("summaryStatus", () => {
     let res = emptyResource()
     res.status!.runtimeStatus = RuntimeStatus.NotApplicable
     res.status!.updateStatus = UpdateStatus.Ok
-    expect(summaryStatus(res)).toBe(ResourceStatus.Healthy)
+    expect(combinedStatus(buildStatus(res), runtimeStatus(res))).toBe(
+      ResourceStatus.Healthy
+    )
   })
 
   it("unhealthy when n/a runtime status and last build failed", () => {
@@ -98,6 +118,8 @@ describe("summaryStatus", () => {
     let res = emptyResource()
     res.status!.runtimeStatus = RuntimeStatus.NotApplicable
     res.status!.updateStatus = UpdateStatus.Error
-    expect(summaryStatus(res)).toBe(ResourceStatus.Unhealthy)
+    expect(combinedStatus(buildStatus(res), runtimeStatus(res))).toBe(
+      ResourceStatus.Unhealthy
+    )
   })
 })

--- a/web/src/status.test.tsx
+++ b/web/src/status.test.tsx
@@ -1,4 +1,4 @@
-import { combinedStatus, warnings } from "./status"
+import { summaryStatus, warnings } from "./status"
 import { oneResource } from "./testdata"
 import { zeroTime } from "./time"
 import { ResourceStatus, RuntimeStatus, UpdateStatus } from "./types"
@@ -13,10 +13,10 @@ function emptyResource() {
   return res
 }
 
-describe("combinedStatus", () => {
+describe("summaryStatus", () => {
   it("pending when no build info", () => {
     let res = emptyResource()
-    expect(combinedStatus(res)).toBe(ResourceStatus.Pending)
+    expect(summaryStatus(res)).toBe(ResourceStatus.Pending)
   })
 
   it("building when current build", () => {
@@ -24,7 +24,7 @@ describe("combinedStatus", () => {
     let res = emptyResource()
     res.status!.updateStatus = UpdateStatus.InProgress
     res.status!.runtimeStatus = RuntimeStatus.Ok
-    expect(combinedStatus(res)).toBe(ResourceStatus.Building)
+    expect(summaryStatus(res)).toBe(ResourceStatus.Building)
   })
 
   it("healthy when runtime ok", () => {
@@ -32,7 +32,7 @@ describe("combinedStatus", () => {
     let res = emptyResource()
     res.status!.updateStatus = UpdateStatus.Ok
     res.status!.runtimeStatus = RuntimeStatus.Ok
-    expect(combinedStatus(res)).toBe(ResourceStatus.Healthy)
+    expect(summaryStatus(res)).toBe(ResourceStatus.Healthy)
   })
 
   it("unhealthy when runtime error", () => {
@@ -40,7 +40,7 @@ describe("combinedStatus", () => {
     let res = emptyResource()
     res.status!.updateStatus = UpdateStatus.Ok
     res.status!.runtimeStatus = RuntimeStatus.Error
-    expect(combinedStatus(res)).toBe(ResourceStatus.Unhealthy)
+    expect(summaryStatus(res)).toBe(ResourceStatus.Unhealthy)
   })
 
   it("unhealthy when last build error", () => {
@@ -48,7 +48,7 @@ describe("combinedStatus", () => {
     let res = emptyResource()
     res.status!.updateStatus = UpdateStatus.Error
     res.status!.runtimeStatus = RuntimeStatus.Ok
-    expect(combinedStatus(res)).toBe(ResourceStatus.Unhealthy)
+    expect(summaryStatus(res)).toBe(ResourceStatus.Unhealthy)
   })
 
   it("building when runtime status error, but also building", () => {
@@ -56,7 +56,7 @@ describe("combinedStatus", () => {
     let res = emptyResource()
     res.status!.updateStatus = UpdateStatus.InProgress
     res.status!.runtimeStatus = RuntimeStatus.Error
-    expect(combinedStatus(res)).toBe(ResourceStatus.Building)
+    expect(summaryStatus(res)).toBe(ResourceStatus.Building)
   })
 
   it("unhealthy when warning and runtime error", () => {
@@ -64,7 +64,7 @@ describe("combinedStatus", () => {
     res.status!.runtimeStatus = RuntimeStatus.Error
     if (!res.status!.k8sResourceInfo) throw new Error("missing k8s info")
     res.status!.k8sResourceInfo.podRestarts = 1
-    expect(combinedStatus(res)).toBe(ResourceStatus.Unhealthy)
+    expect(summaryStatus(res)).toBe(ResourceStatus.Unhealthy)
   })
 
   it("warning when container restarts", () => {
@@ -74,7 +74,7 @@ describe("combinedStatus", () => {
     res.status!.runtimeStatus = RuntimeStatus.Ok
     if (!res.status!.k8sResourceInfo) throw new Error("missing k8s info")
     res.status!.k8sResourceInfo.podRestarts = 1
-    expect(combinedStatus(res)).toBe(ResourceStatus.Warning)
+    expect(summaryStatus(res)).toBe(ResourceStatus.Warning)
     expect(warnings(res)).toEqual(["Container restarted"])
   })
 
@@ -82,7 +82,7 @@ describe("combinedStatus", () => {
     let res = emptyResource()
     res.status!.updateStatus = UpdateStatus.None
     res.status!.runtimeStatus = RuntimeStatus.NotApplicable
-    expect(combinedStatus(res)).toBe(ResourceStatus.None)
+    expect(summaryStatus(res)).toBe(ResourceStatus.None)
   })
 
   it("healthy when n/a runtime status and last build succeeded", () => {
@@ -90,7 +90,7 @@ describe("combinedStatus", () => {
     let res = emptyResource()
     res.status!.runtimeStatus = RuntimeStatus.NotApplicable
     res.status!.updateStatus = UpdateStatus.Ok
-    expect(combinedStatus(res)).toBe(ResourceStatus.Healthy)
+    expect(summaryStatus(res)).toBe(ResourceStatus.Healthy)
   })
 
   it("unhealthy when n/a runtime status and last build failed", () => {
@@ -98,6 +98,6 @@ describe("combinedStatus", () => {
     let res = emptyResource()
     res.status!.runtimeStatus = RuntimeStatus.NotApplicable
     res.status!.updateStatus = UpdateStatus.Error
-    expect(combinedStatus(res)).toBe(ResourceStatus.Unhealthy)
+    expect(summaryStatus(res)).toBe(ResourceStatus.Unhealthy)
   })
 })

--- a/web/src/status.tsx
+++ b/web/src/status.tsx
@@ -52,20 +52,10 @@ function runtimeStatus(r: UIResource): ResourceStatus {
 // 1) If there's a current or pending build, this is "pending".
 // 2) Otherwise, if there's a build error or runtime error, this is "error".
 // 3) Otherwise, we fallback to runtime status.
-function summaryStatus(res: UIResource): ResourceStatus {
-  return summaryStatusFromAllStatuses({
-    buildStatus: buildStatus(res),
-    runtimeStatus: runtimeStatus(res),
-  })
-}
-
-function summaryStatusFromAllStatuses({
-  buildStatus,
-  runtimeStatus,
-}: {
-  buildStatus: ResourceStatus
+function combinedStatus(
+  buildStatus: ResourceStatus,
   runtimeStatus: ResourceStatus
-}) {
+): ResourceStatus {
   if (
     buildStatus !== ResourceStatus.Healthy &&
     buildStatus !== ResourceStatus.None
@@ -104,8 +94,7 @@ function warnings(res: UIResource): string[] {
 export {
   buildStatus,
   runtimeStatus,
-  summaryStatus,
-  summaryStatusFromAllStatuses,
+  combinedStatus,
   warnings,
   buildWarnings,
   runtimeWarnings,

--- a/web/src/status.tsx
+++ b/web/src/status.tsx
@@ -52,16 +52,32 @@ function runtimeStatus(r: UIResource): ResourceStatus {
 // 1) If there's a current or pending build, this is "pending".
 // 2) Otherwise, if there's a build error or runtime error, this is "error".
 // 3) Otherwise, we fallback to runtime status.
-function combinedStatus(res: UIResource): ResourceStatus {
-  let bs = buildStatus(res)
-  if (bs !== ResourceStatus.Healthy && bs !== ResourceStatus.None) {
-    return bs
+function summaryStatus(res: UIResource): ResourceStatus {
+  return summaryStatusFromAllStatuses({
+    buildStatus: buildStatus(res),
+    runtimeStatus: runtimeStatus(res),
+  })
+}
+
+function summaryStatusFromAllStatuses({
+  buildStatus,
+  runtimeStatus,
+}: {
+  buildStatus: ResourceStatus
+  runtimeStatus: ResourceStatus
+}) {
+  if (
+    buildStatus !== ResourceStatus.Healthy &&
+    buildStatus !== ResourceStatus.None
+  ) {
+    return buildStatus
   }
-  let rs = runtimeStatus(res)
-  if (rs === ResourceStatus.None) {
-    return bs
+
+  if (runtimeStatus === ResourceStatus.None) {
+    return buildStatus
   }
-  return rs
+
+  return runtimeStatus
 }
 
 function buildWarnings(res: UIResource): string[] {
@@ -88,7 +104,8 @@ function warnings(res: UIResource): string[] {
 export {
   buildStatus,
   runtimeStatus,
-  combinedStatus,
+  summaryStatus,
+  summaryStatusFromAllStatuses,
   warnings,
   buildWarnings,
   runtimeWarnings,

--- a/web/src/testdata.tsx
+++ b/web/src/testdata.tsx
@@ -1,6 +1,6 @@
 import { Href, UnregisterCallback } from "history"
 import { RouteComponentProps } from "react-router-dom"
-import { TriggerMode } from "./types"
+import { ResourceName, TriggerMode } from "./types"
 
 type UIResource = Proto.v1alpha1UIResource
 type UIButton = Proto.v1alpha1UIButton
@@ -91,7 +91,7 @@ export function tiltfileResource(): UIResource {
   const tsPast = new Date(Date.now() - 12300).toISOString()
   const resource: UIResource = {
     metadata: {
-      name: "(Tiltfile)",
+      name: ResourceName.tiltfile,
     },
     status: {
       lastDeployTime: ts,


### PR DESCRIPTION
(feat) Add accordion functionality for resources grouped by labels in sidebar with styles and status summary

This PR uses Material UI's accordion component to display collapse-able and expand-able groups of resources in the sidebar. It also adds styles to align with the design and a small refactoring of resource summary display to cover different use cases. You can take a look at the `Resources with Labels` storybook entry to test. The resources sidebar should not look any different in the Tilt UI (outside of Storybook), cuz even though the feature flag is enabled in `storybook.tiltfile`, no resources have labels defined in the Tiltfile.

~There are a couple todos (noted in code) that I'd like to take care of before merging this in, but wanted to get this up for code review first.~ ✅ done! (minus the accessibility note, that i will address later)

![2021-07-14 16 14 51](https://user-images.githubusercontent.com/23283986/125704518-d6a81e12-8f50-43f6-9af5-435005ce96c1.gif)

**update:** Styles have been to address the long label name issue, add Tiltfile resource on its own, and italicize the `unlabeled` resources:
![Screen Shot 2021-07-15 at 4 36 22 PM](https://user-images.githubusercontent.com/23283986/125854399-bb921040-5646-405d-a7c1-486a61ea531e.png)

Closes [ch12252](https://app.clubhouse.io/windmill/story/12252/add-expand-collapse-functionality-for-label-groups)
