### PR TITLE
store: log subscriber name on notify error

### DIFF
--- a/internal/store/subscriber.go
+++ b/internal/store/subscriber.go
@@ -204,10 +204,10 @@ func (e *subscriberEntry) notify(ctx context.Context, store *Store) {
 	backoff := activeChange.LastBackoff * 2
 	if backoff == 0 {
 		backoff = time.Second
-		logger.Get(ctx).Debugf("Problem processing change. Subscriber: %s. Backing off %v. Error: %v", subscriberName, backoff, err)
+		logger.Get(ctx).Debugf("Problem processing change. Subscriber: %s. Backing off %v. Error: %v", subscriberName(e.subscriber), backoff, err)
 	} else if backoff > MaxBackoff {
 		backoff = MaxBackoff
-		logger.Get(ctx).Errorf("Problem processing change. Subscriber: %s. Backing off %v. Error: %v", subscriberName, backoff, err)
+		logger.Get(ctx).Errorf("Problem processing change. Subscriber: %s. Backing off %v. Error: %v", subscriberName(e.subscriber), backoff, err)
 	}
 	store.sleeper.Sleep(ctx, backoff)
 

--- a/internal/store/subscriber_test.go
+++ b/internal/store/subscriber_test.go
@@ -245,3 +245,22 @@ func TestSubscriberBackoff(t *testing.T) {
 	assert.Equal(t, call.summary, ChangeSummary{CmdSpecs: NewChangeSet(nn1, nn2, nn3), LastBackoff: 2 * time.Second})
 	close(call.done)
 }
+
+type subscriberWithPointerReceiver struct {
+}
+
+func (s *subscriberWithPointerReceiver) OnChange(ctx context.Context, st RStore, summary ChangeSummary) error {
+	return nil
+}
+
+type subscriberWithNonPointerReceiver struct {
+}
+
+func (s subscriberWithNonPointerReceiver) OnChange(ctx context.Context, st RStore, summary ChangeSummary) error {
+	return nil
+}
+
+func TestSubscriberName(t *testing.T) {
+	require.Equal(t, "store.subscriberWithPointerReceiver", subscriberName(&subscriberWithPointerReceiver{}))
+	require.Equal(t, "store.subscriberWithNonPointerReceiver", subscriberName(subscriberWithNonPointerReceiver{}))
+}


### PR DESCRIPTION
I was hitting one of these errors so I threw this in to track it down.

We could also do this via a `SubscriberName` method on the `Subscriber` interface to avoid the reflection perf hit. I'm guessing in error cases the reflection perf hit is insignificant, relatively.