### PR TITLE
web: add resource status summaries to groups in table view

### DIFF
--- a/web/src/HeaderBar.tsx
+++ b/web/src/HeaderBar.tsx
@@ -6,7 +6,7 @@ import { CustomNav } from "./CustomNav"
 import { GlobalNav } from "./GlobalNav"
 import { usePathBuilder } from "./PathBuilder"
 import {
-  ResourceStatusSummary,
+  AllResourceStatusSummary,
   ResourceStatusSummaryRoot,
 } from "./ResourceStatusSummary"
 import { useSnapshotAction } from "./snapshot"
@@ -93,7 +93,7 @@ export default function HeaderBar(props: HeaderBarProps) {
       <AllResourcesLink to={pb.encpath`/r/(all)/overview`}>
         All Resources
       </AllResourcesLink>
-      <ResourceStatusSummary view={props.view} />
+      <AllResourceStatusSummary resources={resources} />
       <CustomNav view={props.view} />
       <GlobalNav {...globalNavProps} />
     </HeaderBarRoot>

--- a/web/src/OverviewResourceBar.tsx
+++ b/web/src/OverviewResourceBar.tsx
@@ -2,10 +2,9 @@ import React from "react"
 import styled from "styled-components"
 import { GlobalNav, GlobalNavRoot } from "./GlobalNav"
 import { usePathBuilder } from "./PathBuilder"
-import { ResourceStatusSummary } from "./ResourceStatusSummary"
+import { AllResourceStatusSummary } from "./ResourceStatusSummary"
 import { useSnapshotAction } from "./snapshot"
 import { SizeUnit } from "./style-helpers"
-import { TargetType } from "./types"
 import { showUpdate } from "./UpdateDialog"
 
 type OverviewResourceBarProps = {
@@ -32,10 +31,6 @@ export default function OverviewResourceBar(props: OverviewResourceBarProps) {
   let runningBuild = session?.runningTiltBuild
   let suggestedVersion = session?.suggestedTiltVersion
   let resources = view?.uiResources || []
-  let hasK8s = resources.some((r) => {
-    let specs = r.status?.specs ?? []
-    return specs.some((spec) => spec.type === TargetType.K8s)
-  })
 
   let globalNavProps = {
     isSnapshot,
@@ -51,7 +46,7 @@ export default function OverviewResourceBar(props: OverviewResourceBarProps) {
 
   return (
     <OverviewResourceBarRoot>
-      <ResourceStatusSummary view={props.view} />
+      <AllResourceStatusSummary resources={resources} />
       <GlobalNav {...globalNavProps} />
     </OverviewResourceBarRoot>
   )

--- a/web/src/OverviewTable.test.tsx
+++ b/web/src/OverviewTable.test.tsx
@@ -25,6 +25,7 @@ import {
   GroupsState,
   ResourceGroupsContextProvider,
 } from "./ResourceGroupsContext"
+import { TableGroupStatusSummary } from "./ResourceStatusSummary"
 import { nResourceView, nResourceWithLabelsView, oneButton } from "./testdata"
 
 it("shows buttons on the appropriate resources", () => {
@@ -160,6 +161,18 @@ describe("overview table with groups", () => {
       })
 
       expect(actualResourcesFromTable).toEqual(expectedResourcesFromLabelGroups)
+    })
+  })
+
+  describe("resource status summary", () => {
+    it("renders summaries for each label group", () => {
+      const summaries = wrapper.find(TableGroupStatusSummary)
+      const totalLabelCount =
+        resources.labels.length +
+        (resources.tiltfile.length ? 1 : 0) +
+        (resources.unlabeled.length ? 1 : 0)
+
+      expect(summaries.length).toBe(totalLabelCount)
     })
   })
 

--- a/web/src/OverviewTable.tsx
+++ b/web/src/OverviewTable.tsx
@@ -39,12 +39,12 @@ import {
   AccordionDetailsStyleResetMixin,
   AccordionStyleResetMixin,
   AccordionSummaryStyleResetMixin,
-  ResourceGroupNameMixin,
   ResourceGroupSummaryIcon,
   ResourceGroupSummaryMixin,
 } from "./ResourceGroups"
 import { useResourceGroups } from "./ResourceGroupsContext"
 import { useResourceNav } from "./ResourceNav"
+import { TableGroupStatusSummary } from "./ResourceStatusSummary"
 import { useStarredResources } from "./StarredResourcesContext"
 import { buildStatus, runtimeStatus } from "./status"
 import {
@@ -104,7 +104,8 @@ export const OverviewGroup = styled(Accordion)`
 
   /* Set specific margins for table view */
   &.MuiAccordion-root,
-  &.MuiAccordion-root.Mui-expanded {
+  &.MuiAccordion-root.Mui-expanded,
+  &.MuiAccordion-root.Mui-expanded:first-child {
     margin: ${SizeUnit(1 / 2)};
   }
 `
@@ -119,9 +120,7 @@ export const OverviewGroupSummary = styled(AccordionSummary)`
 `
 
 export const OverviewGroupName = styled.span`
-  ${ResourceGroupNameMixin}
-
-  padding-left: ${SizeUnit(1 / 3)};
+  padding: 0 ${SizeUnit(1 / 3)};
 `
 
 export const OverviewGroupDetails = styled(AccordionDetails)`
@@ -747,6 +746,10 @@ function TableGroup(props: { label: string; data: RowValues[] }) {
       <OverviewGroupSummary id={labelNameId}>
         <ResourceGroupSummaryIcon role="presentation" />
         <OverviewGroupName>{formattedLabel}</OverviewGroupName>
+        <TableGroupStatusSummary
+          aria-label={`Status summary for ${props.label} group`}
+          resources={props.data}
+        />
       </OverviewGroupSummary>
       <OverviewGroupDetails>
         <Table columns={columnDefs} data={props.data} isGroupView />

--- a/web/src/ResourceGroups.tsx
+++ b/web/src/ResourceGroups.tsx
@@ -39,6 +39,7 @@ export const AccordionStyleResetMixin = `
   &.MuiAccordion-root,
   &.MuiAccordion-root.Mui-expanded {
     margin: unset;
+    position: unset; /* Removes a mysterious top border only visible on collapse */
   }
 `
 
@@ -103,11 +104,4 @@ export const ResourceGroupSummaryMixin = `
       }
     }
   }
-`
-
-export const ResourceGroupNameMixin = `
-  margin-right: auto;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  width: 100%;
 `

--- a/web/src/SidebarResources.tsx
+++ b/web/src/SidebarResources.tsx
@@ -26,12 +26,11 @@ import {
   AccordionDetailsStyleResetMixin,
   AccordionStyleResetMixin,
   AccordionSummaryStyleResetMixin,
-  ResourceGroupNameMixin,
   ResourceGroupSummaryIcon,
   ResourceGroupSummaryMixin,
 } from "./ResourceGroups"
 import { useResourceGroups } from "./ResourceGroupsContext"
-import { ResourceSidebarStatusSummary } from "./ResourceStatusSummary"
+import { SidebarGroupStatusSummary } from "./ResourceStatusSummary"
 import SidebarItem from "./SidebarItem"
 import SidebarItemView, {
   SidebarItemRoot,
@@ -107,7 +106,10 @@ const SidebarGroupSummary = styled(AccordionSummary)`
 `
 
 const SidebarGroupName = styled.span`
-  ${ResourceGroupNameMixin}
+  margin-right: auto;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  width: 100%;
 `
 
 const SidebarGroupDetails = styled(AccordionDetails)`
@@ -187,17 +189,13 @@ function SidebarLabelListSection(props: { label: string } & SidebarProps) {
   // TODO (lizz): Improve the accessibility interface for accordion feature by adding focus styles
   // according to https://www.w3.org/TR/wai-aria-practices-1.1/examples/accordion/accordion.html
   return (
-    <SidebarLabelSection
-      expanded={expanded}
-      key={labelNameId}
-      onChange={handleChange}
-    >
+    <SidebarLabelSection expanded={expanded} onChange={handleChange}>
       <SidebarGroupSummary id={labelNameId}>
         <ResourceGroupSummaryIcon role="presentation" />
         <SidebarGroupName>{formattedLabel}</SidebarGroupName>
-        <ResourceSidebarStatusSummary
+        <SidebarGroupStatusSummary
           aria-label={`Status summary for ${props.label} group`}
-          items={props.items}
+          resources={props.items}
         />
       </SidebarGroupSummary>
       <SidebarGroupDetails aria-labelledby={labelNameId}>


### PR DESCRIPTION
This PR adds resource status summaries to groups in table view and refactors the core status summary code to take a template type so it can be used for resources in different data forms.

The best way to test this code is to look at Storybook in [Overview > OverviewTable > Ten Resources With Labels](http://localhost:9009/?path=/story/new-ui-overview-overviewtable--ten-resource-with-labels), since groups are available in the main table view just yet!

Collapsed and expanded groups:
![Screen Shot 2021-08-19 at 3 32 54 PM](https://user-images.githubusercontent.com/23283986/130133410-e130b563-387e-4524-a3df-f2a2d52ead33.png)

Collapsed groups:
![Screen Shot 2021-08-19 at 3 32 40 PM](https://user-images.githubusercontent.com/23283986/130133415-012dd702-91a5-4410-8d12-e642a8c98456.png)

Closes [ch12501](https://app.clubhouse.io/windmill/story/12501/display-resource-status-summary-for-each-label-group).