### PR TITLE
docker-compose: Support absolute path to Dockerfile in docker-compose build

### DIFF
--- a/internal/tiltfile/docker_compose.go
+++ b/internal/tiltfile/docker_compose.go
@@ -213,7 +213,10 @@ func DockerComposeConfigToService(c dockercompose.Config, name string) (dcServic
 			// We only expect a Dockerfile if there's a build context specified.
 			dfPath = "Dockerfile"
 		}
-		dfPath = filepath.Join(buildContext, dfPath)
+
+		if !filepath.IsAbs(dfPath) {
+			dfPath = filepath.Join(buildContext, dfPath)
+		}
 	}
 
 	var mountedLocalDirs []string


### PR DESCRIPTION
The Docker Compose V2 beta (enabled by default in the latest Docker for Mac) resolves absolute paths for build Dockerfiles in the output of `docker-compose config`.

Old behavior:

```
❯ cat docker-compose.yml
version: '3'
services:
  foo:
    build:
      context: ../foo
      dockerfile: Dockerfile

❯ docker-compose disable-v2
❯ docker-compose version
docker-compose version 1.29.2, build 5becea4c
docker-py version: 5.0.0
CPython version: 3.9.0
OpenSSL version: OpenSSL 1.1.1h  22 Sep 2020
❯ docker-compose config
services:
  foo:
    build:
      context: /Users/mattm/dev/foo
      dockerfile: Dockerfile
version: '3'
```

New behavior:

```
❯ docker-compose enable-v2
❯ docker-compose version
Docker Compose version v2.0.0-beta.6
❯ docker-compose config
services:
  foo:
    build:
      context: /Users/mattm/dev/foo
      dockerfile: /Users/mattm/dev/foo/Dockerfile
    networks:
      default: null
networks:
  default:
    name: tilt_default
```

This was always allowed according to the [Compose File spec](https://github.com/compose-spec/compose-spec/blob/master/build.md), but Tilt assumes the Dockerfile is relative and unconditionally joins it to the context dir.

This PR adds support for absolute paths to Dockerfiles, whether explicitly configured in the docker-compose.yml or as emitted by Compose V2.