### PR TITLE
podlogstream: do not log context errors

### DIFF
--- a/internal/controllers/core/podlogstream/podlogstreamcontroller.go
+++ b/internal/controllers/core/podlogstream/podlogstreamcontroller.go
@@ -307,8 +307,10 @@ func (m *Controller) consumeLogs(watch PodLogWatch, st store.RStore) {
 		ctx, cancel := context.WithCancel(ctx)
 		readCloser, err := m.kClient.ContainerLogs(ctx, pID, containerName, ns, startReadTime)
 		if err != nil {
+			if ctx.Err() == nil {
+				exitError = err
+			}
 			cancel()
-			exitError = err
 			return
 		}
 


### PR DESCRIPTION
It was possible to get rare (but benign) error messages in the logs
about streaming:
```
Error streaming hello-xbhtp logs: Get "https://0.0.0.0:51700/api/v1/namespaces/default/pods/hello-xbhtp/log?container=hello&follow=true&sinceTime=2021-07-22T18%3A22%3A48Z": context canceled
```

There are two exit paths from the function - one already filtered
out context errors, while the other did not. In both cases, these
are not worthy of being logged, as they're part of normal execution
flow and will be handled (i.e. streaming will resume if it was
interrupted).

Fixes #3196.