### PR TITLE
docker-compose: fix variable resolution type issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,14 +53,14 @@ test: test-go test-js
 # TODO(matt) skiplargetiltfiletests only skips the tiltfile DC+Helm tests at the moment
 # we might also want to skip the ones in engine
 shorttest:
-	go test -mod vendor -p $(GO_PARALLEL_JOBS) -tags skipcontainertests,skiplargetiltfiletests -timeout 100s ./...
+	go test -mod vendor -p $(GO_PARALLEL_JOBS) -short -tags skipcontainertests,skiplargetiltfiletests -timeout 100s ./...
 
 shorttestsum:
 ifneq ($(CIRCLECI),true)
-	gotestsum -- -mod vendor -p $(GO_PARALLEL_JOBS) -tags skipcontainertests,skiplargetiltfiletests -timeout 100s ./...
+	gotestsum -- -mod vendor -p $(GO_PARALLEL_JOBS) -short -tags skipcontainertests,skiplargetiltfiletests -timeout 100s ./...
 else
 	mkdir -p test-results
-	gotestsum --format standard-quiet --junitfile test-results/unit-tests.xml --rerun-fails=2 --rerun-fails-max-failures=10 --packages="./..." -- -mod vendor -count 1 -p $(GO_PARALLEL_JOBS) -tags skipcontainertests,skiplargetiltfiletests -timeout 100s
+	gotestsum --format standard-quiet --junitfile test-results/unit-tests.xml --rerun-fails=2 --rerun-fails-max-failures=10 --packages="./..." -- -mod vendor -count 1 -p $(GO_PARALLEL_JOBS) -short -tags skipcontainertests,skiplargetiltfiletests -timeout 100s
 endif
 
 integration:

--- a/internal/dockercompose/client_test.go
+++ b/internal/dockercompose/client_test.go
@@ -1,0 +1,119 @@
+package dockercompose_test
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/compose-spec/compose-go/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tilt-dev/tilt/internal/docker"
+	"github.com/tilt-dev/tilt/internal/dockercompose"
+	"github.com/tilt-dev/tilt/internal/testutils"
+	"github.com/tilt-dev/tilt/internal/testutils/tempdir"
+)
+
+func setEnvForTest(t testing.TB, key, value string) {
+	t.Helper()
+
+	if curVal, ok := os.LookupEnv(key); ok {
+		t.Cleanup(func() {
+			if err := os.Setenv(key, curVal); err != nil {
+				t.Errorf("Failed to restore env var %q: %v", key, err)
+			}
+		})
+	} else {
+		t.Cleanup(func() {
+			if err := os.Unsetenv(key); err != nil {
+				t.Errorf("Failed to restore env var %q: %v", key, err)
+			}
+		})
+	}
+
+	require.NoError(t, os.Setenv(key, value))
+}
+
+// TestVariableInterpolation both ensures Tilt properly passes environment to Compose for interpolation
+// as well as catches potential regressions in the upstream YAML parsing from compose-go (currently, a
+// fallback mechanism relies on the user having the v1 (Python) docker-compose CLI installed to work
+// around bugs in the compose-go library (also used by the v2 CLI, and is susceptible to the same
+// issues)
+func TestVariableInterpolation(t *testing.T) {
+	if testing.Short() {
+		// remove this once the fallback to docker-compose CLI for YAML parse is eliminated
+		// (dependent upon compose-go upstream bugs being fixed)
+		t.Skip("skipping test that invokes docker-compose CLI in short mode")
+	}
+
+	f := newDCFixture(t)
+
+	output := `services:
+  app:
+    command: sh -c 'node app.js'
+    image: "$DC_TEST_IMAGE"
+    build:
+      context: $DC_TEST_CONTEXT
+      dockerfile: ${DC_TEST_DOCKERFILE}
+    ports:
+      - target: $DC_TEST_PORT
+        published: 8080
+        protocol: tcp
+        mode: ingress
+`
+
+	// the value is already quoted - Compose should NOT add extra quotes
+	setEnvForTest(t, "DC_TEST_IMAGE", "myimage")
+	// unquoted 0 is a number in YAML, but Compose SHOULD quote this properly for the field string
+	// N.B. the path MUST exist or Compose will fail loading!
+	setEnvForTest(t, "DC_TEST_CONTEXT", "0")
+	f.tmpdir.MkdirAll("0")
+	// unquoted Y is a bool in YAML, but Compose SHOULD quote this properly for the field string
+	setEnvForTest(t, "DC_TEST_DOCKERFILE", "Y")
+	// Compose should NOT quote this since the field is numeric
+	setEnvForTest(t, "DC_TEST_PORT", "8081")
+
+	proj := f.loadProject(output)
+	if assert.Len(t, proj.Services, 1) {
+		svc := proj.Services[0]
+		assert.Equal(t, "myimage", svc.Image)
+		if assert.NotNil(t, svc.Build) {
+			assert.Equal(t, f.tmpdir.JoinPath("0"), svc.Build.Context)
+			// resolved Dockerfile path is relative to the context
+			assert.Equal(t, f.tmpdir.JoinPath("0", "Y"), svc.Build.Dockerfile)
+		}
+		if assert.Len(t, svc.Ports, 1) {
+			assert.Equal(t, 8081, int(svc.Ports[0].Target))
+		}
+	}
+}
+
+type dcFixture struct {
+	t      testing.TB
+	ctx    context.Context
+	cli    dockercompose.DockerComposeClient
+	tmpdir *tempdir.TempDirFixture
+}
+
+func newDCFixture(t testing.TB) *dcFixture {
+	ctx, _, _ := testutils.CtxAndAnalyticsForTest()
+
+	tmpdir := tempdir.NewTempDirFixture(t)
+	t.Cleanup(tmpdir.TearDown)
+
+	return &dcFixture{
+		t:      t,
+		ctx:    ctx,
+		cli:    dockercompose.NewDockerComposeClient(docker.LocalEnv{}),
+		tmpdir: tmpdir,
+	}
+}
+
+func (f *dcFixture) loadProject(composeYAML string) *types.Project {
+	f.t.Helper()
+	f.tmpdir.WriteFile("docker-compose.yaml", composeYAML)
+	proj, err := f.cli.Project(f.ctx, []string{f.tmpdir.JoinPath("docker-compose.yaml")})
+	require.NoError(f.t, err, "Failed to parse compose YAML")
+	return proj
+}


### PR DESCRIPTION
Currently, the `compose-go` library (used by the v2 Compose CLI)
has a regression in variable resolution: it applies it to the raw
YAML string _before_ parsing, so does not take field types into
consideration.

In Compose v1, variable substitution would appropriately quote
values based on the field type to avoid automatic YAML coercion
(e.g. `Y` -> `"Y"` for a string field to avoid it being interpreted
as a bool and causing a validation error).

As a temporary workaround, if the "native" (compose-go) parsing
fails, we shell out to `docker-compose config` (as we did previously)
to allow it to resolve the variables/merge configurations, and then
pass the prepared YAML to compose-go. This does rely on the user
having v1 docker-compose since v2 is broken, but the same was true
before even switching to compose-go, so this is still a net
improvement.

Fixes #4795.