### PR TITLE
k8s: allow rancher-desktop context by default

### DIFF
--- a/internal/k8s/env.go
+++ b/internal/k8s/env.go
@@ -26,13 +26,13 @@ const (
 	EnvMicroK8s      Env = "microk8s"
 	EnvCRC           Env = "crc"
 	EnvKrucible      Env = "krucible"
-
 	// Kind v0.6 substantially changed the protocol for detecting and pulling,
 	// so we represent them as two separate envs.
-	EnvKIND5 Env = "kind-0.5-"
-	EnvKIND6 Env = "kind-0.6+"
-	EnvK3D   Env = "k3d"
-	EnvNone  Env = "none" // k8s not running (not neces. a problem, e.g. if using Tilt x Docker Compose)
+	EnvKIND5          Env = "kind-0.5-"
+	EnvKIND6          Env = "kind-0.6+"
+	EnvK3D            Env = "k3d"
+	EnvRancherDesktop Env = "rancher-desktop"
+	EnvNone           Env = "none" // k8s not running (not neces. a problem, e.g. if using Tilt x Docker Compose)
 )
 
 func (e Env) IsDevCluster() bool {
@@ -43,7 +43,8 @@ func (e Env) IsDevCluster() bool {
 		e == EnvKIND5 ||
 		e == EnvKIND6 ||
 		e == EnvK3D ||
-		e == EnvKrucible
+		e == EnvKrucible ||
+		e == EnvRancherDesktop
 }
 
 func ProvideKubeContext(config *api.Config) (KubeContext, error) {
@@ -116,6 +117,8 @@ func ProvideEnv(ctx context.Context, config *api.Config) Env {
 		return EnvKrucible
 	} else if strings.HasPrefix(cn, "k3d-") {
 		return EnvK3D
+	} else if strings.HasPrefix(cn, "rancher-desktop") {
+		return EnvRancherDesktop
 	}
 
 	loc := c.LocationOfOrigin

--- a/internal/k8s/env_test.go
+++ b/internal/k8s/env_test.go
@@ -116,6 +116,9 @@ func TestProvideEnv(t *testing.T) {
 			Cluster: "k3d-k3s-default",
 		},
 	}
+	rancherDesktopContexts := map[string]*api.Context{
+		"rancher-desktop": {Cluster: "rancher-desktop"},
+	}
 
 	table := []expectedConfig{
 		{EnvNone, &api.Config{}},
@@ -139,6 +142,7 @@ func TestProvideEnv(t *testing.T) {
 		{EnvMinikube, &api.Config{CurrentContext: "custom-name", Contexts: minikubeCustomNameContexts, Clusters: minikubeCustomNameClusters}},
 		{EnvUnknown, &api.Config{CurrentContext: "custom-name", Contexts: minikubeCustomNameContexts}},
 		{EnvK3D, &api.Config{CurrentContext: "k3d-k3s-default", Contexts: k3d3xContexts}},
+		{EnvRancherDesktop, &api.Config{CurrentContext: "rancher-desktop", Contexts: rancherDesktopContexts}},
 	}
 
 	for _, tt := range table {


### PR DESCRIPTION
[Rancher Desktop](https://rancherdesktop.io/) is a new local K8s distribution.

See also tilt-dev/tilt.build#931 for a blog post explaining how to use it with Tilt.