### PR TITLE
apicmp: panic if comparing two different types

### DIFF
--- a/internal/controllers/apicmp/delta.go
+++ b/internal/controllers/apicmp/delta.go
@@ -1,6 +1,9 @@
 package apicmp
 
 import (
+	"fmt"
+	"reflect"
+
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/conversion"
@@ -36,5 +39,10 @@ func Comparators() []interface{} {
 var delta = conversion.EqualitiesOrDie(Comparators()...)
 
 func DeepEqual(a, b interface{}) bool {
+	typeA := reflect.TypeOf(a)
+	typeB := reflect.TypeOf(b)
+	if typeA != typeB {
+		panic(fmt.Sprintf("internal error: comparing incommensurable objects: %T, %T", a, b))
+	}
 	return delta.DeepEqual(a, b)
 }

--- a/internal/controllers/apicmp/delta_test.go
+++ b/internal/controllers/apicmp/delta_test.go
@@ -1,6 +1,7 @@
 package apicmp
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -73,4 +74,19 @@ func TestCmp(t *testing.T) {
 		},
 	}))
 
+}
+
+func testCmpPanicHelper() (result string) {
+	defer func() {
+		r := recover()
+		result = fmt.Sprintf("%s", r)
+	}()
+
+	DeepEqual(v1alpha1.Cmd{}, &v1alpha1.Cmd{})
+	return
+}
+
+func TestCmpPanic(t *testing.T) {
+	result := testCmpPanicHelper()
+	assert.Contains(t, result, "comparing incommensurable objects: v1alpha1.Cmd, *v1alpha1.Cmd")
 }


### PR DESCRIPTION
Hello @milas, @landism,

Please review the following commits I made in branch nicks/apicmp:

fb2932ade1507c4dbbc0653f5dbcfb0a7470239c (2021-07-30 16:04:46 -0400)
apicmp: panic if comparing two different types

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics