### PR TITLE
docker-compose: fix stack overflow panic

### DIFF
--- a/internal/tiltfile/docker_compose.go
+++ b/internal/tiltfile/docker_compose.go
@@ -9,7 +9,10 @@ import (
 	"strings"
 
 	"github.com/compose-spec/compose-go/types"
-	"gopkg.in/yaml.v3"
+	// DANGER: some compose-go types are not friendly to being marshaled with gopkg.in/yaml.v3
+	// and will trigger a stack overflow panic
+	// see https://github.com/tilt-dev/tilt/issues/4797
+	composeyaml "gopkg.in/yaml.v2"
 
 	"github.com/docker/distribution/reference"
 	"github.com/pkg/errors"
@@ -238,7 +241,7 @@ func DockerComposeConfigToService(svcConfig types.ServiceConfig) (dcService, err
 		}
 	}
 
-	rawConfig, err := yaml.Marshal(svcConfig)
+	rawConfig, err := composeyaml.Marshal(svcConfig)
 	if err != nil {
 		return dcService{}, err
 	}

--- a/internal/tiltfile/docker_compose_test.go
+++ b/internal/tiltfile/docker_compose_test.go
@@ -117,6 +117,25 @@ version: '3.0'
 	}
 }
 
+func TestMarshalOverflow(t *testing.T) {
+	f := newDCFixture(t)
+
+	// certain Compose types cause a stack overflow panic if marshaled with gopkg.in/yaml.v3
+	// https://github.com/tilt-dev/tilt/issues/4797
+	output := `services:
+  foo:
+    image: myimage
+    ulimits:
+      nproc: 65535
+      nofile:
+        soft: 20000
+        hard: 40000
+`
+
+	services := f.parse(output)
+	assert.NotEmpty(t, services)
+}
+
 type dcFixture struct {
 	t     *testing.T
 	ctx   context.Context

--- a/internal/tiltfile/tiltfile_docker_compose_test.go
+++ b/internal/tiltfile/tiltfile_docker_compose_test.go
@@ -798,7 +798,7 @@ func (f *fixture) assertDcManifest(name model.ManifestName, opts ...interface{})
 		case dcLocalPathsHelper:
 			assert.ElementsMatch(f.t, opt.paths, dcInfo.LocalPaths(), "docker compose local paths")
 		case dcYAMLRawHelper:
-			assert.Equal(f.t, strings.TrimSpace(opt.yaml), strings.TrimSpace(string(dcInfo.YAMLRaw)), "docker compose YAML raw")
+			assert.YAMLEq(f.t, opt.yaml, string(dcInfo.YAMLRaw), "docker compose YAML raw")
 		case dcDfRawHelper:
 			assert.Equal(f.t, strings.TrimSpace(opt.df), strings.TrimSpace(string(dcInfo.DfRaw)), "docker compose Dockerfile raw")
 		case dcPublishedPortsHelper:


### PR DESCRIPTION
Some of the `compose-go` types are not marshalable with `yaml.v3`:
they will trigger infinite recursion and a stack overflow panic.

Internally, `compose-cli` uses `yaml.v2` when marshaling (e.g. for
output via `docker-compose config`).

This is now explicitly used, and a test has been added to prevent
regression. Due to other issues/requirements, `compose-go` is also
in the midst of upgrading to `yaml.v3`, so in the future we should
be able to upgrade it and switch to `yaml.v3` for marshaling its
types.

Fixes #4797.