### PR TITLE
web: add helpful tooltips for trigger mode toggle and regexp log filter

### DIFF
--- a/web/src/AnalyticsNudge.tsx
+++ b/web/src/AnalyticsNudge.tsx
@@ -1,5 +1,6 @@
 import React, { Component } from "react"
 import "./AnalyticsNudge.scss"
+import { linkToTiltDocs, TiltDocsPage } from "./constants"
 
 const nudgeTimeoutMs = 15000
 const nudgeElem = (): JSX.Element => {
@@ -8,7 +9,7 @@ const nudgeElem = (): JSX.Element => {
       Welcome to Tilt! We collect anonymized usage data to help us improve. Is
       that OK? (
       <a
-        href="https://docs.tilt.dev/telemetry_faq.html"
+        href={linkToTiltDocs(TiltDocsPage.TelemetryFaq)}
         target="_blank"
         rel="noopener noreferrer"
       >

--- a/web/src/ErrorModal.tsx
+++ b/web/src/ErrorModal.tsx
@@ -1,5 +1,6 @@
 import React, { PureComponent } from "react"
 import Modal from "react-modal"
+import { linkToTiltDocs, TiltDocsPage } from "./constants"
 import "./FatalErrorModal.scss"
 import { ShowErrorModal } from "./types"
 
@@ -32,7 +33,12 @@ export default class ErrorModal extends PureComponent<props> {
               opening a GitHub issue
             </a>{" "}
             or{" "}
-            <a href="https://docs.tilt.dev/debug_faq.html#where-can-i-ask-questions">
+            <a
+              href={linkToTiltDocs(
+                TiltDocsPage.DebugFaq,
+                "#where-can-i-ask-questions"
+              )}
+            >
               contacting us on Slack
             </a>
             .

--- a/web/src/OverviewActionBar.tsx
+++ b/web/src/OverviewActionBar.tsx
@@ -483,14 +483,6 @@ function FilterTermFieldError({ error }: { error: string }) {
   )
 }
 
-const FilterTermInfoTooltip = styled(TiltInfoTooltip)`
-  margin: 0 ${SizeUnit(1 / 4)};
-
-  & .fillStd {
-    fill: ${Color.grayLight};
-  }
-`
-
 const filterTermTooltipContent = (
   <>
     RegExp should be wrapped in forward slashes, is case-insensitive, and is{" "}
@@ -598,7 +590,7 @@ export function FilterTermField({ termFromUrl }: { termFromUrl: FilterTerm }) {
       <SrOnly component="label" htmlFor={FILTER_FIELD_ID}>
         Filter resource logs by text or /regexp/
       </SrOnly>
-      <FilterTermInfoTooltip
+      <TiltInfoTooltip
         id={FILTER_FIELD_TOOLTIP_ID}
         title={filterTermTooltipContent}
         placement="right-end"

--- a/web/src/OverviewActionBar.tsx
+++ b/web/src/OverviewActionBar.tsx
@@ -491,6 +491,19 @@ const FilterTermInfoTooltip = styled(TiltInfoTooltip)`
   }
 `
 
+const filterTermTooltipContent = (
+  <>
+    RegExp should be wrapped in forward slashes, is case-insensitive, and is{" "}
+    <a
+      href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions"
+      target="_blank"
+    >
+      parsed in JavaScript
+    </a>
+    .
+  </>
+)
+
 const debounceFilterLogs = debounce((history: History, search: string) => {
   // Record the action for analytics
   incr("ui.web.filterTerm", { action: "edit" })
@@ -587,7 +600,7 @@ export function FilterTermField({ termFromUrl }: { termFromUrl: FilterTerm }) {
       </SrOnly>
       <FilterTermInfoTooltip
         id={FILTER_FIELD_TOOLTIP_ID}
-        title="RegExp should be wrapped in forward slashes, is case-insensitive, and parsed in JavaScript."
+        title={filterTermTooltipContent}
         placement="right-end"
       />
     </>

--- a/web/src/OverviewActionBar.tsx
+++ b/web/src/OverviewActionBar.tsx
@@ -46,6 +46,7 @@ import {
   mixinResetButtonStyle,
   SizeUnit,
 } from "./style-helpers"
+import { TiltInfoTooltip } from "./Tooltip"
 import { ResourceName } from "./types"
 
 type UIResource = Proto.v1alpha1UIResource
@@ -471,6 +472,7 @@ export function FilterRadioButton(props: FilterRadioButtonProps) {
 
 export const FILTER_INPUT_DEBOUNCE = 500 // in ms
 export const FILTER_FIELD_ID = "FilterTermTextInput"
+export const FILTER_FIELD_TOOLTIP_ID = "FilterTermInfoTooltip"
 
 function FilterTermFieldError({ error }: { error: string }) {
   return (
@@ -480,6 +482,14 @@ function FilterTermFieldError({ error }: { error: string }) {
     </FieldErrorTooltip>
   )
 }
+
+const FilterTermInfoTooltip = styled(TiltInfoTooltip)`
+  margin: 0 ${SizeUnit(1 / 4)};
+
+  & .fillStd {
+    fill: ${Color.grayLight};
+  }
+`
 
 const debounceFilterLogs = debounce((history: History, search: string) => {
   // Record the action for analytics
@@ -556,6 +566,7 @@ export function FilterTermField({ termFromUrl }: { termFromUrl: FilterTerm }) {
   return (
     <>
       <FilterTermTextField
+        aria-describedby={FILTER_FIELD_TOOLTIP_ID}
         error={state === TermState.Error}
         id={FILTER_FIELD_ID}
         helperText={
@@ -574,6 +585,11 @@ export function FilterTermField({ termFromUrl }: { termFromUrl: FilterTerm }) {
       <SrOnly component="label" htmlFor={FILTER_FIELD_ID}>
         Filter resource logs by text or /regexp/
       </SrOnly>
+      <FilterTermInfoTooltip
+        id={FILTER_FIELD_TOOLTIP_ID}
+        title="RegExp should be wrapped in forward slashes, is case-insensitive, and parsed in JavaScript."
+        placement="right-end"
+      />
     </>
   )
 }

--- a/web/src/OverviewTable.tsx
+++ b/web/src/OverviewTable.tsx
@@ -7,6 +7,7 @@ import { incr } from "./analytics"
 import { ReactComponent as CheckmarkSvg } from "./assets/svg/checkmark.svg"
 import { ReactComponent as CopySvg } from "./assets/svg/copy.svg"
 import { ReactComponent as LinkSvg } from "./assets/svg/link.svg"
+import { linkToTiltDocs, TiltDocsPage } from "./constants"
 import { InstrumentedButton } from "./instrumentedComponents"
 import { displayURL } from "./links"
 import { LogAlertIndex, useLogStore } from "./LogStore"
@@ -26,6 +27,7 @@ import {
 } from "./style-helpers"
 import { isZeroTime, timeDiff } from "./time"
 import { timeAgoFormatter } from "./timeFormatters"
+import { TiltInfoTooltip } from "./Tooltip"
 import { ResourceStatus, TargetType, TriggerMode } from "./types"
 
 type UIResource = Proto.v1alpha1UIResource
@@ -172,6 +174,14 @@ const PodIdCopy = styled(InstrumentedButton)`
 
   svg {
     fill: ${Color.gray6};
+  }
+`
+
+const HeaderInfoTooltip = styled(TiltInfoTooltip)`
+  margin: 0 ${SizeUnit(1 / 4)};
+
+  & .fillStd {
+    fill: ${Color.grayLight};
   }
 `
 
@@ -375,6 +385,30 @@ const columns: Column<RowValues>[] = [
   },
 ]
 
+const columnNameToInfoTooltip: {
+  [key: string]: NonNullable<React.ReactNode>
+} = {
+  "Trigger Mode": (
+    <>
+      Trigger mode can be toggled through the UI. To set it persistantly, see{" "}
+      <a href={linkToTiltDocs(TiltDocsPage.TriggerMode)}>Tiltfile docs</a>.
+    </>
+  ),
+}
+
+function ResourceTableHeaderTip(props: { name?: string }) {
+  if (!props.name) {
+    return null
+  }
+
+  const tooltipContent = columnNameToInfoTooltip[props.name]
+  if (!tooltipContent) {
+    return null
+  }
+
+  return <HeaderInfoTooltip title={tooltipContent} size={10} />
+}
+
 async function copyTextToClipboard(text: string, cb: () => void) {
   await navigator.clipboard.writeText(text)
   cb()
@@ -476,6 +510,7 @@ export default function OverviewTable(props: OverviewTableProps) {
                 ])}
               >
                 {column.render("Header")}
+                <ResourceTableHeaderTip name={String(column.Header)} />
                 {column.canSort && (
                   <ResourceTableHeaderSortTriangle
                     className={

--- a/web/src/OverviewTable.tsx
+++ b/web/src/OverviewTable.tsx
@@ -390,7 +390,7 @@ const columnNameToInfoTooltip: {
 } = {
   "Trigger Mode": (
     <>
-      Trigger mode can be toggled through the UI. To set it persistantly, see{" "}
+      Trigger mode can be toggled through the UI. To set it persistently, see{" "}
       <a href={linkToTiltDocs(TiltDocsPage.TriggerMode)}>Tiltfile docs</a>.
     </>
   ),

--- a/web/src/OverviewTable.tsx
+++ b/web/src/OverviewTable.tsx
@@ -97,6 +97,11 @@ const ResourceTableHeader = styled(ResourceTableData)`
   white-space: nowrap;
 `
 
+const ResourceTableHeaderLabel = styled.div`
+  display: flex;
+  align-items: center;
+`
+
 const ResourceTableHeaderSortTriangle = styled.div`
   display: inline-block;
   margin-left: ${SizeUnit(0.25)};
@@ -174,14 +179,6 @@ const PodIdCopy = styled(InstrumentedButton)`
 
   svg {
     fill: ${Color.gray6};
-  }
-`
-
-const HeaderInfoTooltip = styled(TiltInfoTooltip)`
-  margin: 0 ${SizeUnit(1 / 4)};
-
-  & .fillStd {
-    fill: ${Color.grayLight};
   }
 `
 
@@ -406,7 +403,7 @@ function ResourceTableHeaderTip(props: { name?: string }) {
     return null
   }
 
-  return <HeaderInfoTooltip title={tooltipContent} size={10} />
+  return <TiltInfoTooltip title={tooltipContent} />
 }
 
 async function copyTextToClipboard(text: string, cb: () => void) {
@@ -509,19 +506,21 @@ export default function OverviewTable(props: OverviewTableProps) {
                   }),
                 ])}
               >
-                {column.render("Header")}
-                <ResourceTableHeaderTip name={String(column.Header)} />
-                {column.canSort && (
-                  <ResourceTableHeaderSortTriangle
-                    className={
-                      column.isSorted
-                        ? column.isSortedDesc
-                          ? "is-sorted-desc"
-                          : "is-sorted-asc"
-                        : ""
-                    }
-                  />
-                )}
+                <ResourceTableHeaderLabel>
+                  {column.render("Header")}
+                  <ResourceTableHeaderTip name={String(column.Header)} />
+                  {column.canSort && (
+                    <ResourceTableHeaderSortTriangle
+                      className={
+                        column.isSorted
+                          ? column.isSortedDesc
+                            ? "is-sorted-desc"
+                            : "is-sorted-asc"
+                          : ""
+                      }
+                    />
+                  )}
+                </ResourceTableHeaderLabel>
               </ResourceTableHeader>
             ))}
           </ResourceTableRow>

--- a/web/src/ShortcutsDialog.tsx
+++ b/web/src/ShortcutsDialog.tsx
@@ -3,6 +3,7 @@ import styled from "styled-components"
 import { ReactComponent as GithubSvg } from "./assets/svg/github.svg"
 import { ReactComponent as SlackSvg } from "./assets/svg/slack.svg"
 import ButtonLink from "./ButtonLink"
+import { linkToTiltDocs } from "./constants"
 import FloatDialog, { HR } from "./FloatDialog"
 import { AnimDuration, Color } from "./style-helpers"
 
@@ -111,7 +112,7 @@ export default function ShortcutsDialog(props: props) {
       <HR />
       <ShortcutRow style={{ marginBottom: "24px" }}>
         <ButtonLink
-          href="https://docs.tilt.dev/"
+          href={linkToTiltDocs()}
           target="_blank"
           rel="noopener noreferrer"
         >

--- a/web/src/SidebarResources.tsx
+++ b/web/src/SidebarResources.tsx
@@ -20,7 +20,7 @@ import SidebarItemView, {
 } from "./SidebarItemView"
 import SidebarKeyboardShortcuts from "./SidebarKeyboardShortcuts"
 import { Color, FontSize, SizeUnit } from "./style-helpers"
-import TiltTooltip from "./Tooltip"
+import { TiltInfoTooltip } from "./Tooltip"
 import { ResourceView, SidebarOptions } from "./types"
 
 let SidebarResourcesRoot = styled.nav`
@@ -160,9 +160,7 @@ function SidebarLabelInfo() {
 
   return (
     <SidebarGroupInfo>
-      <TiltTooltip interactive title={tooltipInfo} leaveDelay={500}>
-        <InfoIcon id={GROUP_INFO_TOOLTIP_ID} />
-      </TiltTooltip>
+      <TiltInfoTooltip title={tooltipInfo} />
     </SidebarGroupInfo>
   )
 }

--- a/web/src/Tooltip.tsx
+++ b/web/src/Tooltip.tsx
@@ -1,7 +1,11 @@
 import { makeStyles } from "@material-ui/core/styles"
 import Tooltip, { TooltipProps } from "@material-ui/core/Tooltip"
 import React from "react"
+import styled from "styled-components"
+import { ReactComponent as InfoSvg } from "./assets/svg/info.svg"
 import { Color, Font, FontSize, SizeUnit } from "./style-helpers"
+
+const INFO_TOOLTIP_LEAVE_DELAY = 500
 
 let useStyles = makeStyles((theme) => ({
   arrow: {
@@ -35,5 +39,30 @@ export default function TiltTooltip(props: TooltipProps) {
       role="tooltip"
       {...props}
     />
+  )
+}
+
+const InfoIcon = styled(InfoSvg)`
+  .fillStd {
+    fill: ${Color.blueLight};
+  }
+`
+
+interface InfoTooltipProps {
+  idForIcon?: string // Use to semantically associate the tooltip with another element through `aria-describedby` or `aria-labelledby`
+  size?: number
+}
+
+export function TiltInfoTooltip(
+  props: Omit<TooltipProps, "children"> & InfoTooltipProps
+) {
+  return (
+    <TiltTooltip interactive leaveDelay={INFO_TOOLTIP_LEAVE_DELAY} {...props}>
+      <InfoIcon
+        id={props.idForIcon ?? ""}
+        height={props.size ?? 20}
+        width={props.size ?? 20}
+      />
+    </TiltTooltip>
   )
 }

--- a/web/src/Tooltip.tsx
+++ b/web/src/Tooltip.tsx
@@ -43,14 +43,16 @@ export default function TiltTooltip(props: TooltipProps) {
 }
 
 const InfoIcon = styled(InfoSvg)`
+  padding: ${SizeUnit(0.25)};
+  cursor: pointer;
+
   .fillStd {
-    fill: ${Color.blueLight};
+    fill: ${Color.gray6};
   }
 `
 
 interface InfoTooltipProps {
   idForIcon?: string // Use to semantically associate the tooltip with another element through `aria-describedby` or `aria-labelledby`
-  size?: number
 }
 
 export function TiltInfoTooltip(
@@ -58,11 +60,7 @@ export function TiltInfoTooltip(
 ) {
   return (
     <TiltTooltip interactive leaveDelay={INFO_TOOLTIP_LEAVE_DELAY} {...props}>
-      <InfoIcon
-        id={props.idForIcon ?? ""}
-        height={props.size ?? 20}
-        width={props.size ?? 20}
-      />
+      <InfoIcon id={props.idForIcon ?? ""} height={16} width={16} />
     </TiltTooltip>
   )
 }

--- a/web/src/UpdateDialog.tsx
+++ b/web/src/UpdateDialog.tsx
@@ -1,6 +1,7 @@
 import { withStyles } from "@material-ui/core/styles"
 import Switch from "@material-ui/core/Switch"
 import React from "react"
+import { linkToTiltDocs, TiltDocsPage } from "./constants"
 import FloatDialog from "./FloatDialog"
 import { usePathBuilder } from "./PathBuilder"
 import { Color } from "./style-helpers"
@@ -69,7 +70,7 @@ export default function UpdateDialog(props: props) {
         </span>
         &nbsp;
         <a
-          href="https://docs.tilt.dev/upgrade.html"
+          href={linkToTiltDocs(TiltDocsPage.Upgrade)}
           target="_blank"
           rel="noopener noreferrer"
         >

--- a/web/src/constants.ts
+++ b/web/src/constants.ts
@@ -22,3 +22,24 @@ function podStatusIsError(status: string | undefined) {
 }
 
 export { podStatusIsCrash, podStatusIsError }
+
+// Links to Tilt's documentation
+export const TILT_DOCS_LINK = "https://docs.tilt.dev"
+
+export enum TiltDocsPage {
+  DebugFaq = "debug_faq.html",
+  Faq = "faq.html",
+  Snapshots = "snapshots.html",
+  TelemetryFaq = "telemetry_faq.html",
+  TiltfileConcepts = "tiltfile_concepts.html",
+  TriggerMode = "manual_update_control.html",
+  Upgrade = "upgrade.html",
+}
+
+export function linkToTiltDocs(page?: TiltDocsPage, anchor?: string) {
+  if (!page) {
+    return TILT_DOCS_LINK
+  }
+
+  return `${TILT_DOCS_LINK}/${page}${anchor ?? ""}`
+}


### PR DESCRIPTION
This pr adds two informational tooltips for trigger mode and for regexp log filtering, plus helpers for generating Tilt docs links.

![Screen Shot 2021-07-29 at 1 46 11 PM](https://user-images.githubusercontent.com/23283986/127542850-0a743bb6-76d1-41ef-a176-c9c3c456851d.png)
![Screen Shot 2021-07-29 at 1 50 12 PM](https://user-images.githubusercontent.com/23283986/127542851-40c33f27-9abc-45d1-81a3-47d87d717c8a.png)
