### PR TITLE
container: don't rebase image names that don't need it

### DIFF
--- a/internal/container/default_registry.go
+++ b/internal/container/default_registry.go
@@ -3,6 +3,7 @@ package container
 import (
 	"fmt"
 	"regexp"
+	"strings"
 
 	"github.com/docker/distribution/reference"
 	"github.com/pkg/errors"
@@ -123,6 +124,13 @@ func (r Registry) HostFromCluster() string {
 // names is not that important.
 func (r Registry) replaceRegistry(defaultReg string, rs RefSelector) (reference.Named, error) {
 	if defaultReg == "" {
+		return rs.AsNamedOnly(), nil
+	}
+
+	// Sometimes users get confused and put the local registry name in the YAML.
+	// No need to replace the registry in that case.
+	// https://github.com/tilt-dev/tilt/issues/4911
+	if strings.HasPrefix(rs.RefFamiliarName(), fmt.Sprintf("%s/", defaultReg)) {
 		return rs.AsNamedOnly(), nil
 	}
 

--- a/internal/container/default_registry_test.go
+++ b/internal/container/default_registry_test.go
@@ -36,6 +36,10 @@ var namedTestCases = []struct {
 	{"aws_account_id.dkr.ecr.region.amazonaws.com/bar", "gcr.io/baz/foo/bar", "aws_account_id.dkr.ecr.region.amazonaws.com/bar/gcr.io_baz_foo_bar"},
 	{"gcr.io/foo", "docker.io/library/busybox", "gcr.io/foo/busybox"},
 	{"gcr.io/foo", "bar", "gcr.io/foo/bar"},
+	{"myreg.com", "myreg.com/bar", "myreg.com/bar"},
+	{"myreg.com:5000", "myreg.com:5000/bar", "myreg.com:5000/bar"},
+	{"myreg.com:5000", "myreg.com/bar", "myreg.com:5000/myreg.com_bar"},
+	{"myreg.com", "myreg.com:5000/bar", "myreg.com/myreg.com_5000_bar"},
 }
 
 func TestReplaceNamed(t *testing.T) {


### PR DESCRIPTION
Hello @milas,

Please review the following commits I made in branch nicks/ch12648:

144a76fe1aa8c5c11626e0afe8c4023009e10748 (2021-08-31 12:50:41 -0400)
container: don't rebase image names that don't need it
Fixes https://github.com/tilt-dev/tilt/issues/4911

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics