### PR TITLE
web: add resource grouping (tool)tip with link to docs in the sidebar

### DIFF
--- a/web/src/SidebarResources.tsx
+++ b/web/src/SidebarResources.tsx
@@ -6,6 +6,7 @@ import {
 import React, { Dispatch, PropsWithChildren, SetStateAction } from "react"
 import styled from "styled-components"
 import { ReactComponent as CaretSvg } from "./assets/svg/caret.svg"
+import { ReactComponent as InfoSvg } from "./assets/svg/info.svg"
 import Features, { FeaturesContext, Flag } from "./feature"
 import { orderLabels } from "./labels"
 import { PersistentStateProvider } from "./LocalStorage"
@@ -19,6 +20,7 @@ import SidebarItemView, {
 } from "./SidebarItemView"
 import SidebarKeyboardShortcuts from "./SidebarKeyboardShortcuts"
 import { Color, FontSize, SizeUnit } from "./style-helpers"
+import TiltTooltip from "./Tooltip"
 import { ResourceView, SidebarOptions } from "./types"
 
 let SidebarResourcesRoot = styled.nav`
@@ -30,7 +32,9 @@ let SidebarResourcesRoot = styled.nav`
   }
 `
 
-let SidebarList = styled.div``
+let SidebarList = styled.div`
+  margin-bottom: ${SizeUnit(1.75)};
+`
 
 let SidebarListSectionName = styled.div`
   margin-top: ${SizeUnit(0.5)};
@@ -61,6 +65,23 @@ const SidebarLabelSection = styled(Accordion)`
   &.MuiAccordion-root,
   &.MuiAccordion-root.Mui-expanded {
     margin: ${SizeUnit(1 / 3)} ${SizeUnit(1 / 2)};
+  }
+`
+
+const SidebarGroupInfo = styled.aside`
+  background-color: ${Color.grayDark};
+  bottom: 0;
+  box-sizing: border-box;
+  left: 0;
+  padding: 10px 10px 5px 10px;
+  position: absolute;
+  width: 100%;
+  z-index: 2;
+`
+
+const InfoIcon = styled(InfoSvg)`
+  .fillStd {
+    fill: ${Color.blueLight};
   }
 `
 
@@ -121,6 +142,30 @@ const SidebarGroupDetails = styled(AccordionDetails)`
     }
   }
 `
+
+const GROUP_INFO_TOOLTIP_ID = "sidebar-groups-info"
+function SidebarLabelInfo() {
+  const tooltipInfo = (
+    <>
+      Resources can be grouped by adding custom labels.{" "}
+      <a
+        href="https://docs.tilt.dev/tiltfile_concepts.html#resource-groups"
+        target="_blank"
+      >
+        See docs for more info
+      </a>
+      .
+    </>
+  )
+
+  return (
+    <SidebarGroupInfo>
+      <TiltTooltip interactive title={tooltipInfo} leaveDelay={500}>
+        <InfoIcon id={GROUP_INFO_TOOLTIP_ID} />
+      </TiltTooltip>
+    </SidebarGroupInfo>
+  )
+}
 
 export function SidebarListSection(
   props: PropsWithChildren<{ name: string }>
@@ -337,7 +382,8 @@ export class SidebarResources extends React.Component<SidebarProps> {
 
     return (
       <SidebarResourcesRoot className={`Sidebar-resources ${isOverviewClass}`}>
-        <SidebarList>
+        <SidebarLabelInfo />
+        <SidebarList aria-describedby={GROUP_INFO_TOOLTIP_ID}>
           <OverviewSidebarOptions options={options} setOptions={setOptions} />
           {displayLabelGroups ? (
             <SidebarGroupedByLabels {...this.props} items={filteredItems} />

--- a/web/src/Tooltip.tsx
+++ b/web/src/Tooltip.tsx
@@ -1,13 +1,7 @@
 import { makeStyles } from "@material-ui/core/styles"
-import Tooltip from "@material-ui/core/Tooltip"
+import Tooltip, { TooltipProps } from "@material-ui/core/Tooltip"
 import React from "react"
 import { Color, Font, FontSize, SizeUnit } from "./style-helpers"
-
-type TooltipProps = {
-  title: string
-  children: React.ReactElement
-  open?: boolean // Useful for keeping the tooltip open in storybook
-}
 
 let useStyles = makeStyles((theme) => ({
   arrow: {
@@ -33,5 +27,13 @@ let useStyles = makeStyles((theme) => ({
 export default function TiltTooltip(props: TooltipProps) {
   const classes = useStyles()
 
-  return <Tooltip arrow placement="top-end" classes={classes} {...props} />
+  return (
+    <Tooltip
+      arrow
+      placement="top-end"
+      classes={classes}
+      role="tooltip"
+      {...props}
+    />
+  )
 }

--- a/web/src/assets/svg/info.svg
+++ b/web/src/assets/svg/info.svg
@@ -1,0 +1,3 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path class="fillStd" d="M10 20C4.48 20 0 15.52 0 10C0 4.48 4.48 0 10 0C15.52 0 20 4.48 20 10C20 15.52 15.52 20 10 20ZM11 4H9V6H11V4ZM11 8H9V16H11V8Z" fill="#03C7D3"/>
+</svg>


### PR DESCRIPTION
This PR adds an info icon with a tooltip that gives the user information about grouping resources with a link to the docs. The icon will display regardless of whether labels are  The implementation is a little different than the design in Figma. After seeing how the icon overlapped with a resource item when scrolling, Surbhi recommended displaying the icon is against a solid, fixed background instead.

Info icon:
![Screen Shot 2021-07-27 at 4 25 40 PM](https://user-images.githubusercontent.com/23283986/127225283-1185b842-ddc9-4a9e-a488-b62de3284649.png)

Info icon with tooltip:
![Screen Shot 2021-07-27 at 4 25 50 PM](https://user-images.githubusercontent.com/23283986/127225284-bf4a7fe4-dbed-4f11-808d-e7b2f0f06be4.png)

Info icon with tooltip, when resource list is long:
![Screen Shot 2021-07-27 at 4 26 16 PM](https://user-images.githubusercontent.com/23283986/127225285-3eb22a08-2389-4166-b6ed-e633068e64d2.png)


This PR is blocked by [#895](https://github.com/tilt-dev/tilt.build/pull/895) and closes [ch12254](https://app.clubhouse.io/windmill/story/12254/add-documentation-and-help-callout).