### PR TITLE
localexec: two improvements for running controllers with local_resource:

### DIFF
--- a/internal/cli/wire.go
+++ b/internal/cli/wire.go
@@ -50,6 +50,7 @@ import (
 	"github.com/tilt-dev/tilt/internal/hud/prompt"
 	"github.com/tilt-dev/tilt/internal/hud/server"
 	"github.com/tilt-dev/tilt/internal/k8s"
+	"github.com/tilt-dev/tilt/internal/localexec"
 	"github.com/tilt-dev/tilt/internal/openurl"
 	"github.com/tilt-dev/tilt/internal/store"
 	"github.com/tilt-dev/tilt/internal/tiltfile"
@@ -82,6 +83,7 @@ var BaseWireSet = wire.NewSet(
 	tiltfile.WireSet,
 	git.ProvideGitRemote,
 
+	localexec.DefaultEnv,
 	docker.SwitchWireSet,
 
 	ProvideDeferredExporter,

--- a/internal/controllers/core/cmd/execer_test.go
+++ b/internal/controllers/core/cmd/execer_test.go
@@ -154,7 +154,7 @@ func TestExecCmd(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			c := localexec.ExecCmd(tc.cmd, l)
+			c := localexec.EmptyEnv().ExecCmd(tc.cmd, l)
 			assertCommandEqual(t, tc.cmd, c)
 		})
 	}
@@ -197,7 +197,7 @@ type processExecFixture struct {
 }
 
 func newProcessExecFixture(t *testing.T) *processExecFixture {
-	execer := NewProcessExecer()
+	execer := NewProcessExecer(localexec.EmptyEnv())
 	execer.gracePeriod = time.Second
 	testWriter := bufsync.NewThreadSafeBuffer()
 	ctx, _, _ := testutils.ForkedCtxAndAnalyticsForTest(testWriter)

--- a/internal/engine/buildcontrol/local_target_build_and_deployer_test.go
+++ b/internal/engine/buildcontrol/local_target_build_and_deployer_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/tilt-dev/tilt/internal/controllers/core/cmd"
 	"github.com/tilt-dev/tilt/internal/controllers/fake"
+	"github.com/tilt-dev/tilt/internal/localexec"
 	"github.com/tilt-dev/tilt/internal/store"
 	"github.com/tilt-dev/tilt/internal/testutils"
 	"github.com/tilt-dev/tilt/internal/testutils/tempdir"
@@ -166,7 +167,7 @@ func newLTFixture(t *testing.T) *ltFixture {
 
 	ctrlClient := fake.NewFakeTiltClient()
 
-	fe := cmd.NewProcessExecer()
+	fe := cmd.NewProcessExecer(localexec.EmptyEnv())
 	fpm := cmd.NewFakeProberManager()
 	cclock := clockwork.NewFakeClock()
 	st := NewTestingStore(out)

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/tilt-dev/tilt/internal/controllers/core/kubernetesapply"
 	"github.com/tilt-dev/tilt/internal/controllers/core/kubernetesdiscovery"
+	"github.com/tilt-dev/tilt/internal/localexec"
 
 	"github.com/davecgh/go-spew/spew"
 
@@ -3884,7 +3885,7 @@ func newTestFixture(t *testing.T) *testFixture {
 	k8sContextExt := k8scontext.NewExtension("fake-context", env)
 	versionExt := version.NewExtension(model.TiltBuild{Version: "0.5.0"})
 	configExt := config.NewExtension("up")
-	tfl := tiltfile.ProvideTiltfileLoader(ta, b.kClient, k8sContextExt, versionExt, configExt, fakeDcc, "localhost", model.WebPort(12345), feature.MainDefaults, env)
+	tfl := tiltfile.ProvideTiltfileLoader(ta, b.kClient, k8sContextExt, versionExt, configExt, fakeDcc, "localhost", localexec.EmptyEnv(), feature.MainDefaults, env)
 	cc := configs.NewConfigsController(tfl, dockerClient, cdc)
 	dcw := dcwatch.NewEventWatcher(fakeDcc, dockerClient)
 	dclm := runtimelog.NewDockerComposeLogManager(fakeDcc)

--- a/internal/engine/wire.go
+++ b/internal/engine/wire.go
@@ -12,17 +12,17 @@ import (
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/tilt-dev/tilt/internal/analytics"
+	"github.com/tilt-dev/tilt/internal/build"
 	"github.com/tilt-dev/tilt/internal/container"
 	"github.com/tilt-dev/tilt/internal/controllers/core/cmd"
 	"github.com/tilt-dev/tilt/internal/controllers/core/kubernetesapply"
-	"github.com/tilt-dev/tilt/internal/engine/buildcontrol"
-	"github.com/tilt-dev/tilt/internal/store"
-
-	"github.com/tilt-dev/tilt/internal/analytics"
-	"github.com/tilt-dev/tilt/internal/build"
 	"github.com/tilt-dev/tilt/internal/docker"
 	"github.com/tilt-dev/tilt/internal/dockercompose"
+	"github.com/tilt-dev/tilt/internal/engine/buildcontrol"
 	"github.com/tilt-dev/tilt/internal/k8s"
+	"github.com/tilt-dev/tilt/internal/localexec"
+	"github.com/tilt-dev/tilt/internal/store"
 )
 
 var DeployerBaseWireSet = wire.NewSet(
@@ -67,9 +67,14 @@ func provideFakeBuildAndDeployer(
 		kubernetesapply.NewReconciler,
 		cmd.WireSet,
 		clockwork.NewRealClock,
+		provideFakeEnv,
 	)
 
 	return nil, nil
+}
+
+func provideFakeEnv() *localexec.Env {
+	return localexec.EmptyEnv()
 }
 
 func provideFakeK8sNamespace() k8s.Namespace {

--- a/internal/engine/wire_gen.go
+++ b/internal/engine/wire_gen.go
@@ -25,6 +25,7 @@ import (
 	"github.com/tilt-dev/tilt/internal/dockerfile"
 	"github.com/tilt-dev/tilt/internal/engine/buildcontrol"
 	"github.com/tilt-dev/tilt/internal/k8s"
+	"github.com/tilt-dev/tilt/internal/localexec"
 	"github.com/tilt-dev/tilt/internal/store"
 	"github.com/tilt-dev/tilt/internal/tracer"
 	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
@@ -53,7 +54,8 @@ func provideFakeBuildAndDeployer(ctx context.Context, docker2 docker.Client, kCl
 	imageBuildAndDeployer := buildcontrol.NewImageBuildAndDeployer(dockerBuilder, execCustomBuilder, kClient, env, kubeContext, analytics2, buildcontrolUpdateMode, clock, kp, ctrlClient, reconciler)
 	imageBuilder := buildcontrol.NewImageBuilder(dockerBuilder, execCustomBuilder, buildcontrolUpdateMode)
 	dockerComposeBuildAndDeployer := buildcontrol.NewDockerComposeBuildAndDeployer(dcc, docker2, imageBuilder, clock)
-	execer := cmd.ProvideExecer()
+	localexecEnv := provideFakeEnv()
+	execer := cmd.ProvideExecer(localexecEnv)
 	proberManager := cmd.ProvideProberManager()
 	clockworkClock := clockwork.NewRealClock()
 	controller := cmd.NewController(ctx, execer, proberManager, ctrlClient, st, clockworkClock, scheme)
@@ -84,6 +86,10 @@ var DeployerWireSetTest = wire.NewSet(
 var DeployerWireSet = wire.NewSet(
 	DeployerBaseWireSet,
 )
+
+func provideFakeEnv() *localexec.Env {
+	return localexec.EmptyEnv()
+}
 
 func provideFakeK8sNamespace() k8s.Namespace {
 	return "default"

--- a/internal/localexec/localexec_test.go
+++ b/internal/localexec/localexec_test.go
@@ -1,0 +1,30 @@
+package localexec
+
+import (
+	"bytes"
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/tilt-dev/tilt/pkg/logger"
+	"github.com/tilt-dev/tilt/pkg/model"
+)
+
+func TestDefaultEnv(t *testing.T) {
+	env := DefaultEnv(8000, "tilt.local")
+	env.environ = func() []string { return nil }
+	l := logger.NewTestLogger(bytes.NewBuffer(nil))
+	cmd := &exec.Cmd{}
+	cmdModel := model.Cmd{Argv: []string{"x"}, Env: []string{"x=y"}}
+	env.populateExecCmd(cmd, cmdModel, l)
+	assert.Equal(t, cmd.Env, []string{
+		"LINES=24",
+		"COLUMNS=80",
+		"PYTHONUNBUFFERED=1",
+		"TILT_PORT=8000",
+		"TILT_HOST=tilt.local",
+		"TILT_DISABLE_ANALYTICS=1",
+		"x=y",
+	})
+}

--- a/internal/tiltfile/files.go
+++ b/internal/tiltfile/files.go
@@ -8,11 +8,9 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strconv"
 	"strings"
 
 	"github.com/tilt-dev/tilt/internal/k8s"
-	"github.com/tilt-dev/tilt/internal/localexec"
 	tiltfile_io "github.com/tilt-dev/tilt/internal/tiltfile/io"
 	"github.com/tilt-dev/tilt/internal/tiltfile/starkit"
 	"github.com/tilt-dev/tilt/internal/tiltfile/value"
@@ -69,7 +67,7 @@ func (s *tiltfileState) execLocalCmd(t *starlark.Thread, cmd model.Cmd, logOutpu
 		return "", err
 	}
 
-	c := localexec.ExecCmd(cmd, logger.Get(ctx))
+	c := s.localEnv.ExecCmd(cmd, logger.Get(ctx))
 
 	// TODO(nick): Should this also inject any docker.Env overrides?
 	c.Stdout = stdout
@@ -80,12 +78,6 @@ func (s *tiltfileState) execLocalCmd(t *starlark.Thread, cmd model.Cmd, logOutpu
 		c.Stdout = io.MultiWriter(stdout, logOutput)
 		c.Stderr = io.MultiWriter(stderr, logOutput)
 	}
-
-	// if Tilt was invoked with `tilt up --port=XXXXX`, local() calls to use the Tilt API will fail due to trying to
-	// connect to the default port, so explicitly populate the TILT_PORT environment variable if it isn't already
-	addEnvIfNotPresent(c, "TILT_PORT", strconv.Itoa(int(s.webPort)))
-	// some Tilt commands, such as `tilt dump engine`, also require the host
-	addEnvIfNotPresent(c, "TILT_HOST", string(s.webHost))
 
 	err = c.Run()
 	if err != nil {
@@ -309,16 +301,4 @@ func getHelmCRDs(path string) ([]string, error) {
 func hasYAMLExtension(fname string) bool {
 	ext := filepath.Ext(fname)
 	return strings.EqualFold(ext, ".yaml") || strings.EqualFold(ext, ".yml")
-}
-
-func addEnvIfNotPresent(c *exec.Cmd, key, value string) bool {
-	prefix := key + "="
-	for _, e := range c.Env {
-		if strings.HasPrefix(e, prefix) {
-			return false
-		}
-	}
-
-	c.Env = append(c.Env, key+"="+value)
-	return true
 }

--- a/internal/tiltfile/tiltfile.go
+++ b/internal/tiltfile/tiltfile.go
@@ -17,6 +17,7 @@ import (
 	"github.com/tilt-dev/tilt/internal/dockercompose"
 	"github.com/tilt-dev/tilt/internal/feature"
 	"github.com/tilt-dev/tilt/internal/k8s"
+	"github.com/tilt-dev/tilt/internal/localexec"
 	"github.com/tilt-dev/tilt/internal/ospath"
 	"github.com/tilt-dev/tilt/internal/sliceutils"
 	tiltfileanalytics "github.com/tilt-dev/tilt/internal/tiltfile/analytics"
@@ -107,7 +108,7 @@ func ProvideTiltfileLoader(
 	configExt *config.Extension,
 	dcCli dockercompose.DockerComposeClient,
 	webHost model.WebHost,
-	webPort model.WebPort,
+	localEnv *localexec.Env,
 	fDefaults feature.Defaults,
 	env k8s.Env) TiltfileLoader {
 	return tiltfileLoader{
@@ -118,7 +119,7 @@ func ProvideTiltfileLoader(
 		configExt:     configExt,
 		dcCli:         dcCli,
 		webHost:       webHost,
-		webPort:       webPort,
+		localEnv:      localEnv,
 		fDefaults:     fDefaults,
 		env:           env,
 	}
@@ -129,7 +130,7 @@ type tiltfileLoader struct {
 	kCli      k8s.Client
 	dcCli     dockercompose.DockerComposeClient
 	webHost   model.WebHost
-	webPort   model.WebPort
+	localEnv  *localexec.Env
 
 	k8sContextExt k8scontext.Extension
 	versionExt    version.Extension
@@ -175,7 +176,7 @@ func (tfl tiltfileLoader) Load(ctx context.Context, filename string, userConfigS
 
 	localRegistry := tfl.kCli.LocalRegistry(ctx)
 
-	s := newTiltfileState(ctx, tfl.dcCli, tfl.webHost, tfl.webPort, tfl.k8sContextExt, tfl.versionExt, tfl.configExt, localRegistry, feature.FromDefaults(tfl.fDefaults))
+	s := newTiltfileState(ctx, tfl.dcCli, tfl.webHost, tfl.localEnv, tfl.k8sContextExt, tfl.versionExt, tfl.configExt, localRegistry, feature.FromDefaults(tfl.fDefaults))
 
 	manifests, result, err := s.loadManifests(absFilename, userConfigState)
 

--- a/internal/tiltfile/tiltfile_state.go
+++ b/internal/tiltfile/tiltfile_state.go
@@ -12,6 +12,7 @@ import (
 	"go.starlark.net/starlark"
 	"go.starlark.net/syntax"
 
+	"github.com/tilt-dev/tilt/internal/localexec"
 	links "github.com/tilt-dev/tilt/internal/tiltfile/links"
 	"github.com/tilt-dev/tilt/internal/tiltfile/print"
 	"github.com/tilt-dev/tilt/internal/tiltfile/probe"
@@ -65,7 +66,7 @@ type tiltfileState struct {
 	ctx           context.Context
 	dcCli         dockercompose.DockerComposeClient
 	webHost       model.WebHost
-	webPort       model.WebPort
+	localEnv      *localexec.Env
 	k8sContextExt k8scontext.Extension
 	versionExt    version.Extension
 	configExt     *config.Extension
@@ -135,7 +136,7 @@ func newTiltfileState(
 	ctx context.Context,
 	dcCli dockercompose.DockerComposeClient,
 	webHost model.WebHost,
-	webPort model.WebPort,
+	localEnv *localexec.Env,
 	k8sContextExt k8scontext.Extension,
 	versionExt version.Extension,
 	configExt *config.Extension,
@@ -145,7 +146,7 @@ func newTiltfileState(
 		ctx:                       ctx,
 		dcCli:                     dcCli,
 		webHost:                   webHost,
-		webPort:                   webPort,
+		localEnv:                  localEnv,
 		k8sContextExt:             k8sContextExt,
 		versionExt:                versionExt,
 		configExt:                 configExt,

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -13,10 +13,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/tilt-dev/tilt/internal/tiltfile/config"
-
-	"github.com/tilt-dev/tilt/internal/tiltfile/version"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tilt-dev/wmclient/pkg/analytics"
@@ -32,13 +28,16 @@ import (
 	"github.com/tilt-dev/tilt/internal/ignore"
 	"github.com/tilt-dev/tilt/internal/k8s"
 	"github.com/tilt-dev/tilt/internal/k8s/testyaml"
+	"github.com/tilt-dev/tilt/internal/localexec"
 	"github.com/tilt-dev/tilt/internal/ospath"
 	"github.com/tilt-dev/tilt/internal/sliceutils"
 	"github.com/tilt-dev/tilt/internal/testutils"
 	"github.com/tilt-dev/tilt/internal/testutils/tempdir"
+	"github.com/tilt-dev/tilt/internal/tiltfile/config"
 	tiltfile_k8s "github.com/tilt-dev/tilt/internal/tiltfile/k8s"
 	"github.com/tilt-dev/tilt/internal/tiltfile/k8scontext"
 	"github.com/tilt-dev/tilt/internal/tiltfile/testdata"
+	"github.com/tilt-dev/tilt/internal/tiltfile/version"
 	"github.com/tilt-dev/tilt/internal/yaml"
 	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
 	"github.com/tilt-dev/tilt/pkg/logger"
@@ -5713,7 +5712,8 @@ func (f *fixture) newTiltfileLoader() TiltfileLoader {
 	k8sContextExt := k8scontext.NewExtension(f.k8sContext, f.k8sEnv)
 	versionExt := version.NewExtension(model.TiltBuild{Version: "0.5.0"})
 	configExt := config.NewExtension("up")
-	return ProvideTiltfileLoader(f.ta, f.kCli, k8sContextExt, versionExt, configExt, dcc, f.webHost, model.WebPort(12345), features, f.k8sEnv)
+	localEnv := localexec.DefaultEnv(12345, f.webHost)
+	return ProvideTiltfileLoader(f.ta, f.kCli, k8sContextExt, versionExt, configExt, dcc, f.webHost, localEnv, features, f.k8sEnv)
 }
 
 func newFixture(t *testing.T) *fixture {


### PR DESCRIPTION
Hello @milas,

Please review the following commits I made in branch nicks/env:

e24fe359841eb5f889bc1b53d96e63a882116e03 (2021-07-20 18:34:14 -0400)
localexec: two improvements for running controllers with local_resource:
- disable analytics
- set TILT_PORT and TILT_HOST to ensure we're talking to the right tilt instance

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics