### PR TITLE
web: make info buttons hideable by user

### DIFF
--- a/web/src/OverviewActionBar.tsx
+++ b/web/src/OverviewActionBar.tsx
@@ -538,6 +538,7 @@ export function FilterTermField({ termFromUrl }: { termFromUrl: FilterTerm }) {
       </SrOnly>
       <TiltInfoTooltip
         id={FILTER_FIELD_TOOLTIP_ID}
+        dismissId="log-filter-term"
         title={filterTermTooltipContent}
         placement="right-end"
       />

--- a/web/src/OverviewTable.tsx
+++ b/web/src/OverviewTable.tsx
@@ -544,7 +544,12 @@ function ResourceTableHeaderTip(props: { name?: string }) {
     return null
   }
 
-  return <TiltInfoTooltip title={tooltipContent} />
+  return (
+    <TiltInfoTooltip
+      title={tooltipContent}
+      dismissId={`table-header-${props.name}`}
+    />
+  )
 }
 
 async function copyTextToClipboard(text: string, cb: () => void) {

--- a/web/src/ResourceGroups.tsx
+++ b/web/src/ResourceGroups.tsx
@@ -136,6 +136,7 @@ export function ResourceGroupsInfoTip(props: { idForIcon: string }) {
         displayShadow={true}
         idForIcon={props.idForIcon}
         dismissId="resource-groups"
+        open={true}
       />
     </BottomLeftContainer>
   )

--- a/web/src/ResourceGroups.tsx
+++ b/web/src/ResourceGroups.tsx
@@ -136,7 +136,6 @@ export function ResourceGroupsInfoTip(props: { idForIcon: string }) {
         displayShadow={true}
         idForIcon={props.idForIcon}
         dismissId="resource-groups"
-        open={true}
       />
     </BottomLeftContainer>
   )

--- a/web/src/ResourceGroups.tsx
+++ b/web/src/ResourceGroups.tsx
@@ -1,7 +1,7 @@
 import styled from "styled-components"
 import { ReactComponent as CaretSvg } from "./assets/svg/caret.svg"
 import { Color, SizeUnit } from "./style-helpers"
-import { InfoTooltipProps, TiltInfoTooltip } from "./Tooltip"
+import { TiltInfoTooltip } from "./Tooltip"
 
 /**
  * This file contains style-reset versions of the Material UI Accordion
@@ -115,7 +115,7 @@ const BottomLeftContainer = styled.aside`
   z-index: 2;
 `
 
-export function ResourceGroupsInfoTip(props: InfoTooltipProps) {
+export function ResourceGroupsInfoTip(props: { idForIcon: string }) {
   const tooltipInfo = (
     <>
       Resources can be grouped by adding custom labels.{" "}
@@ -131,7 +131,12 @@ export function ResourceGroupsInfoTip(props: InfoTooltipProps) {
 
   return (
     <BottomLeftContainer>
-      <TiltInfoTooltip title={tooltipInfo} displayShadow={true} {...props} />
+      <TiltInfoTooltip
+        title={tooltipInfo}
+        displayShadow={true}
+        idForIcon={props.idForIcon}
+        dismissId="resource-groups"
+      />
     </BottomLeftContainer>
   )
 }

--- a/web/src/Tooltip.test.tsx
+++ b/web/src/Tooltip.test.tsx
@@ -2,16 +2,7 @@ import { Button } from "@material-ui/core"
 import { mount } from "enzyme"
 import React from "react"
 import { act } from "react-test-renderer"
-import { tiltfileKeyContext } from "./LocalStorage"
 import TiltTooltip, { TiltInfoTooltip } from "./Tooltip"
-
-function mountWithContext(children: JSX.Element) {
-  return mount(
-    <tiltfileKeyContext.Provider value="test">
-      {children}
-    </tiltfileKeyContext.Provider>
-  )
-}
 
 describe("TiltInfoTooltip", () => {
   beforeEach(() => {
@@ -23,7 +14,7 @@ describe("TiltInfoTooltip", () => {
   })
 
   it("hides info button when clicked", () => {
-    const root = mountWithContext(
+    const root = mount(
       <TiltInfoTooltip title="Hello!" dismissId="test-tooltip" open={true} />
     )
 

--- a/web/src/Tooltip.test.tsx
+++ b/web/src/Tooltip.test.tsx
@@ -1,0 +1,45 @@
+import { Button } from "@material-ui/core"
+import { mount } from "enzyme"
+import React from "react"
+import { act } from "react-test-renderer"
+import { tiltfileKeyContext } from "./LocalStorage"
+import TiltTooltip, { TiltInfoTooltip } from "./Tooltip"
+
+function mountWithContext(children: JSX.Element) {
+  return mount(
+    <tiltfileKeyContext.Provider value="test">
+      {children}
+    </tiltfileKeyContext.Provider>
+  )
+}
+
+describe("TiltInfoTooltip", () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  afterEach(() => {
+    localStorage.clear()
+  })
+
+  it("hides info button when clicked", () => {
+    const root = mountWithContext(
+      <TiltInfoTooltip title="Hello!" dismissId="test-tooltip" open={true} />
+    )
+
+    expect(root.find(TiltTooltip).length).toEqual(1)
+
+    act(() => {
+      root.find(Button).simulate("click")
+    })
+    root.update()
+
+    // the tooltip is gone!
+    expect(root.find(TiltTooltip).length).toEqual(0)
+
+    // and the setting is in localStorage
+    expect(localStorage.getItem("tooltip-dismissed-test-tooltip")).toEqual(
+      "true"
+    )
+  })
+})

--- a/web/src/Tooltip.tsx
+++ b/web/src/Tooltip.tsx
@@ -3,7 +3,16 @@ import Tooltip, { TooltipProps } from "@material-ui/core/Tooltip"
 import React from "react"
 import styled from "styled-components"
 import { ReactComponent as InfoSvg } from "./assets/svg/info.svg"
-import { Color, ColorRGBA, Font, FontSize, SizeUnit } from "./style-helpers"
+import { InstrumentedButton } from "./instrumentedComponents"
+import { usePersistentState } from "./LocalStorage"
+import {
+  Color,
+  ColorRGBA,
+  Font,
+  FontSize,
+  mixinResetButtonStyle,
+  SizeUnit,
+} from "./style-helpers"
 
 const INFO_TOOLTIP_LEAVE_DELAY = 500
 
@@ -55,8 +64,18 @@ const InfoIcon = styled(InfoSvg)`
     fill: ${Color.gray6};
   }
 `
+const DismissButton = styled(InstrumentedButton)`
+  ${mixinResetButtonStyle};
+
+  .MuiButton-label {
+    font-size: ${FontSize.smallester};
+    font-style: italic;
+    color: ${Color.grayLight};
+  }
+`
 
 export interface InfoTooltipProps {
+  dismissId?: string // If set, this tooltip will be dismissable, keyed by this string
   displayShadow?: boolean
   idForIcon?: string // Use to semantically associate the tooltip with another element through `aria-describedby` or `aria-labelledby`
 }
@@ -64,13 +83,42 @@ export interface InfoTooltipProps {
 export function TiltInfoTooltip(
   props: Omit<TooltipProps, "children"> & InfoTooltipProps
 ) {
-  const { displayShadow, idForIcon, ...tooltipProps } = props
+  const { displayShadow, idForIcon, title, dismissId, ...tooltipProps } = props
   const shadowClass = displayShadow ? "shadow" : ""
+
+  const [
+    dismissed,
+    setDismissed,
+  ] = usePersistentState(`tooltip-dismissed-${props.dismissId}`, false, {
+    keyedByTiltfile: false,
+  })
+  if (dismissed) {
+    return null
+  }
+
+  let content = title
+
+  if (dismissId !== undefined) {
+    content = (
+      <>
+        <div>{title}</div>
+        <DismissButton
+          size="small"
+          analyticsName={"ui.web.dismissTooltip"}
+          analyticsTags={{ tooltip: props.dismissId }}
+          onClick={() => setDismissed(true)}
+        >
+          Hide this info button
+        </DismissButton>
+      </>
+    )
+  }
 
   return (
     <TiltTooltip
       interactive
       leaveDelay={INFO_TOOLTIP_LEAVE_DELAY}
+      title={content}
       {...tooltipProps}
     >
       <InfoIcon id={idForIcon} height={16} width={16} className={shadowClass} />

--- a/web/src/Tooltip.tsx
+++ b/web/src/Tooltip.tsx
@@ -86,12 +86,13 @@ export function TiltInfoTooltip(
   const { displayShadow, idForIcon, title, dismissId, ...tooltipProps } = props
   const shadowClass = displayShadow ? "shadow" : ""
 
-  const [
-    dismissed,
-    setDismissed,
-  ] = usePersistentState(`tooltip-dismissed-${props.dismissId}`, false, {
-    keyedByTiltfile: false,
-  })
+  const [dismissed, setDismissed] = usePersistentState(
+    `tooltip-dismissed-${props.dismissId}`,
+    false,
+    {
+      keyedByTiltfile: false,
+    }
+  )
   if (dismissed) {
     return null
   }

--- a/web/src/Tooltip.tsx
+++ b/web/src/Tooltip.tsx
@@ -1,10 +1,10 @@
 import { makeStyles } from "@material-ui/core/styles"
 import Tooltip, { TooltipProps } from "@material-ui/core/Tooltip"
 import React from "react"
+import { useStorageState } from "react-storage-hooks"
 import styled from "styled-components"
 import { ReactComponent as InfoSvg } from "./assets/svg/info.svg"
 import { InstrumentedButton } from "./instrumentedComponents"
-import { usePersistentState } from "./LocalStorage"
 import {
   Color,
   ColorRGBA,
@@ -67,10 +67,14 @@ const InfoIcon = styled(InfoSvg)`
 const DismissButton = styled(InstrumentedButton)`
   ${mixinResetButtonStyle};
 
+  width: 100%;
+
   .MuiButton-label {
     font-size: ${FontSize.smallester};
     font-style: italic;
     color: ${Color.grayLight};
+    text-align: right;
+    display: block;
   }
 `
 
@@ -86,12 +90,13 @@ export function TiltInfoTooltip(
   const { displayShadow, idForIcon, title, dismissId, ...tooltipProps } = props
   const shadowClass = displayShadow ? "shadow" : ""
 
-  const [dismissed, setDismissed] = usePersistentState(
+  // bug: if multiple tooltips are on the same page with the same key,
+  // "dismiss" will only affect the tooltip clicked, until next refresh
+  // https://app.clubhouse.io/windmill/story/12654/modifying-usepersistentstate-state-doesn-t-update-other-components-in-the-same-page-using-the-same-key
+  const [dismissed, setDismissed] = useStorageState(
+    localStorage,
     `tooltip-dismissed-${props.dismissId}`,
-    false,
-    {
-      keyedByTiltfile: false,
-    }
+    false
   )
   if (dismissed) {
     return null
@@ -109,7 +114,7 @@ export function TiltInfoTooltip(
           analyticsTags={{ tooltip: props.dismissId }}
           onClick={() => setDismissed(true)}
         >
-          Hide this info button
+          Don't show this tip
         </DismissButton>
       </>
     )


### PR DESCRIPTION
### Problem

Info tooltips are really helpful for introducing users to new features! However, they can be kind of distracting and annoying if you're already familiar with their information.

### Solution

Add a button to the info tooltip to allow the user to hide the info button.

![image](https://user-images.githubusercontent.com/7453991/131411614-372e07ec-7655-408c-a441-5da37784cc6e.png)

When clicked, a bool will be written to localStorage and the user will no longer see that little (i) or the tooltip (unless they do something like switch browsers or clear local storage).

Notes:
1. There is currently no way to undo this other than digging into your browser's localStorage.
2. Until now, all of the info Tilt stores in localStorage has had its key namespaced by the path to the currently running Tiltfile. That seems like it'd be much more annoying than useful for this feature, so dismissals do not use the Tiltfile in their localStorage key.