### PR TITLE
web: show options forms on uibuttons w/ inputs

### DIFF
--- a/web/src/ApiButton.stories.tsx
+++ b/web/src/ApiButton.stories.tsx
@@ -1,0 +1,51 @@
+import React from "react"
+import { MemoryRouter } from "react-router"
+import styled from "styled-components"
+import { ApiButton } from "./ApiButton"
+import { makeUIButton, textField } from "./ApiButton.testhelpers"
+import { OverviewButtonMixin } from "./OverviewButton"
+
+type UIButton = Proto.v1alpha1UIButton
+type UIInputSpec = Proto.v1alpha1UIInputSpec
+type UITextInputSpec = Proto.v1alpha1UITextInputSpec
+type UIInputStatus = Proto.v1alpha1UIInputStatus
+
+export default {
+  title: "New UI/Shared/ApiButton",
+  decorators: [
+    (Story: any) => (
+      <MemoryRouter initialEntries={["/"]}>
+        <div style={{ margin: "-1rem" }}>
+          <Story />
+        </div>
+      </MemoryRouter>
+    ),
+  ],
+}
+
+const StyledButton = styled(ApiButton)`
+  button {
+    ${OverviewButtonMixin};
+  }
+`
+
+export const SimpleButton = () => {
+  const button = makeUIButton()
+  return <StyledButton button={button} />
+}
+
+export const ThreeTextInputs = () => {
+  const inputs: UIInputSpec[] = [1, 2, 3].map((i) => textField(`text${i}`))
+  const button = makeUIButton({ inputSpecs: inputs })
+  return <StyledButton button={button} />
+}
+
+export const TextInputOptions = () => {
+  const button = makeUIButton({
+    inputSpecs: [
+      textField("text1", undefined, "placeholder"),
+      textField("text2", "default value"),
+    ],
+  })
+  return <StyledButton button={button} />
+}

--- a/web/src/ApiButton.test.tsx
+++ b/web/src/ApiButton.test.tsx
@@ -1,0 +1,126 @@
+import { Button, Icon, TextField } from "@material-ui/core"
+import { mount } from "enzyme"
+import fetchMock from "fetch-mock"
+import React from "react"
+import { act } from "react-dom/test-utils"
+import {
+  cleanupMockAnalyticsCalls,
+  mockAnalyticsCalls,
+} from "./analytics_test_helpers"
+import {
+  ApiButton,
+  ApiButtonForm,
+  ApiButtonInputsToggleButton,
+  ApiButtonLabel,
+} from "./ApiButton"
+import { makeUIButton, textField } from "./ApiButton.testhelpers"
+import { flushPromises } from "./promise"
+
+type UIButtonStatus = Proto.v1alpha1UIButtonStatus
+
+describe("ApiButton", () => {
+  beforeEach(() => {
+    fetchMock.reset()
+    mockAnalyticsCalls()
+    fetchMock.mock(
+      (url) => url.startsWith("/proxy/apis/tilt.dev/v1alpha1/uibuttons"),
+      JSON.stringify({})
+    )
+    Date.now = jest.fn(() => 1482363367071)
+  })
+
+  afterEach(() => {
+    cleanupMockAnalyticsCalls()
+  })
+
+  it("renders a simple button", () => {
+    const b = makeUIButton()
+    const root = mount(<ApiButton button={b} />)
+    const button = root.find(ApiButton).find("button")
+    expect(button.length).toEqual(1)
+    expect(button.find(Icon).text()).toEqual(b.spec!.iconName)
+    expect(button.find(ApiButtonLabel).text()).toEqual(b.spec!.text)
+  })
+
+  it("renders an options button when the button has inputs", () => {
+    const inputs = [1, 2, 3].map((i) => textField(`text${i}`))
+    const b = makeUIButton({ inputSpecs: inputs })
+    const root = mount(<ApiButton button={b} />)
+    expect(
+      root.find(ApiButton).find(ApiButtonInputsToggleButton).length
+    ).toEqual(1)
+  })
+
+  it("shows the options form when the options button is clicked", () => {
+    const inputs = [1, 2, 3].map((i) => textField(`text${i}`))
+    const b = makeUIButton({ inputSpecs: inputs })
+    const root = mount(<ApiButton button={b} />)
+
+    const optionsButton = root.find(ApiButtonInputsToggleButton)
+    optionsButton.simulate("click")
+    root.update()
+
+    const optionsForm = root.find(ApiButtonForm)
+    expect(optionsForm.length).toEqual(1)
+
+    const expectedInputNames = inputs.map((i) => i.label)
+    const actualInputNames = optionsForm
+      .find(TextField)
+      .map((i) => i.prop("label"))
+    expect(actualInputNames).toEqual(expectedInputNames)
+  })
+
+  it("submits the current options when the submit button is clicked", async () => {
+    const inputSpec = textField("text1")
+    const b = makeUIButton({ inputSpecs: [inputSpec] })
+    const root = mount(<ApiButton button={b} />)
+
+    const optionsButton = root.find(ApiButtonInputsToggleButton)
+    act(() => {
+      optionsButton.simulate("click")
+    })
+    root.update()
+
+    const tf = root.find(ApiButtonForm).find("input")
+    act(() => {
+      tf.simulate("change", { target: { value: "new_value" } })
+    })
+    root.update()
+
+    const submit = root.find(ApiButton).find(Button).at(0)
+    await act(async () => {
+      submit.simulate("click")
+      // the button's onclick updates the button so we need to wait for that to resolve
+      // within the act() before continuing
+      // some related info: https://github.com/testing-library/react-testing-library/issues/281
+      return flushPromises()
+    })
+    root.update()
+
+    const calls = fetchMock
+      .calls()
+      .filter((c) => c[0] !== "http://localhost/api/analytics")
+    expect(calls.length).toEqual(1)
+    const call = calls[0]
+    expect(call[0]).toEqual(
+      "/proxy/apis/tilt.dev/v1alpha1/uibuttons/TestButton/status"
+    )
+    expect(call[1]).toBeTruthy()
+    expect(call[1]!.method).toEqual("PUT")
+    expect(call[1]!.body).toBeTruthy()
+    const actualStatus: UIButtonStatus = JSON.parse(call[1]!.body!.toString())
+      .status
+    const expectedStatus: UIButtonStatus = {
+      lastClickedAt: "2016-12-21T18:36:07.071000-05:00",
+      inputs: [
+        {
+          name: "text1",
+          text: {
+            value: "new_value",
+          },
+        },
+      ],
+    }
+    expect(actualStatus).toEqual(expectedStatus)
+  })
+})

--- a/web/src/ApiButton.testhelpers.tsx
+++ b/web/src/ApiButton.testhelpers.tsx
@@ -1,0 +1,37 @@
+type UIButton = Proto.v1alpha1UIButton
+type UIInputSpec = Proto.v1alpha1UIInputSpec
+type UIInputStatus = Proto.v1alpha1UIInputStatus
+
+export function textField(
+  name: string,
+  defaultValue?: string,
+  placeholder?: string
+): UIInputSpec {
+  return {
+    name: name,
+    label: name,
+    text: {
+      defaultValue: defaultValue,
+      placeholder: placeholder,
+    },
+  }
+}
+
+export function makeUIButton(args?: {
+  inputSpecs?: UIInputSpec[]
+  inputStatuses?: UIInputStatus[]
+}): UIButton {
+  return {
+    metadata: {
+      name: "TestButton",
+    },
+    spec: {
+      text: "Click Me!",
+      iconName: "flight_takeoff",
+      inputs: args?.inputSpecs,
+    },
+    status: {
+      inputs: args?.inputStatuses,
+    },
+  }
+}

--- a/web/src/ApiButton.tsx
+++ b/web/src/ApiButton.tsx
@@ -1,14 +1,37 @@
-import { Icon, SvgIcon } from "@material-ui/core"
+import { ButtonGroup, Icon, SvgIcon, TextField } from "@material-ui/core"
+import ArrowDropDownIcon from "@material-ui/icons/ArrowDropDown"
 import moment from "moment"
-import React, { useState } from "react"
+import React, { useRef, useState } from "react"
 import { convertFromNode, convertFromString } from "react-from-dom"
+import styled from "styled-components"
+import FloatDialog from "./FloatDialog"
 import { InstrumentedButton } from "./instrumentedComponents"
+import { Color, FontSize, SizeUnit } from "./style-helpers"
 
 type UIButton = Proto.v1alpha1UIButton
+type UIInputSpec = Proto.v1alpha1UIInputSpec
+type UIInputStatus = Proto.v1alpha1UIInputStatus
+
+const ApiButtonFormRoot = styled.span`
+  z-index: 20;
+`
+const ApiButtonFormFooter = styled.div`
+  margin-top: ${SizeUnit(0.5)};
+  text-align: right;
+  font-color: ${Color.grayLighter};
+  font-size: ${FontSize.smallester};
+`
+export const ApiButtonLabel = styled.span``
 
 type ApiButtonProps = { className?: string; button: UIButton }
 
 type ApiIconProps = { iconName?: string; iconSVG?: string }
+
+export const ApiButtonInputsToggleButton = styled(InstrumentedButton)`
+  &&&& {
+    padding: 0 0;
+  }
+`
 
 const svgElement = (src: string): React.ReactElement => {
   const node = convertFromString(src, {
@@ -17,6 +40,97 @@ const svgElement = (src: string): React.ReactElement => {
     nodeOnly: true,
   }) as SVGSVGElement
   return convertFromNode(node) as React.ReactElement
+}
+
+type ApiButtonInputProps = {
+  spec: UIInputSpec
+  status: UIInputStatus | undefined
+  value: string | undefined
+  setValue: (name: string, value: string) => void
+}
+
+function ApiButtonInput(props: ApiButtonInputProps) {
+  return (
+    <TextField
+      label={props.spec.label ?? props.spec.name}
+      id={props.spec.name}
+      defaultValue={props.spec.text?.defaultValue}
+      placeholder={props.spec.text?.placeholder}
+      value={props.value || props.spec.text?.defaultValue || ""}
+      onChange={(e) => props.setValue(props.spec.name!, e.target.value)}
+      fullWidth
+    />
+  )
+}
+
+type ApiButtonFormProps = {
+  uiButton: UIButton
+  setInputValue: (name: string, value: string) => void
+  getInputValue: (name: string) => string | undefined
+}
+
+export function ApiButtonForm(props: ApiButtonFormProps) {
+  return (
+    <ApiButtonFormRoot>
+      {props.uiButton.spec?.inputs?.map((spec) => {
+        const name = spec.name!
+        const status = props.uiButton.status?.inputs?.find(
+          (status) => status.name === name
+        )
+        const value = props.getInputValue(name)
+        return (
+          <ApiButtonInput
+            key={name}
+            spec={spec}
+            status={status}
+            value={value}
+            setValue={props.setInputValue}
+          />
+        )
+      })}
+      <ApiButtonFormFooter>(Changes automatically applied)</ApiButtonFormFooter>
+    </ApiButtonFormRoot>
+  )
+}
+
+type ApiButtonWithOptionsProps = {
+  submit: JSX.Element
+  uiButton: UIButton
+  setInputValue: (name: string, value: string) => void
+  getInputValue: (name: string) => string | undefined
+  className?: string
+}
+
+function ApiButtonWithOptions(props: ApiButtonWithOptionsProps) {
+  const [open, setOpen] = useState(false)
+  const anchorRef = useRef(null)
+
+  return (
+    <>
+      <ButtonGroup ref={anchorRef} className={props.className}>
+        {props.submit}
+        <ApiButtonInputsToggleButton
+          size="small"
+          onClick={() => {
+            setOpen((prevOpen) => !prevOpen)
+          }}
+          analyticsName="ui.web.uiButton.inputs"
+        >
+          <ArrowDropDownIcon />
+        </ApiButtonInputsToggleButton>
+      </ButtonGroup>
+      <FloatDialog
+        open={open}
+        onClose={() => {
+          setOpen(false)
+        }}
+        anchorEl={anchorRef.current}
+        title={`Options for ${props.uiButton.spec?.text}`}
+      >
+        <ApiButtonForm {...props} />
+      </FloatDialog>
+    </>
+  )
 }
 
 export const ApiIcon: React.FC<ApiIconProps> = (props) => {
@@ -39,8 +153,16 @@ export const ApiIcon: React.FC<ApiIconProps> = (props) => {
   return null
 }
 
+// Renders a UIButton.
+// NB: The `Button` in `ApiButton` refers to a UIButton, not an html <button>.
+// This can be confusing because each ApiButton consists of one or two <button>s:
+// 1. A submit <button>, which fires the button's action.
+// 2. Optionally, an options <button>, which allows the user to configure the
+//    options used on submit.
 export const ApiButton: React.FC<ApiButtonProps> = (props) => {
   const [loading, setLoading] = useState(false)
+  const [inputValues, setInputValues] = useState(new Map<string, string>())
+
   const onClick = async () => {
     const toUpdate = {
       metadata: { ...props.button.metadata },
@@ -52,6 +174,17 @@ export const ApiButton: React.FC<ApiButtonProps> = (props) => {
     toUpdate.status!.lastClickedAt = moment().format(
       "YYYY-MM-DDTHH:mm:ss.SSSSSSZ"
     )
+
+    toUpdate.status!.inputs = []
+    props.button.spec!.inputs?.forEach((spec) => {
+      const value = inputValues.get(spec.name!)
+      if (value !== undefined) {
+        toUpdate.status!.inputs!.push({
+          name: spec.name,
+          text: { value: value },
+        })
+      }
+    })
 
     // TODO(milas): currently the loading state just disables the button for the duration of
     //  the AJAX request to avoid duplicate clicks - there is no progress tracking at the
@@ -74,13 +207,13 @@ export const ApiButton: React.FC<ApiButtonProps> = (props) => {
       setLoading(false)
     }
   }
+
   // button text is not included in analytics name since that can be user data
-  return (
+  const button = (
     <InstrumentedButton
       analyticsName={"ui.web.uibutton"}
       onClick={onClick}
       disabled={loading || props.button.spec?.disabled}
-      className={props.className}
     >
       {props.children || (
         <>
@@ -88,11 +221,31 @@ export const ApiButton: React.FC<ApiButtonProps> = (props) => {
             iconName={props.button.spec?.iconName}
             iconSVG={props.button.spec?.iconSVG}
           />
-          {props.button.spec?.text ?? "Button"}
+          <ApiButtonLabel>{props.button.spec?.text ?? "Button"}</ApiButtonLabel>
         </>
       )}
     </InstrumentedButton>
   )
+
+  if (props.button.spec?.inputs?.length) {
+    const setInputValue = (name: string, value: string) => {
+      // We need a `new Map` to ensure the reference changes to force a rerender.
+      setInputValues(new Map(inputValues.set(name, value)))
+    }
+    const getInputValue = (name: string) => inputValues.get(name)
+
+    return (
+      <ApiButtonWithOptions
+        className={props.className}
+        submit={button}
+        uiButton={props.button}
+        setInputValue={setInputValue}
+        getInputValue={getInputValue}
+      />
+    )
+  } else {
+    return <ButtonGroup className={props.className}>{button}</ButtonGroup>
+  }
 }
 
 export function buttonsForComponent(

--- a/web/src/CustomNav.tsx
+++ b/web/src/CustomNav.tsx
@@ -8,7 +8,18 @@ type CustomNavProps = {
 }
 
 const CustomNavButton = styled(ApiButton)`
-  ${MenuButtonMixin}
+  align-items: center;
+
+  // If the api button has an options toggle, remove padding between the submit
+  // button and the options button.
+  button:first-child {
+    ${MenuButtonMixin};
+    padding-right: 0px;
+  }
+  // If there is no options toggle, then use the default padding.
+  button:only-child {
+    ${MenuButtonMixin};
+  }
   .apibtn-label {
     display: none;
   }

--- a/web/src/FloatDialog.tsx
+++ b/web/src/FloatDialog.tsx
@@ -6,7 +6,7 @@ import { ReactComponent as CloseSvg } from "./assets/svg/close.svg"
 import { Color, Font, FontSize } from "./style-helpers"
 
 type props = {
-  id: string
+  id?: string
   title: string | React.ReactElement
   open: boolean
   anchorEl: Element | null

--- a/web/src/OverviewActionBar.tsx
+++ b/web/src/OverviewActionBar.tsx
@@ -15,6 +15,7 @@ import { useHistory, useLocation } from "react-router"
 import styled from "styled-components"
 import { Alert } from "./alerts"
 import { AnalyticsAction, incr } from "./analytics"
+import { ApiButton } from "./ApiButton"
 import { ReactComponent as AlertSvg } from "./assets/svg/alert.svg"
 import { ReactComponent as CheckmarkSvg } from "./assets/svg/checkmark.svg"
 import { ReactComponent as CloseSvg } from "./assets/svg/close.svg"
@@ -35,7 +36,7 @@ import {
 } from "./logfilters"
 import { useLogStore } from "./LogStore"
 import OverviewActionBarKeyboardShortcuts from "./OverviewActionBarKeyboardShortcuts"
-import { CustomActionButton, OverviewButtonMixin } from "./OverviewButton"
+import { OverviewButtonMixin } from "./OverviewButton"
 import { usePathBuilder } from "./PathBuilder"
 import SrOnly from "./SrOnly"
 import {
@@ -176,6 +177,10 @@ function FilterSourceMenu(props: FilterSourceMenuProps) {
     </Menu>
   )
 }
+
+const CustomActionButton = styled(ApiButton)`
+  ${OverviewButtonMixin};
+`
 
 const ButtonRoot = styled(InstrumentedButton)`
   ${OverviewButtonMixin}

--- a/web/src/OverviewButton.tsx
+++ b/web/src/OverviewButton.tsx
@@ -1,5 +1,3 @@
-import styled from "styled-components"
-import { ApiButton } from "./ApiButton"
 import {
   AnimDuration,
   Color,
@@ -61,6 +59,9 @@ export const OverviewButtonMixin = `
   &:hover {
     color: ${Color.blue};
     border-color: ${Color.blue};
+    // When in a ButtonGroup, adjacent buttons share a border.
+    // Force this button to the front so that its highlighted border shows.
+    z-index: 10;
   }
   &:hover .fillStd {
     fill: ${Color.blue};
@@ -72,8 +73,4 @@ export const OverviewButtonMixin = `
   &.isEnabled:hover .fillStd {
     fill: ${Color.blue};
   }
-`
-
-export const CustomActionButton = styled(ApiButton)`
-  ${OverviewButtonMixin}
 `

--- a/web/src/OverviewTable.test.tsx
+++ b/web/src/OverviewTable.test.tsx
@@ -5,9 +5,9 @@ import {
   cleanupMockAnalyticsCalls,
   mockAnalyticsCalls,
 } from "./analytics_test_helpers"
+import { ApiButton } from "./ApiButton"
 import { GroupByLabelView, TILTFILE_LABEL, UNLABELED_LABEL } from "./labels"
 import LogStore from "./LogStore"
-import { CustomActionButton } from "./OverviewButton"
 import OverviewTable, {
   OverviewGroup,
   OverviewGroupName,
@@ -48,7 +48,7 @@ it("shows buttons on the appropriate resources", () => {
   // first row is headers, so skip it
   const rows = root.find(ResourceTableRow).slice(1)
   const actualButtons = rows.map((row) =>
-    row.find(CustomActionButton).map((e) => e.prop("button").metadata.name)
+    row.find(ApiButton).map((e) => e.prop("button").metadata?.name)
   )
 
   expect(actualButtons).toEqual(expectedButtons)

--- a/web/src/OverviewTable.tsx
+++ b/web/src/OverviewTable.tsx
@@ -15,7 +15,7 @@ import TimeAgo from "react-timeago"
 import styled from "styled-components"
 import { buildAlerts, runtimeAlerts } from "./alerts"
 import { AnalyticsAction, AnalyticsType, incr } from "./analytics"
-import { ApiIcon, buttonsForComponent } from "./ApiButton"
+import { ApiButton, ApiIcon, buttonsForComponent } from "./ApiButton"
 import { ReactComponent as CheckmarkSvg } from "./assets/svg/checkmark.svg"
 import { ReactComponent as CopySvg } from "./assets/svg/copy.svg"
 import { ReactComponent as LinkSvg } from "./assets/svg/link.svg"
@@ -30,7 +30,7 @@ import {
 } from "./labels"
 import { displayURL } from "./links"
 import LogStore, { LogAlertIndex, useLogStore } from "./LogStore"
-import { CustomActionButton } from "./OverviewButton"
+import { OverviewButtonMixin } from "./OverviewButton"
 import OverviewTableStarResourceButton from "./OverviewTableStarResourceButton"
 import OverviewTableStatus from "./OverviewTableStatus"
 import OverviewTableTriggerButton from "./OverviewTableTriggerButton"
@@ -249,12 +249,17 @@ const PodIdCopy = styled(InstrumentedButton)`
     fill: ${Color.gray6};
   }
 `
+const CustomActionButton = styled(ApiButton)`
+  button {
+    ${OverviewButtonMixin};
+  }
+`
 const WidgetCell = styled.span`
   display: flex;
   flex-wrap: wrap;
   max-width: ${SizeUnit(8)};
 
-  ${CustomActionButton} {
+  .MuiButtonGroup-root {
     margin-bottom: ${SizeUnit(0.125)};
     margin-right: ${SizeUnit(0.125)};
   }

--- a/web/src/Tooltip.tsx
+++ b/web/src/Tooltip.tsx
@@ -34,7 +34,7 @@ export default function TiltTooltip(props: TooltipProps) {
   return (
     <Tooltip
       arrow
-      placement="top-end"
+      placement="top-start"
       classes={classes}
       role="tooltip"
       {...props}

--- a/web/src/promise.ts
+++ b/web/src/promise.ts
@@ -1,0 +1,6 @@
+// This promise resolves when all in-flight promises have resolved.
+// See: https://github.com/facebook/jest/issues/2157#issuecomment-279171856
+
+export function flushPromises() {
+  return new Promise((resolve) => setImmediate(resolve))
+}


### PR DESCRIPTION
When a UIButton's spec defines one or more inputs:
1. Attach a little arrow next to the button in the UI, which pops up a form allowing the user to set those inputs' values.
2. Include those inputs' values in the UIButtonStatus when the button is clicked.

The design/flow is currently a bit awkward but probably good enough to have people play around with it. The main goal was to come up one design that'd work for all button locations for now.

Here's how it looks in the nav bar:
<img src="https://user-images.githubusercontent.com/7453991/130526328-1529a602-e402-4789-ad68-9a4015ef6f4e.png" width=400>

In table view:
<img src="https://user-images.githubusercontent.com/7453991/130526346-9fbc4c57-ff63-4644-8b73-43e9cecfaa98.png" width=400>

In overview action bar (on resource pane):
<img src="https://user-images.githubusercontent.com/7453991/130526585-896e50dc-9539-49dd-bc6b-0b08becc642a.png" width=400>

In action:
<img src="https://user-images.githubusercontent.com/7453991/130527003-ca658e8d-7f00-4fea-bd87-d40f7a0df283.gif" width=400>