### PR TITLE
test: rearrange how fake tiltfile loaders are injected

### DIFF
--- a/internal/controllers/core/tiltfile/actions.go
+++ b/internal/controllers/core/tiltfile/actions.go
@@ -1,4 +1,4 @@
-package configs
+package tiltfile
 
 import (
 	"time"

--- a/internal/engine/configs/configs_controller_test.go
+++ b/internal/engine/configs/configs_controller_test.go
@@ -38,7 +38,7 @@ func TestConfigsController(t *testing.T) {
 	f.setManifestResult(bar)
 	_ = f.cc.OnChange(f.ctx, f.st, store.LegacyChangeSummary())
 
-	expected := &ConfigsReloadedAction{
+	expected := &ctrltiltfile.ConfigsReloadedAction{
 		Name:       model.MainTiltfileManifestName,
 		Manifests:  []model.Manifest{bar},
 		FinishTime: f.fc.Times[1],
@@ -116,8 +116,8 @@ func TestErrorLog(t *testing.T) {
 type testStore struct {
 	*store.TestingStore
 	out   *bytes.Buffer
-	start *ConfigsReloadStartedAction
-	end   *ConfigsReloadedAction
+	start *ctrltiltfile.ConfigsReloadStartedAction
+	end   *ctrltiltfile.ConfigsReloadedAction
 }
 
 func NewTestingStore() *testStore {
@@ -139,12 +139,12 @@ func (s *testStore) Dispatch(action store.Action) {
 		_, _ = fmt.Fprintf(s.out, "%s %s", level, logAction.Message())
 	}
 
-	start, ok := action.(ConfigsReloadStartedAction)
+	start, ok := action.(ctrltiltfile.ConfigsReloadStartedAction)
 	if ok {
 		s.start = &start
 	}
 
-	end, ok := action.(ConfigsReloadedAction)
+	end, ok := action.(ctrltiltfile.ConfigsReloadedAction)
 	if ok {
 		s.end = &end
 	}

--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -13,10 +13,10 @@ import (
 	tiltanalytics "github.com/tilt-dev/tilt/internal/analytics"
 	"github.com/tilt-dev/tilt/internal/container"
 	"github.com/tilt-dev/tilt/internal/controllers/core/filewatch"
+	ctrltiltfile "github.com/tilt-dev/tilt/internal/controllers/core/tiltfile"
 	"github.com/tilt-dev/tilt/internal/docker"
 	"github.com/tilt-dev/tilt/internal/dockercompose"
 	"github.com/tilt-dev/tilt/internal/engine/buildcontrol"
-	"github.com/tilt-dev/tilt/internal/engine/configs"
 	"github.com/tilt-dev/tilt/internal/engine/dcwatch"
 	"github.com/tilt-dev/tilt/internal/engine/k8swatch"
 	"github.com/tilt-dev/tilt/internal/engine/local"
@@ -137,9 +137,9 @@ func upperReducerFn(ctx context.Context, state *store.EngineState, action store.
 		handleBuildCompleted(ctx, state, action)
 	case buildcontrol.BuildStartedAction:
 		handleBuildStarted(ctx, state, action)
-	case configs.ConfigsReloadStartedAction:
+	case ctrltiltfile.ConfigsReloadStartedAction:
 		handleConfigsReloadStarted(ctx, state, action)
-	case configs.ConfigsReloadedAction:
+	case ctrltiltfile.ConfigsReloadedAction:
 		handleConfigsReloaded(ctx, state, action)
 	case dcwatch.EventAction:
 		handleDockerComposeEvent(ctx, state, action)
@@ -485,7 +485,7 @@ func handleStartProfilingAction(state *store.EngineState) {
 func handleConfigsReloadStarted(
 	ctx context.Context,
 	state *store.EngineState,
-	event configs.ConfigsReloadStartedAction,
+	event ctrltiltfile.ConfigsReloadStartedAction,
 ) {
 	ms, ok := state.TiltfileStates[event.Name]
 	if !ok {
@@ -507,7 +507,7 @@ func handleConfigsReloadStarted(
 func handleConfigsReloaded(
 	ctx context.Context,
 	state *store.EngineState,
-	event configs.ConfigsReloadedAction,
+	event ctrltiltfile.ConfigsReloadedAction,
 ) {
 
 	manifests := event.Manifests

--- a/internal/tiltfile/fake.go
+++ b/internal/tiltfile/fake.go
@@ -1,0 +1,32 @@
+package tiltfile
+
+import (
+	"context"
+
+	"github.com/tilt-dev/tilt/pkg/model"
+)
+
+type FakeTiltfileLoader struct {
+	Result          TiltfileLoadResult
+	userConfigState model.UserConfigState
+	Delegate        TiltfileLoader
+}
+
+var _ TiltfileLoader = &FakeTiltfileLoader{}
+
+func NewFakeTiltfileLoader() *FakeTiltfileLoader {
+	return &FakeTiltfileLoader{}
+}
+
+func (tfl *FakeTiltfileLoader) Load(ctx context.Context, filename string, userConfigState model.UserConfigState) TiltfileLoadResult {
+	tfl.userConfigState = userConfigState
+	if tfl.Delegate != nil {
+		return tfl.Delegate.Load(ctx, filename, userConfigState)
+	}
+	return tfl.Result
+}
+
+// the UserConfigState that was passed to the last invocation of Load
+func (tfl *FakeTiltfileLoader) PassedUserConfigState() model.UserConfigState {
+	return tfl.userConfigState
+}

--- a/internal/tiltfile/tiltfile.go
+++ b/internal/tiltfile/tiltfile.go
@@ -79,27 +79,6 @@ type TiltfileLoader interface {
 	Load(ctx context.Context, filename string, userConfigState model.UserConfigState) TiltfileLoadResult
 }
 
-type FakeTiltfileLoader struct {
-	Result          TiltfileLoadResult
-	userConfigState model.UserConfigState
-}
-
-var _ TiltfileLoader = &FakeTiltfileLoader{}
-
-func NewFakeTiltfileLoader() *FakeTiltfileLoader {
-	return &FakeTiltfileLoader{}
-}
-
-func (tfl *FakeTiltfileLoader) Load(ctx context.Context, filename string, userConfigState model.UserConfigState) TiltfileLoadResult {
-	tfl.userConfigState = userConfigState
-	return tfl.Result
-}
-
-// the UserConfigState that was passed to the last invocation of Load
-func (tfl *FakeTiltfileLoader) PassedUserConfigState() model.UserConfigState {
-	return tfl.userConfigState
-}
-
 func ProvideTiltfileLoader(
 	analytics *analytics.TiltAnalytics,
 	kCli k8s.Client,


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/tiltfile4:

6a7e67e1675937090939d92b3d0d9b1e79e88b13 (2021-07-30 17:11:14 -0400)
test: rearrange how fake tiltfile loaders are injected
also, reorganize actions into the controllers package

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics