### PR TITLE
tiltfile: pass TILT_HOST + TILT_PORT to local() commands

### DIFF
--- a/internal/cli/wire_gen.go
+++ b/internal/cli/wire_gen.go
@@ -103,8 +103,9 @@ func wireTiltfileResult(ctx context.Context, analytics2 *analytics.TiltAnalytics
 	localEnv := docker.ProvideLocalEnv(ctx, kubeContext, env, clusterEnv)
 	dockerComposeClient := dockercompose.NewDockerComposeClient(localEnv)
 	webHost := provideWebHost()
+	webPort := provideWebPort()
 	defaults := _wireDefaultsValue
-	tiltfileLoader := tiltfile.ProvideTiltfileLoader(analytics2, client, extension, versionExtension, configExtension, dockerComposeClient, webHost, defaults, env)
+	tiltfileLoader := tiltfile.ProvideTiltfileLoader(analytics2, client, extension, versionExtension, configExtension, dockerComposeClient, webHost, webPort, defaults, env)
 	cliCmdTiltfileResultDeps := newTiltfileResultDeps(tiltfileLoader)
 	return cliCmdTiltfileResultDeps, nil
 }
@@ -147,8 +148,9 @@ func wireDockerPrune(ctx context.Context, analytics2 *analytics.TiltAnalytics, s
 	configExtension := config.NewExtension(subcommand)
 	dockerComposeClient := dockercompose.NewDockerComposeClient(localEnv)
 	webHost := provideWebHost()
+	webPort := provideWebPort()
 	defaults := _wireDefaultsValue
-	tiltfileLoader := tiltfile.ProvideTiltfileLoader(analytics2, client, extension, versionExtension, configExtension, dockerComposeClient, webHost, defaults, env)
+	tiltfileLoader := tiltfile.ProvideTiltfileLoader(analytics2, client, extension, versionExtension, configExtension, dockerComposeClient, webHost, webPort, defaults, env)
 	cliDpDeps := newDPDeps(switchCli, tiltfileLoader)
 	return cliDpDeps, nil
 }
