### PR TITLE
k8s: fix a race condition where two goroutines were modifying the rest.Config

### DIFF
--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -261,7 +261,7 @@ func timeoutError(timeout time.Duration) error {
 }
 
 func (k *K8sClient) ToRESTConfig() (*rest.Config, error) {
-	return k.restConfig, nil
+	return rest.CopyConfig(k.restConfig), nil
 }
 func (k *K8sClient) ToDiscoveryClient() (discovery.CachedDiscoveryInterface, error) {
 	return k.discovery, nil

--- a/internal/k8s/helm.go
+++ b/internal/k8s/helm.go
@@ -66,9 +66,18 @@ func (c *helmKubeClient) Apply(target kube.ResourceList) (*kube.Result, error) {
 	return &kube.Result{Updated: target}, nil
 }
 
+var helmNopLogger = func(_ string, _ ...interface{}) {}
+
 func newHelmKubeClient(c *K8sClient) HelmKubeClient {
+	f := cmdutil.NewFactory(c)
+
+	// Don't use kube.New() here, because it modifies globals in
+	// a way that breaks tests.
 	return &helmKubeClient{
-		Client:  kube.New(c),
-		factory: cmdutil.NewFactory(c),
+		Client: &kube.Client{
+			Factory: f,
+			Log:     helmNopLogger,
+		},
+		factory: f,
 	}
 }

--- a/internal/k8s/helm_test.go
+++ b/internal/k8s/helm_test.go
@@ -1,0 +1,58 @@
+package k8s
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+	"helm.sh/helm/v3/pkg/kube"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// This tests a race condition where if there were two Build()s
+// happening in parallel, they would overwrite each other's configs
+// due to a race condition.
+func TestRESTClientBuilder(t *testing.T) {
+	config := &rest.Config{}
+	loader, err := clientcmd.NewClientConfigFromBytes(nil)
+	require.NoError(t, err)
+
+	client := &K8sClient{
+		restConfig:   config,
+		clientLoader: loader,
+		drm:          fakeRESTMapper{},
+	}
+	helm := newHelmKubeClient(client)
+
+	g, _ := errgroup.WithContext(context.Background())
+	var list1, list2 kube.ResourceList
+	g.Go(func() error {
+		var err error
+		list1, err = helm.Build(strings.NewReader(`
+apiVersion: v1
+kind: Pod
+metadata:
+  name: fe
+`), false)
+		return err
+	})
+
+	g.Go(func() error {
+		var err error
+		list2, err = helm.Build(strings.NewReader(`
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fe
+`), false)
+		return err
+	})
+	require.NoError(t, g.Wait())
+
+	assert.Equal(t, "v1", list1[0].Client.(*rest.RESTClient).APIVersion().String())
+	assert.Equal(t, "apps/v1", list2[0].Client.(*rest.RESTClient).APIVersion().String())
+}


### PR DESCRIPTION
Hello @landism, @milas,

Please review the following commits I made in branch nicks/k8s:

d4a3d674e6091b14569551f478a7b9838f0e4d47 (2021-07-19 11:16:54 -0400)
k8s: fix a race condition where two goroutines were modifying the rest.Config
This caused weird k8s failures in CI
https://app.circleci.com/pipelines/github/tilt-dev/tilt/8267/workflows/299e4ca4-ef7a-4f49-be85-47b81cee3903/jobs/69248/tests#failed-test-0

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics