### PR TITLE
hud: sort objects on complete view

### DIFF
--- a/web/src/HUD.test.tsx
+++ b/web/src/HUD.test.tsx
@@ -301,7 +301,8 @@ describe("mergeAppUpdates", () => {
 
     let update = {
       view: {
-        uiResources: [{ metadata: { name: "vigoda" } }],
+        uiResources: [{ metadata: { name: "b" } }, { metadata: { name: "a" } }],
+        uiButtons: [{ metadata: { name: "z" } }, { metadata: { name: "y" } }],
         logList: logList(["line1", "line2"]),
         isComplete: true,
       },
@@ -313,6 +314,14 @@ describe("mergeAppUpdates", () => {
       "line1",
       "line2",
     ])
+    const expectedResourceOrder = ["a", "b"]
+    expect(result!.view.uiResources?.map((r) => r.metadata!.name)).toEqual(
+      expectedResourceOrder
+    )
+    const expectedButtonOrder = ["y", "z"]
+    expect(result!.view.uiButtons?.map((r) => r.metadata!.name)).toEqual(
+      expectedButtonOrder
+    )
   })
 
   it("handles log only update", () => {

--- a/web/src/HUD.tsx
+++ b/web/src/HUD.tsx
@@ -401,6 +401,8 @@ export function mergeAppUpdate<K extends keyof HudState>(
     newState.view = state.view
     newState.logStore = new LogStore()
     newState.logStore.append(logListUpdate)
+    newState.view?.uiResources?.sort(compareObjectsOrder)
+    newState.view?.uiButtons?.sort(compareObjectsOrder)
     return newState
   }
 


### PR DESCRIPTION
### Problem

UIButtons are in seemingly random order when you refresh the web UI.

#4886 fixed object sorting in hud view updates, except that codepath only runs on view updates, not on complete views.

### Solution

Also apply the sorting on complete views.

(this wasn't a problem previously because on complete views, the backend sends UIResources in sorted order anyway, and UIButtons had redundant sorting elsewhere, which #4886 removed)