### PR TITLE
web: have InstrumentedButton use MUI Button instead of a plain ol' button

### DIFF
--- a/web/src/OverviewButton.tsx
+++ b/web/src/OverviewButton.tsx
@@ -1,8 +1,14 @@
 import styled from "styled-components"
 import { ApiButton } from "./ApiButton"
-import { AnimDuration, Color, Font } from "./style-helpers"
+import {
+  AnimDuration,
+  Color,
+  Font,
+  mixinResetButtonStyle,
+} from "./style-helpers"
 
 export const OverviewButtonMixin = `
+  ${mixinResetButtonStyle};
   font-family: ${Font.sansSerif};
   display: flex;
   align-items: center;

--- a/web/src/instrumentedComponents.tsx
+++ b/web/src/instrumentedComponents.tsx
@@ -18,5 +18,7 @@ export function InstrumentedButton(props: InstrumentedButtonProps) {
       onClick(e)
     }
   }
-  return <Button variant="outlined" onClick={instrumentedOnClick} {...buttonProps} />
+  return (
+    <Button variant="outlined" onClick={instrumentedOnClick} {...buttonProps} />
+  )
 }

--- a/web/src/instrumentedComponents.tsx
+++ b/web/src/instrumentedComponents.tsx
@@ -19,6 +19,6 @@ export function InstrumentedButton(props: InstrumentedButtonProps) {
     }
   }
   return (
-    <Button variant="outlined" onClick={instrumentedOnClick} {...buttonProps} />
+    <Button variant="outlined" disableRipple={true} onClick={instrumentedOnClick} {...buttonProps} />
   )
 }

--- a/web/src/instrumentedComponents.tsx
+++ b/web/src/instrumentedComponents.tsx
@@ -19,6 +19,11 @@ export function InstrumentedButton(props: InstrumentedButtonProps) {
     }
   }
   return (
-    <Button variant="outlined" disableRipple={true} onClick={instrumentedOnClick} {...buttonProps} />
+    <Button
+      variant="outlined"
+      disableRipple={true}
+      onClick={instrumentedOnClick}
+      {...buttonProps}
+    />
   )
 }

--- a/web/src/instrumentedComponents.tsx
+++ b/web/src/instrumentedComponents.tsx
@@ -1,10 +1,10 @@
-import React, { LegacyRef } from "react"
+import { Button, ButtonProps } from "@material-ui/core"
+import React from "react"
 import { AnalyticsAction, incr, Tags } from "./analytics"
 
-export type InstrumentedButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
+export type InstrumentedButtonProps = ButtonProps & {
   analyticsName: string
   analyticsTags?: Tags
-  ref?: LegacyRef<HTMLButtonElement>
 }
 
 export function InstrumentedButton(props: InstrumentedButtonProps) {
@@ -18,5 +18,5 @@ export function InstrumentedButton(props: InstrumentedButtonProps) {
       onClick(e)
     }
   }
-  return <button onClick={instrumentedOnClick} {...buttonProps} />
+  return <Button variant="outlined" onClick={instrumentedOnClick} {...buttonProps} />
 }

--- a/web/src/style-helpers.ts
+++ b/web/src/style-helpers.ts
@@ -104,11 +104,15 @@ export const mixinResetButtonStyle = `
   cursor: pointer;
 
   // undo Material UI's Button styling
+  // TODO - maybe we should be doing it like this? https://material-ui.com/customization/globals/#css
   letter-spacing: normal;
   min-width: 0px;
   text-transform: none;
   line-height: normal;
   font-size: ${FontSize.smallest};
+  &:hover {
+    background-color: transparent;
+  }
 `
 
 export const mixinTruncateText = `

--- a/web/src/style-helpers.ts
+++ b/web/src/style-helpers.ts
@@ -102,6 +102,13 @@ export const mixinResetButtonStyle = `
   margin: 0;
   font-family: inherit;
   cursor: pointer;
+
+  // undo Material UI's Button styling
+  letter-spacing: normal;
+  min-width: 0px;
+  text-transform: none;
+  line-height: normal;
+  font-size: ${FontSize.smallest};
 `
 
 export const mixinTruncateText = `


### PR DESCRIPTION
In a separate branch, I'm trying to use MUI's [ButtonGroup](https://material-ui.com/components/button-group/), which needs MUI `Button`s rather than `button`s.

This might be a bit controversial since `InstrumentedButton` is kind of controversial in the first place for mixing analytics and rendering, but I don't think this really commits us further to it?

(fwiw (and at the risk of sparking that controversy in this PR) - I went down the path of getting rid of `InstrumentedButton` and replacing it with an `instrumentedOnClick` that takes a click handler and wraps it with a call that reports the click to analytics, but didn't like result - it seemed too much up to every single component to remember to call `instrumentedOnClick`, while with `InstrumentedButton`, the compiler ensures we specify analytics for the vast majority of our buttons)