### PR TITLE
web: fix object update sorting when Orders are equal

### DIFF
--- a/web/src/ApiButton.tsx
+++ b/web/src/ApiButton.tsx
@@ -111,7 +111,4 @@ export function buttonsForComponent(
           componentType.toUpperCase() &&
         b.spec?.location?.componentID === componentID
     )
-    .sort((a, b) =>
-      (a.metadata?.name || "").localeCompare(b.metadata?.name || "")
-    )
 }

--- a/web/src/HUD.test.tsx
+++ b/web/src/HUD.test.tsx
@@ -9,7 +9,7 @@ import LogStore from "./LogStore"
 import SocketBar from "./SocketBar"
 import {
   logList,
-  nButtonView,
+  nButtonView, nResourceView,
   oneResourceView,
   twoResourceView,
 } from "./testdata"
@@ -191,16 +191,25 @@ describe("mergeAppUpdates", () => {
   })
 
   it("handles add resource out of order", () => {
-    let prevState = { view: twoResourceView() }
-    prevState.view.uiResources = [twoResourceView().uiResources[1]]
+    let prevState = { view: nResourceView(10) }
+    let addedResources = prevState.view.uiResources.splice(3, 1)
 
-    let update = { view: { uiResources: [twoResourceView().uiResources[0]] } }
+    let update = { view: { uiResources: addedResources } }
     let result = mergeAppUpdate(prevState as any, update)
     expect(result!.view).not.toBe(prevState.view)
     expect(result!.view.uiSession).toBe(prevState.view.uiSession)
-    expect(result!.view.uiResources!.length).toEqual(2)
-    expect(result!.view.uiResources![0].metadata!.name).toEqual("vigoda")
-    expect(result!.view.uiResources![1].metadata!.name).toEqual("snack")
+    expect(result!.view.uiResources).toEqual(nResourceView(10).uiResources)
+  })
+
+  it("handles add button out of order", () => {
+    let prevState = { view: nButtonView(9) }
+    let addedButtons = prevState.view.uiButtons.splice(3, 1)
+
+    let update = { view: { uiButtons: addedButtons } }
+    let result = mergeAppUpdate(prevState as any, update)
+    expect(result!.view).not.toBe(prevState.view)
+    expect(result!.view.uiSession).toBe(prevState.view.uiSession)
+    expect(result!.view.uiButtons).toEqual(nButtonView(9).uiButtons)
   })
 
   it("handles delete resource", () => {

--- a/web/src/HUD.tsx
+++ b/web/src/HUD.tsx
@@ -349,7 +349,7 @@ function compareObjectsOrder<
   }
 
   let aName = a.metadata?.name || ""
-  let bName = a.metadata?.name || ""
+  let bName = b.metadata?.name || ""
   return aName < bName ? -1 : aName == bName ? 0 : 1
 }
 


### PR DESCRIPTION
I spotted this when briefly looking into #4885. I don't know if it will affect that issue. If it is caused by resources having equal Order, then it will eliminate the "jumping around" symptom, which will be nice for the user but make the actual issue harder to debug.

This makes the sorting added in #4869 redundant, so removing that.

Also updated the UIResource sorting test to be less likely to pass by chance.