### PR TITLE
extensions: fix extension loading in non-git Tilt projects

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -65,7 +65,7 @@ require (
 	github.com/tilt-dev/dockerignore v0.0.0-20200910202654-0d8c17a73277
 	github.com/tilt-dev/fsevents v0.0.0-20200515134857-2efe37af20de
 	github.com/tilt-dev/fsnotify v1.4.8-0.20210701141043-dd524499d3fe
-	github.com/tilt-dev/go-get v0.2.0
+	github.com/tilt-dev/go-get v0.2.1
 	github.com/tilt-dev/localregistry-go v0.0.0-20200615231835-07e386f4ebd7
 	github.com/tilt-dev/probe v0.3.0
 	github.com/tilt-dev/tilt-apiserver v0.4.1

--- a/go.sum
+++ b/go.sum
@@ -1103,6 +1103,8 @@ github.com/tilt-dev/fsnotify v1.4.8-0.20210701141043-dd524499d3fe h1:dULiU6eWdUf
 github.com/tilt-dev/fsnotify v1.4.8-0.20210701141043-dd524499d3fe/go.mod h1:9wJjkpCk7ADlLOAl+yIXbHwnMoV9i0+uLr9CG3D5434=
 github.com/tilt-dev/go-get v0.2.0 h1:VELDyR4hky5R3u7UpWciF1LqKmNPGlxNKmsYlpNAGVU=
 github.com/tilt-dev/go-get v0.2.0/go.mod h1:sqJ1OH6ggqbd2+J5TFsDGP/CXeRAXBxR52m5FtL0+xo=
+github.com/tilt-dev/go-get v0.2.1 h1:HUIbKVc6yGv+g4QfsIsjcgQKGTLIgwHFMBIFyiJzB2Q=
+github.com/tilt-dev/go-get v0.2.1/go.mod h1:sqJ1OH6ggqbd2+J5TFsDGP/CXeRAXBxR52m5FtL0+xo=
 github.com/tilt-dev/json-patch/v4 v4.8.1 h1:AbrhK3NMDfk/+/oMXz3NcKaCNwHYdhUJMDjBHNOHF5o=
 github.com/tilt-dev/json-patch/v4 v4.8.1/go.mod h1:tS8rrXPNPgltwGinFPfBjCwHFLxMa3ozjPngreH2eW0=
 github.com/tilt-dev/localregistry-go v0.0.0-20200615231835-07e386f4ebd7 h1:ysHGLJJRVcnG6WoZJt7GGD4hsMSwMxEg7Rxx4fJrSrY=

--- a/vendor/github.com/tilt-dev/go-get/vcs.go
+++ b/vendor/github.com/tilt-dev/go-get/vcs.go
@@ -433,7 +433,8 @@ func (v *vcsCmd) run1(ctx cmdContext, cmdline string, keyval []string, verbose b
 	}
 
 	cmd := exec.Command(v.cmd, args...)
-	cmd.Dir = ctx.dir
+	// dir defaults to ctx.dir but will be overridden if the command starts with `-go-internal-cd`
+	cmd.Dir = dir
 	cmd.Env = envForDir(cmd.Dir, os.Environ())
 
 	out, err := cmd.Output()
@@ -443,7 +444,7 @@ func (v *vcsCmd) run1(ctx cmdContext, cmdline string, keyval []string, verbose b
 			if ee, ok := err.(*exec.ExitError); ok && len(ee.Stderr) > 0 {
 				ctx.stderr.Write(ee.Stderr)
 			} else {
-				fmt.Fprintf(ctx.stderr, err.Error())
+				fmt.Fprintf(ctx.stderr, "%s\n", err.Error())
 			}
 		}
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -525,7 +525,7 @@ github.com/tilt-dev/fsevents
 # github.com/tilt-dev/fsnotify v1.4.8-0.20210701141043-dd524499d3fe
 ## explicit
 github.com/tilt-dev/fsnotify
-# github.com/tilt-dev/go-get v0.2.0
+# github.com/tilt-dev/go-get v0.2.1
 ## explicit
 github.com/tilt-dev/go-get
 github.com/tilt-dev/go-get/internal/auth


### PR DESCRIPTION
Update to `tilt-dev/go-get@v0.2.1` which includes a small fix for
CWD when executing commands.

In general, this would result in a spurious git submodule update in
the user's Tilt project repo (i.e. wherever the `Tiltfile` lives)
but things would still work since the `tilt-extensions` repo does
not rely on submodules.

However, if the directory with the `Tiltfile` happened to not be a
git repo, the extension load would fail with a cryptic error about
it not being in a git repo:
```
fatal: not a git repository (or any of the parent directories): .git
```
This is because it was trying to do the submodule update
in the wrong place.