@@ -301,7 +303,7 @@ func wireCmdUp(ctx context.Context, analytics3 *analytics.TiltAnalytics, cmdTags
 	versionExtension := version.NewExtension(tiltBuild)
 	configExtension := config.NewExtension(subcommand)
 	defaults := _wireDefaultsValue
-	tiltfileLoader := tiltfile.ProvideTiltfileLoader(analytics3, client, extension, versionExtension, configExtension, dockerComposeClient, webHost, defaults, env)
+	tiltfileLoader := tiltfile.ProvideTiltfileLoader(analytics3, client, extension, versionExtension, configExtension, dockerComposeClient, webHost, webPort, defaults, env)
 	configsController := configs.NewConfigsController(tiltfileLoader, switchCli, deferredClient)
 	eventWatcher := dcwatch.NewEventWatcher(dockerComposeClient, localClient)
 	dockerComposeLogManager := runtimelog.NewDockerComposeLogManager(dockerComposeClient)
@@ -495,7 +497,7 @@ func wireCmdCI(ctx context.Context, analytics3 *analytics.TiltAnalytics, subcomm
 	versionExtension := version.NewExtension(tiltBuild)
 	configExtension := config.NewExtension(subcommand)
 	defaults := _wireDefaultsValue
-	tiltfileLoader := tiltfile.ProvideTiltfileLoader(analytics3, client, extension, versionExtension, configExtension, dockerComposeClient, webHost, defaults, env)
+	tiltfileLoader := tiltfile.ProvideTiltfileLoader(analytics3, client, extension, versionExtension, configExtension, dockerComposeClient, webHost, webPort, defaults, env)
 	configsController := configs.NewConfigsController(tiltfileLoader, switchCli, deferredClient)
 	eventWatcher := dcwatch.NewEventWatcher(dockerComposeClient, localClient)
 	dockerComposeLogManager := runtimelog.NewDockerComposeLogManager(dockerComposeClient)
@@ -870,8 +872,9 @@ func wireDownDeps(ctx context.Context, tiltAnalytics *analytics.TiltAnalytics, s
 	localEnv := docker.ProvideLocalEnv(ctx, kubeContext, env, clusterEnv)
 	dockerComposeClient := dockercompose.NewDockerComposeClient(localEnv)
 	webHost := provideWebHost()
+	webPort := provideWebPort()
 	defaults := _wireDefaultsValue
-	tiltfileLoader := tiltfile.ProvideTiltfileLoader(tiltAnalytics, k8sClient, extension, versionExtension, configExtension, dockerComposeClient, webHost, defaults, env)
+	tiltfileLoader := tiltfile.ProvideTiltfileLoader(tiltAnalytics, k8sClient, extension, versionExtension, configExtension, dockerComposeClient, webHost, webPort, defaults, env)
 	downDeps := ProvideDownDeps(tiltfileLoader, dockerComposeClient, k8sClient)
 	return downDeps, nil
 }

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -3884,7 +3884,7 @@ func newTestFixture(t *testing.T) *testFixture {
 	k8sContextExt := k8scontext.NewExtension("fake-context", env)
 	versionExt := version.NewExtension(model.TiltBuild{Version: "0.5.0"})
 	configExt := config.NewExtension("up")
-	tfl := tiltfile.ProvideTiltfileLoader(ta, b.kClient, k8sContextExt, versionExt, configExt, fakeDcc, "localhost", feature.MainDefaults, env)
+	tfl := tiltfile.ProvideTiltfileLoader(ta, b.kClient, k8sContextExt, versionExt, configExt, fakeDcc, "localhost", model.WebPort(12345), feature.MainDefaults, env)
 	cc := configs.NewConfigsController(tfl, dockerClient, cdc)
 	dcw := dcwatch.NewEventWatcher(fakeDcc, dockerClient)
 	dclm := runtimelog.NewDockerComposeLogManager(fakeDcc)

--- a/internal/tiltfile/tiltfile.go
+++ b/internal/tiltfile/tiltfile.go
@@ -107,6 +107,7 @@ func ProvideTiltfileLoader(
 	configExt *config.Extension,
 	dcCli dockercompose.DockerComposeClient,
 	webHost model.WebHost,
+	webPort model.WebPort,
 	fDefaults feature.Defaults,
 	env k8s.Env) TiltfileLoader {
 	return tiltfileLoader{
@@ -117,6 +118,7 @@ func ProvideTiltfileLoader(
 		configExt:     configExt,
 		dcCli:         dcCli,
 		webHost:       webHost,
+		webPort:       webPort,
 		fDefaults:     fDefaults,
 		env:           env,
 	}
@@ -127,6 +129,7 @@ type tiltfileLoader struct {
 	kCli      k8s.Client
 	dcCli     dockercompose.DockerComposeClient
 	webHost   model.WebHost
+	webPort   model.WebPort
 
 	k8sContextExt k8scontext.Extension
 	versionExt    version.Extension
@@ -172,7 +175,7 @@ func (tfl tiltfileLoader) Load(ctx context.Context, filename string, userConfigS
 
 	localRegistry := tfl.kCli.LocalRegistry(ctx)
 
-	s := newTiltfileState(ctx, tfl.dcCli, tfl.webHost, tfl.k8sContextExt, tfl.versionExt, tfl.configExt, localRegistry, feature.FromDefaults(tfl.fDefaults))
+	s := newTiltfileState(ctx, tfl.dcCli, tfl.webHost, tfl.webPort, tfl.k8sContextExt, tfl.versionExt, tfl.configExt, localRegistry, feature.FromDefaults(tfl.fDefaults))
 
 	manifests, result, err := s.loadManifests(absFilename, userConfigState)
 

--- a/internal/tiltfile/tiltfile_state.go
+++ b/internal/tiltfile/tiltfile_state.go
@@ -65,6 +65,7 @@ type tiltfileState struct {
 	ctx           context.Context
 	dcCli         dockercompose.DockerComposeClient
 	webHost       model.WebHost
+	webPort       model.WebPort
 	k8sContextExt k8scontext.Extension
 	versionExt    version.Extension
 	configExt     *config.Extension
@@ -134,6 +135,7 @@ func newTiltfileState(
 	ctx context.Context,
 	dcCli dockercompose.DockerComposeClient,
 	webHost model.WebHost,
+	webPort model.WebPort,
 	k8sContextExt k8scontext.Extension,
 	versionExt version.Extension,
 	configExt *config.Extension,
@@ -143,6 +145,7 @@ func newTiltfileState(
 		ctx:                       ctx,
 		dcCli:                     dcCli,
 		webHost:                   webHost,
+		webPort:                   webPort,
 		k8sContextExt:             k8sContextExt,
 		versionExt:                versionExt,
 		configExt:                 configExt,

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -382,7 +382,7 @@ func TestLocalTiltEnvPropagation(t *testing.T) {
 	}
 	resetEnv()
 
-	doTest := func(expectedHost string, expectedPort int) {
+	doTest := func(t testing.TB, expectedHost string, expectedPort int) {
 		t.Helper()
 
 		f.file("Tiltfile", `
@@ -400,7 +400,7 @@ local(command='echo Tilt port is $TILT_PORT', command_bat='echo Tilt port is %TI
 		// $TILT_HOST + $TILT_PORT are not explicitly defined anywhere in the test fixture but should be
 		// auto-populated (hardcoded to 1.2.3.4/12345 for tests - no real apiserver is actually loaded)
 		f.webHost = "1.2.3.4"
-		doTest("1.2.3.4", 12345)
+		doTest(t, "1.2.3.4", 12345)
 	})
 
 	t.Run("Explicit", func(t *testing.T) {
@@ -409,7 +409,7 @@ local(command='echo Tilt port is $TILT_PORT', command_bat='echo Tilt port is %TI
 		require.NoError(t, os.Setenv("TILT_PORT", "7890"))
 
 		// if values were explicitly passed (e.g. `local('...', env={"TILT_PORT": 7890})`, they should be respected
-		doTest("7.8.9.0", 7890)
+		doTest(t, "7.8.9.0", 7890)
 	})
 }
 

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -386,8 +386,8 @@ func TestLocalTiltEnvPropagation(t *testing.T) {
 		t.Helper()
 
 		f.file("Tiltfile", `
-local('echo Tilt host is $TILT_HOST')
-local('echo Tilt port is $TILT_PORT')
+local(command='echo Tilt host is $TILT_HOST', command_bat='echo Tilt host is %TILT_HOST%', echo_off=True)
+local(command='echo Tilt port is $TILT_PORT', command_bat='echo Tilt port is %TILT_PORT%', echo_off=True)
 `)
 		f.load()
 


### PR DESCRIPTION
Various Tilt extensions have been using `local()` to shell back
out to Tilt to use the API (e.g. `tilt apply -f ...`). This does
not play nice with custom ports if Tilt was invoked using the
`--port` argument.

Now, the current Tilt instance's port is passed as the `TILT_PORT`
argument so that the invoked command will automatically connect to
the same instance of Tilt.

Fixes #4737.