### PR TITLE
engine: introduce a system for live-updating images we didn't deploy

### DIFF
--- a/internal/engine/buildcontrol/build_control.go
+++ b/internal/engine/buildcontrol/build_control.go
@@ -401,7 +401,8 @@ func IsLiveUpdateTargetWaitingOnDeploy(state store.EngineState, mt *store.Manife
 		// This is the mechanism that live update uses to determine if the container to live-update
 		// is still pending.
 		if mt.Manifest.IsK8s() {
-			cInfos, err := store.RunningContainersForTargetForOnePod(iTarget, mt.State.K8sRuntimeState())
+			cInfos, err := store.RunningContainersForTargetForOnePod(
+				iTarget.ID().Name.String(), iTarget.LiveUpdateSpec, mt.State.K8sRuntimeState())
 			if err != nil {
 				return false
 			}

--- a/internal/engine/buildcontrol/extractors.go
+++ b/internal/engine/buildcontrol/extractors.go
@@ -43,7 +43,9 @@ func extractImageTargetsForLiveUpdates(specs []model.TargetSpec, stateSet store.
 	deployedImages := g.DeployedImages()
 	for _, iTarget := range deployedImages {
 		state := stateSet[iTarget.ID()]
-		if state.IsEmpty() {
+		// If this is a normal image build, it must have info about the deployed image.
+		// Otherwise, we can update pods if we can find their containers.
+		if !iTarget.IsLiveUpdateOnly && state.IsEmpty() {
 			return nil, SilentRedirectToNextBuilderf("In-place build does not support initial deploy")
 		}
 

--- a/internal/engine/buildcontrol/image_build_and_deployer.go
+++ b/internal/engine/buildcontrol/image_build_and_deployer.go
@@ -157,6 +157,10 @@ func (ibd *ImageBuildAndDeployer) BuildAndDeploy(ctx context.Context, st store.R
 	iTargetMap := model.ImageTargetsByID(iTargets)
 	imageMapSet := make(map[types.NamespacedName]*v1alpha1.ImageMap, len(kTarget.ImageMaps))
 	for _, iTarget := range iTargets {
+		if iTarget.IsLiveUpdateOnly {
+			continue
+		}
+
 		var im v1alpha1.ImageMap
 		nn := types.NamespacedName{Name: iTarget.ID().Name.String()}
 		err := ibd.ctrlClient.Get(ctx, nn, &im)

--- a/internal/engine/buildcontrol/live_update_state_tree.go
+++ b/internal/engine/buildcontrol/live_update_state_tree.go
@@ -19,7 +19,6 @@ type liveUpdateStateTree struct {
 func (t liveUpdateStateTree) createResultSet() store.BuildResultSet {
 	iTargetID := t.iTarget.ID()
 	state := t.iTargetState
-	res := state.LastResult
 
 	liveUpdatedContainerIDs := []container.ID{}
 	for _, c := range state.RunningContainers {
@@ -27,7 +26,7 @@ func (t liveUpdateStateTree) createResultSet() store.BuildResultSet {
 	}
 
 	resultSet := store.BuildResultSet{}
-	resultSet[iTargetID] = store.NewLiveUpdateBuildResult(res.TargetID(), liveUpdatedContainerIDs)
+	resultSet[iTargetID] = store.NewLiveUpdateBuildResult(iTargetID, liveUpdatedContainerIDs)
 
 	// Invalidate all the image builds for images we depend on.
 	// Otherwise, the image builder will think the existing image ID

--- a/internal/engine/buildcontrol/target_queue.go
+++ b/internal/engine/buildcontrol/target_queue.go
@@ -47,6 +47,9 @@ type TargetQueue struct {
 func NewImageTargetQueue(ctx context.Context, iTargets []model.ImageTarget, state store.BuildStateSet, canReuseRef ReuseRefChecker) (*TargetQueue, error) {
 	targets := make([]model.TargetSpec, 0, len(iTargets))
 	for _, iTarget := range iTargets {
+		if iTarget.IsLiveUpdateOnly {
+			continue
+		}
 		targets = append(targets, iTarget)
 	}
 

--- a/internal/engine/buildcontrol/testdata_test.go
+++ b/internal/engine/buildcontrol/testdata_test.go
@@ -171,7 +171,7 @@ func NewSanchoLiveUpdateMultiStageManifest(fixture Fixture) model.Manifest {
 		WithDependencyIDs([]model.TargetID{baseImage.ID()})
 
 	kTarget := k8s.MustTarget("sancho", SanchoYAML).
-		WithDependencyIDs([]model.TargetID{srcImage.ID()})
+		WithDependencyIDs([]model.TargetID{srcImage.ID()}, nil)
 
 	return model.Manifest{Name: "sancho"}.
 		WithImageTargets([]model.ImageTarget{baseImage, srcImage}).

--- a/internal/engine/buildcontroller.go
+++ b/internal/engine/buildcontroller.go
@@ -176,7 +176,8 @@ func buildStateSet(ctx context.Context, manifest model.Manifest, specs []model.T
 			iTarget, ok := spec.(model.ImageTarget)
 			if ok {
 				if manifest.IsK8s() {
-					cInfos, err := store.RunningContainersForTargetForOnePod(iTarget, ms.K8sRuntimeState())
+					cInfos, err := store.RunningContainersForTargetForOnePod(
+						iTarget.ID().Name.String(), iTarget.LiveUpdateSpec, ms.K8sRuntimeState())
 					if err != nil {
 						buildState = buildState.WithRunningContainerError(err)
 					} else {

--- a/internal/engine/configs/api.go
+++ b/internal/engine/configs/api.go
@@ -166,6 +166,10 @@ func toImageMapObjects(tlr tiltfile.TiltfileLoadResult) typedObjectSet {
 
 	for _, m := range tlr.Manifests {
 		for _, iTarget := range m.ImageTargets {
+			if iTarget.IsLiveUpdateOnly {
+				continue
+			}
+
 			name := apis.SanitizeName(iTarget.ID().Name.String())
 			// Note that an ImageMap might be in more than one Manifest, so we
 			// can't annotate them to a particular manifest.

--- a/internal/engine/testdata_test.go
+++ b/internal/engine/testdata_test.go
@@ -163,7 +163,7 @@ func NewSanchoLiveUpdateMultiStageManifest(fixture Fixture) model.Manifest {
 		WithDependencyIDs([]model.TargetID{baseImage.ID()})
 
 	kTarget := k8s.MustTarget("sancho", SanchoYAML).
-		WithDependencyIDs([]model.TargetID{srcImage.ID()})
+		WithDependencyIDs([]model.TargetID{srcImage.ID()}, nil)
 
 	return model.Manifest{Name: "sancho"}.
 		WithImageTargets([]model.ImageTarget{baseImage, srcImage}).

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -4460,7 +4460,7 @@ func (f *testFixture) newManifestWithRef(name string, ref reference.Named) model
 	refSel := container.NewRefSelector(ref)
 
 	iTarget := NewSanchoLiveUpdateImageTarget(f)
-	iTarget.Refs.ConfigurationRef = refSel
+	iTarget = iTarget.MustWithRef(refSel)
 
 	return manifestbuilder.New(f, model.ManifestName(name)).
 		WithK8sYAML(SanchoYAML).
@@ -4471,7 +4471,7 @@ func (f *testFixture) newManifestWithRef(name string, ref reference.Named) model
 func (f *testFixture) newDockerBuildManifestWithBuildPath(name string, path string) model.Manifest {
 	db := model.DockerBuild{Dockerfile: "FROM alpine", BuildPath: path}
 	iTarget := NewSanchoLiveUpdateImageTarget(f).WithBuildDetails(db)
-	iTarget.Refs.ConfigurationRef = container.MustParseSelector(strings.ToLower(name)) // each target should have a unique ID
+	iTarget = iTarget.MustWithRef(container.MustParseSelector(strings.ToLower(name))) // each target should have a unique ID
 	return manifestbuilder.New(f, model.ManifestName(name)).
 		WithK8sYAML(SanchoYAML).
 		WithImageTarget(iTarget).

--- a/internal/k8s/target.go
+++ b/internal/k8s/target.go
@@ -24,7 +24,8 @@ func MustTarget(name model.TargetName, yaml string) model.K8sTarget {
 	if err != nil {
 		panic(fmt.Errorf("MustTarget: %v", err))
 	}
-	target, err := NewTarget(name, entities, nil, nil, nil, nil, model.PodReadinessIgnore, nil, nil, model.UpdateSettings{})
+	target, err := NewTarget(name, entities, nil, nil, nil, nil,
+		nil, model.PodReadinessIgnore, nil, nil, model.UpdateSettings{})
 	if err != nil {
 		panic(fmt.Errorf("MustTarget: %v", err))
 	}
@@ -37,6 +38,7 @@ func NewTarget(
 	portForwards []model.PortForward,
 	extraPodSelectors []labels.Set,
 	dependencyIDs []model.TargetID,
+	imageTargets []model.ImageTarget,
 	refInjectCounts map[string]int,
 	podReadinessMode model.PodReadinessMode,
 	allLocators []ImageLocator,
@@ -90,11 +92,13 @@ func NewTarget(
 		ObjectRefs:          objectRefs,
 		PodReadinessMode:    podReadinessMode,
 		Links:               links,
-	}.WithDependencyIDs(dependencyIDs).WithRefInjectCounts(refInjectCounts), nil
+	}.WithDependencyIDs(dependencyIDs, model.ToLiveUpdateOnlyMap(imageTargets)).
+		WithRefInjectCounts(refInjectCounts), nil
 }
 
 func NewK8sOnlyManifest(name model.ManifestName, entities []K8sEntity, allLocators []ImageLocator) (model.Manifest, error) {
-	kTarget, err := NewTarget(name.TargetName(), entities, nil, nil, nil, nil, model.PodReadinessIgnore, allLocators, nil, model.UpdateSettings{})
+	kTarget, err := NewTarget(name.TargetName(), entities, nil, nil, nil, nil,
+		nil, model.PodReadinessIgnore, allLocators, nil, model.UpdateSettings{})
 	if err != nil {
 		return model.Manifest{}, err
 	}

--- a/internal/k8s/target_test.go
+++ b/internal/k8s/target_test.go
@@ -12,7 +12,8 @@ import (
 
 func TestNewTargetSortsK8sEntities(t *testing.T) {
 	entities := MustParseYAMLFromString(t, testyaml.OutOfOrderYaml)
-	targ, err := NewTarget("foo", entities, nil, nil, nil, nil, model.PodReadinessWait, nil, nil, model.UpdateSettings{})
+	targ, err := NewTarget("foo", entities, nil, nil, nil, nil,
+		nil, model.PodReadinessWait, nil, nil, model.UpdateSettings{})
 	require.NoError(t, err)
 
 	expectedKindOrder := []string{"PersistentVolume", "PersistentVolumeClaim", "ConfigMap", "Service", "StatefulSet", "Job", "Pod"}

--- a/internal/testutils/manifestbuilder/assemble.go
+++ b/internal/testutils/manifestbuilder/assemble.go
@@ -23,7 +23,7 @@ func assembleK8s(m model.Manifest, k model.K8sTarget, iTargets ...model.ImageTar
 		}
 		ids = append(ids, iTarget.ID())
 	}
-	k = k.WithDependencyIDs(ids)
+	k = k.WithDependencyIDs(ids, model.ToLiveUpdateOnlyMap(iTargets))
 	return m.
 		WithImageTargets(iTargets).
 		WithDeployTarget(k)

--- a/internal/tiltfile/live_update_test.go
+++ b/internal/tiltfile/live_update_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/tilt-dev/tilt/pkg/model"
 )
 
@@ -168,6 +170,19 @@ func TestLiveUpdateCustomBuild(t *testing.T) {
 	f.load("foo")
 
 	f.assertNextManifest("foo", cb(image("foo"), f.expectedLU))
+}
+
+func TestLiveUpdateOnlyCustomBuild(t *testing.T) {
+	f := newLiveUpdateFixture(t)
+	defer f.TearDown()
+
+	f.tiltfileCode = "custom_build('foo', ':', ['foo'], live_update=%s)"
+	f.init()
+
+	f.load("foo")
+
+	m := f.assertNextManifest("foo", cb(image("foo"), f.expectedLU))
+	assert.True(t, m.ImageTargets[0].IsLiveUpdateOnly)
 }
 
 func TestLiveUpdateSyncFilesOutsideOfDockerBuildContext(t *testing.T) {

--- a/pkg/model/target_test.go
+++ b/pkg/model/target_test.go
@@ -114,5 +114,5 @@ func newK8sTarget(name string, deps ...string) K8sTarget {
 	for i, dep := range deps {
 		depIDs[i] = ImageID(container.MustParseSelector(dep))
 	}
-	return K8sTarget{Name: TargetName(name)}.WithDependencyIDs(depIDs)
+	return K8sTarget{Name: TargetName(name)}.WithDependencyIDs(depIDs, nil)
 }

--- a/pkg/webview/view.pb.go
+++ b/pkg/webview/view.pb.go
@@ -7,6 +7,7 @@ import (
 	context "context"
 	fmt "fmt"
 	math "math"
+
 	v1alpha1 "github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
 
 	proto "github.com/golang/protobuf/proto"


### PR DESCRIPTION
Hello @landism,

Please review the following commits I made in branch nicks/ch12386:

7b1dbae447968c04f5009b6905b8078e1f3fb0e9 (2021-07-16 14:42:19 -0400)
engine: introduce a system for live-updating images we didn't deploy
This is the first step towards a general-purpose live-update API
that's independent of a general-purpose image build API, and suggests
how they might interoperate.

Fixes https://github.com/tilt-dev/tilt/issues/4577

I played around with a couple different ways to test this effectively,
but ultimately, the most valuable test was the file_sync_only
integration test we already have. Almost all of our live-update
specs are ultimately designed to catch bugs in how we do the live-update,
rather than asserting things about the live-update spec itself.

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics