### PR TITLE
web: remove log filter links on resource status summary for label groups

### DIFF
--- a/web/src/ResourceStatusSummary.test.tsx
+++ b/web/src/ResourceStatusSummary.test.tsx
@@ -26,22 +26,24 @@ function expectStatusCounts(
   expect(actual).toEqual(expected)
 }
 
+const testCounts: StatusCounts = {
+  total: 11,
+  healthy: 0,
+  warning: 2,
+  unhealthy: 4,
+  pending: 0,
+}
+
 it("shows the counts it's given", () => {
-  const counts: StatusCounts = {
-    total: 11,
-    healthy: 0,
-    warning: 2,
-    unhealthy: 4,
-    pending: 0,
-  }
   const root = mount(
     <MemoryRouter>
       <ResourceGroupStatus
-        counts={counts}
+        counts={testCounts}
         healthyLabel="healthy"
         label="resources"
         unhealthyLabel="unhealthy"
         warningLabel="warning"
+        linkToLogFilters={true}
       />
     </MemoryRouter>
   )
@@ -53,4 +55,50 @@ it("shows the counts it's given", () => {
     { label: "warning", counts: [2] },
     { label: "healthy", counts: [0, 11] },
   ])
+})
+
+it("links to warning and unhealthy resources when `linkToLogFilters` is true", () => {
+  const root = mount(
+    <MemoryRouter>
+      <ResourceGroupStatus
+        counts={testCounts}
+        healthyLabel="healthy"
+        label="resources"
+        unhealthyLabel="unhealthy"
+        warningLabel="warning"
+        linkToLogFilters={true}
+      />
+    </MemoryRouter>
+  )
+
+  const warningLinkCount = root
+    .find(ResourceGroupStatusItem)
+    .filterWhere((item) => item.props().label === "warning")
+    .find("a").length
+  const errorLinkCount = root
+    .find(ResourceGroupStatusItem)
+    .filterWhere((item) => item.props().label === "unhealthy")
+    .find("a").length
+
+  expect(warningLinkCount).toBe(1)
+  expect(errorLinkCount).toBe(1)
+})
+
+it("does NOT link to warning and unhealthy resources when `linkToLogFilters` is false", () => {
+  const root = mount(
+    <MemoryRouter>
+      <ResourceGroupStatus
+        counts={testCounts}
+        healthyLabel="healthy"
+        label="resources"
+        unhealthyLabel="unhealthy"
+        warningLabel="warning"
+        linkToLogFilters={false}
+      />
+    </MemoryRouter>
+  )
+
+  const linkCount = root.find(ResourceGroupStatusItem).find("a").length
+
+  expect(linkCount).toBe(0)
 })

--- a/web/src/ResourceStatusSummary.tsx
+++ b/web/src/ResourceStatusSummary.tsx
@@ -139,6 +139,7 @@ type ResourceGroupStatusProps = {
   healthyLabel: string
   unhealthyLabel: string
   warningLabel: string
+  linkToLogFilters: boolean
 }
 
 export function ResourceGroupStatus(props: ResourceGroupStatusProps) {
@@ -150,12 +151,15 @@ export function ResourceGroupStatus(props: ResourceGroupStatusProps) {
   let items = new Array<JSX.Element>()
 
   if (props.counts.unhealthy) {
+    const errorHref = props.linkToLogFilters
+      ? pb.encpath`/r/${ResourceName.all}/overview?level=${FilterLevel.error}`
+      : undefined
     items.push(
       <ResourceGroupStatusItem
         key={props.unhealthyLabel}
         label={props.unhealthyLabel}
         count={props.counts.unhealthy}
-        href={pb.encpath`/r/${ResourceName.all}/overview?level=${FilterLevel.error}`}
+        href={errorHref}
         className="is-highlightError"
         icon={<CloseSvg width="11" key="icon" />}
       />
@@ -163,12 +167,15 @@ export function ResourceGroupStatus(props: ResourceGroupStatusProps) {
   }
 
   if (props.counts.warning) {
+    const warningHref = props.linkToLogFilters
+      ? pb.encpath`/r/${ResourceName.all}/overview?level=${FilterLevel.warn}`
+      : undefined
     items.push(
       <ResourceGroupStatusItem
         key={props.warningLabel}
         label={props.warningLabel}
         count={props.counts.warning}
-        href={pb.encpath`/r/${ResourceName.all}/overview?level=${FilterLevel.warn}`}
+        href={warningHref}
         className="is-highlightWarning"
         icon={<WarningSvg width="7" key="icon" />}
       />
@@ -299,6 +306,7 @@ export function ResourceStatusSummary(props: ResourceStatusSummaryProps) {
         healthyLabel={"healthy"}
         unhealthyLabel={"err"}
         warningLabel={"warn"}
+        linkToLogFilters={true}
       />
     </ResourceStatusSummaryRoot>
   )
@@ -326,6 +334,7 @@ export function ResourceSidebarStatusSummary(
         healthyLabel={"healthy"}
         unhealthyLabel={"err"}
         warningLabel={"warn"}
+        linkToLogFilters={false}
       />
     </ResourceStatusSummaryRoot>
   )


### PR DESCRIPTION
Clicking on a label group heading should only expand or collapse a group and not add/change log filters, (especially since we don't have log filtering by label group available). This PR removes those log filter links in label groups.