### PR TITLE
kubernetesapply: add support for discovery_mode='selectors-only'

### DIFF
--- a/internal/controllers/core/kubernetesapply/disco.go
+++ b/internal/controllers/core/kubernetesapply/disco.go
@@ -124,7 +124,7 @@ func (r *Reconciler) toDesiredKubernetesDiscovery(ka *v1alpha1.KubernetesApply) 
 func (r *Reconciler) toWatchRefs(ka *v1alpha1.KubernetesApply) ([]v1alpha1.KubernetesWatchRef, error) {
 	seenNamespaces := make(map[k8s.Namespace]bool)
 	var result []v1alpha1.KubernetesWatchRef
-	if ka.Status.ResultYAML != "" {
+	if ka.Status.ResultYAML != "" && ka.Spec.DiscoveryStrategy != v1alpha1.KubernetesDiscoveryStrategySelectorsOnly {
 		deployed, err := k8s.ParseYAMLFromString(ka.Status.ResultYAML)
 		if err != nil {
 			return nil, err

--- a/internal/k8s/target_test.go
+++ b/internal/k8s/target_test.go
@@ -7,13 +7,14 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/tilt-dev/tilt/internal/k8s/testyaml"
+	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
 	"github.com/tilt-dev/tilt/pkg/model"
 )
 
 func TestNewTargetSortsK8sEntities(t *testing.T) {
 	entities := MustParseYAMLFromString(t, testyaml.OutOfOrderYaml)
 	targ, err := NewTarget("foo", entities, nil, nil, nil, nil,
-		nil, model.PodReadinessWait, nil, nil, model.UpdateSettings{})
+		nil, model.PodReadinessWait, v1alpha1.KubernetesDiscoveryStrategyDefault, nil, nil, model.UpdateSettings{})
 	require.NoError(t, err)
 
 	expectedKindOrder := []string{"PersistentVolume", "PersistentVolumeClaim", "ConfigMap", "Service", "StatefulSet", "Job", "Pod"}

--- a/internal/tiltfile/k8s.go
+++ b/internal/tiltfile/k8s.go
@@ -21,6 +21,7 @@ import (
 	"github.com/tilt-dev/tilt/internal/tiltfile/io"
 	tiltfile_k8s "github.com/tilt-dev/tilt/internal/tiltfile/k8s"
 	"github.com/tilt-dev/tilt/internal/tiltfile/value"
+	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
 	"github.com/tilt-dev/tilt/pkg/model"
 )
 
@@ -51,6 +52,8 @@ type k8sResource struct {
 
 	podReadinessMode model.PodReadinessMode
 
+	discoveryStrategy v1alpha1.KubernetesDiscoveryStrategy
+
 	dependencyIDs []model.TargetID
 
 	triggerMode triggerMode
@@ -79,6 +82,7 @@ type k8sResourceOptions struct {
 	objects           []string
 	manuallyGrouped   bool
 	podReadinessMode  model.PodReadinessMode
+	discoveryStrategy v1alpha1.KubernetesDiscoveryStrategy
 	links             []model.Link
 	labels            map[string]string
 }
@@ -269,6 +273,7 @@ func (s *tiltfileState) k8sResource(thread *starlark.Thread, fn *starlark.Builti
 	var links links.LinkList
 	var autoInit = value.BoolOrNone{Value: true}
 	var labels value.LabelSet
+	var discoveryStrategy tiltfile_k8s.DiscoveryStrategy
 
 	if err := s.unpackArgs(fn.Name(), args, kwargs,
 		"workload?", &workload,
@@ -282,6 +287,7 @@ func (s *tiltfileState) k8sResource(thread *starlark.Thread, fn *starlark.Builti
 		"pod_readiness?", &podReadinessMode,
 		"links?", &links,
 		"labels?", &labels,
+		"discovery_strategy?", &discoveryStrategy,
 	); err != nil {
 		return nil, err
 	}
@@ -341,6 +347,7 @@ func (s *tiltfileState) k8sResource(thread *starlark.Thread, fn *starlark.Builti
 		podReadinessMode:  podReadinessMode.Value,
 		links:             links.Links,
 		labels:            labelMap,
+		discoveryStrategy: v1alpha1.KubernetesDiscoveryStrategy(discoveryStrategy),
 	})
 
 	return starlark.None, nil

--- a/internal/tiltfile/k8s/types.go
+++ b/internal/tiltfile/k8s/types.go
@@ -1,0 +1,32 @@
+package k8s
+
+import (
+	"fmt"
+
+	"go.starlark.net/starlark"
+
+	"github.com/tilt-dev/tilt/internal/tiltfile/value"
+	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
+)
+
+// Deserializing discovery strategy from starlark values.
+type DiscoveryStrategy v1alpha1.KubernetesDiscoveryStrategy
+
+func (ds *DiscoveryStrategy) Unpack(v starlark.Value) error {
+	s, ok := value.AsString(v)
+	if !ok {
+		return fmt.Errorf("Must be a string. Got: %s", v.Type())
+	}
+
+	kdStrategy := v1alpha1.KubernetesDiscoveryStrategy(s)
+	if !(kdStrategy == "" ||
+		kdStrategy == v1alpha1.KubernetesDiscoveryStrategyDefault ||
+		kdStrategy == v1alpha1.KubernetesDiscoveryStrategySelectorsOnly) {
+		return fmt.Errorf("Invalid. Must be one of: %q, %q",
+			v1alpha1.KubernetesDiscoveryStrategyDefault,
+			v1alpha1.KubernetesDiscoveryStrategySelectorsOnly)
+	}
+
+	*ds = DiscoveryStrategy(kdStrategy)
+	return nil
+}

--- a/internal/tiltfile/tiltfile_state.go
+++ b/internal/tiltfile/tiltfile_state.go
@@ -716,6 +716,9 @@ func (s *tiltfileState) assembleK8s() error {
 			if opts.podReadinessMode != model.PodReadinessNone {
 				r.podReadinessMode = opts.podReadinessMode
 			}
+			if opts.discoveryStrategy != "" {
+				r.discoveryStrategy = opts.discoveryStrategy
+			}
 			r.portForwards = append(r.portForwards, opts.portForwards...)
 			if opts.triggerMode != TriggerModeUnset {
 				r.triggerMode = opts.triggerMode
@@ -1071,6 +1074,7 @@ func (s *tiltfileState) translateK8s(resources []*k8sResource, updateSettings mo
 		k8sTarget, err := k8s.NewTarget(mn.TargetName(), r.entities,
 			s.defaultedPortForwards(r.portForwards), r.extraPodSelectors,
 			r.dependencyIDs, iTargets, r.imageRefMap, s.inferPodReadinessMode(r),
+			r.discoveryStrategy,
 			locators, r.links, updateSettings)
 		if err != nil {
 			return nil, err

--- a/pkg/apis/core/v1alpha1/generated.proto
+++ b/pkg/apis/core/v1alpha1/generated.proto
@@ -899,6 +899,8 @@ message KubernetesWatchRef {
   // UID is a Kubernetes object UID.
   //
   // It should either be the exact object UID or the transitive owner.
+  //
+  // +optional
   optional string uid = 1;
 
   // Namespace is the Kubernetes namespace for discovery. Required.
@@ -907,6 +909,8 @@ message KubernetesWatchRef {
   // Name is the Kubernetes object name.
   //
   // This is not directly used in discovery; it is extra metadata.
+  //
+  // +optional
   optional string name = 3;
 }
 

--- a/pkg/apis/core/v1alpha1/kubernetesapply_types.go
+++ b/pkg/apis/core/v1alpha1/kubernetesapply_types.go
@@ -18,6 +18,7 @@ package v1alpha1
 
 import (
 	"context"
+	fmt "fmt"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -187,10 +188,20 @@ func (in *KubernetesApply) IsStorageVersion() bool {
 func (in *KubernetesApply) Validate(ctx context.Context) field.ErrorList {
 	var fieldErrors field.ErrorList
 	if in.Spec.YAML == "" {
-		fieldErrors = append(fieldErrors, field.Required(field.NewPath("yaml"), "cannot be empty"))
+		fieldErrors = append(fieldErrors, field.Required(field.NewPath("spec.yaml"), "cannot be empty"))
 	}
 
-	// TODO(nick): Validate the image locators as well.
+	kdStrategy := in.Spec.DiscoveryStrategy
+	if !(kdStrategy == "" ||
+		kdStrategy == KubernetesDiscoveryStrategyDefault ||
+		kdStrategy == KubernetesDiscoveryStrategySelectorsOnly) {
+		fieldErrors = append(fieldErrors, field.Invalid(
+			field.NewPath("spec.discoveryStrategy"),
+			kdStrategy,
+			fmt.Sprintf("Must be one of: %s, %s",
+				KubernetesDiscoveryStrategyDefault,
+				KubernetesDiscoveryStrategySelectorsOnly)))
+	}
 
 	return fieldErrors
 }

--- a/pkg/apis/core/v1alpha1/kubernetesdiscovery_types.go
+++ b/pkg/apis/core/v1alpha1/kubernetesdiscovery_types.go
@@ -97,12 +97,18 @@ type KubernetesWatchRef struct {
 	// UID is a Kubernetes object UID.
 	//
 	// It should either be the exact object UID or the transitive owner.
-	UID string `json:"uid" protobuf:"bytes,1,opt,name=uid"`
+	//
+	// +optional
+	UID string `json:"uid,omitempty" protobuf:"bytes,1,opt,name=uid"`
+
 	// Namespace is the Kubernetes namespace for discovery. Required.
 	Namespace string `json:"namespace" protobuf:"bytes,2,opt,name=namespace"`
+
 	// Name is the Kubernetes object name.
 	//
 	// This is not directly used in discovery; it is extra metadata.
+	//
+	// +optional
 	Name string `json:"name,omitempty" protobuf:"bytes,3,opt,name=name"`
 }
 

--- a/pkg/openapi/zz_generated.openapi.go
+++ b/pkg/openapi/zz_generated.openapi.go
@@ -2426,7 +2426,6 @@ func schema_pkg_apis_core_v1alpha1_KubernetesWatchRef(ref common.ReferenceCallba
 					"uid": {
 						SchemaProps: spec.SchemaProps{
 							Description: "UID is a Kubernetes object UID.\n\nIt should either be the exact object UID or the transitive owner.",
-							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -2447,7 +2446,7 @@ func schema_pkg_apis_core_v1alpha1_KubernetesWatchRef(ref common.ReferenceCallba
 						},
 					},
 				},
-				Required: []string{"uid", "namespace"},
+				Required: []string{"namespace"},
 			},
 		},
 	}


### PR DESCRIPTION
Hello @milas, @landism,

Please review the following commits I made in branch nicks/ch12592:

775362907588eedee90fe5363dfe5434925d7d5a (2021-08-23 18:46:54 -0400)
kubernetesapply: add support for discovery_strategy='selectors-only'
You can specify this in the tiltfile as

k8s_resource(..., discovery_strategy='selectors-only')

and tilt will create kdisco objects with namespace-only watches (no UIDs).

Fixes https://github.com/tilt-dev/tilt/issues/4867

b88eb3c55ca0c14a13474270f489987551aafb05 (2021-08-23 17:38:08 -0400)
apis: data model for k8s discovery options

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics