### PR TITLE
tiltfile: dc_resource and k8s_resource should both be additive

### DIFF
--- a/internal/tiltfile/docker_compose.go
+++ b/internal/tiltfile/docker_compose.go
@@ -132,8 +132,10 @@ func (s *tiltfileState) dcResource(thread *starlark.Thread, fn *starlark.Builtin
 		return nil, err
 	}
 
-	svc.TriggerMode = triggerMode
-	svc.Links = links.Links
+	if triggerMode != TriggerModeUnset {
+		svc.TriggerMode = triggerMode
+	}
+	svc.Links = append(svc.Links, links.Links...)
 
 	if imageRefAsStr != nil {
 		normalized, err := container.ParseNamed(*imageRefAsStr)
@@ -147,7 +149,7 @@ func (s *tiltfileState) dcResource(thread *starlark.Thread, fn *starlark.Builtin
 	if err != nil {
 		return nil, errors.Wrapf(err, "%s: resource_deps", fn.Name())
 	}
-	svc.resourceDeps = rds
+	svc.resourceDeps = append(svc.resourceDeps, rds...)
 
 	return starlark.None, nil
 }

--- a/internal/tiltfile/tiltfile_state.go
+++ b/internal/tiltfile/tiltfile_state.go
@@ -703,7 +703,7 @@ func (s *tiltfileState) assembleK8s() error {
 			r.links = opts.links
 			if opts.newName != "" && opts.newName != r.name {
 				if _, ok := s.k8sByName[opts.newName]; ok {
-					return fmt.Errorf("k8s_resource at %s specified to rename %q to %q, but there already exists a resource with that name", opts.tiltfilePosition.String(), r.name, opts.newName)
+					return fmt.Errorf("k8s_resource() specified to rename %q to %q, but there already exists a resource with that name", r.name, opts.newName)
 				}
 				delete(s.k8sByName, r.name)
 				r.name = opts.newName
@@ -753,7 +753,7 @@ func (s *tiltfileState) assembleK8s() error {
 			for name := range s.k8sByName {
 				knownResources = append(knownResources, name)
 			}
-			return fmt.Errorf("k8s_resource at %s specified unknown resource %q. known resources: %s\n\nNote: Tilt's resource naming has recently changed. See https://docs.tilt.dev/resource_assembly_migration.html for more info", opts.tiltfilePosition.String(), workload, strings.Join(knownResources, ", "))
+			return fmt.Errorf("k8s_resource() specified unknown resource %q. known resources: %s", workload, strings.Join(knownResources, ", "))
 		}
 	}
 

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -564,7 +564,7 @@ docker_build("gcr.io/foo", "foo", cache='/paths/to/cache')
 	f.loadAssertWarnings(cacheObsoleteWarning)
 }
 
-func TestDuplicateResourceNames(t *testing.T) {
+func TestK8sResourceAdditiveLinks(t *testing.T) {
 	f := newFixture(t)
 	defer f.TearDown()
 
@@ -572,11 +572,19 @@ func TestDuplicateResourceNames(t *testing.T) {
 	f.file("Tiltfile", `
 
 k8s_yaml('all.yaml')
+k8s_resource('a', links=['http://demo-a.localhost/'])
 k8s_resource('a')
-k8s_resource('a')
+k8s_resource('b', links=['http://demo-b.localhost/'])
+k8s_resource('b', links=['http://demo-b.localhost/api'])
 `)
-
-	f.loadErrString("k8s_resource already called for a")
+	f.load()
+	f.assertNextManifest("a",
+		k8sResourceLinks{model.MustNewLink("http://demo-a.localhost/", "")})
+	f.assertNextManifest("b",
+		k8sResourceLinks{
+			model.MustNewLink("http://demo-b.localhost/", ""),
+			model.MustNewLink("http://demo-b.localhost/api", ""),
+		})
 }
 
 func TestDuplicateImageNames(t *testing.T) {
@@ -804,7 +812,9 @@ local_resource('foo', 'echo hi', links=%s)
 docker_build('gcr.io/foo', 'foo')
 k8s_yaml('foo.yaml')
 k8s_resource('foo', links=EXPR)
+k8s_resource('foo') # test that subsequent calls don't clear the links
 `
+
 			s = strings.Replace(s, "EXPR", c.expr, -1)
 			f.file("Tiltfile", s)
 
@@ -831,7 +841,9 @@ services:
 `)
 			s := `
 docker_compose('docker-compose.yml')
-dc_resource('foo', links=EXPR)`
+dc_resource('foo', links=EXPR)
+dc_resource('foo') # test that subsequent calls don't clear the links
+`
 
 			s = strings.Replace(s, "EXPR", c.expr, -1)
 			f.file("Tiltfile", s)
@@ -3067,7 +3079,7 @@ k8s_resource('foo:deployment:ns2', new_name='foo')
 	f.assertNextManifest("foo", db(image("gcr.io/foo2")))
 }
 
-func TestMultipleK8sResourceOptionsForOneResource(t *testing.T) {
+func TestAdditivePortForwards(t *testing.T) {
 	f := newFixture(t)
 	defer f.TearDown()
 
@@ -3079,7 +3091,9 @@ k8s_yaml('foo.yaml')
 k8s_resource('foo', port_forwards=8001)
 k8s_resource('foo', port_forwards=8000)
 `)
-	f.loadErrString("k8s_resource already called for foo")
+
+	f.load()
+	f.assertNextManifest("foo", []model.PortForward{{LocalPort: 8001}, {LocalPort: 8000}})
 }
 
 func TestWorkloadToResourceFunction(t *testing.T) {

--- a/internal/tiltfile/value/bool.go
+++ b/internal/tiltfile/value/bool.go
@@ -1,0 +1,29 @@
+package value
+
+import (
+	"fmt"
+
+	"go.starlark.net/starlark"
+)
+
+// Unpack values that could be Bool or None
+type BoolOrNone struct {
+	Value bool
+	IsSet bool
+}
+
+func (b *BoolOrNone) Unpack(v starlark.Value) error {
+	if v == nil {
+		return nil
+	}
+	switch v := v.(type) {
+	case starlark.NoneType:
+		return nil
+	case starlark.Bool:
+		b.Value = bool(v)
+		b.IsSet = true
+		return nil
+	}
+
+	return fmt.Errorf("got %s, want bool or None", v.Type())
+}


### PR DESCRIPTION
Hello @hyu, @landism,

Please review the following commits I made in branch nicks/dc:

dd8b1b13744e5000f01760e28ca4b5d34f51bc87 (2021-07-15 15:59:39 -0400)
tiltfile: dc_resource and k8s_resource should both be additive
Before this change,
- If you had 2 k8s_resource calls for the same resource, it would be an error.
- If you had 2 dc_resource calls for the same resource, some properties
  would merge and some would overwrite.

This behavior was confusing.

This changes both functions to "aggregate" options.

Fixes https://github.com/tilt-dev/tilt/issues/4736
Fixes https://github.com/tilt-dev/tilt/issues/3738

I think that has much better semantics in a world with extensions that want to
"add" things to a resource, and is a good stopgap as we add more things
to the API server.

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics