### PR TITLE
engine: don't look in completed pods for running containers

### DIFF
--- a/internal/engine/buildcontrol/build_control.go
+++ b/internal/engine/buildcontrol/build_control.go
@@ -3,6 +3,8 @@ package buildcontrol
 import (
 	"time"
 
+	v1 "k8s.io/api/core/v1"
+
 	"github.com/tilt-dev/tilt/internal/build"
 	"github.com/tilt-dev/tilt/internal/store"
 	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
@@ -421,6 +423,12 @@ func IsLiveUpdateTargetWaitingOnDeploy(state store.EngineState, mt *store.Manife
 				if c.Restarts > 0 {
 					return false
 				}
+			}
+
+			// If the pod is in a finished state, then the containers
+			// may never re-enter Running.
+			if pod.Phase == string(v1.PodSucceeded) || pod.Phase == string(v1.PodFailed) {
+				return false
 			}
 
 		} else if mt.Manifest.IsDC() {

--- a/internal/engine/buildcontrol/build_control_test.go
+++ b/internal/engine/buildcontrol/build_control_test.go
@@ -278,6 +278,9 @@ func TestHoldForDeploy(t *testing.T) {
 
 	sancho.State.K8sRuntimeState().Pods["pod-1"] = sidecarCrashedPod("pod-1", sanchoImage.Refs.ClusterRef())
 	f.assertNextTargetToBuild("sancho")
+
+	sancho.State.K8sRuntimeState().Pods["pod-1"] = completedPod("pod-1", sanchoImage.Refs.ClusterRef())
+	f.assertNextTargetToBuild("sancho")
 }
 
 func readyPod(podID k8s.PodID, ref reference.Named) *v1alpha1.Pod {
@@ -371,6 +374,30 @@ func sidecarCrashedPod(podID k8s.PodID, ref reference.Named) *v1alpha1.Pod {
 						FinishedAt: metav1.Now(),
 						Reason:     "Error",
 						ExitCode:   127,
+					}},
+			},
+		},
+	}
+}
+
+func completedPod(podID k8s.PodID, ref reference.Named) *v1alpha1.Pod {
+	return &v1alpha1.Pod{
+		Name:   podID.String(),
+		Phase:  string(v1.PodSucceeded),
+		Status: "Completed",
+		Containers: []v1alpha1.Container{
+			{
+				ID:       string(podID + "-container"),
+				Name:     "c",
+				Ready:    false,
+				Image:    ref.String(),
+				Restarts: 0,
+				State: v1alpha1.ContainerState{
+					Terminated: &v1alpha1.ContainerStateTerminated{
+						StartedAt:  metav1.Now(),
+						FinishedAt: metav1.Now(),
+						Reason:     "Succcess!",
+						ExitCode:   0,
 					}},
 			},
 		},

--- a/internal/engine/k8swatch/reducers.go
+++ b/internal/engine/k8swatch/reducers.go
@@ -118,6 +118,12 @@ func CheckForContainerCrash(state *store.EngineState, mt *store.ManifestTarget) 
 	}
 
 	runningContainers := store.AllRunningContainers(mt)
+	if len(runningContainers) == 0 {
+		// If there are no running containers, it might mean the containers are
+		// being deleted. We don't need to intervene yet.
+		return
+	}
+
 	hitList := make(map[container.ID]bool, len(ms.LiveUpdatedContainerIDs))
 	for cID := range ms.LiveUpdatedContainerIDs {
 		hitList[cID] = true
@@ -131,7 +137,8 @@ func CheckForContainerCrash(state *store.EngineState, mt *store.ManifestTarget) 
 		return
 	}
 
-	// The pod isn't what we expect!
+	// There are new running containers that don't match
+	// what we live-updated!
 	ms.NeedsRebuildFromCrash = true
 	ms.LiveUpdatedContainerIDs = container.NewIDSet()
 


### PR DESCRIPTION
Hello @milas, @landism,

Please review the following commits I made in branch nicks/jobs:

ef490cca875b509964c65f54d655f3b890c8546b (2021-08-19 20:12:49 -0400)
engine: don't look in completed pods for running containers
I was playing around with live-update Jobs.

I saw weird behavior where:
- builds would get stuck pending forever on already completed jobs
- tilt would think that a pod had crash when a job completed normally

Note that this changes the behavior of crash rebuild.
Before, if a pod crashed, Tilt would immediately begin a new build.
Now, if a pod crashes, Tilt waits for the controller to replace
it before starting the crash rebuild.
I think this behavior is probably more correct, given
that Tilt can't know if the controller is going to replace the Pod.

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics