### PR TITLE
pod rollout: don't show completed jobs as pending

### DIFF
--- a/internal/engine/k8srollout/testdata/TestJobCompletedAfterReady_master
+++ b/internal/engine/k8srollout/testdata/TestJobCompletedAfterReady_master
@@ -1,0 +1,8 @@
+
+Tracking new pod rollout (pod-id):
+     ┊ Scheduled       - 1s
+     ┊ Initialized     - 4s
+     ┊ Ready           - 5s
+     ┊ Scheduled       - 1s
+     ┊ Initialized     - 4s
+     ┊ Completed       - 15s

--- a/internal/engine/k8srollout/testdata/TestJobCompleted_master
+++ b/internal/engine/k8srollout/testdata/TestJobCompleted_master
@@ -1,0 +1,5 @@
+
+Tracking new pod rollout (pod-id):
+     ┊ Scheduled       - 1s
+     ┊ Initialized     - 4s
+     ┊ Completed       - 5s


### PR DESCRIPTION
### Problem
Fixes #3513
When a job's pod finishes, we get a PodCondition that says it's no longer in the ready state. This means we go back and update the pod rollout's "Ready" line in the log to "pending", which is very confusing. This is what the log shows for a completed job:
```
Tracking new pod rollout (echo-hi-rr7xd):
     ┊ Scheduled       - <1s
     ┊ Initialized     - <1s
     ┊ Ready           - (…) Pending
```

### Solution
Treat PodCondition w/ Type="Ready" and Reason="PodCompleted" as meaning we're done with the pod, and munge "completed" into the "ready" field. I don't love this solution except for its cheapness, and am not sure doing something fancier is worth it right now.