### PR TITLE
store: stop retrying subscriber notifications on shutdown

### DIFF
--- a/internal/store/subscriber.go
+++ b/internal/store/subscriber.go
@@ -188,6 +188,13 @@ func (e *subscriberEntry) notify(ctx context.Context, store *Store) {
 		return
 	}
 
+	select {
+	case <-ctx.Done():
+		// don't keep retrying after context is done
+		return
+	default:
+	}
+
 	// Backoff on error
 	// TODO(nick): Include the subscriber name in the error message.
 	backoff := activeChange.LastBackoff * 2

--- a/internal/store/subscriber.go
+++ b/internal/store/subscriber.go
@@ -188,11 +188,9 @@ func (e *subscriberEntry) notify(ctx context.Context, store *Store) {
 		return
 	}
 
-	select {
-	case <-ctx.Done():
-		// don't keep retrying after context is done
+	if ctx.Err() != nil {
+		// context finished
 		return
-	default:
 	}
 
 	// Backoff on error


### PR DESCRIPTION
repro: `go test ./internal/engine -run TestConfigChange_ManifestWithPendingChangesBuildsIfTriggerModeChangedToAuto -count 100`

Sometimes on failures, I've gotten 100s of these in my output:
```
Problem processing change. Backing off 15s. Error: context canceled
Problem processing change. Backing off 15s. Error: context canceled
Problem processing change. Backing off 15s. Error: context canceled
Problem processing change. Backing off 15s. Error: context canceled
Problem processing change. Backing off 15s. Error: context canceled
Problem processing change. Backing off 15s. Error: context canceled
Problem processing change. Backing off 15s. Error: context canceled
Problem processing change. Backing off 15s. Error: context canceled
Problem processing change. Backing off 15s. Error: context canceled
Problem processing change. Backing off 15s. Error: context canceled
Problem processing change. Backing off 15s. Error: context canceled
Problem processing change. Backing off 15s. Error: context canceled
Problem processing change. Backing off 15s. Error: context canceled
Problem processing change. Backing off 15s. Error: context canceled
Problem processing change. Backing off 15s. Error: context canceled
```

It seems reasonable to skip retrying when the context is done.