### PR TITLE
uibutton: opens link to trigger mode docs in a new tab

### DIFF
--- a/web/src/OverviewTable.tsx
+++ b/web/src/OverviewTable.tsx
@@ -388,7 +388,7 @@ const columnNameToInfoTooltip: {
   "Trigger Mode": (
     <>
       Trigger mode can be toggled through the UI. To set it persistently, see{" "}
-      <a href={linkToTiltDocs(TiltDocsPage.TriggerMode)}>Tiltfile docs</a>.
+      <a href={linkToTiltDocs(TiltDocsPage.TriggerMode)} target="_blank" rel="noopener noreferrer">Tiltfile docs</a>.
     </>
   ),
 }


### PR DESCRIPTION
This link in the Trigger mode tooltip (shown in picture) is now opening in a new tab.

![example](https://user-images.githubusercontent.com/1905651/128392320-220d2ddf-2ff6-4697-8d08-5ff502786ccb.png)
