### PR TITLE
web: only add margin to apibutton label when there's an icon

### DIFF
--- a/web/src/ApiButton.tsx
+++ b/web/src/ApiButton.tsx
@@ -175,11 +175,19 @@ export const ApiIcon: React.FC<ApiIconProps> = (props) => {
       // merge the props from material-ui while keeping the children of the actual SVG
       return React.cloneElement(svgEl, { ...props }, ...svgEl.props.children)
     }
-    return <ApiIconRoot><SvgIcon component={svg} /></ApiIconRoot>
+    return (
+      <ApiIconRoot>
+        <SvgIcon component={svg} />
+      </ApiIconRoot>
+    )
   }
 
   if (props.iconName) {
-    return <ApiIconRoot><Icon>{props.iconName}</Icon></ApiIconRoot>
+    return (
+      <ApiIconRoot>
+        <Icon>{props.iconName}</Icon>
+      </ApiIconRoot>
+    )
   }
 
   return null

--- a/web/src/ApiButton.tsx
+++ b/web/src/ApiButton.tsx
@@ -28,9 +28,10 @@ const ApiButtonFormFooter = styled.div`
   font-color: ${Color.grayLighter};
   font-size: ${FontSize.smallester};
 `
+const ApiIconRoot = styled.div``
 export const ApiButtonLabel = styled.div``
 export const ApiButtonRoot = styled(ButtonGroup)`
-  ${ApiButtonLabel} {
+  ${ApiIconRoot} + ${ApiButtonLabel} {
     margin-left: ${SizeUnit(0.25)};
   }
 `
@@ -174,11 +175,11 @@ export const ApiIcon: React.FC<ApiIconProps> = (props) => {
       // merge the props from material-ui while keeping the children of the actual SVG
       return React.cloneElement(svgEl, { ...props }, ...svgEl.props.children)
     }
-    return <SvgIcon component={svg} />
+    return <ApiIconRoot><SvgIcon component={svg} /></ApiIconRoot>
   }
 
   if (props.iconName) {
-    return <Icon>{props.iconName}</Icon>
+    return <ApiIconRoot><Icon>{props.iconName}</Icon></ApiIconRoot>
   }
 
   return null


### PR DESCRIPTION
### Problem

#4894 always added a left margin to button labels, even when there was no icon

![image](https://user-images.githubusercontent.com/7453991/131168361-ba5a9787-b3e0-4e76-ab04-3fdac79be668.png)

### Solution

Only add the margin when the label follows an icon