### PR TITLE
portforward: handle broken spdy connections

### DIFF
--- a/internal/k8s/portforward/error.go
+++ b/internal/k8s/portforward/error.go
@@ -1,0 +1,31 @@
+package portforward
+
+import "sync"
+
+// A little data structure to get the first error
+// from many connections.
+type errorHandler struct {
+	once  sync.Once
+	errCh chan error
+}
+
+func newErrorHandler() *errorHandler {
+	return &errorHandler{
+		errCh: make(chan error),
+	}
+}
+
+func (h *errorHandler) Close() {
+	h.once.Do(func() {})
+	close(h.errCh)
+}
+
+func (h *errorHandler) Stop(err error) {
+	h.once.Do(func() {
+		h.errCh <- err
+	})
+}
+
+func (h *errorHandler) Done() chan error {
+	return h.errCh
+}

--- a/internal/k8s/portforward/error_test.go
+++ b/internal/k8s/portforward/error_test.go
@@ -1,0 +1,36 @@
+package portforward
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestManyErrors(t *testing.T) {
+	h := newErrorHandler()
+	defer h.Close()
+
+	go func() {
+		h.Stop(fmt.Errorf("my error 1"))
+	}()
+	go func() {
+		h.Stop(fmt.Errorf("my error 2"))
+	}()
+	go func() {
+		h.Stop(fmt.Errorf("my error 3"))
+	}()
+
+	err := <-h.Done()
+	assert.Contains(t, err.Error(), "my error")
+}
+
+func TestNoErrors(t *testing.T) {
+	h := newErrorHandler()
+	go func() {
+		h.Close()
+	}()
+
+	err := <-h.Done()
+	assert.Nil(t, err)
+}


### PR DESCRIPTION
Hello @landism,

Please review the following commits I made in branch nicks/ch12459:

4cdd6a54f84b5893a8a897c1d286844bcdc4f8f9 (2021-07-30 19:11:18 -0400)
portforward: handle broken spdy connections
Fixes https://github.com/tilt-dev/tilt/issues/4801

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics