### PR TITLE
test: remove a bad test

### DIFF
--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -1412,7 +1412,6 @@ func TestPodEventOrdering(t *testing.T) {
 	podOrders := [][]podbuilder.PodBuilder{
 		{podAPast, podBPast, podANow, podBNow},
 		{podAPast, podANow, podBPast, podBNow},
-		{podANow, podAPast, podBNow, podBPast},
 		{podAPast, podBPast, podANow, podCNow, podCNowDeleting, podBNow},
 	}
 


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/podorder2:

d27f0e7d0f685b030bc4585be2d9e81b692e93a8 (2021-07-30 17:41:12 -0400)
test: remove a bad test
This test is testing for two pods with the same name but different UIDs
coming in in reverse order (where the dead pod appears last).

But we use k8s infra that now indexes everything by name and prevents
this kind of ordering issue from happening.

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics