### PR TITLE
tiltfile: add exit() built-in to stop execution

### DIFF
--- a/internal/tiltfile/print/print.go
+++ b/internal/tiltfile/print/print.go
@@ -25,6 +25,10 @@ func (Extension) OnStart(env *starkit.Environment) error {
 	if err != nil {
 		return err
 	}
+	err = env.AddBuiltin("exit", exit)
+	if err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -53,4 +57,23 @@ func warn(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kw
 	logger.Get(ctx).Warnf("%s", msg)
 
 	return starlark.None, nil
+}
+
+func exit(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var msg string
+	err := starkit.UnpackArgs(thread, fn.Name(), args, kwargs, "msg?", &msg)
+	if err != nil {
+		return nil, err
+	}
+
+	ctx, err := starkit.ContextFromThread(thread)
+	if err != nil {
+		return nil, err
+	}
+
+	if msg != "" {
+		logger.Get(ctx).Infof("%s", msg)
+	}
+
+	return starlark.None, starkit.ErrStopExecution
 }

--- a/internal/tiltfile/print/print.go
+++ b/internal/tiltfile/print/print.go
@@ -60,8 +60,8 @@ func warn(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kw
 }
 
 func exit(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-	var msg string
-	err := starkit.UnpackArgs(thread, fn.Name(), args, kwargs, "msg?", &msg)
+	var codeVal starlark.Value
+	err := starkit.UnpackArgs(thread, fn.Name(), args, kwargs, "code?", &codeVal)
 	if err != nil {
 		return nil, err
 	}
@@ -71,8 +71,11 @@ func exit(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kw
 		return nil, err
 	}
 
-	if msg != "" {
-		logger.Get(ctx).Infof("%s", msg)
+	if codeVal != nil && codeVal != starlark.None {
+		code := codeVal.String()
+		if code != "" {
+			logger.Get(ctx).Infof("%s", code)
+		}
 	}
 
 	return starlark.None, starkit.ErrStopExecution

--- a/internal/tiltfile/print/print_test.go
+++ b/internal/tiltfile/print/print_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/tilt-dev/tilt/internal/tiltfile/starkit"
 	"github.com/tilt-dev/tilt/pkg/logger"
@@ -14,15 +15,11 @@ import (
 func TestWarn(t *testing.T) {
 	f := newFixture(t)
 	defer f.TearDown()
-	out := bytes.NewBuffer(nil)
-	log := logger.NewLogger(logger.WarnLvl, out)
-	ctx := logger.WithLogger(context.Background(), log)
-	f.SetContext(ctx)
 
 	f.File("Tiltfile", "warn('problem 1')")
 	_, err := f.ExecFile("Tiltfile")
-	assert.NoError(t, err)
-	assert.Equal(t, "problem 1\n", out.String())
+	require.NoError(t, err)
+	assert.Contains(t, f.PrintOutput(), "problem 1")
 }
 
 func TestFail(t *testing.T) {
@@ -35,6 +32,44 @@ func TestFail(t *testing.T) {
 	}
 }
 
+func TestExit(t *testing.T) {
+	f := newFixture(t)
+	defer f.TearDown()
+
+	f.File(
+		"Tiltfile", `
+exit("goodbye")
+fail("this can't happen!")
+`)
+
+	_, err := f.ExecFile("Tiltfile")
+	require.NoError(t, err)
+	out := f.PrintOutput()
+	assert.Contains(t, out, "goodbye")
+	assert.NotContains(t, out, "this can't happen!")
+}
+
+func TestExitNoMessage(t *testing.T) {
+	f := newFixture(t)
+	defer f.TearDown()
+
+	f.File(
+		"Tiltfile", `
+exit()
+fail("this can't happen!")
+`)
+
+	_, err := f.ExecFile("Tiltfile")
+	require.NoError(t, err)
+	assert.Empty(t, f.PrintOutput())
+}
+
 func newFixture(tb testing.TB) *starkit.Fixture {
-	return starkit.NewFixture(tb, NewExtension())
+	f := starkit.NewFixture(tb, NewExtension())
+	out := bytes.NewBuffer(nil)
+	f.SetOutput(out)
+	log := logger.NewLogger(logger.VerboseLvl, out)
+	ctx := logger.WithLogger(context.Background(), log)
+	f.SetContext(ctx)
+	return f
 }

--- a/internal/tiltfile/starkit/environment.go
+++ b/internal/tiltfile/starkit/environment.go
@@ -197,6 +197,9 @@ func (e *Environment) start(path string) (Model, error) {
 
 	_, err = e.exec(t, path)
 	model.BuiltinCalls = e.builtinCalls
+	if errors.Is(err, ErrStopExecution) {
+		return model, nil
+	}
 	return model, err
 }
 

--- a/internal/tiltfile/starkit/error.go
+++ b/internal/tiltfile/starkit/error.go
@@ -5,6 +5,11 @@ import (
 	"go.starlark.net/starlark"
 )
 
+// ErrStopExecution is a sentinel value to stop Starlark execution but will not be propagated back to callers.
+//
+// It is used by the custom exit() built-in to allow halting Tiltfile execution in a non-fatal manner.
+var ErrStopExecution = errors.New("stop execution")
+
 // Keep unwrapping errors until we find an error with a backtrace.
 func UnpackBacktrace(err error) error {
 	var bestEvalError *starlark.EvalError

--- a/internal/tiltfile/starkit/fixture.go
+++ b/internal/tiltfile/starkit/fixture.go
@@ -48,6 +48,10 @@ func (f *Fixture) SetContext(ctx context.Context) {
 	f.ctx = ctx
 }
 
+func (f *Fixture) SetOutput(out *bytes.Buffer) {
+	f.out = out
+}
+
 func (f *Fixture) OnStart(e *Environment) error {
 	if !f.useRealFS {
 		e.SetFakeFileSystem(f.fs)


### PR DESCRIPTION
Currently we have `fatal()` for terminating Tiltfile execution
with an error.

However, there are some circumstances where it's desirable to
stop Tiltfile execution but NOT trigger an error. For example,
when debugging a problem, it's useful to disable everything
subsequent in the Tiltfile.

This adds `exit()` which will stop execution in a "successful"
manner.

An optional message can be provided which will be printed before
exiting.

Closes #4501.