### PR TITLE
controllers: move some APIs into the tiltfile reconciler package

### DIFF
--- a/internal/controllers/core/tiltfile/api.go
+++ b/internal/controllers/core/tiltfile/api.go
@@ -1,4 +1,4 @@
-package configs
+package tiltfile
 
 import (
 	"context"
@@ -47,7 +47,7 @@ type typedObjectSet map[string]object
 //
 // In the future, anything that creates objects based on the Tiltfile (e.g., FileWatch specs,
 // LocalServer specs) should go here.
-func updateOwnedObjects(ctx context.Context, client ctrlclient.Client, tlr tiltfile.TiltfileLoadResult, mode store.EngineMode) error {
+func UpdateOwnedObjects(ctx context.Context, client ctrlclient.Client, tlr tiltfile.TiltfileLoadResult, mode store.EngineMode) error {
 	apiObjects := toAPIObjects(tlr, mode)
 
 	// Retry until the cache has started.

--- a/internal/controllers/core/tiltfile/api_test.go
+++ b/internal/controllers/core/tiltfile/api_test.go
@@ -1,4 +1,4 @@
-package configs
+package tiltfile
 
 import (
 	"context"
@@ -27,7 +27,7 @@ func TestAPICreate(t *testing.T) {
 	ctx := context.Background()
 	c := fake.NewFakeTiltClient()
 	fe := manifestbuilder.New(f, "fe").WithK8sYAML(testyaml.SanchoYAML).Build()
-	err := updateOwnedObjects(ctx, c, tiltfile.TiltfileLoadResult{Manifests: []model.Manifest{fe}}, store.EngineModeUp)
+	err := UpdateOwnedObjects(ctx, c, tiltfile.TiltfileLoadResult{Manifests: []model.Manifest{fe}}, store.EngineModeUp)
 	assert.NoError(t, err)
 
 	var ka v1alpha1.KubernetesApply
@@ -42,13 +42,13 @@ func TestAPIDelete(t *testing.T) {
 	ctx := context.Background()
 	c := fake.NewFakeTiltClient()
 	fe := manifestbuilder.New(f, "fe").WithK8sYAML(testyaml.SanchoYAML).Build()
-	err := updateOwnedObjects(ctx, c, tiltfile.TiltfileLoadResult{Manifests: []model.Manifest{fe}}, store.EngineModeUp)
+	err := UpdateOwnedObjects(ctx, c, tiltfile.TiltfileLoadResult{Manifests: []model.Manifest{fe}}, store.EngineModeUp)
 	assert.NoError(t, err)
 
 	var ka1 v1alpha1.KubernetesApply
 	assert.NoError(t, c.Get(ctx, types.NamespacedName{Name: "fe"}, &ka1))
 
-	err = updateOwnedObjects(ctx, c, tiltfile.TiltfileLoadResult{Manifests: []model.Manifest{}}, store.EngineModeUp)
+	err = UpdateOwnedObjects(ctx, c, tiltfile.TiltfileLoadResult{Manifests: []model.Manifest{}}, store.EngineModeUp)
 	assert.NoError(t, err)
 
 	var ka2 v1alpha1.KubernetesApply
@@ -65,13 +65,13 @@ func TestAPINoGarbageCollectOnError(t *testing.T) {
 	ctx := context.Background()
 	c := fake.NewFakeTiltClient()
 	fe := manifestbuilder.New(f, "fe").WithK8sYAML(testyaml.SanchoYAML).Build()
-	err := updateOwnedObjects(ctx, c, tiltfile.TiltfileLoadResult{Manifests: []model.Manifest{fe}}, store.EngineModeUp)
+	err := UpdateOwnedObjects(ctx, c, tiltfile.TiltfileLoadResult{Manifests: []model.Manifest{fe}}, store.EngineModeUp)
 	assert.NoError(t, err)
 
 	var ka1 v1alpha1.KubernetesApply
 	assert.NoError(t, c.Get(ctx, types.NamespacedName{Name: "fe"}, &ka1))
 
-	err = updateOwnedObjects(ctx, c, tiltfile.TiltfileLoadResult{
+	err = UpdateOwnedObjects(ctx, c, tiltfile.TiltfileLoadResult{
 		Error:     fmt.Errorf("random failure"),
 		Manifests: []model.Manifest{},
 	}, store.EngineModeUp)
@@ -89,7 +89,7 @@ func TestAPIUpdate(t *testing.T) {
 	ctx := context.Background()
 	c := fake.NewFakeTiltClient()
 	fe := manifestbuilder.New(f, "fe").WithK8sYAML(testyaml.SanchoYAML).Build()
-	err := updateOwnedObjects(ctx, c, tiltfile.TiltfileLoadResult{Manifests: []model.Manifest{fe}}, store.EngineModeUp)
+	err := UpdateOwnedObjects(ctx, c, tiltfile.TiltfileLoadResult{Manifests: []model.Manifest{fe}}, store.EngineModeUp)
 	assert.NoError(t, err)
 
 	var ka v1alpha1.KubernetesApply
@@ -98,7 +98,7 @@ func TestAPIUpdate(t *testing.T) {
 	assert.NotContains(t, ka.Spec.YAML, "sidecar")
 
 	fe = manifestbuilder.New(f, "fe").WithK8sYAML(testyaml.SanchoSidecarYAML).Build()
-	err = updateOwnedObjects(ctx, c, tiltfile.TiltfileLoadResult{Manifests: []model.Manifest{fe}}, store.EngineModeUp)
+	err = UpdateOwnedObjects(ctx, c, tiltfile.TiltfileLoadResult{Manifests: []model.Manifest{fe}}, store.EngineModeUp)
 	assert.NoError(t, err)
 
 	err = c.Get(ctx, types.NamespacedName{Name: "fe"}, &ka)
@@ -116,7 +116,7 @@ func TestImageMapCreate(t *testing.T) {
 		WithImageTarget(NewSanchoDockerBuildImageTarget(f)).
 		WithK8sYAML(testyaml.SanchoYAML).
 		Build()
-	err := updateOwnedObjects(ctx, c, tiltfile.TiltfileLoadResult{Manifests: []model.Manifest{fe}}, store.EngineModeUp)
+	err := UpdateOwnedObjects(ctx, c, tiltfile.TiltfileLoadResult{Manifests: []model.Manifest{fe}}, store.EngineModeUp)
 	assert.NoError(t, err)
 
 	name := apis.SanitizeName(SanchoRef.String())

--- a/internal/controllers/core/tiltfile/filewatch.go
+++ b/internal/controllers/core/tiltfile/filewatch.go
@@ -1,4 +1,4 @@
-package configs
+package tiltfile
 
 import (
 	"path/filepath"

--- a/internal/controllers/core/tiltfile/filewatch_test.go
+++ b/internal/controllers/core/tiltfile/filewatch_test.go
@@ -1,4 +1,4 @@
-package configs
+package tiltfile
 
 import (
 	"context"

--- a/internal/controllers/core/tiltfile/testdata_test.go
+++ b/internal/controllers/core/tiltfile/testdata_test.go
@@ -1,0 +1,27 @@
+package tiltfile
+
+import (
+	"github.com/tilt-dev/tilt/internal/container"
+	"github.com/tilt-dev/tilt/internal/k8s/testyaml"
+	"github.com/tilt-dev/tilt/pkg/model"
+)
+
+const SanchoDockerfile = `
+FROM go:1.10
+ADD . .
+RUN go install github.com/tilt-dev/sancho
+ENTRYPOINT /go/bin/sancho
+`
+
+var SanchoRef = container.MustParseSelector(testyaml.SanchoImage)
+
+type pathFixture interface {
+	Path() string
+}
+
+func NewSanchoDockerBuildImageTarget(f pathFixture) model.ImageTarget {
+	return model.MustNewImageTarget(SanchoRef).WithBuildDetails(model.DockerBuild{
+		Dockerfile: SanchoDockerfile,
+		BuildPath:  f.Path(),
+	})
+}

--- a/internal/engine/configs/configs_controller.go
+++ b/internal/engine/configs/configs_controller.go
@@ -170,7 +170,7 @@ func (cc *ConfigsController) loadTiltfile(ctx context.Context, st store.RStore, 
 	}
 
 	// TODO(nick): Rewrite to handle multiple tiltfiles.
-	err := updateOwnedObjects(ctx, cc.ctrlClient, tlr, entry.EngineMode)
+	err := ctrltiltfile.UpdateOwnedObjects(ctx, cc.ctrlClient, tlr, entry.EngineMode)
 	if err != nil {
 		if tlr.Error == nil {
 			tlr.Error = errors.Wrap(err, "Failed to update API server")

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -4091,7 +4091,7 @@ func (f *testFixture) Init(action InitAction) {
 	})
 
 	state := f.store.LockMutableStateForTesting()
-	expectedFileWatches := configs.ToFileWatchObjects(configs.WatchInputs{
+	expectedFileWatches := ctrltiltfile.ToFileWatchObjects(ctrltiltfile.WatchInputs{
 		Manifests:     state.Manifests(),
 		ConfigFiles:   state.ConfigFiles,
 		WatchSettings: state.WatchSettings,


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/tiltfile3:

e02644d4fe5e9909e6f049d7fd53b112ea1d6a61 (2021-07-30 09:43:12 -0400)
controllers: move some APIs into the tiltfile reconciler package

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics