### PR TITLE
tiltfile: add Tiltfile owner label to all manifests

### DIFF
--- a/internal/engine/configs/api.go
+++ b/internal/engine/configs/api.go
@@ -234,15 +234,10 @@ func toUIResourceObjects(tlr tiltfile.TiltfileLoadResult) typedObjectSet {
 	for _, m := range tlr.Manifests {
 		name := string(m.Name)
 
-		m = m.WithLabels(m.Labels)
-		labels := m.Labels
-		// TODO(lizz): consider moving this label assignment to the Tiltfile itself
-		labels[LabelOwnerKind] = LabelOwnerKindTiltfile
-
 		r := &v1alpha1.UIResource{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:   name,
-				Labels: labels,
+				Labels: m.Labels,
 				Annotations: map[string]string{
 					v1alpha1.AnnotationManifest: m.Name.String(),
 				},

--- a/internal/testutils/manifestbuilder/manifestbuilder.go
+++ b/internal/testutils/manifestbuilder/manifestbuilder.go
@@ -188,7 +188,11 @@ func (b ManifestBuilder) Build() model.Manifest {
 		b.f.T().Fatalf("No deploy target specified: %s", b.name)
 		return model.Manifest{}
 	}
-	m = m.WithTriggerMode(b.triggerMode)
+	m = m.
+		WithTriggerMode(b.triggerMode).
+		WithLabels(map[string]string{
+			"tilt.dev/owner-kind": "Tiltfile",
+		})
 	return m
 }
 

--- a/internal/tiltfile/tiltfile_state.go
+++ b/internal/tiltfile/tiltfile_state.go
@@ -294,8 +294,17 @@ to your Tiltfile. Otherwise, switch k8s contexts and restart Tilt.`, kubeContext
 		return nil, starkit.Model{}, err
 	}
 
-	for _, m := range manifests {
-		err := m.Validate()
+	for i := range manifests {
+		// ensure all manifests have a label indicating they're owned
+		// by the Tiltfile - some reconcilers have special handling
+		l := manifests[i].Labels
+		if l == nil {
+			l = make(map[string]string)
+		}
+		l[v1alpha1.LabelOwnerKind] = v1alpha1.LabelOwnerKindTiltfile
+		manifests[i] = manifests[i].WithLabels(l)
+
+		err := manifests[i].Validate()
 		if err != nil {
 			// Even on manifest validation errors, we may be able
 			// to use other kinds of models (e.g., watched files)

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -6435,7 +6435,10 @@ type resourceLabelsHelper struct {
 
 func resourceLabels(labels ...string) resourceLabelsHelper {
 	ret := resourceLabelsHelper{
-		labels: make(map[string]string),
+		// initialize with global labels inherited by all resources
+		labels: map[string]string{
+			"tilt.dev/owner-kind": "Tiltfile",
+		},
 	}
 	for _, l := range labels {
 		ret.labels[l] = l


### PR DESCRIPTION
As part of apiserver transition, there is special handling for
certain objects that originate from the Tiltfile that can't be
represented via `OwnerReference` (since the Tiltfile does not
yet live in the API).

Because multiple places create/manage these objects and the
label assignment logic was inconsistent, there was a race where
the `uiresource` objects could get created without the label,
so the subscriber would not find them when looking for objects
to manage and instead try to (re)create them and fail with an
already exists error:
```
Failed to update API server: create uiresources/local: uiresources.tilt.dev "foo" already exists
```

Assignment is now done on ALL manifests via their new label
support during Tiltfile load. This label (along with any other
custom labels) are propagated elsewhere.