### PR TITLE
web: add some daylight between uibutton's icon and label

### DIFF
--- a/web/src/ApiButton.tsx
+++ b/web/src/ApiButton.tsx
@@ -12,7 +12,7 @@ type UIButton = Proto.v1alpha1UIButton
 type UIInputSpec = Proto.v1alpha1UIInputSpec
 type UIInputStatus = Proto.v1alpha1UIInputStatus
 
-const ApiButtonFormRoot = styled.span`
+const ApiButtonFormRoot = styled.div`
   z-index: 20;
 `
 const ApiButtonFormFooter = styled.div`
@@ -21,7 +21,12 @@ const ApiButtonFormFooter = styled.div`
   font-color: ${Color.grayLighter};
   font-size: ${FontSize.smallester};
 `
-export const ApiButtonLabel = styled.span``
+export const ApiButtonLabel = styled.div``
+export const ApiButtonRoot = styled(ButtonGroup)`
+  ${ApiButtonLabel} {
+    margin-left: ${SizeUnit(0.25)};
+  }
+`
 
 type ApiButtonProps = { className?: string; button: UIButton }
 
@@ -107,7 +112,7 @@ function ApiButtonWithOptions(props: ApiButtonWithOptionsProps) {
 
   return (
     <>
-      <ButtonGroup ref={anchorRef} className={props.className}>
+      <ApiButtonRoot ref={anchorRef} className={props.className}>
         {props.submit}
         <ApiButtonInputsToggleButton
           size="small"
@@ -118,7 +123,7 @@ function ApiButtonWithOptions(props: ApiButtonWithOptionsProps) {
         >
           <ArrowDropDownIcon />
         </ApiButtonInputsToggleButton>
-      </ButtonGroup>
+      </ApiButtonRoot>
       <FloatDialog
         open={open}
         onClose={() => {
@@ -244,7 +249,7 @@ export const ApiButton: React.FC<ApiButtonProps> = (props) => {
       />
     )
   } else {
-    return <ButtonGroup className={props.className}>{button}</ButtonGroup>
+    return <ApiButtonRoot className={props.className}>{button}</ApiButtonRoot>
   }
 }
 


### PR DESCRIPTION
I screwed up this spacing with one of my recent uibutton changes

(also just change some spans to divs that I noticed while fixing this)

change from this:
<img width="136" alt="Screen Shot 2021-08-26 at 11 58 25 AM" src="https://user-images.githubusercontent.com/7453991/130996207-6f0e5edd-2ffc-42c2-bfeb-18d4976b2a78.png">

to this:
<img width="139" alt="Screen Shot 2021-08-26 at 11 58 39 AM" src="https://user-images.githubusercontent.com/7453991/130996223-4fde3c9d-e1a5-499e-a99a-e6777d38b46b.png">