### PR TITLE
storybook: add a global decorator

### DIFF
--- a/web/.storybook/preview.js
+++ b/web/.storybook/preview.js
@@ -1,4 +1,5 @@
 import "../src/index.scss"
+import { StylesProvider } from '@material-ui/core/styles';
 
 export const parameters = {
   options: {
@@ -7,3 +8,19 @@ export const parameters = {
     },
   },
 };
+
+export const decorators = [
+  (Story) => (
+    <>
+      {/* required for MUI <Icon> */}
+      <link
+          rel="stylesheet"
+          href="https://fonts.googleapis.com/icon?family=Material+Icons"
+      />
+      { /* https://material-ui.com/guides/interoperability/#controlling-priority-3 */ }
+      <StylesProvider injectFirst>
+        <Story />
+      </StylesProvider>
+    </>
+  ),
+]

--- a/web/src/OverviewTable.stories.tsx
+++ b/web/src/OverviewTable.stories.tsx
@@ -16,11 +16,6 @@ export default {
     (Story: any) => (
       <MemoryRouter initialEntries={["/"]}>
         <ResourceGroupsContextProvider>
-          {/* required for MUI <Icon> */}
-          <link
-            rel="stylesheet"
-            href="https://fonts.googleapis.com/icon?family=Material+Icons"
-          />
           <div style={{ margin: "-1rem" }}>
             <Story />
           </div>


### PR DESCRIPTION
(not necessarily looking for reviews from everyone but figured it'd be worth a bit of wider awareness since this might lead to surprises)

This fixes two issues that can lead to annoying/hard-to-debug differences between the webui and stories:
1. <Icon>${iconName}</Icon> will just show the value of the string `iconName` rather than the material icon named `${IconName}` (I don't know why icons work without this in the Tilt UI - I figure it just ends up happening via one of the many libraries we load, and haven't had much reason to actually take time to figure it out)
2. MUI styles take precedence over styled components' styles (this just makes the storybooks consistent with the [hud](https://github.com/tilt-dev/tilt/blob/d403ec100466fcb239f07854e18e179c4302d888/web/src/HUD.tsx#L246-L247))