### PR TITLE
configs: also store trigger queue reasons in the apiserver

### DIFF
--- a/internal/controllers/apis/configmap/triggerqueue.go
+++ b/internal/controllers/apis/configmap/triggerqueue.go
@@ -1,0 +1,65 @@
+package configmap
+
+// Functions for parsing out common ConfigMaps.
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/tilt-dev/tilt/internal/store/tiltfiles"
+	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
+	"github.com/tilt-dev/tilt/pkg/model"
+)
+
+func TriggerQueue(ctx context.Context, client client.Client) (*v1alpha1.ConfigMap, error) {
+	var cm v1alpha1.ConfigMap
+	err := client.Get(ctx, types.NamespacedName{Name: tiltfiles.TriggerQueueConfigMapName}, &cm)
+	if err != nil && !apierrors.IsNotFound(err) {
+		return nil, err
+	}
+
+	return &cm, nil
+}
+
+func InTriggerQueue(cm *v1alpha1.ConfigMap, nn types.NamespacedName) bool {
+	name := nn.Name
+	for k, v := range cm.Data {
+		if !strings.HasSuffix(k, "-name") {
+			continue
+		}
+
+		if v == name {
+			return true
+		}
+	}
+	return false
+}
+
+func TriggerQueueReason(cm *v1alpha1.ConfigMap, nn types.NamespacedName) model.BuildReason {
+	name := nn.Name
+	for k, v := range cm.Data {
+		if !strings.HasSuffix(k, "-name") {
+			continue
+		}
+
+		if v != name {
+			continue
+		}
+
+		cur := strings.TrimSuffix(k, "-name")
+		reasonCode := cm.Data[fmt.Sprintf("%s-reason-code", cur)]
+		i, err := strconv.Atoi(reasonCode)
+		if err != nil {
+			return model.BuildReasonFlagTriggerUnknown
+		}
+		return model.BuildReason(i)
+	}
+	return model.BuildReasonNone
+}

--- a/internal/engine/configs/trigger_queue_subscriber.go
+++ b/internal/engine/configs/trigger_queue_subscriber.go
@@ -36,7 +36,13 @@ func (s *TriggerQueueSubscriber) fromState(st store.RStore) *v1alpha1.ConfigMap 
 	}
 
 	for i, v := range state.TriggerQueue {
-		cm.Data[fmt.Sprintf("%d", i)] = v.String()
+		cm.Data[fmt.Sprintf("%d-name", i)] = v.String()
+
+		ms, ok := state.ManifestState(v)
+		if !ok {
+			continue
+		}
+		cm.Data[fmt.Sprintf("%d-reason-code", i)] = fmt.Sprintf("%d", ms.TriggerReason)
 	}
 	return cm
 }

--- a/internal/engine/configs/trigger_queue_subscriber_test.go
+++ b/internal/engine/configs/trigger_queue_subscriber_test.go
@@ -1,0 +1,50 @@
+package configs
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/tilt-dev/tilt/internal/controllers/apis/configmap"
+	"github.com/tilt-dev/tilt/internal/controllers/fake"
+	"github.com/tilt-dev/tilt/internal/store"
+	"github.com/tilt-dev/tilt/pkg/model"
+)
+
+func TestTriggerQueue(t *testing.T) {
+	st := store.NewTestingStore()
+	st.WithState(func(s *store.EngineState) {
+		s.UpsertManifestTarget(store.NewManifestTarget(model.Manifest{Name: "a"}))
+		s.UpsertManifestTarget(store.NewManifestTarget(model.Manifest{Name: "b"}))
+		s.UpsertManifestTarget(store.NewManifestTarget(model.Manifest{Name: "c"}))
+		s.AppendToTriggerQueue("a", model.BuildReasonFlagTriggerCLI)
+		s.AppendToTriggerQueue("b", model.BuildReasonFlagTriggerWeb)
+	})
+
+	ctx := context.Background()
+	client := fake.NewFakeTiltClient()
+	cm, err := configmap.TriggerQueue(ctx, client)
+	require.NoError(t, err)
+
+	nnA := types.NamespacedName{Name: "a"}
+	nnB := types.NamespacedName{Name: "b"}
+	nnC := types.NamespacedName{Name: "c"}
+	assert.False(t, configmap.InTriggerQueue(cm, nnA))
+
+	tqs := NewTriggerQueueSubscriber(client)
+	require.NoError(t, tqs.OnChange(ctx, st, store.ChangeSummary{}))
+
+	cm, err = configmap.TriggerQueue(ctx, client)
+	require.NoError(t, err)
+
+	assert.True(t, configmap.InTriggerQueue(cm, nnA))
+	assert.True(t, configmap.InTriggerQueue(cm, nnB))
+	assert.False(t, configmap.InTriggerQueue(cm, nnC))
+
+	assert.Equal(t, model.BuildReasonFlagTriggerCLI, configmap.TriggerQueueReason(cm, nnA))
+	assert.Equal(t, model.BuildReasonFlagTriggerWeb, configmap.TriggerQueueReason(cm, nnB))
+	assert.Equal(t, model.BuildReasonNone, configmap.TriggerQueueReason(cm, nnC))
+}


### PR DESCRIPTION
Hello @milas,

Please review the following commits I made in branch nicks/triggerqueue:

9f0907ffe54df9478a29535a177669ca5d0c21a2 (2021-09-02 17:25:37 -0400)
configs: also store trigger queue reasons in the apiserver

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics