### PR TITLE
server: store global extensions and repos on disk

### DIFF
--- a/internal/cli/get_test.go
+++ b/internal/cli/get_test.go
@@ -74,7 +74,7 @@ func newServerFixture(t *testing.T) *serverFixture {
 	require.NoError(t, err)
 
 	cfg, err := server.ProvideTiltServerOptions(ctx, model.TiltBuild{}, memconn, "corgi-charge", testdata.CertKey(),
-		server.APIServerPort(apiPort))
+		server.APIServerPort(apiPort), dir)
 	require.NoError(t, err)
 
 	webListener, err := server.ProvideWebListener("localhost", model.WebPort(webPort))

--- a/internal/cli/wire_gen.go
+++ b/internal/cli/wire_gen.go
@@ -188,7 +188,7 @@ func wireCmdUp(ctx context.Context, analytics3 *analytics.TiltAnalytics, cmdTags
 	if err != nil {
 		return CmdUpDeps{}, err
 	}
-	apiserverConfig, err := server.ProvideTiltServerOptions(ctx, tiltBuild, connProvider, bearerToken, generatableKeyCert, apiServerPort)
+	apiserverConfig, err := server.ProvideTiltServerOptions(ctx, tiltBuild, connProvider, bearerToken, generatableKeyCert, apiServerPort, tiltDevDir)
 	if err != nil {
 		return CmdUpDeps{}, err
 	}
@@ -387,7 +387,7 @@ func wireCmdCI(ctx context.Context, analytics3 *analytics.TiltAnalytics, subcomm
 	if err != nil {
 		return CmdCIDeps{}, err
 	}
-	apiserverConfig, err := server.ProvideTiltServerOptions(ctx, tiltBuild, connProvider, bearerToken, generatableKeyCert, apiServerPort)
+	apiserverConfig, err := server.ProvideTiltServerOptions(ctx, tiltBuild, connProvider, bearerToken, generatableKeyCert, apiServerPort, tiltDevDir)
 	if err != nil {
 		return CmdCIDeps{}, err
 	}
@@ -583,7 +583,7 @@ func wireCmdUpdog(ctx context.Context, analytics3 *analytics.TiltAnalytics, cmdT
 	if err != nil {
 		return CmdUpdogDeps{}, err
 	}
-	apiserverConfig, err := server.ProvideTiltServerOptions(ctx, tiltBuild, connProvider, bearerToken, generatableKeyCert, apiServerPort)
+	apiserverConfig, err := server.ProvideTiltServerOptions(ctx, tiltBuild, connProvider, bearerToken, generatableKeyCert, apiServerPort, tiltDevDir)
 	if err != nil {
 		return CmdUpdogDeps{}, err
 	}

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -3936,7 +3936,7 @@ func newTestFixture(t *testing.T) *testFixture {
 	cc := configs.NewConfigsController(cdc, buildSource)
 	dcw := dcwatch.NewEventWatcher(fakeDcc, dockerClient)
 	dclm := runtimelog.NewDockerComposeLogManager(fakeDcc)
-	serverOptions, err := server.ProvideTiltServerOptionsForTesting(ctx)
+	serverOptions, err := server.ProvideTiltServerOptionsForTesting(ctx, dir)
 	require.NoError(t, err)
 	webListener, err := server.ProvideWebListener("localhost", 0)
 	require.NoError(t, err)

--- a/internal/hud/server/apiserver_test.go
+++ b/internal/hud/server/apiserver_test.go
@@ -169,7 +169,7 @@ func newAPIServerFixture(t testing.TB) *apiserverFixture {
 
 	memconn := ProvideMemConn()
 
-	cfg, err := ProvideTiltServerOptions(ctx, model.TiltBuild{}, memconn, "corgi-charge", testdata.CertKey(), 0)
+	cfg, err := ProvideTiltServerOptions(ctx, model.TiltBuild{}, memconn, "corgi-charge", testdata.CertKey(), 0, dir)
 	require.NoError(t, err)
 
 	const host = "localhost"


### PR DESCRIPTION
Hello @milas, @landism,

Please review the following commits I made in branch nicks/storage:

b84de2c2e97505b835ae58637675067faa989674 (2021-08-03 13:06:53 -0400)
server: store global extensions and repos on disk

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics