### PR TITLE
tiltfile: add ref field to v1alpha1.extension_repo

### DIFF
--- a/internal/tiltfile/v1alpha1/plugin_test.go
+++ b/internal/tiltfile/v1alpha1/plugin_test.go
@@ -14,7 +14,7 @@ func TestExtension(t *testing.T) {
 	defer f.TearDown()
 
 	f.File("Tiltfile", `
-v1alpha1.extension_repo(name='default', url='https://github.com/tilt-dev/tilt-extensions')
+v1alpha1.extension_repo(name='default', url='https://github.com/tilt-dev/tilt-extensions', ref='HEAD')
 v1alpha1.extension(name='cancel', repo_name='default', repo_path='cancel')
 `)
 	result, err := f.ExecFile("Tiltfile")
@@ -25,6 +25,7 @@ v1alpha1.extension(name='cancel', repo_name='default', repo_path='cancel')
 	repo := set[(&v1alpha1.ExtensionRepo{}).GetGroupVersionResource()]["default"].(*v1alpha1.ExtensionRepo)
 	require.NotNil(t, repo)
 	require.Equal(t, "https://github.com/tilt-dev/tilt-extensions", repo.Spec.URL)
+	require.Equal(t, "HEAD", repo.Spec.Ref)
 
 	ext := set[(&v1alpha1.Extension{}).GetGroupVersionResource()]["cancel"].(*v1alpha1.Extension)
 	require.NotNil(t, ext)

--- a/internal/tiltfile/v1alpha1/types.go
+++ b/internal/tiltfile/v1alpha1/types.go
@@ -15,11 +15,13 @@ func (p Plugin) extensionRepo(t *starlark.Thread, fn *starlark.Builtin, args sta
 	var labels value.StringStringMap
 	var annotations value.StringStringMap
 	var url string
+	var ref string
 	err := starkit.UnpackArgs(t, fn.Name(), args, kwargs,
 		"name", &name,
 		"labels?", &labels,
 		"annotations?", &annotations,
 		"url?", &url,
+		"ref?", &ref,
 	)
 	if err != nil {
 		return nil, err
@@ -33,6 +35,7 @@ func (p Plugin) extensionRepo(t *starlark.Thread, fn *starlark.Builtin, args sta
 		},
 		Spec: v1alpha1.ExtensionRepoSpec{
 			URL: url,
+			Ref: ref,
 		},
 	}
 


### PR DESCRIPTION
Hello @milas, @landism,

Please review the following commits I made in branch nicks/ref:

cb91c56b89b09d155908ce33e5e742dbc79ade25 (2021-08-13 14:40:14 -0400)
tiltfile: add ref field to v1alpha1.extension_repo

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics