### PR TITLE
hud: fix a nil pointer exception in tilt logs

### DIFF
--- a/internal/hud/server/logs_reader.go
+++ b/internal/hud/server/logs_reader.go
@@ -79,7 +79,7 @@ func NewLogStreamer(resources []string, p *hud.IncrementalPrinter) *LogStreamer 
 }
 
 func (ls *LogStreamer) Handle(v proto_webview.View) error {
-	if v.LogList.FromCheckpoint == -1 {
+	if v.LogList == nil || v.LogList.FromCheckpoint == -1 {
 		// Server has no new logs to send
 		return nil
 	}

--- a/internal/hud/server/logs_reader_test.go
+++ b/internal/hud/server/logs_reader_test.go
@@ -36,6 +36,12 @@ func TestLogStreamerPrintsLogs(t *testing.T) {
 	f.assertExpectedLogLines(expected)
 }
 
+func TestHandleEmptyView(t *testing.T) {
+	f := newLogStreamerFixture(t)
+	f.handle(proto_webview.View{})
+	f.assertExpectedLogLines([]expectedLine{expectedLine{}}) // Always end in a newline
+}
+
 func TestLogStreamerPrefixing(t *testing.T) {
 	f := newLogStreamerFixture(t)
 	manifestNames := []string{"foo", "", "foo", "bar"}


### PR DESCRIPTION
Hello @landism, @milas,

Please review the following commits I made in branch nicks/debug:

89b3aaaa585008d820ac120cae8dd536f2a4d906 (2021-08-13 18:39:53 -0400)
hud: fix a nil pointer exception in tilt logs

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics