### PR TITLE
web: add persistent state to resource grouping

### DIFF
--- a/web/src/HUD.tsx
+++ b/web/src/HUD.tsx
@@ -19,6 +19,7 @@ import LogStore, { LogStoreProvider } from "./LogStore"
 import OverviewResourcePane from "./OverviewResourcePane"
 import OverviewTablePane from "./OverviewTablePane"
 import PathBuilder, { PathBuilderProvider } from "./PathBuilder"
+import { ResourceGroupsContextProvider } from "./ResourceGroupsContext"
 import { ResourceNavProvider } from "./ResourceNav"
 import ShareSnapshotModal from "./ShareSnapshotModal"
 import { SnapshotActionProvider } from "./snapshot"
@@ -248,17 +249,21 @@ export default class HUD extends Component<HudProps, HudState> {
           <SnapshotActionProvider value={snapshotAction}>
             <PathBuilderProvider value={this.pathBuilder}>
               <LogStoreProvider value={this.state.logStore || new LogStore()}>
-                <Switch>
-                  <Route
-                    path={this.path("/r/:name/overview")}
-                    render={(props: RouteComponentProps<any>) => (
-                      <OverviewResourcePane view={this.state.view} />
-                    )}
-                  />
-                  <Route
-                    render={() => <OverviewTablePane view={this.state.view} />}
-                  />
-                </Switch>
+                <ResourceGroupsContextProvider>
+                  <Switch>
+                    <Route
+                      path={this.path("/r/:name/overview")}
+                      render={(props: RouteComponentProps<any>) => (
+                        <OverviewResourcePane view={this.state.view} />
+                      )}
+                    />
+                    <Route
+                      render={() => (
+                        <OverviewTablePane view={this.state.view} />
+                      )}
+                    />
+                  </Switch>
+                </ResourceGroupsContextProvider>
               </LogStoreProvider>
             </PathBuilderProvider>
           </SnapshotActionProvider>

--- a/web/src/OverviewResourcePane.stories.tsx
+++ b/web/src/OverviewResourcePane.stories.tsx
@@ -4,6 +4,7 @@ import { MemoryRouter } from "react-router"
 import Features, { FeaturesProvider, Flag } from "./feature"
 import LogStore, { LogStoreProvider } from "./LogStore"
 import OverviewResourcePane from "./OverviewResourcePane"
+import { ResourceGroupsContextProvider } from "./ResourceGroupsContext"
 import { ResourceNavProvider } from "./ResourceNav"
 import { StarredResourceMemoryProvider } from "./StarredResourcesContext"
 import {
@@ -24,13 +25,15 @@ export default {
       return (
         <MemoryRouter initialEntries={["/"]}>
           <FeaturesProvider value={features}>
-            <StarredResourceMemoryProvider>
-              <div style={{ margin: "-1rem", height: "80vh" }}>
-                <StylesProvider injectFirst>
-                  <Story />
-                </StylesProvider>
-              </div>
-            </StarredResourceMemoryProvider>
+            <ResourceGroupsContextProvider>
+              <StarredResourceMemoryProvider>
+                <div style={{ margin: "-1rem", height: "80vh" }}>
+                  <StylesProvider injectFirst>
+                    <Story />
+                  </StylesProvider>
+                </div>
+              </StarredResourceMemoryProvider>
+            </ResourceGroupsContextProvider>
           </FeaturesProvider>
         </MemoryRouter>
       )

--- a/web/src/OverviewResourceSidebar.stories.tsx
+++ b/web/src/OverviewResourceSidebar.stories.tsx
@@ -4,6 +4,7 @@ import SplitPane from "react-split-pane"
 import Features, { FeaturesProvider, Flag } from "./feature"
 import LogStore, { LogStoreProvider } from "./LogStore"
 import OverviewResourceSidebar from "./OverviewResourceSidebar"
+import { ResourceGroupsContextProvider } from "./ResourceGroupsContext"
 import { Width } from "./style-helpers"
 import {
   nResourceView,
@@ -27,15 +28,17 @@ export default {
       return (
         <MemoryRouter initialEntries={["/"]}>
           <FeaturesProvider value={features}>
-            <div style={{ margin: "-1rem", height: "80vh" }}>
-              <SplitPane
-                split="vertical"
-                minSize={Width.sidebarDefault}
-                defaultSize={Width.sidebarDefault}
-              >
-                <Story />
-              </SplitPane>
-            </div>
+            <ResourceGroupsContextProvider>
+              <div style={{ margin: "-1rem", height: "80vh" }}>
+                <SplitPane
+                  split="vertical"
+                  minSize={Width.sidebarDefault}
+                  defaultSize={Width.sidebarDefault}
+                >
+                  <Story />
+                </SplitPane>
+              </div>
+            </ResourceGroupsContextProvider>
           </FeaturesProvider>
         </MemoryRouter>
       )

--- a/web/src/OverviewTable.stories.tsx
+++ b/web/src/OverviewTable.stories.tsx
@@ -1,6 +1,7 @@
 import React from "react"
 import { MemoryRouter } from "react-router"
 import OverviewTable, { TableGroupedByLabels } from "./OverviewTable"
+import { ResourceGroupsContextProvider } from "./ResourceGroupsContext"
 import {
   nButtonView,
   nResourceView,
@@ -14,14 +15,16 @@ export default {
   decorators: [
     (Story: any) => (
       <MemoryRouter initialEntries={["/"]}>
-        {/* required for MUI <Icon> */}
-        <link
-          rel="stylesheet"
-          href="https://fonts.googleapis.com/icon?family=Material+Icons"
-        />
-        <div style={{ margin: "-1rem" }}>
-          <Story />
-        </div>
+        <ResourceGroupsContextProvider>
+          {/* required for MUI <Icon> */}
+          <link
+            rel="stylesheet"
+            href="https://fonts.googleapis.com/icon?family=Material+Icons"
+          />
+          <div style={{ margin: "-1rem" }}>
+            <Story />
+          </div>
+        </ResourceGroupsContextProvider>
       </MemoryRouter>
     ),
   ],

--- a/web/src/OverviewTable.test.tsx
+++ b/web/src/OverviewTable.test.tsx
@@ -1,10 +1,8 @@
 import { mount, ReactWrapper } from "enzyme"
 import React from "react"
 import { MemoryRouter } from "react-router"
-import { AnalyticsAction, AnalyticsType } from "./analytics"
 import {
   cleanupMockAnalyticsCalls,
-  expectIncrs,
   mockAnalyticsCalls,
 } from "./analytics_test_helpers"
 import { GroupByLabelView, TILTFILE_LABEL, UNLABELED_LABEL } from "./labels"
@@ -22,6 +20,11 @@ import OverviewTable, {
   TableGroupedByLabels,
   TableNameColumn,
 } from "./OverviewTable"
+import {
+  DEFAULT_GROUP_STATE,
+  GroupsState,
+  ResourceGroupsContextProvider,
+} from "./ResourceGroupsContext"
 import { nResourceView, nResourceWithLabelsView, oneButton } from "./testdata"
 
 it("shows buttons on the appropriate resources", () => {
@@ -53,15 +56,29 @@ it("shows buttons on the appropriate resources", () => {
 describe("overview table with groups", () => {
   let view: Proto.webviewView
   let wrapper: ReactWrapper<OverviewTableProps, typeof TableGroupedByLabels>
+  let resources: GroupByLabelView<RowValues>
 
   beforeEach(() => {
     view = nResourceWithLabelsView(5)
-    wrapper = mount(<TableGroupedByLabels view={view} />)
+    wrapper = mount(
+      <ResourceGroupsContextProvider>
+        <TableGroupedByLabels view={view} />
+      </ResourceGroupsContextProvider>
+    )
+    resources = resourcesToTableCells(
+      view.uiResources,
+      view.uiButtons,
+      new LogStore()
+    )
 
     mockAnalyticsCalls()
+    localStorage.clear()
   })
 
-  afterEach(() => cleanupMockAnalyticsCalls())
+  afterEach(() => {
+    cleanupMockAnalyticsCalls()
+    localStorage.clear()
+  })
 
   // TODO: When resource groups are live in table view, add tests for:
   //       If no resources have labels, it renders a single table view
@@ -69,16 +86,6 @@ describe("overview table with groups", () => {
   //       If there are labels and feature is enabled, it renders table with groups
 
   describe("display", () => {
-    let resources: GroupByLabelView<RowValues>
-
-    beforeEach(() => {
-      resources = resourcesToTableCells(
-        view.uiResources,
-        view.uiButtons,
-        new LogStore()
-      )
-    })
-
     it("renders each label group in order", () => {
       const { labels: sortedLabels } = resources
       const groupNames = wrapper.find(OverviewGroupName)
@@ -166,9 +173,36 @@ describe("overview table with groups", () => {
       groups = getResourceGroups()
     })
 
-    it("sets resource groups as expanded by default", () => {
-      groups.forEach((group) => {
-        expect(group.props().expanded).toBe(true)
+    it("displays as expanded or collapsed based on the ResourceGroupContext", () => {
+      // Create an existing randomized group state from the labels
+      const { labels } = resources
+      const testData: GroupsState = [
+        ...labels,
+        UNLABELED_LABEL,
+        TILTFILE_LABEL,
+      ].reduce((groupsState: GroupsState, label) => {
+        const randomLabelState = Math.random() > 0.5
+        groupsState[label] = {
+          ...DEFAULT_GROUP_STATE,
+          expanded: randomLabelState,
+        }
+
+        return groupsState
+      }, {})
+
+      // Re-mount the component with the initial groups context values
+      wrapper = mount(
+        <ResourceGroupsContextProvider initialValuesForTesting={testData}>
+          <TableGroupedByLabels view={view} />
+        </ResourceGroupsContextProvider>
+      )
+
+      // Loop through each resource group and expect that its expanded state
+      // matches with the hardcoded test data
+      const resourceGroups = wrapper.find(OverviewGroup)
+      resourceGroups.forEach((group) => {
+        const groupName = group.find(OverviewGroupName).text()
+        expect(group.props().expanded).toEqual(testData[groupName].expanded)
       })
     })
 
@@ -207,21 +241,6 @@ describe("overview table with groups", () => {
 
       const updatedGroup = getResourceGroups().first()
       expect(updatedGroup.props().expanded).toBe(true)
-    })
-
-    it("submits analytics with the correct payload", () => {
-      const group = groups.first()
-      const expanded = group.props().expanded
-
-      group.find(OverviewGroupSummary).simulate("click")
-
-      expectIncrs({
-        name: "ui.web.resourceGroup",
-        tags: {
-          action: expanded ? AnalyticsAction.Collapse : AnalyticsAction.Expand,
-          type: AnalyticsType.Grid,
-        },
-      })
     })
   })
 })

--- a/web/src/OverviewTable.test.tsx
+++ b/web/src/OverviewTable.test.tsx
@@ -199,11 +199,13 @@ describe("overview table with groups", () => {
 
       // Loop through each resource group and expect that its expanded state
       // matches with the hardcoded test data
-      const resourceGroups = wrapper.find(OverviewGroup)
-      resourceGroups.forEach((group) => {
+      const actualExpandedState: GroupsState = {}
+      wrapper.find(OverviewGroup).forEach((group) => {
         const groupName = group.find(OverviewGroupName).text()
-        expect(group.props().expanded).toEqual(testData[groupName].expanded)
+        actualExpandedState[groupName] = { expanded: group.props().expanded }
       })
+
+      expect(actualExpandedState).toEqual(testData)
     })
 
     it("is collapsed when an expanded resource group summary is clicked on", () => {

--- a/web/src/OverviewTable.tsx
+++ b/web/src/OverviewTable.tsx
@@ -43,6 +43,7 @@ import {
   ResourceGroupSummaryIcon,
   ResourceGroupSummaryMixin,
 } from "./ResourceGroups"
+import { useResourceGroups } from "./ResourceGroupsContext"
 import { useResourceNav } from "./ResourceNav"
 import { useStarredResources } from "./StarredResourcesContext"
 import { buildStatus, runtimeStatus } from "./status"
@@ -736,13 +737,10 @@ function TableGroup(props: { label: string; data: RowValues[] }) {
     props.label === UNLABELED_LABEL ? <em>{props.label}</em> : props.label
   const labelNameId = `tableOverview-${props.label}`
 
-  // Groups are expanded by default
-  const [expanded, setExpanded] = useState(true)
-  const handleChange = (_e: ChangeEvent<{}>) => {
-    const action = expanded ? AnalyticsAction.Collapse : AnalyticsAction.Expand
-    incr("ui.web.resourceGroup", { action, type: AnalyticsType.Grid })
-    setExpanded(!expanded)
-  }
+  const { getGroup, setGroup } = useResourceGroups()
+  const expanded = getGroup(props.label)
+  const handleChange = (_e: ChangeEvent<{}>) =>
+    setGroup(props.label, AnalyticsType.Grid)
 
   return (
     <OverviewGroup expanded={expanded} onChange={handleChange}>
@@ -797,7 +795,7 @@ function TableWithoutGroups(props: OverviewTableProps) {
 }
 
 export default function OverviewTable(props: OverviewTableProps) {
-  // TODO: Add support for table groups by feature flag
+  // TODO (lizz): Add support for table groups by feature flag
   // when groups are ready to launch
   return <TableWithoutGroups {...props} />
 }

--- a/web/src/OverviewTable.tsx
+++ b/web/src/OverviewTable.tsx
@@ -737,10 +737,10 @@ function TableGroup(props: { label: string; data: RowValues[] }) {
     props.label === UNLABELED_LABEL ? <em>{props.label}</em> : props.label
   const labelNameId = `tableOverview-${props.label}`
 
-  const { getGroup, setGroup } = useResourceGroups()
-  const expanded = getGroup(props.label)
+  const { getGroup, toggleGroupExpanded } = useResourceGroups()
+  const { expanded } = getGroup(props.label)
   const handleChange = (_e: ChangeEvent<{}>) =>
-    setGroup(props.label, AnalyticsType.Grid)
+    toggleGroupExpanded(props.label, AnalyticsType.Grid)
 
   return (
     <OverviewGroup expanded={expanded} onChange={handleChange}>

--- a/web/src/ResourceGroupsContext.test.tsx
+++ b/web/src/ResourceGroupsContext.test.tsx
@@ -1,0 +1,152 @@
+import { mount, ReactWrapper } from "enzyme"
+import React from "react"
+import { AnalyticsAction, AnalyticsType } from "./analytics"
+import {
+  cleanupMockAnalyticsCalls,
+  expectIncrs,
+  mockAnalyticsCalls,
+} from "./analytics_test_helpers"
+import {
+  DEFAULT_GROUP_STATE,
+  ResourceGroupsContextProvider,
+  useResourceGroups,
+} from "./ResourceGroupsContext"
+
+const GROUP_STATE_ID = "test-group-state"
+const LABEL_STATE_ID = "test-label-state"
+
+// This is a very basic test component that prints out the state
+// from the ResourceGroups context and provides buttons to trigger
+// methods returned by the context, so they can be tested
+const TestConsumer = (props: { labelName?: string }) => {
+  const { groups, getGroup, toggleGroupExpanded } = useResourceGroups()
+
+  return (
+    <>
+      <p id={GROUP_STATE_ID}>{JSON.stringify(groups)}</p>
+      {/* Display the label state if a specific label is present */}
+      {props.labelName && (
+        <p id={LABEL_STATE_ID}>{JSON.stringify(getGroup(props.labelName))}</p>
+      )}
+      {/* Display a button to toggle the label state if a specific label is present */}
+      {props.labelName && (
+        <button
+          onClick={() =>
+            toggleGroupExpanded(props.labelName || "", AnalyticsType.Grid)
+          }
+        />
+      )}
+    </>
+  )
+}
+
+describe("ResourceGroupsContext", () => {
+  let wrapper: ReactWrapper<typeof TestConsumer>
+
+  beforeEach(() => {
+    mockAnalyticsCalls()
+  })
+
+  afterEach(() => {
+    localStorage.clear()
+    cleanupMockAnalyticsCalls()
+  })
+
+  it("defaults to an empty state with no groups", () => {
+    wrapper = mount(
+      <ResourceGroupsContextProvider>
+        <TestConsumer />
+      </ResourceGroupsContextProvider>
+    )
+
+    const groupState = wrapper.find(`#${GROUP_STATE_ID}`).text()
+
+    expect(groupState).toBe(JSON.stringify({}))
+  })
+
+  describe("toggleGroupExpanded", () => {
+    it("sets expanded to `true` when group is collapsed", () => {
+      const testValues = { test: { expanded: false } }
+      wrapper = mount(
+        <ResourceGroupsContextProvider initialValuesForTesting={testValues}>
+          <TestConsumer labelName="test" />
+        </ResourceGroupsContextProvider>
+      )
+      wrapper.find("button").simulate("click")
+      wrapper.update()
+
+      const labelState = wrapper.find(`#${LABEL_STATE_ID}`).text()
+      expect(labelState).toBe(JSON.stringify({ expanded: true }))
+    })
+
+    it("sets expanded to `false` when group is expanded", () => {
+      const testValues = { test: { expanded: true } }
+      wrapper = mount(
+        <ResourceGroupsContextProvider initialValuesForTesting={testValues}>
+          <TestConsumer labelName="test" />
+        </ResourceGroupsContextProvider>
+      )
+      wrapper.find("button").simulate("click")
+      wrapper.update()
+
+      const labelState = wrapper.find(`#${LABEL_STATE_ID}`).text()
+      expect(labelState).toBe(JSON.stringify({ expanded: false }))
+    })
+
+    it("sets expanded to `false` if a group isn't saved yet and is toggled", () => {
+      wrapper = mount(
+        <ResourceGroupsContextProvider>
+          <TestConsumer labelName="a-non-existent-group" />
+        </ResourceGroupsContextProvider>
+      )
+      wrapper.find("button").simulate("click")
+      wrapper.update()
+
+      const labelState = wrapper.find(`#${LABEL_STATE_ID}`).text()
+      expect(labelState).toBe(JSON.stringify({ expanded: false }))
+    })
+
+    it("makes an analytics call with the right payload", () => {
+      const testValues = { test: { expanded: true } }
+      wrapper = mount(
+        <ResourceGroupsContextProvider initialValuesForTesting={testValues}>
+          <TestConsumer labelName="test" />
+        </ResourceGroupsContextProvider>
+      )
+      wrapper.find("button").simulate("click")
+      // Expect the "collapse" action value because the test label group is expanded
+      // when it's clicked on and the "grid" type value because it's hardcoded in the
+      // test component
+      expectIncrs({
+        name: "ui.web.resourceGroup",
+        tags: { action: AnalyticsAction.Collapse, type: AnalyticsType.Grid },
+      })
+    })
+  })
+
+  describe("getGroup", () => {
+    it("returns the correct state of a resource group", () => {
+      const testValues = { frontend: { expanded: false } }
+      wrapper = mount(
+        <ResourceGroupsContextProvider initialValuesForTesting={testValues}>
+          <TestConsumer labelName="frontend" />
+        </ResourceGroupsContextProvider>
+      )
+
+      const labelState = wrapper.find(`#${LABEL_STATE_ID}`).text()
+      expect(labelState).toBe(JSON.stringify({ expanded: false }))
+    })
+
+    it("returns a default state of a resource group if a group isn't saved yet", () => {
+      const testValues = { frontend: { expanded: false } }
+      wrapper = mount(
+        <ResourceGroupsContextProvider initialValuesForTesting={testValues}>
+          <TestConsumer labelName="backend" />
+        </ResourceGroupsContextProvider>
+      )
+
+      const labelState = wrapper.find(`#${LABEL_STATE_ID}`).text()
+      expect(labelState).toBe(JSON.stringify(DEFAULT_GROUP_STATE))
+    })
+  })
+})

--- a/web/src/ResourceGroupsContext.test.tsx
+++ b/web/src/ResourceGroupsContext.test.tsx
@@ -43,6 +43,14 @@ const TestConsumer = (props: { labelName?: string }) => {
 describe("ResourceGroupsContext", () => {
   let wrapper: ReactWrapper<typeof TestConsumer>
 
+  // Helpers
+  const groupState = () => wrapper.find(`#${GROUP_STATE_ID}`).text()
+  const labelState = () => wrapper.find(`#${LABEL_STATE_ID}`).text()
+  const clickButton = () => {
+    wrapper.find("button").simulate("click")
+    wrapper.update()
+  }
+
   beforeEach(() => {
     mockAnalyticsCalls()
   })
@@ -59,9 +67,7 @@ describe("ResourceGroupsContext", () => {
       </ResourceGroupsContextProvider>
     )
 
-    const groupState = wrapper.find(`#${GROUP_STATE_ID}`).text()
-
-    expect(groupState).toBe(JSON.stringify({}))
+    expect(groupState()).toBe(JSON.stringify({}))
   })
 
   describe("toggleGroupExpanded", () => {
@@ -72,11 +78,9 @@ describe("ResourceGroupsContext", () => {
           <TestConsumer labelName="test" />
         </ResourceGroupsContextProvider>
       )
-      wrapper.find("button").simulate("click")
-      wrapper.update()
+      clickButton()
 
-      const labelState = wrapper.find(`#${LABEL_STATE_ID}`).text()
-      expect(labelState).toBe(JSON.stringify({ expanded: true }))
+      expect(labelState()).toBe(JSON.stringify({ expanded: true }))
     })
 
     it("sets expanded to `false` when group is expanded", () => {
@@ -86,11 +90,9 @@ describe("ResourceGroupsContext", () => {
           <TestConsumer labelName="test" />
         </ResourceGroupsContextProvider>
       )
-      wrapper.find("button").simulate("click")
-      wrapper.update()
+      clickButton()
 
-      const labelState = wrapper.find(`#${LABEL_STATE_ID}`).text()
-      expect(labelState).toBe(JSON.stringify({ expanded: false }))
+      expect(labelState()).toBe(JSON.stringify({ expanded: false }))
     })
 
     it("sets expanded to `false` if a group isn't saved yet and is toggled", () => {
@@ -99,11 +101,9 @@ describe("ResourceGroupsContext", () => {
           <TestConsumer labelName="a-non-existent-group" />
         </ResourceGroupsContextProvider>
       )
-      wrapper.find("button").simulate("click")
-      wrapper.update()
+      clickButton()
 
-      const labelState = wrapper.find(`#${LABEL_STATE_ID}`).text()
-      expect(labelState).toBe(JSON.stringify({ expanded: false }))
+      expect(labelState()).toBe(JSON.stringify({ expanded: false }))
     })
 
     it("makes an analytics call with the right payload", () => {
@@ -113,7 +113,7 @@ describe("ResourceGroupsContext", () => {
           <TestConsumer labelName="test" />
         </ResourceGroupsContextProvider>
       )
-      wrapper.find("button").simulate("click")
+      clickButton()
       // Expect the "collapse" action value because the test label group is expanded
       // when it's clicked on and the "grid" type value because it's hardcoded in the
       // test component
@@ -133,8 +133,7 @@ describe("ResourceGroupsContext", () => {
         </ResourceGroupsContextProvider>
       )
 
-      const labelState = wrapper.find(`#${LABEL_STATE_ID}`).text()
-      expect(labelState).toBe(JSON.stringify({ expanded: false }))
+      expect(labelState()).toBe(JSON.stringify({ expanded: false }))
     })
 
     it("returns a default state of a resource group if a group isn't saved yet", () => {
@@ -145,8 +144,7 @@ describe("ResourceGroupsContext", () => {
         </ResourceGroupsContextProvider>
       )
 
-      const labelState = wrapper.find(`#${LABEL_STATE_ID}`).text()
-      expect(labelState).toBe(JSON.stringify(DEFAULT_GROUP_STATE))
+      expect(labelState()).toBe(JSON.stringify(DEFAULT_GROUP_STATE))
     })
   })
 })

--- a/web/src/ResourceGroupsContext.tsx
+++ b/web/src/ResourceGroupsContext.tsx
@@ -1,0 +1,61 @@
+import { createContext, PropsWithChildren, useContext, useState } from "react"
+import { AnalyticsAction, AnalyticsType, incr } from "./analytics"
+
+// To use local storage, you can use the `usePersistentState` hook instead of `useState`
+// I'm not sure how the provider or context ingestion is different, but I think everything else is the same
+
+export const DEFAULT_GROUP_STATE = true
+
+export type GroupExpandedState = { [key: string]: boolean }
+
+type ResourceGroupsContext = {
+  expanded: GroupExpandedState
+  setGroup: (groupLabel: string, page: AnalyticsType) => void
+  getGroup: (groupLabel: string) => boolean
+}
+
+const resourceGroupsContext = createContext<ResourceGroupsContext>({
+  expanded: {},
+  setGroup: () => {
+    console.warn("Resource group context is not set.")
+  },
+  getGroup: () => {
+    console.warn("Resource group context is not set.")
+    return DEFAULT_GROUP_STATE
+  },
+})
+
+export function useResourceGroups(): ResourceGroupsContext {
+  return useContext(resourceGroupsContext)
+}
+
+export function ResourceGroupsContextProvider(props: PropsWithChildren<{}>) {
+  const [expanded, setExpandedState] = useState<GroupExpandedState>({})
+
+  function setGroup(groupLabel: string, page: AnalyticsType) {
+    const currentGroupState = expanded[groupLabel] ?? DEFAULT_GROUP_STATE
+    const nextGroupState = !currentGroupState
+
+    const action = nextGroupState
+      ? AnalyticsAction.Expand
+      : AnalyticsAction.Collapse
+    incr("ui.web.resourceGroup", { action, type: page })
+
+    setExpandedState((prevState) => ({
+      ...prevState,
+      [groupLabel]: nextGroupState,
+    }))
+  }
+
+  function getGroup(groupLabel: string) {
+    return expanded[groupLabel] ?? DEFAULT_GROUP_STATE
+  }
+
+  const defaultValue = { expanded: {}, setGroup, getGroup }
+
+  return (
+    <resourceGroupsContext.Provider value={defaultValue}>
+      {props.children}
+    </resourceGroupsContext.Provider>
+  )
+}

--- a/web/src/SidebarResources.tsx
+++ b/web/src/SidebarResources.tsx
@@ -179,10 +179,10 @@ function SidebarLabelListSection(props: { label: string } & SidebarProps) {
     props.label === UNLABELED_LABEL ? <em>{props.label}</em> : props.label
   const labelNameId = `sidebarItem-${props.label}`
 
-  const { getGroup, setGroup } = useResourceGroups()
-  const expanded = getGroup(props.label)
+  const { getGroup, toggleGroupExpanded } = useResourceGroups()
+  const { expanded } = getGroup(props.label)
   const handleChange = (_e: ChangeEvent<{}>) =>
-    setGroup(props.label, AnalyticsType.Detail)
+    toggleGroupExpanded(props.label, AnalyticsType.Detail)
 
   // TODO (lizz): Improve the accessibility interface for accordion feature by adding focus styles
   // according to https://www.w3.org/TR/wai-aria-practices-1.1/examples/accordion/accordion.html

--- a/web/src/SidebarResources.tsx
+++ b/web/src/SidebarResources.tsx
@@ -8,10 +8,9 @@ import React, {
   Dispatch,
   PropsWithChildren,
   SetStateAction,
-  useState,
 } from "react"
 import styled from "styled-components"
-import { AnalyticsAction, AnalyticsType, incr } from "./analytics"
+import { AnalyticsType } from "./analytics"
 import { FeaturesContext } from "./feature"
 import {
   GroupByLabelView,
@@ -31,6 +30,7 @@ import {
   ResourceGroupSummaryIcon,
   ResourceGroupSummaryMixin,
 } from "./ResourceGroups"
+import { useResourceGroups } from "./ResourceGroupsContext"
 import { ResourceSidebarStatusSummary } from "./ResourceStatusSummary"
 import SidebarItem from "./SidebarItem"
 import SidebarItemView, {
@@ -179,13 +179,10 @@ function SidebarLabelListSection(props: { label: string } & SidebarProps) {
     props.label === UNLABELED_LABEL ? <em>{props.label}</em> : props.label
   const labelNameId = `sidebarItem-${props.label}`
 
-  // Groups are expanded by default
-  const [expanded, setExpanded] = useState(true)
-  const handleChange = (_e: ChangeEvent<{}>) => {
-    const action = expanded ? AnalyticsAction.Collapse : AnalyticsAction.Expand
-    incr("ui.web.resourceGroup", { action, type: AnalyticsType.Detail })
-    setExpanded(!expanded)
-  }
+  const { getGroup, setGroup } = useResourceGroups()
+  const expanded = getGroup(props.label)
+  const handleChange = (_e: ChangeEvent<{}>) =>
+    setGroup(props.label, AnalyticsType.Detail)
 
   // TODO (lizz): Improve the accessibility interface for accordion feature by adding focus styles
   // according to https://www.w3.org/TR/wai-aria-practices-1.1/examples/accordion/accordion.html

--- a/web/src/labels.test.ts
+++ b/web/src/labels.test.ts
@@ -1,0 +1,78 @@
+import Features, { Flag } from "./feature"
+import { getResourceLabels, resourcesHaveLabels } from "./labels"
+import { nResourceView, nResourceWithLabelsView } from "./testdata"
+
+describe("Resource label helpers", () => {
+  describe("resourcesHaveLabels", () => {
+    it("returns `false` if labels feature is not enabled", () => {
+      const { uiResources } = nResourceWithLabelsView(5)
+      const features = new Features({ [Flag.Labels]: false })
+
+      expect(
+        resourcesHaveLabels(features, uiResources, getResourceLabels)
+      ).toBe(false)
+    })
+
+    it("returns `false` if labels feature is enabled but no resources have labels", () => {
+      const { uiResources } = nResourceView(5)
+      const features = new Features({ [Flag.Labels]: true })
+
+      expect(
+        resourcesHaveLabels(features, uiResources, getResourceLabels)
+      ).toBe(false)
+    })
+
+    it("returns `true` if labels feature is enabled and at least one resource has labels", () => {
+      const { uiResources } = nResourceWithLabelsView(2)
+      const features = new Features({ [Flag.Labels]: true })
+
+      expect(
+        resourcesHaveLabels(features, uiResources, getResourceLabels)
+      ).toBe(true)
+    })
+  })
+
+  describe("getResourceLabels", () => {
+    describe("when a resource doesn't have labels", () => {
+      it("returns an empty list if there are no labels", () => {
+        const resource = nResourceView(1).uiResources[0]
+        expect(getResourceLabels(resource)).toStrictEqual([])
+      })
+
+      it("returns an empty list if metadata is undefined", () => {
+        const resource = nResourceView(1).uiResources[0]
+        resource.metadata = undefined
+        expect(getResourceLabels(resource)).toStrictEqual([])
+      })
+
+      it("returns an empty list if labels are undefined", () => {
+        const resource = nResourceView(1).uiResources[0]
+        resource.metadata!.labels = undefined
+        expect(getResourceLabels(resource)).toStrictEqual([])
+      })
+    })
+
+    describe("when a resource has labels", () => {
+      it("returns a list of labels", () => {
+        const resource = nResourceView(1).uiResources[0]
+        resource.metadata!.labels = {
+          testLabel: "testLabel",
+          anotherLabel: "anotherLabel",
+        }
+        expect(getResourceLabels(resource)).toEqual([
+          "testLabel",
+          "anotherLabel",
+        ])
+      })
+
+      it("does not return prefixed labels", () => {
+        const resource = nResourceView(1).uiResources[0]
+        resource.metadata!.labels = {
+          "prefixed/label": "prefixed/label",
+          anotherLabel: "anotherLabel",
+        }
+        expect(getResourceLabels(resource)).toEqual(["anotherLabel"])
+      })
+    })
+  })
+})


### PR DESCRIPTION
This PR adds state that tracks which label groups are expanded / collapsed and persists across views within the dashboard and across user sessions. If there isn't any saved state for a label group, then it'll default to expanded. As a user toggles a group closed and open, the `ResourceGroupsContext` will track that label's expanded state in local storage, under the "resource-groups" key.

Resource groups aren't live in table view yet, so the best way to test locally is in Storybook. You can toggle [OverviewResourcePane > Ten Resources With Labels](http://localhost:9009/?path=/story/new-ui-overviewresourcepane--ten-resources-with-labels) and [Overview > OverviewTable > Ten Resources With Labels](http://localhost:9009/?path=/story/new-ui-overview-overviewtable--ten-resource-with-labels) and see that the expanded state is the same across views.

I also added tests for the label helpers.

Closes [ch12556](https://app.clubhouse.io/windmill/story/12556/add-persistent-expanded-state-for-resource-grouping).
