### PR TITLE
extension: group each extension by its own label

### DIFF
--- a/internal/controllers/core/extension/reconciler_test.go
+++ b/internal/controllers/core/extension/reconciler_test.go
@@ -38,6 +38,7 @@ func TestDefault(t *testing.T) {
 	var tf v1alpha1.Tiltfile
 	f.MustGet(types.NamespacedName{Name: "my-repo:my-ext"}, &tf)
 	require.Equal(t, p, tf.Spec.Path)
+	require.Equal(t, map[string]string{"extension.my-repo_my-ext": "extension.my-repo_my-ext"}, tf.Spec.Labels)
 }
 
 func TestCleanupTiltfile(t *testing.T) {

--- a/internal/controllers/core/extension/tiltfiles.go
+++ b/internal/controllers/core/extension/tiltfiles.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/tilt-dev/tilt/internal/controllers/apicmp"
 	"github.com/tilt-dev/tilt/internal/controllers/indexer"
+	"github.com/tilt-dev/tilt/pkg/apis"
 	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
 )
 
@@ -88,6 +89,10 @@ func (r *Reconciler) toDesiredTiltfile(owner *v1alpha1.Extension) (*v1alpha1.Til
 		return nil, nil
 	}
 
+	// Each extensions resources get their own group.
+	// We prefix it with 'extension' so that all extensions get put together.
+	// TODO(nick): Let the user choose the label when they register the extension.
+	label := apis.SanitizeLabel(fmt.Sprintf("extension.%s", owner.Name))
 	child := &v1alpha1.Tiltfile{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: owner.Name,
@@ -98,8 +103,7 @@ func (r *Reconciler) toDesiredTiltfile(owner *v1alpha1.Extension) (*v1alpha1.Til
 		Spec: v1alpha1.TiltfileSpec{
 			Path: path,
 			Labels: map[string]string{
-				// All tiltfiles are under the "extensions" group.
-				"extensions": "extensions",
+				label: label,
 			},
 		},
 	}


### PR DESCRIPTION
Hello @landism, @lizzthabet,

Please review the following commits I made in branch nicks/labels:

5a9a3b7eaa94dfee4cbf8c98c5311c33e3861bf9 (2021-08-24 19:32:25 -0400)
extension: group each extension by its own label

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics