### PR TITLE
web: remove test and non-test default resource grouping

### DIFF
--- a/web/src/OverviewSidebarOptions.tsx
+++ b/web/src/OverviewSidebarOptions.tsx
@@ -127,7 +127,6 @@ export const ClearResourceNameFilterButton = styled(InstrumentedButton)`
 `
 
 type OverviewSidebarOptionsProps = {
-  showFilters: boolean
   options: SidebarOptions
   setOptions: Dispatch<SetStateAction<SidebarOptions>>
 }
@@ -141,30 +140,6 @@ function setAlertsOnTop(
   })
 }
 
-function toggleTestsOnly(props: OverviewSidebarOptionsProps) {
-  props.setOptions((prevOptions) => {
-    // Always set the option you're not currently toggling to 'false', because both
-    // of these settings cannot be 'true' at the same time
-    return {
-      ...prevOptions,
-      testsHidden: false,
-      testsOnly: !prevOptions.testsOnly,
-    }
-  })
-}
-
-function toggleTestsHidden(props: OverviewSidebarOptionsProps) {
-  props.setOptions((prevOptions) => {
-    // Always set the option you're not currently toggling to 'false', because both
-    // of these settings cannot be 'true' at the same time
-    return {
-      ...prevOptions,
-      testsHidden: !prevOptions.testsHidden,
-      testsOnly: false,
-    }
-  })
-}
-
 function setResourceNameFilter(
   newValue: string,
   props: OverviewSidebarOptionsProps
@@ -175,36 +150,6 @@ function setResourceNameFilter(
       resourceNameFilter: newValue,
     }
   })
-}
-
-function filterOptions(props: OverviewSidebarOptionsProps) {
-  return (
-    <FilterOptionList>
-      Tests:
-      <ResourceFilterSegmentedControls>
-        <TestsHiddenToggle
-          className={props.options.testsHidden ? "is-enabled" : ""}
-          onClick={(e) => toggleTestsHidden(props)}
-          analyticsName="ui.web.testsHiddenToggle"
-          analyticsTags={{
-            newTestsHiddenState: (!props.options.testsHidden).toString(),
-          }}
-        >
-          Hidden
-        </TestsHiddenToggle>
-        <TestsOnlyToggle
-          className={props.options.testsOnly ? "is-enabled" : ""}
-          onClick={(e) => toggleTestsOnly(props)}
-          analyticsName="ui.web.testsOnlyToggle"
-          analyticsTags={{
-            newTestsOnlyState: (!props.options.testsOnly).toString(),
-          }}
-        >
-          Only
-        </TestsOnlyToggle>
-      </ResourceFilterSegmentedControls>
-    </FilterOptionList>
-  )
 }
 
 // debounce so we don't send for every single keypress
@@ -260,13 +205,10 @@ export function OverviewSidebarOptions(
 ): JSX.Element {
   return (
     <OverviewSidebarOptionsRoot>
-      <OverviewSidebarOptionsButtonsRoot
-        className={!props.showFilters ? "is-filterButtonsHidden" : ""}
-      >
-        {props.showFilters ? filterOptions(props) : null}
+      <OverviewSidebarOptionsButtonsRoot className="is-filterButtonsHidden">
         <AlertsOnTopToggle
           className={props.options.alertsOnTop ? "is-enabled" : ""}
-          onClick={(e) => setAlertsOnTop(props, !props.options.alertsOnTop)}
+          onClick={(_e) => setAlertsOnTop(props, !props.options.alertsOnTop)}
           analyticsName="ui.web.alertsOnTopToggle"
         >
           Alerts on Top

--- a/web/src/ResourceStatusSummary.tsx
+++ b/web/src/ResourceStatusSummary.tsx
@@ -285,35 +285,19 @@ type ResourceStatusSummaryProps = {
 export function ResourceStatusSummary(props: ResourceStatusSummaryProps) {
   // Count and calculate the combined statuses.
   let resources = props.view.uiResources || []
-  const allStatuses: ResourceStatus[] = []
 
-  const testStatuses: ResourceStatus[] = []
-  const otherStatuses: ResourceStatus[] = []
-  resources.forEach((r) => {
-    const status = combinedStatus(buildStatus(r), runtimeStatus(r))
-    allStatuses.push(status)
-    if (r.status?.localResourceInfo?.isTest) {
-      testStatuses.push(status)
-    } else {
-      otherStatuses.push(status)
-    }
-  })
+  const allStatuses = resources.map((r) =>
+    combinedStatus(buildStatus(r), runtimeStatus(r))
+  )
 
   return (
     <ResourceStatusSummaryRoot>
       <ResourceMetadata counts={statusCounts(allStatuses)} />
       <ResourceGroupStatus
-        counts={statusCounts(otherStatuses)}
+        counts={statusCounts(allStatuses)}
         label={"Resources"}
         healthyLabel={"healthy"}
         unhealthyLabel={"err"}
-        warningLabel={"warn"}
-      />
-      <ResourceGroupStatus
-        counts={statusCounts(testStatuses)}
-        label={"Tests"}
-        healthyLabel={"pass"}
-        unhealthyLabel={"fail"}
         warningLabel={"warn"}
       />
     </ResourceStatusSummaryRoot>

--- a/web/src/SidebarResources.test.tsx
+++ b/web/src/SidebarResources.test.tsx
@@ -10,8 +10,6 @@ import { accessorsForTesting, tiltfileKeyContext } from "./LocalStorage"
 import {
   AlertsOnTopToggle,
   ResourceNameFilterTextField,
-  TestsHiddenToggle,
-  TestsOnlyToggle,
 } from "./OverviewSidebarOptions"
 import { assertSidebarItemsAndOptions } from "./OverviewSidebarOptions.test"
 import PathBuilder from "./PathBuilder"
@@ -117,15 +115,11 @@ describe("SidebarResources", () => {
   })
 
   const falseyOptions: SidebarOptions = {
-    testsHidden: false,
-    testsOnly: false,
     alertsOnTop: false,
     resourceNameFilter: "",
   }
 
   const loadCases: [string, any, string[]][] = [
-    ["tests only", { ...falseyOptions, testsOnly: true }, ["a", "b"]],
-    ["tests hidden", { ...falseyOptions, testsHidden: true }, ["vigoda"]],
     [
       "alertsOnTop",
       { ...falseyOptions, alertsOnTop: true },
@@ -166,19 +160,11 @@ describe("SidebarResources", () => {
         </MemoryRouter>
       )
 
-      assertSidebarItemsAndOptions(
-        root,
-        expectedItems,
-        options.testsHidden,
-        options.testsOnly,
-        options.alertsOnTop
-      )
+      assertSidebarItemsAndOptions(root, expectedItems, options.alertsOnTop)
     }
   )
 
   const saveCases: [string, SidebarOptions][] = [
-    ["testsHidden", { ...falseyOptions, testsHidden: true }],
-    ["testsOnly", { ...falseyOptions, testsOnly: true }],
     ["alertsOnTop", { ...falseyOptions, alertsOnTop: true }],
     ["resourceNameFilter", { ...falseyOptions, resourceNameFilter: "foo" }],
   ]
@@ -203,21 +189,6 @@ describe("SidebarResources", () => {
           </tiltfileKeyContext.Provider>
         </MemoryRouter>
       )
-
-      let testsHiddenControl = root.find(TestsHiddenToggle)
-      if (
-        testsHiddenControl.hasClass("is-enabled") !==
-        expectedOptions.testsHidden
-      ) {
-        testsHiddenControl.simulate("click")
-      }
-
-      let testsOnlyControl = root.find(TestsOnlyToggle)
-      if (
-        testsOnlyControl.hasClass("is-enabled") !== expectedOptions.testsOnly
-      ) {
-        testsOnlyControl.simulate("click")
-      }
 
       let aotToggle = root.find(AlertsOnTopToggle)
       if (aotToggle.hasClass("is-enabled") !== expectedOptions.alertsOnTop) {

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -142,12 +142,9 @@ export enum ResourceName {
 }
 
 export type SidebarOptions = {
-  // Which cards to show in sidebar
-  testsHidden: boolean
-  testsOnly: boolean
-
   // Sorting options
   alertsOnTop: boolean
 
+  // Filter options
   resourceNameFilter: string
 }


### PR DESCRIPTION
This PR removes the test / non-test resource grouping and filtering, since that delineating will be replaced with labels.

If we want to keep the test / non-test filters code, but turn it off instead of deleting it, I can do that instead.

Closes [ch12251](https://app.clubhouse.io/windmill/story/12251/hide-non-test-test-resource-code-throughout-ui-with-labels-feature-flag)