### PR TITLE
tiltfile: add a mechanism to suppress unused image warnings

### DIFF
--- a/internal/tiltfile/build_index.go
+++ b/internal/tiltfile/build_index.go
@@ -116,6 +116,10 @@ func (idx *buildIndex) unmatchedImageWarning(image *dockerImage, configType stri
 		matchLines = append(matchLines, fmt.Sprintf("    - %s\n", match))
 	}
 
-	return fmt.Errorf("Image not used in any %s config:\n    ✕ %v\n%sSkipping this image build",
-		configType, container.FamiliarString(image.configurationRef), strings.Join(matchLines, ""))
+	return fmt.Errorf("Image not used in any %s config:\n    ✕ %v\n%sSkipping this image build\n"+
+		"If this is deliberate, suppress this warning with: update_settings(suppress_unused_image_warnings=[%q])",
+		configType,
+		container.FamiliarString(image.configurationRef),
+		strings.Join(matchLines, ""),
+		container.FamiliarString(image.configurationRef))
 }

--- a/internal/tiltfile/docker.go
+++ b/internal/tiltfile/docker.go
@@ -569,3 +569,29 @@ func (s *tiltfileState) dockerignoresForImage(image *dockerImage) ([]model.Docke
 		source,
 		paths, image.ignores, image.onlys, image.dbDockerfilePath)
 }
+
+// Filter out all images that are suppressed.
+func filterUnmatchedImages(us model.UpdateSettings, images []*dockerImage) []*dockerImage {
+	result := make([]*dockerImage, 0, len(images))
+	for _, image := range images {
+		name := container.FamiliarString(image.configurationRef)
+
+		ok := true
+		for _, suppressed := range us.SuppressUnusedImageWarnings {
+			if suppressed == "*" {
+				ok = false
+				break
+			}
+
+			if suppressed == name {
+				ok = false
+				break
+			}
+		}
+
+		if ok {
+			result = append(result, image)
+		}
+	}
+	return result
+}

--- a/internal/tiltfile/tiltfile_docker_compose_test.go
+++ b/internal/tiltfile/tiltfile_docker_compose_test.go
@@ -596,7 +596,8 @@ docker_compose('docker-compose.yml')
     ✕ gcr.typo.io/foo
 Did you mean…
     - gcr.io/foo
-Skipping this image build`)
+Skipping this image build
+If this is deliberate, suppress this warning with: update_settings(suppress_unused_image_warnings=["gcr.typo.io/foo"])`)
 }
 
 func TestDockerComposeOnlySomeWithDockerBuild(t *testing.T) {

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -6073,6 +6073,7 @@ func unusedImageWarning(unusedImage string, suggestedImages []string, configType
 		}
 	}
 	ret = ret + "\nSkipping this image build"
+	ret = ret + fmt.Sprintf("\nIf this is deliberate, suppress this warning with: update_settings(suppress_unused_image_warnings=[%q])", unusedImage)
 	return ret
 }
 

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -1898,6 +1898,22 @@ k8s_yaml('foo.yaml')
 	f.loadAssertWarnings(w)
 }
 
+func TestDockerBuildUnusedSuppressWarning(t *testing.T) {
+	f := newFixture(t)
+	defer f.TearDown()
+
+	f.gitInit("")
+	f.file("Dockerfile", "FROM golang:1.10")
+	f.file("Tiltfile", `
+docker_build('a', '.')
+docker_build('b', '.')
+update_settings(suppress_unused_image_warnings=['a'])
+update_settings(suppress_unused_image_warnings=['b'])
+`)
+
+	f.load()
+}
+
 func TestDockerBuildButK8sNonMatchingTag(t *testing.T) {
 	f := newFixture(t)
 	defer f.TearDown()

--- a/internal/tiltfile/updatesettings/update_settings.go
+++ b/internal/tiltfile/updatesettings/update_settings.go
@@ -10,6 +10,7 @@ import (
 	"github.com/tilt-dev/tilt/pkg/model"
 
 	"github.com/tilt-dev/tilt/internal/tiltfile/starkit"
+	"github.com/tilt-dev/tilt/internal/tiltfile/value"
 )
 
 // Implements functions for dealing with update settings.
@@ -29,9 +30,11 @@ func (e Plugin) OnStart(env *starkit.Environment) error {
 
 func (e *Plugin) updateSettings(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	var maxParallelUpdates, k8sUpsertTimeoutSecs starlark.Value
+	var unusedImageWarnings value.StringOrStringList
 	if err := starkit.UnpackArgs(thread, fn.Name(), args, kwargs,
 		"max_parallel_updates?", &maxParallelUpdates,
-		"k8s_upsert_timeout_secs?", &k8sUpsertTimeoutSecs); err != nil {
+		"k8s_upsert_timeout_secs?", &k8sUpsertTimeoutSecs,
+		"suppress_unused_image_warnings?", &unusedImageWarnings); err != nil {
 		return nil, err
 	}
 
@@ -60,6 +63,7 @@ func (e *Plugin) updateSettings(thread *starlark.Thread, fn *starlark.Builtin, a
 		if kutsPassed {
 			settings = settings.WithK8sUpsertTimeout(time.Duration(kuts) * time.Second)
 		}
+		settings.SuppressUnusedImageWarnings = append(settings.SuppressUnusedImageWarnings, unusedImageWarnings.Values...)
 		return settings
 	})
 

--- a/pkg/model/update_settings.go
+++ b/pkg/model/update_settings.go
@@ -13,6 +13,9 @@ const (
 type UpdateSettings struct {
 	maxParallelUpdates int           // max number of updates to run concurrently
 	k8sUpsertTimeout   time.Duration // timeout for k8s upsert operations
+
+	// A list of images to suppress the warning for.
+	SuppressUnusedImageWarnings []string
 }
 
 func (us UpdateSettings) MaxParallelUpdates() int {


### PR DESCRIPTION
Hello @landism,

Please review the following commits I made in branch nicks/ch12647:

6803f9615d09d6aba53b73a5531f56edf86b08a9 (2021-08-31 12:29:22 -0400)
tiltfile: add a mechanism to suppress unused image warnings
Examples:

update_settings(suppress_unused_image_warnings=['image-name'])
update_settings(suppress_unused_image_warnings='*') # suppress all

Fixes https://github.com/tilt-dev/tilt/issues/4891

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics