### PR TITLE
internal: enable resource grouping and labels feature flag

### DIFF
--- a/internal/feature/flags.go
+++ b/internal/feature/flags.go
@@ -58,7 +58,7 @@ var MainDefaults = Defaults{
 		Status:  Obsolete,
 	},
 	Labels: Value{
-		Enabled: false,
+		Enabled: true,
 		Status:  Active,
 	},
 }


### PR DESCRIPTION
Enable resource grouping by default for the release tomorrow 🎉 

Closes [ch12255](https://app.clubhouse.io/windmill/story/12255/turn-feature-flag-on)