### PR TITLE
web: increase font size and add padding between table cells in table view

### DIFF
--- a/web/src/OverviewTable.tsx
+++ b/web/src/OverviewTable.tsx
@@ -114,6 +114,11 @@ const ResourceTable = styled.table`
     padding-right: ${SizeUnit(1)};
   }
 
+  td + td {
+    padding-left: ${SizeUnit(1 / 4)};
+    padding-right: ${SizeUnit(1 / 4)};
+  }
+
   &.isGroup {
     border: 1px ${Color.grayLighter} solid;
     border-radius: 0 ${SizeUnit(1 / 4)};
@@ -127,13 +132,13 @@ export const ResourceTableRow = styled.tr`
 `
 const ResourceTableData = styled.td`
   font-family: ${Font.monospace};
-  font-size: ${FontSize.smallest};
+  font-size: ${FontSize.small};
   color: ${Color.gray6};
   box-sizing: border-box;
 `
 const ResourceTableHeader = styled(ResourceTableData)`
   color: ${Color.gray7};
-  font-size: ${FontSize.smallest};
+  font-size: ${FontSize.small};
   padding-top: ${SizeUnit(0.5)};
   padding-bottom: ${SizeUnit(0.5)};
   box-sizing: border-box;

--- a/web/src/OverviewTable.tsx
+++ b/web/src/OverviewTable.tsx
@@ -19,6 +19,7 @@ import { ApiButton, ApiIcon, buttonsForComponent } from "./ApiButton"
 import { ReactComponent as CheckmarkSvg } from "./assets/svg/checkmark.svg"
 import { ReactComponent as CopySvg } from "./assets/svg/copy.svg"
 import { ReactComponent as LinkSvg } from "./assets/svg/link.svg"
+import { ReactComponent as StarSvg } from "./assets/svg/star.svg"
 import { linkToTiltDocs, TiltDocsPage } from "./constants"
 import { Flag, useFeatures } from "./feature"
 import { InstrumentedButton } from "./instrumentedComponents"
@@ -32,7 +33,9 @@ import {
 import { displayURL } from "./links"
 import LogStore, { LogAlertIndex, useLogStore } from "./LogStore"
 import { OverviewButtonMixin } from "./OverviewButton"
-import OverviewTableStarResourceButton from "./OverviewTableStarResourceButton"
+import OverviewTableStarResourceButton, {
+  StyledTableStarResourceButton,
+} from "./OverviewTableStarResourceButton"
 import OverviewTableStatus from "./OverviewTableStatus"
 import OverviewTableTriggerButton from "./OverviewTableTriggerButton"
 import OverviewTableTriggerModeToggle from "./OverviewTableTriggerModeToggle"
@@ -102,6 +105,10 @@ type OverviewTableStatus = {
 }
 
 // Table styles
+const OverviewTableRoot = styled.section`
+  margin-bottom: ${SizeUnit(1 / 2)};
+`
+
 const ResourceTable = styled.table`
   margin-top: ${SizeUnit(0.5)};
   border-collapse: collapse;
@@ -109,14 +116,17 @@ const ResourceTable = styled.table`
 
   td:first-child {
     padding-left: ${SizeUnit(1)};
+
+    & ${StyledTableStarResourceButton} {
+      margin-left: -15px; /* Center the star button underneath the header */
+    }
   }
   td:last-child {
     padding-right: ${SizeUnit(1)};
   }
 
   td + td {
-    padding-left: ${SizeUnit(1 / 4)};
-    padding-right: ${SizeUnit(1 / 4)};
+    padding-right: ${SizeUnit(1 / 2)};
   }
 
   &.isGroup {
@@ -167,6 +177,13 @@ const ResourceTableHeaderSortTriangle = styled.div`
     transform: rotate(180deg);
   }
 `
+
+const TableHeaderStarIcon = styled(StarSvg)`
+  fill: ${Color.gray7};
+  height: 13px;
+  width: 13px;
+`
+
 const Name = styled.button`
   ${mixinResetButtonStyle};
   color: ${Color.offWhite};
@@ -460,13 +477,16 @@ function TableWidgetsColumn({ row }: CellProps<RowValues>) {
 // TODO: fix existing columns to return reasonable primitives from `accessor`
 const columnDefs: Column<RowValues>[] = [
   {
-    Header: "Starred",
-    width: "20px",
+    Header: () => <TableHeaderStarIcon title="Starred" />,
+    id: "starred",
+    accessor: "name", // Note: this accessor is meaningless but required when `Header` returns JSX.The starred column gets its data directly from the StarredResources context and sort on this column is disabled.
+    disableSortBy: true,
+    width: "10px",
     Cell: TableStarColumn,
   },
   {
     Header: "Updated",
-    width: "20px",
+    width: "25px",
     accessor: "lastDeployTime",
     Cell: TableUpdateColumn,
   },
@@ -492,7 +512,7 @@ const columnDefs: Column<RowValues>[] = [
     Header: "Status",
     accessor: "statusLine",
     disableSortBy: true,
-    width: "150px",
+    width: "200px",
     Cell: TableStatusColumn,
   },
   {
@@ -619,21 +639,6 @@ function resourceTypeLabel(r: UIResource): string {
     }
   }
   return "Unknown"
-}
-
-function hasWidgets(view: Proto.webviewView): boolean {
-  return !!view.uiButtons?.length
-}
-
-function viewToRowValues(
-  view: Proto.webviewView,
-  logStore: LogStore
-): RowValues[] {
-  return (
-    view.uiResources?.map((r) =>
-      uiResourceToCell(r, view.uiButtons, logStore)
-    ) || []
-  )
 }
 
 export function resourcesToTableCells(
@@ -828,10 +833,14 @@ export default function OverviewTable(props: OverviewTableProps) {
   const displayLabelGroupsTip = labelsEnabled && !resourcesHaveLabels
 
   if (labelsEnabled && resourcesHaveLabels) {
-    return <TableGroupedByLabels {...props} />
+    return (
+      <OverviewTableRoot title="Resources overview">
+        <TableGroupedByLabels {...props} />
+      </OverviewTableRoot>
+    )
   } else {
     return (
-      <>
+      <OverviewTableRoot title="Resources overview">
         {displayLabelGroupsTip && (
           <ResourceGroupsInfoTip idForIcon={GROUP_INFO_TOOLTIP_ID} />
         )}
@@ -841,7 +850,7 @@ export default function OverviewTable(props: OverviewTableProps) {
           }
           {...props}
         />
-      </>
+      </OverviewTableRoot>
     )
   }
 }

--- a/web/src/OverviewTableStatus.tsx
+++ b/web/src/OverviewTableStatus.tsx
@@ -6,6 +6,7 @@ import { ReactComponent as PendingSvg } from "./assets/svg/pending.svg"
 import { useResourceNav } from "./ResourceNav"
 import {
   Color,
+  FontSize,
   Glow,
   mixinResetButtonStyle,
   SizeUnit,
@@ -20,6 +21,7 @@ const StyledOverviewTableStatus = styled.button`
   color: inherit;
   display: flex;
   align-items: center;
+  font-size: ${FontSize.small};
 
   & + & {
     margin-top: ${SizeUnit(0.15)};

--- a/web/src/OverviewTableStatus.tsx
+++ b/web/src/OverviewTableStatus.tsx
@@ -22,6 +22,7 @@ const StyledOverviewTableStatus = styled.button`
   display: flex;
   align-items: center;
   font-size: ${FontSize.small};
+  text-align: left;
 
   & + & {
     margin-top: ${SizeUnit(0.15)};

--- a/web/src/ResourceGroups.tsx
+++ b/web/src/ResourceGroups.tsx
@@ -111,7 +111,7 @@ const BottomLeftContainer = styled.aside`
   bottom: 0;
   left: 0;
   padding: 10px 10px 5px 10px;
-  position: absolute;
+  position: fixed;
   z-index: 2;
 `
 

--- a/web/src/StarredResourceBar.tsx
+++ b/web/src/StarredResourceBar.tsx
@@ -134,7 +134,7 @@ const StarredResourceRoot = styled.div`
     padding-left: ${SizeUnit(0.25)};
   }
 `
-const StarredResourceBarRoot = styled.div`
+const StarredResourceBarRoot = styled.section`
   padding-left: ${SizeUnit(0.5)};
   padding-right: ${SizeUnit(0.5)};
   padding-top: ${SizeUnit(0.25)};
@@ -200,7 +200,7 @@ export function StarredResource(props: {
 
 export default function StarredResourceBar(props: StarredResourceBarProps) {
   return (
-    <StarredResourceBarRoot>
+    <StarredResourceBarRoot title="Starred resources">
       {props.resources.map((r) => (
         <StarredResource
           resource={r}


### PR DESCRIPTION
This PR makes two style changes I chatted about with @SurbhiSGupta: 
* increase font size so text is easier to read
* add a little bit of padding in between columns / table cells so text from different columns doesn't run into other columns

before:
![Screen Shot 2021-08-31 at 3 59 29 PM](https://user-images.githubusercontent.com/23283986/131568180-28abb2a8-82e4-4378-bc89-accde6990480.png)

after:
![Screen Shot 2021-08-31 at 3 58 14 PM](https://user-images.githubusercontent.com/23283986/131568157-ca1fa957-2393-424c-b417-b67960b661b6.png)

![Screen Shot 2021-08-31 at 3 41 57 PM](https://user-images.githubusercontent.com/23283986/131567593-ee11825e-1ab9-49ea-9aa3-2627c23c18ef.png)
