### PR TITLE
engine: don't log spurious uiresource/uisession errors

### DIFF
--- a/internal/engine/uiresource/subscriber.go
+++ b/internal/engine/uiresource/subscriber.go
@@ -14,7 +14,6 @@ import (
 	"github.com/tilt-dev/tilt/internal/hud/webview"
 	"github.com/tilt-dev/tilt/internal/store"
 	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
-	"github.com/tilt-dev/tilt/pkg/logger"
 )
 
 // Creates UIResource objects from the EngineState
@@ -56,8 +55,7 @@ func (s *Subscriber) OnChange(ctx context.Context, st store.RStore, summary stor
 			return nil
 		}
 
-		logger.Get(ctx).Infof("listing uiresource: %v", err)
-		return nil
+		return err
 	}
 
 	storedMap := make(map[types.NamespacedName]v1alpha1.UIResource)
@@ -75,8 +73,7 @@ func (s *Subscriber) OnChange(ctx context.Context, st store.RStore, summary stor
 			// If there's no current version of this resource, we should delete it.
 			err := s.client.Delete(ctx, &v1alpha1.UIResource{ObjectMeta: metav1.ObjectMeta{Name: name.Name}})
 			if err != nil && !apierrors.IsNotFound(err) {
-				st.Dispatch(store.NewErrorAction(fmt.Errorf("deleting resource %s: %v", name.Name, err)))
-				return nil
+				return err
 			}
 			continue
 		}
@@ -87,8 +84,7 @@ func (s *Subscriber) OnChange(ctx context.Context, st store.RStore, summary stor
 			// create it.
 			err := s.client.Create(ctx, resource)
 			if err != nil {
-				logger.Get(ctx).Infof("creating uiresource %s: %v", name.Name, err)
-				return nil
+				return err
 			}
 			continue
 		}
@@ -102,8 +98,7 @@ func (s *Subscriber) OnChange(ctx context.Context, st store.RStore, summary stor
 			}
 			err = s.client.Status().Update(ctx, update)
 			if err != nil {
-				logger.Get(ctx).Infof("updating uiresource %s: %v", name.Name, err)
-				return nil
+				return err
 			}
 			continue
 		}

--- a/internal/engine/uisession/subscriber.go
+++ b/internal/engine/uisession/subscriber.go
@@ -12,7 +12,6 @@ import (
 	"github.com/tilt-dev/tilt/internal/hud/webview"
 	"github.com/tilt-dev/tilt/internal/store"
 	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
-	"github.com/tilt-dev/tilt/pkg/logger"
 )
 
 type Subscriber struct {
@@ -38,8 +37,7 @@ func (s *Subscriber) OnChange(ctx context.Context, st store.RStore, summary stor
 		// If nothing is stored, create it.
 		err := s.client.Create(ctx, session)
 		if err != nil {
-			logger.Get(ctx).Infof("creating uisession: %v", err)
-			return nil
+			return err
 		}
 		return nil
 	} else if err != nil {
@@ -49,8 +47,7 @@ func (s *Subscriber) OnChange(ctx context.Context, st store.RStore, summary stor
 			return nil
 		}
 
-		logger.Get(ctx).Infof("fetching uisession: %v", err)
-		return nil
+		return err
 	}
 
 	if !apicmp.DeepEqual(session.Status, stored.Status) {
@@ -62,8 +59,7 @@ func (s *Subscriber) OnChange(ctx context.Context, st store.RStore, summary stor
 		}
 		err = s.client.Status().Update(ctx, update)
 		if err != nil {
-			logger.Get(ctx).Infof("updating uisession: %v", err)
-			return nil
+			return err
 		}
 	}
 


### PR DESCRIPTION
### Problem

Tilt regularly (~40% of the time on my machine) logs messages like this on startup:
```
creating uisession: uisessions.tilt.dev "Tiltfile" already exists
creating uiresource (Tiltfile): uiresources.tilt.dev "(Tiltfile)" already exists
```

These errors aren't really actionable or problematic but make it look like something went wrong.

### Solution

Don't log the error - just return it and let the retry happen.