### PR TITLE
cmd: error instead of panic when empty

### DIFF
--- a/internal/controllers/core/cmd/execer.go
+++ b/internal/controllers/core/cmd/execer.go
@@ -150,14 +150,23 @@ func (e *processExecer) processRun(ctx context.Context, cmd model.Cmd, w io.Writ
 	defer close(statusCh)
 
 	logger.Get(ctx).Infof("Running cmd: %s", cmd.String())
-	c := e.localEnv.ExecCmd(cmd, logger.Get(ctx))
+	c, err := e.localEnv.ExecCmd(cmd, logger.Get(ctx))
+	if err != nil {
+		logger.Get(ctx).Errorf("%s invalid cmd: %v", cmd.String(), err)
+		statusCh <- statusAndMetadata{
+			status:   Error,
+			exitCode: 1,
+			reason:   fmt.Sprintf("invalid cmd: %v", err),
+		}
+		return
+	}
 
 	c.SysProcAttr = &syscall.SysProcAttr{}
 	procutil.SetOptNewProcessGroup(c.SysProcAttr)
 	c.Stderr = w
 	c.Stdout = w
 
-	err := c.Start()
+	err = c.Start()
 	if err != nil {
 		logger.Get(ctx).Errorf("%s failed to start: %v", cmd.String(), err)
 		statusCh <- statusAndMetadata{

--- a/internal/controllers/core/cmd/execer.go
+++ b/internal/controllers/core/cmd/execer.go
@@ -152,7 +152,7 @@ func (e *processExecer) processRun(ctx context.Context, cmd model.Cmd, w io.Writ
 	logger.Get(ctx).Infof("Running cmd: %s", cmd.String())
 	c, err := e.localEnv.ExecCmd(cmd, logger.Get(ctx))
 	if err != nil {
-		logger.Get(ctx).Errorf("%s invalid cmd: %v", cmd.String(), err)
+		logger.Get(ctx).Errorf("%q invalid cmd: %v", cmd.String(), err)
 		statusCh <- statusAndMetadata{
 			status:   Error,
 			exitCode: 1,

--- a/internal/controllers/core/cmd/execer_test.go
+++ b/internal/controllers/core/cmd/execer_test.go
@@ -147,6 +147,15 @@ func TestHandlesProcessThatFailsToStart(t *testing.T) {
 	f.assertLogContains("failed to start: ")
 }
 
+func TestExecEmpty(t *testing.T) {
+	f := newProcessExecFixture(t)
+	defer f.tearDown()
+
+	f.start("")
+	f.waitForError()
+	f.assertLogContains("empty cmd")
+}
+
 func TestExecCmd(t *testing.T) {
 	testCases := execTestCases()
 
@@ -154,7 +163,8 @@ func TestExecCmd(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			c := localexec.EmptyEnv().ExecCmd(tc.cmd, l)
+			c, err := localexec.EmptyEnv().ExecCmd(tc.cmd, l)
+			require.NoError(t, err)
 			assertCommandEqual(t, tc.cmd, c)
 		})
 	}

--- a/internal/localexec/localexec.go
+++ b/internal/localexec/localexec.go
@@ -3,6 +3,7 @@
 package localexec
 
 import (
+	"errors"
 	"os"
 	"os/exec"
 	"strconv"
@@ -55,10 +56,13 @@ func (e *Env) Add(k, v string) {
 // NOTE: To avoid confusion with ExecCmdContext, this method accepts a logger instance
 // directly rather than using logger.Get(ctx); the returned exec.Cmd from this function
 // will NOT be associated with any context.
-func (e *Env) ExecCmd(cmd model.Cmd, l logger.Logger) *exec.Cmd {
+func (e *Env) ExecCmd(cmd model.Cmd, l logger.Logger) (*exec.Cmd, error) {
+	if len(cmd.Argv) == 0 {
+		return nil, errors.New("empty cmd")
+	}
 	c := exec.Command(cmd.Argv[0], cmd.Argv[1:]...)
 	e.populateExecCmd(c, cmd, l)
-	return c
+	return c, nil
 }
 
 func (e *Env) populateExecCmd(c *exec.Cmd, cmd model.Cmd, l logger.Logger) {

--- a/internal/tiltfile/files.go
+++ b/internal/tiltfile/files.go
@@ -84,7 +84,10 @@ func (s *tiltfileState) execLocalCmd(t *starlark.Thread, cmd model.Cmd, options 
 		s.logger.Infof("%s %s", prefix, cmd)
 	}
 
-	c := s.localEnv.ExecCmd(cmd, logger.Get(ctx))
+	c, err := s.localEnv.ExecCmd(cmd, logger.Get(ctx))
+	if err != nil {
+		return "", err
+	}
 
 	// TODO(nick): Should this also inject any docker.Env overrides?
 	c.Stdout = stdout

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -288,6 +288,28 @@ watch_settings(ignore=ignore)
 	assert.Equal(t, []string{"bar"}, f.loadResult.WatchSettings.Ignores[0].Patterns)
 }
 
+func TestLocalEmptyArray(t *testing.T) {
+	f := newFixture(t)
+	defer f.TearDown()
+
+	f.file("Tiltfile", `
+local([])
+`)
+
+	f.loadErrString("empty cmd")
+}
+
+func TestLocalEmptyString(t *testing.T) {
+	f := newFixture(t)
+	defer f.TearDown()
+
+	f.file("Tiltfile", `
+local('')
+`)
+
+	f.loadErrString("empty cmd")
+}
+
 func TestCustomBuildBat(t *testing.T) {
 	f := newFixture(t)
 	defer f.TearDown()


### PR DESCRIPTION
### Problem

`Env.ExecCmd` panics if given an empty `Cmd`. This reproduces with `local('')` or `local([])`.

### Solution

Have it return an `error` instead.

We could instead check for empty at the starlark builtin level, but it seems good to also avoid panics if someone, e.g. creates a `Cmd` object with an empty argv.