### PR TITLE
controllers: move all rebuild triggers to the tiltfile controller

### DIFF
--- a/internal/cli/wire_gen.go
+++ b/internal/cli/wire_gen.go
@@ -321,7 +321,7 @@ func wireCmdUp(ctx context.Context, analytics3 *analytics.TiltAnalytics, cmdTags
 	}
 	compositeBuildAndDeployer := engine.NewCompositeBuildAndDeployer(buildOrder, traceTracer)
 	buildController := engine.NewBuildController(compositeBuildAndDeployer)
-	configsController := configs.NewConfigsController(deferredClient, buildSource)
+	configsController := configs.NewConfigsController(deferredClient)
 	triggerQueueSubscriber := configs.NewTriggerQueueSubscriber(deferredClient)
 	eventWatcher := dcwatch.NewEventWatcher(dockerComposeClient, localClient)
 	dockerComposeLogManager := runtimelog.NewDockerComposeLogManager(dockerComposeClient)
@@ -527,7 +527,7 @@ func wireCmdCI(ctx context.Context, analytics3 *analytics.TiltAnalytics, subcomm
 	}
 	compositeBuildAndDeployer := engine.NewCompositeBuildAndDeployer(buildOrder, traceTracer)
 	buildController := engine.NewBuildController(compositeBuildAndDeployer)
-	configsController := configs.NewConfigsController(deferredClient, buildSource)
+	configsController := configs.NewConfigsController(deferredClient)
 	triggerQueueSubscriber := configs.NewTriggerQueueSubscriber(deferredClient)
 	eventWatcher := dcwatch.NewEventWatcher(dockerComposeClient, localClient)
 	dockerComposeLogManager := runtimelog.NewDockerComposeLogManager(dockerComposeClient)

--- a/internal/controllers/apis/configmap/triggerqueue.go
+++ b/internal/controllers/apis/configmap/triggerqueue.go
@@ -28,6 +28,18 @@ func TriggerQueue(ctx context.Context, client client.Client) (*v1alpha1.ConfigMa
 	return &cm, nil
 }
 
+func NamesInTriggerQueue(cm *v1alpha1.ConfigMap) []string {
+	result := make([]string, 0, len(cm.Data)/2)
+	for k, v := range cm.Data {
+		if !strings.HasSuffix(k, "-name") {
+			continue
+		}
+
+		result = append(result, v)
+	}
+	return result
+}
+
 func InTriggerQueue(cm *v1alpha1.ConfigMap, nn types.NamespacedName) bool {
 	name := nn.Name
 	for k, v := range cm.Data {

--- a/internal/controllers/apis/restarton/restarton.go
+++ b/internal/controllers/apis/restarton/restarton.go
@@ -155,6 +155,9 @@ func LastRestartEvent(restartOn *v1alpha1.RestartOnSpec, fileWatches map[string]
 // this build but are not sure).
 func FilesChanged(restartOn *v1alpha1.RestartOnSpec, fileWatches map[string]*v1alpha1.FileWatch, lastBuild time.Time) []string {
 	filesChanged := []string{}
+	if restartOn == nil {
+		return filesChanged
+	}
 	for _, fwn := range restartOn.FileWatches {
 		fw, ok := fileWatches[fwn]
 		if !ok {

--- a/internal/controllers/core/extension/tiltfiles.go
+++ b/internal/controllers/core/extension/tiltfiles.go
@@ -105,6 +105,7 @@ func (r *Reconciler) toDesiredTiltfile(owner *v1alpha1.Extension) (*v1alpha1.Til
 			Labels: map[string]string{
 				label: label,
 			},
+			Args: owner.Spec.Args,
 		},
 	}
 	err := controllerutil.SetControllerReference(owner, child, r.ctrlClient.Scheme())

--- a/internal/controllers/core/tiltfile/reconciler.go
+++ b/internal/controllers/core/tiltfile/reconciler.go
@@ -20,6 +20,8 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/tilt-dev/tilt/internal/controllers/apicmp"
+	"github.com/tilt-dev/tilt/internal/controllers/apis/configmap"
+	"github.com/tilt-dev/tilt/internal/controllers/apis/restarton"
 	"github.com/tilt-dev/tilt/internal/controllers/indexer"
 	"github.com/tilt-dev/tilt/internal/docker"
 	"github.com/tilt-dev/tilt/internal/engine/buildcontrol"
@@ -41,6 +43,7 @@ type Reconciler struct {
 	indexer      *indexer.Indexer
 	buildSource  *BuildSource
 	engineMode   store.EngineMode
+	loadCount    int // used to differentiate spans
 
 	runs map[types.NamespacedName]*runStatus
 }
@@ -110,28 +113,39 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		}
 	}
 
-	// If the spec has changed, cancel any existing runs
-	if run != nil && !apicmp.DeepEqual(run.spec, &(tf.Spec)) {
-		run.cancel()
-		delete(r.runs, nn)
-		run = nil
-	}
-
 	step := runStepNone
 	if run != nil {
 		step = run.step
 		ctx = run.entry.WithLogger(ctx, r.st)
 	}
 
-	// Check to see if we have a BuildEntry triggering this tiltfile.
-	//
-	// This is a short-term hack to make this interoperate with the legacy subscriber.
-	// The "right" version would read from FileWatch and other dependencies to determine
-	// when to build.
-	be := r.buildSource.Entry()
-	if be != nil && be.Name.String() == nn.Name && (step == runStepNone || step == runStepDone) {
-		r.startRunAsync(ctx, nn, &tf, be)
-	} else if step == runStepLoaded {
+	// If the tiltfile isn't being run, check to see if anything has triggered a run.
+	if step == runStepNone || step == runStepDone {
+		buttons, err := restarton.Buttons(ctx, r.ctrlClient, tf.Spec.RestartOn, nil)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+
+		fileWatches, err := restarton.FileWatches(ctx, r.ctrlClient, tf.Spec.RestartOn)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+
+		lastRestartEventTime, _ := restarton.LastRestartEvent(tf.Spec.RestartOn, fileWatches, buttons)
+		queue, err := configmap.TriggerQueue(ctx, r.ctrlClient)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+
+		be := r.needsBuild(ctx, nn, &tf, run, fileWatches, queue, lastRestartEventTime)
+		if be != nil {
+			r.startRunAsync(ctx, nn, &tf, be)
+		}
+	}
+
+	// If the tiltfile has been loaded, we may still need to copy all its outputs
+	// to the apiserver.
+	if step == runStepLoaded {
 		err := r.handleLoaded(ctx, nn, &tf, run.entry, run.tlr)
 		if err != nil {
 			return ctrl.Result{}, err
@@ -154,6 +168,69 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	return ctrl.Result{}, nil
 }
 
+// Modeled after BuildController.needsBuild and NextBuildReason(). Check to see that:
+// 1) There's currently no Tiltfile build running,
+// 2) There are pending file changes, and
+// 3) Those files have changed since the last Tiltfile build
+//    (so that we don't keep re-running a failed build)
+// 4) OR the command-line args have changed since the last Tiltfile build
+// 5) OR user has manually triggered a Tiltfile build
+//
+// In some cases, there may be race conditions where a tiltfile has finished executing,
+// but its results haven't bee
+func (r *Reconciler) needsBuild(ctx context.Context, nn types.NamespacedName, tf *v1alpha1.Tiltfile, run *runStatus, fileWatches map[string]*v1alpha1.FileWatch, triggerQueue *v1alpha1.ConfigMap, lastRestartEvent time.Time) *BuildEntry {
+	var reason model.BuildReason
+	filesChanged := []string{}
+
+	step := runStepNone
+	lastStartTime := time.Time{}
+	lastStartArgs := []string{}
+	if run != nil {
+		step = run.step
+		lastStartTime = run.startTime
+		lastStartArgs = run.startArgs
+	}
+
+	if step == runStepNone {
+		reason = reason.With(model.BuildReasonFlagInit)
+	} else {
+		filesChanged = restarton.FilesChanged(tf.Spec.RestartOn, fileWatches, lastStartTime)
+		if len(filesChanged) > 0 {
+			reason = reason.With(model.BuildReasonFlagChangedFiles)
+		} else if lastRestartEvent.After(lastStartTime) {
+			reason = reason.With(model.BuildReasonFlagTriggerUnknown)
+		}
+	}
+
+	userConfigState := model.NewUserConfigState(tf.Spec.Args)
+	if !lastStartTime.IsZero() && !apicmp.DeepEqual(tf.Spec.Args, lastStartArgs) {
+		reason = reason.With(model.BuildReasonFlagTiltfileArgs)
+	}
+
+	if configmap.InTriggerQueue(triggerQueue, nn) {
+		reason = reason.With(configmap.TriggerQueueReason(triggerQueue, nn))
+	}
+
+	if reason == model.BuildReasonNone {
+		return nil
+	}
+
+	state := r.st.RLockState()
+	defer r.st.RUnlockState()
+
+	r.loadCount++
+
+	return &BuildEntry{
+		Name:                  model.ManifestName(nn.Name),
+		FilesChanged:          filesChanged,
+		BuildReason:           reason,
+		UserConfigState:       userConfigState,
+		TiltfilePath:          tf.Spec.Path,
+		CheckpointAtExecStart: state.LogStore.Checkpoint(),
+		LoadCount:             r.loadCount,
+	}
+}
+
 // Start a tiltfile run asynchronously, returning immediately.
 func (r *Reconciler) startRunAsync(ctx context.Context, nn types.NamespacedName, tf *v1alpha1.Tiltfile, entry *BuildEntry) {
 	ctx = entry.WithLogger(ctx, r.st)
@@ -166,6 +243,7 @@ func (r *Reconciler) startRunAsync(ctx context.Context, nn types.NamespacedName,
 		spec:      tf.Spec.DeepCopy(),
 		entry:     entry,
 		startTime: time.Now(),
+		startArgs: entry.UserConfigState.Args,
 	}
 	go r.run(ctx, nn, tf, entry)
 }
@@ -234,9 +312,6 @@ func (r *Reconciler) handleLoaded(ctx context.Context, nn types.NamespacedName, 
 	if tlr.Error != nil {
 		logger.Get(ctx).Errorf("%s", tlr.Error.Error())
 	}
-
-	// We've consumed the build entry, and are ready for the next one.
-	r.buildSource.SetEntry(nil)
 
 	r.st.Dispatch(ConfigsReloadedAction{
 		Name:                  entry.Name,
@@ -366,6 +441,7 @@ type runStatus struct {
 	entry      *BuildEntry
 	tlr        *tiltfile.TiltfileLoadResult
 	startTime  time.Time
+	startArgs  []string
 	finishTime time.Time
 }
 

--- a/internal/controllers/core/tiltfile/reconciler_test.go
+++ b/internal/controllers/core/tiltfile/reconciler_test.go
@@ -36,7 +36,6 @@ func TestDefault(t *testing.T) {
 			Path: p,
 		},
 	}
-	f.bs.SetEntry(&BuildEntry{Name: "my-tf", TiltfilePath: p})
 	f.Create(&tf)
 
 	// Make sure the FileWatch was created

--- a/internal/controllers/core/tiltfile/reconciler_test.go
+++ b/internal/controllers/core/tiltfile/reconciler_test.go
@@ -75,7 +75,6 @@ func TestSteadyState(t *testing.T) {
 			Path: p,
 		},
 	}
-	f.bs.SetEntry(&BuildEntry{Name: "my-tf", TiltfilePath: p})
 	f.Create(&tf)
 
 	assert.Eventually(t, func() bool {

--- a/internal/controllers/manager.go
+++ b/internal/controllers/manager.go
@@ -78,7 +78,9 @@ func (m *TiltServerControllerManager) SetUp(ctx context.Context, _ store.RStore)
 		if e.Message == "Starting EventSource" ||
 			e.Message == "Starting Controller" ||
 			e.Message == "Starting workers" ||
-			e.Message == "error received after stop sequence was engaged" {
+			e.Message == "error received after stop sequence was engaged" ||
+			e.Message == "Shutdown signal received, waiting for all workers to finish" ||
+			e.Message == "All workers finished" {
 			return
 		}
 

--- a/internal/engine/buildcontroller.go
+++ b/internal/engine/buildcontroller.go
@@ -80,7 +80,11 @@ func (c *BuildController) DisableForTesting() {
 	c.disabledForTesting = true
 }
 
-func (c *BuildController) OnChange(ctx context.Context, st store.RStore, _ store.ChangeSummary) error {
+func (c *BuildController) OnChange(ctx context.Context, st store.RStore, summary store.ChangeSummary) error {
+	if summary.IsLogOnly() {
+		return nil
+	}
+
 	if c.disabledForTesting {
 		return nil
 	}

--- a/internal/engine/configs/configs_controller.go
+++ b/internal/engine/configs/configs_controller.go
@@ -2,116 +2,27 @@ package configs
 
 import (
 	"context"
+	"fmt"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
-	ctrltiltfile "github.com/tilt-dev/tilt/internal/controllers/core/tiltfile"
-	"github.com/tilt-dev/tilt/internal/sliceutils"
 	"github.com/tilt-dev/tilt/internal/store"
+	"github.com/tilt-dev/tilt/pkg/apis"
 	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
 	"github.com/tilt-dev/tilt/pkg/model"
 )
 
 type ConfigsController struct {
 	ctrlClient               ctrlclient.Client
-	buildSource              *ctrltiltfile.BuildSource
-	loadStartedCount         int // used to synchronize with state
 	isInitialTiltfileCreated bool
 }
 
-func NewConfigsController(ctrlClient ctrlclient.Client, buildSource *ctrltiltfile.BuildSource) *ConfigsController {
+func NewConfigsController(ctrlClient ctrlclient.Client) *ConfigsController {
 	return &ConfigsController{
-		ctrlClient:  ctrlClient,
-		buildSource: buildSource,
+		ctrlClient: ctrlClient,
 	}
-}
-
-// Modeled after BuildController.needsBuild and NextBuildReason(). Check to see that:
-// 1) There's currently no Tiltfile build running,
-// 2) There are pending file changes, and
-// 3) Those files have changed since the last Tiltfile build
-//    (so that we don't keep re-running a failed build)
-// 4) OR the command-line args have changed since the last Tiltfile build
-// 5) OR user has manually triggered a Tiltfile build
-func (cc *ConfigsController) needsBuild(ctx context.Context, st store.RStore) (*ctrltiltfile.BuildEntry, bool) {
-	state := st.RLockState()
-	defer st.RUnlockState()
-
-	// Don't start the next build until the previous action has been recorded,
-	// so that we don't accidentally repeat the same build.
-	if cc.loadStartedCount != state.StartedTiltfileLoadCount {
-		return nil, false
-	}
-
-	// Don't start the next build if the last completion hasn't been recorded yet.
-	for _, ms := range state.TiltfileStates {
-		isRunning := !ms.CurrentBuild.StartTime.IsZero()
-		if isRunning {
-			return nil, false
-		}
-	}
-
-	for _, name := range state.TiltfileDefinitionOrder {
-		tf, ok := state.Tiltfiles[name.String()]
-		if !ok {
-			continue
-		}
-
-		tfState, ok := state.TiltfileStates[name]
-		if !ok {
-			continue
-		}
-
-		var reason model.BuildReason
-		lastStartTime := tfState.LastBuild().StartTime
-		if !tfState.StartedFirstBuild() {
-			reason = reason.With(model.BuildReasonFlagInit)
-		}
-
-		hasPendingChanges, _ := tfState.HasPendingChanges()
-		if hasPendingChanges {
-			reason = reason.With(model.BuildReasonFlagChangedFiles)
-		}
-
-		// Only the main tiltfile may read tilt configs and args.
-		userConfigState := state.UserConfigState
-		if name != model.MainTiltfileManifestName {
-			userConfigState = model.UserConfigState{}
-		}
-
-		if userConfigState.ArgsChangeTime.After(lastStartTime) {
-			reason = reason.With(model.BuildReasonFlagTiltfileArgs)
-		}
-
-		if state.ManifestInTriggerQueue(name) {
-			reason = reason.With(tfState.TriggerReason)
-		}
-
-		if reason == model.BuildReasonNone {
-			continue
-		}
-
-		filesChanged := []string{}
-		for _, st := range tfState.BuildStatuses {
-			for k := range st.PendingFileChanges {
-				filesChanged = append(filesChanged, k)
-			}
-		}
-		filesChanged = sliceutils.DedupedAndSorted(filesChanged)
-
-		return &ctrltiltfile.BuildEntry{
-			Name:                  name,
-			FilesChanged:          filesChanged,
-			BuildReason:           reason,
-			UserConfigState:       userConfigState,
-			TiltfilePath:          tf.Spec.Path,
-			CheckpointAtExecStart: state.LogStore.Checkpoint(),
-		}, true
-	}
-
-	return nil, false
 }
 
 func (cc *ConfigsController) OnChange(ctx context.Context, st store.RStore, summary store.ChangeSummary) error {
@@ -124,21 +35,7 @@ func (cc *ConfigsController) OnChange(ctx context.Context, st store.RStore, summ
 		if err != nil {
 			return err
 		}
-
-		if !cc.isInitialTiltfileCreated {
-			return nil
-		}
 	}
-
-	entry, ok := cc.needsBuild(ctx, st)
-	if !ok {
-		return nil
-	}
-
-	// Don't increment until we know we've updated the apiserver.
-	cc.loadStartedCount++
-	entry.LoadCount = cc.loadStartedCount
-	cc.buildSource.SetEntry(entry)
 	return nil
 }
 
@@ -146,12 +43,19 @@ func (cc *ConfigsController) OnChange(ctx context.Context, st store.RStore, summ
 func (cc *ConfigsController) maybeCreateInitialTiltfile(ctx context.Context, st store.RStore) error {
 	state := st.RLockState()
 	desired := state.DesiredTiltfilePath
+	ucs := state.UserConfigState
 	st.RUnlockState()
 
+	name := model.MainTiltfileManifestName.String()
+	fwName := apis.SanitizeName(fmt.Sprintf("%s:%s", model.TargetTypeConfigs, name))
 	newTF := &v1alpha1.Tiltfile{
-		ObjectMeta: metav1.ObjectMeta{Name: model.MainTiltfileManifestName.String()},
+		ObjectMeta: metav1.ObjectMeta{Name: name},
 		Spec: v1alpha1.TiltfileSpec{
 			Path: desired,
+			Args: ucs.Args,
+			RestartOn: &v1alpha1.RestartOnSpec{
+				FileWatches: []string{fwName},
+			},
 		},
 	}
 	err := cc.ctrlClient.Create(ctx, newTF)

--- a/internal/engine/configs/configs_controller_test.go
+++ b/internal/engine/configs/configs_controller_test.go
@@ -1,337 +1,37 @@
 package configs
 
 import (
-	"bytes"
 	"context"
-	"fmt"
-	"runtime"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/util/workqueue"
-	"sigs.k8s.io/controller-runtime/pkg/handler"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	"github.com/tilt-dev/tilt/internal/container"
-	ctrltiltfile "github.com/tilt-dev/tilt/internal/controllers/core/tiltfile"
 	"github.com/tilt-dev/tilt/internal/controllers/fake"
-	"github.com/tilt-dev/tilt/internal/docker"
-	"github.com/tilt-dev/tilt/internal/k8s/testyaml"
 	"github.com/tilt-dev/tilt/internal/store"
-	"github.com/tilt-dev/tilt/internal/store/tiltfiles"
-	"github.com/tilt-dev/tilt/internal/testutils"
-	"github.com/tilt-dev/tilt/internal/testutils/manifestbuilder"
-	"github.com/tilt-dev/tilt/internal/testutils/tempdir"
-	"github.com/tilt-dev/tilt/internal/tiltfile"
 	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
-	"github.com/tilt-dev/tilt/pkg/logger"
 	"github.com/tilt-dev/tilt/pkg/model"
 )
 
-func TestConfigsController(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("TODO(nick): investigate")
-	}
-	f := newCCFixture(t)
-	defer f.TearDown()
-
-	assert.Equal(t, model.OrchestratorUnknown, f.docker.Orchestrator)
-	f.addManifest("fe")
-
-	bar := manifestbuilder.New(f, "bar").WithK8sYAML(testyaml.SanchoYAML).Build()
-	bar.SourceTiltfile = model.MainTiltfileManifestName
-	f.setManifestResult(bar)
-	f.onChange()
-	f.popQueue()
-	f.popQueue()
-
-	require.NotNil(t, f.st.end)
-	assert.Equal(t, []model.Manifest{bar}, f.st.end.Manifests)
-	assert.Equal(t, model.OrchestratorK8s, f.docker.Orchestrator)
-}
-
-func TestConfigsControllerDockerNotConnected(t *testing.T) {
-	f := newCCFixture(t)
-	defer f.TearDown()
-
-	assert.Equal(t, model.OrchestratorUnknown, f.docker.Orchestrator)
-	f.addManifest("fe")
-	f.docker.CheckConnectedErr = fmt.Errorf("connection-error")
-
-	bar := manifestbuilder.New(f, "bar").
-		WithK8sYAML(testyaml.SanchoYAML).
-		WithImageTarget(NewSanchoDockerBuildImageTarget(f)).
-		Build()
-	f.setManifestResult(bar)
-	f.onChange()
-	f.popQueue()
-	f.popQueue()
-
-	if assert.Error(t, f.st.end.Err) {
-		assert.Equal(t, "Failed to connect to Docker: connection-error", f.st.end.Err.Error())
-	}
-}
-
-func TestConfigsControllerDockerNotConnectedButNotRequired(t *testing.T) {
-	f := newCCFixture(t)
-	defer f.TearDown()
-
-	assert.Equal(t, model.OrchestratorUnknown, f.docker.Orchestrator)
-	f.addManifest("fe")
-	f.docker.CheckConnectedErr = fmt.Errorf("connection-error")
-
-	bar := manifestbuilder.New(f, "bar").
-		WithK8sYAML(testyaml.SanchoYAML).
-		Build()
-	f.setManifestResult(bar)
-	f.onChange()
-	f.popQueue()
-	f.popQueue()
-
-	assert.NoError(t, f.st.end.Err)
-}
-
-func TestBuildReasonTrigger(t *testing.T) {
-	f := newCCFixture(t)
-	defer f.TearDown()
-
-	f.addManifest("fe")
-	bar := manifestbuilder.New(f, "bar").WithK8sYAML(testyaml.SanchoYAML).Build()
-
-	state := f.st.LockMutableStateForTesting()
-	state.AppendToTriggerQueue(model.MainTiltfileManifestName, model.BuildReasonFlagTriggerWeb)
-	f.st.UnlockMutableState()
-
-	f.setManifestResult(bar)
-	f.onChange()
-	f.popQueue()
-	f.popQueue()
-
-	assert.True(t, f.st.start.Reason.Has(model.BuildReasonFlagTriggerWeb),
-		"expected build reason has flag: TriggerWeb")
-}
-
-func TestErrorLog(t *testing.T) {
-	f := newCCFixture(t)
-	defer f.TearDown()
-
-	f.tfl.Result = tiltfile.TiltfileLoadResult{Error: fmt.Errorf("The goggles do nothing!")}
-	f.onChange()
-	f.popQueue()
-	f.popQueue()
-
-	assert.Contains(f.T(), f.st.out.String(), "ERROR LEVEL: The goggles do nothing!")
-}
-
-func TestExtensionTiltfile(t *testing.T) {
-	f := newCCFixture(t)
-	defer f.TearDown()
-
-	// Initialize the Main tiltfile
-	f.st.WithState(func(es *store.EngineState) {
-		es.UserConfigState = model.UserConfigState{
-			Args: []string{"fe"},
-		}
+func TestCreateTiltfile(t *testing.T) {
+	st := store.NewTestingStore()
+	st.WithState(func(s *store.EngineState) {
+		s.DesiredTiltfilePath = "./fake-tiltfile-path"
+		s.UserConfigState = model.NewUserConfigState([]string{"arg1", "arg2"})
 	})
-	f.addManifest("fe")
+	ctx := context.Background()
+	client := fake.NewFakeTiltClient()
+	cc := NewConfigsController(client)
+	require.NoError(t, cc.OnChange(ctx, st, store.ChangeSummary{}))
 
-	bar := manifestbuilder.New(f, "fe").WithK8sYAML(testyaml.SanchoYAML).Build()
-	f.setManifestResult(bar)
-	f.onChange()
-	f.popQueue()
-	f.popQueue()
-
-	// Add an extension tiltfile.
-	f.st.WithState(func(es *store.EngineState) {
-		tiltfiles.HandleTiltfileUpsertAction(es, tiltfiles.TiltfileUpsertAction{
-			Tiltfile: &v1alpha1.Tiltfile{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "ext",
-				},
-				Spec: v1alpha1.TiltfileSpec{
-					Path: "extpath",
-				},
-			},
-		})
-	})
-	f.onChange()
-
-	entry := f.bs.Entry()
-	assert.Equal(t, "ext", string(entry.Name))
-	assert.Equal(t, model.UserConfigState{}, entry.UserConfigState)
-}
-
-type testStore struct {
-	ctx context.Context
-	*store.TestingStore
-	out   *bytes.Buffer
-	start *ctrltiltfile.ConfigsReloadStartedAction
-	end   *ctrltiltfile.ConfigsReloadedAction
-}
-
-func NewTestingStore() *testStore {
-	return &testStore{
-		TestingStore: store.NewTestingStore(),
-		out:          bytes.NewBuffer(nil),
-	}
-}
-
-func (s *testStore) Dispatch(action store.Action) {
-	s.TestingStore.Dispatch(action)
-
-	logAction, ok := action.(store.LogAction)
-	if ok {
-		level := ""
-		if logAction.Level() == logger.ErrorLvl {
-			level = "ERROR LEVEL:"
-		}
-		_, _ = fmt.Fprintf(s.out, "%s %s", level, logAction.Message())
-	}
-
-	start, ok := action.(ctrltiltfile.ConfigsReloadStartedAction)
-	if ok {
-		state := s.LockMutableStateForTesting()
-		ctrltiltfile.HandleConfigsReloadStarted(s.ctx, state, start)
-		s.UnlockMutableState()
-		s.start = &start
-	}
-
-	end, ok := action.(ctrltiltfile.ConfigsReloadedAction)
-	if ok {
-		state := s.LockMutableStateForTesting()
-		ctrltiltfile.HandleConfigsReloaded(s.ctx, state, end)
-		s.UnlockMutableState()
-		s.end = &end
-	}
-
-	tfa, ok := action.(tiltfiles.TiltfileUpsertAction)
-	if ok {
-		state := s.LockMutableStateForTesting()
-		tiltfiles.HandleTiltfileUpsertAction(state, tfa)
-		s.UnlockMutableState()
-	}
-}
-
-type ccFixture struct {
-	*tempdir.TempDirFixture
-	ctx    context.Context
-	cancel func()
-	cc     *ConfigsController
-	st     *testStore
-	tfl    *tiltfile.FakeTiltfileLoader
-	docker *docker.FakeClient
-	tfr    *ctrltiltfile.Reconciler
-	q      workqueue.RateLimitingInterface
-	bs     *ctrltiltfile.BuildSource
-}
-
-func newCCFixture(t *testing.T) *ccFixture {
-	f := tempdir.NewTempDirFixture(t)
-	st := NewTestingStore()
-	tfl := tiltfile.NewFakeTiltfileLoader()
-	d := docker.NewFakeClient()
-	tc := fake.NewFakeTiltClient()
-	q := workqueue.NewRateLimitingQueue(
-		workqueue.NewItemExponentialFailureRateLimiter(time.Millisecond, time.Millisecond))
-	buildSource := ctrltiltfile.NewBuildSource()
-	tfr := ctrltiltfile.NewReconciler(st, tfl, d, tc, v1alpha1.NewScheme(), buildSource, store.EngineModeUp)
-	cc := NewConfigsController(tc, buildSource)
-	ctx, _, _ := testutils.CtxAndAnalyticsForTest()
-	ctx, cancel := context.WithCancel(ctx)
-	st.ctx = ctx
-	_ = buildSource.Start(ctx, handler.Funcs{}, q)
-
-	// configs_controller uses state.RelativeTiltfilePath, which is relative to wd
-	// sometimes the original directory was invalid (e.g., it was another test's temp dir, which was deleted,
-	// but not changed out of), and if it was already invalid, then let's not worry about it.
-	f.Chdir()
-
-	state := st.LockMutableStateForTesting()
-	state.DesiredTiltfilePath = f.JoinPath("Tiltfile")
-	st.UnlockMutableState()
-
-	// Simulate tiltfile initialization
-	_ = cc.maybeCreateInitialTiltfile(ctx, st)
-	_, _ = tfr.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: model.MainTiltfileManifestName.String()}})
-
-	return &ccFixture{
-		TempDirFixture: f,
-		ctx:            ctx,
-		cancel:         cancel,
-		cc:             cc,
-		st:             st,
-		tfl:            tfl,
-		docker:         d,
-		tfr:            tfr,
-		q:              q,
-		bs:             buildSource,
-	}
-}
-
-func (f *ccFixture) TearDown() {
-	f.cancel()
-	f.TempDirFixture.TearDown()
-	f.st.AssertNoErrorActions(f.T())
-}
-
-func (f *ccFixture) addManifest(name model.ManifestName) {
-	state := f.st.LockMutableStateForTesting()
-	m := manifestbuilder.New(f, name).WithK8sYAML(testyaml.SanchoYAML).Build()
-	mt := store.NewManifestTarget(m)
-	state.UpsertManifestTarget(mt)
-	f.st.UnlockMutableState()
-}
-
-func (f *ccFixture) setManifestResult(m model.Manifest) {
-	f.tfl.Result = tiltfile.TiltfileLoadResult{
-		Manifests: []model.Manifest{m},
-	}
-}
-
-func (f *ccFixture) onChange() {
-	_ = f.cc.OnChange(f.ctx, f.st, store.LegacyChangeSummary())
-}
-
-// Wait for the next item on the workqueue, then run reconcile on it.
-func (f *ccFixture) popQueue() {
-	f.T().Helper()
-
-	done := make(chan error)
-	go func() {
-		item, _ := f.q.Get()
-		_, err := f.tfr.Reconcile(f.ctx, item.(reconcile.Request))
-		f.q.Done(item)
-		done <- err
-	}()
-
-	select {
-	case <-time.After(time.Second):
-		f.T().Fatal("timeout waiting for workqueue")
-	case err := <-done:
-		assert.NoError(f.T(), err)
-	}
-}
-
-const SanchoDockerfile = `
-FROM go:1.10
-ADD . .
-RUN go install github.com/tilt-dev/sancho
-ENTRYPOINT /go/bin/sancho
-`
-
-var SanchoRef = container.MustParseSelector(testyaml.SanchoImage)
-
-type pathFixture interface {
-	Path() string
-}
-
-func NewSanchoDockerBuildImageTarget(f pathFixture) model.ImageTarget {
-	return model.MustNewImageTarget(SanchoRef).WithBuildDetails(model.DockerBuild{
-		Dockerfile: SanchoDockerfile,
-		BuildPath:  f.Path(),
+	var tf v1alpha1.Tiltfile
+	require.NoError(t, client.Get(ctx, types.NamespacedName{Name: model.MainTiltfileManifestName.String()}, &tf))
+	assert.Equal(t, tf.Spec, v1alpha1.TiltfileSpec{
+		Path: "./fake-tiltfile-path",
+		Args: []string{"arg1", "arg2"},
+		RestartOn: &v1alpha1.RestartOnSpec{
+			FileWatches: []string{"configs:(Tiltfile)"},
+		},
 	})
 }

--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -155,7 +155,7 @@ func upperReducerFn(ctx context.Context, state *store.EngineState, action store.
 		handleUserStartedTiltCloudRegistrationAction(state)
 	case store.PanicAction:
 		handlePanicAction(state, action)
-	case server.SetTiltfileArgsAction:
+	case tiltfiles.SetTiltfileArgsAction:
 		handleSetTiltfileArgsAction(state, action)
 	case store.LogAction:
 		handleLogAction(state, action)
@@ -543,7 +543,7 @@ func handlePanicAction(state *store.EngineState, action store.PanicAction) {
 	state.PanicExited = action.Err
 }
 
-func handleSetTiltfileArgsAction(state *store.EngineState, action server.SetTiltfileArgsAction) {
+func handleSetTiltfileArgsAction(state *store.EngineState, action tiltfiles.SetTiltfileArgsAction) {
 	state.UserConfigState = state.UserConfigState.WithArgs(action.Args)
 }
 

--- a/internal/hud/server/actions.go
+++ b/internal/hud/server/actions.go
@@ -11,12 +11,6 @@ type AppendToTriggerQueueAction struct {
 
 func (AppendToTriggerQueueAction) Action() {}
 
-type SetTiltfileArgsAction struct {
-	Args []string
-}
-
-func (SetTiltfileArgsAction) Action() {}
-
 // TODO: a way to clear an override
 type OverrideTriggerModeAction struct {
 	ManifestNames []model.ManifestName

--- a/internal/hud/server/server.go
+++ b/internal/hud/server/server.go
@@ -22,6 +22,7 @@ import (
 	"github.com/tilt-dev/tilt/internal/cloud"
 	"github.com/tilt-dev/tilt/internal/hud/webview"
 	"github.com/tilt-dev/tilt/internal/store"
+	"github.com/tilt-dev/tilt/internal/store/tiltfiles"
 	"github.com/tilt-dev/tilt/pkg/assets"
 	"github.com/tilt-dev/tilt/pkg/model"
 	proto_webview "github.com/tilt-dev/tilt/pkg/webview"
@@ -220,9 +221,15 @@ func (s *HeadsUpServer) HandleSetTiltfileArgs(w http.ResponseWriter, req *http.R
 	err := jsoniter.NewDecoder(req.Body).Decode(&args)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("error parsing JSON payload: %v", err), http.StatusBadRequest)
+		return
 	}
 
-	s.store.Dispatch(SetTiltfileArgsAction{args})
+	ctx := req.Context()
+	err = tiltfiles.SetTiltfileArgs(ctx, s.store, s.ctrlClient, args)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("error updating apiserver: %v", err), http.StatusInternalServerError)
+		return
+	}
 }
 
 func (s *HeadsUpServer) HandleTrigger(w http.ResponseWriter, req *http.Request) {

--- a/internal/store/engine_state.go
+++ b/internal/store/engine_state.go
@@ -656,7 +656,13 @@ func (ms *ManifestState) AddPendingFileChange(targetID model.TargetID, file stri
 		// which files it consumed from which FileWatches. But we're changing
 		// this architecture anyway. For now, we record the time it got into
 		// the EngineState, rather than the time it was originally changed.
-		timestamp = time.Now()
+		//
+		// This will all go away as we move things into reconcilers,
+		// because reconcilers do synchronous state updates.
+		isReconciler := targetID.Type == model.TargetTypeConfigs
+		if !isReconciler {
+			timestamp = time.Now()
+		}
 	}
 
 	bs := ms.MutableBuildStatus(targetID)

--- a/internal/store/tiltfiles/args.go
+++ b/internal/store/tiltfiles/args.go
@@ -1,0 +1,42 @@
+package tiltfiles
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/tilt-dev/tilt/internal/controllers/apicmp"
+	"github.com/tilt-dev/tilt/internal/store"
+	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
+	"github.com/tilt-dev/tilt/pkg/model"
+)
+
+type SetTiltfileArgsAction struct {
+	Args []string
+}
+
+func (SetTiltfileArgsAction) Action() {}
+
+func SetTiltfileArgs(ctx context.Context, st store.RStore, client client.Client, args []string) error {
+	nn := types.NamespacedName{Name: model.MainTiltfileManifestName.String()}
+	var tf v1alpha1.Tiltfile
+	err := client.Get(ctx, nn, &tf)
+	if err != nil {
+		return err
+	}
+
+	if apicmp.DeepEqual(tf.Spec.Args, args) {
+		return nil
+	}
+
+	update := tf.DeepCopy()
+	update.Spec.Args = args
+	err = client.Update(ctx, update)
+	if err != nil {
+		return err
+	}
+
+	st.Dispatch(SetTiltfileArgsAction{args})
+	return nil
+}


### PR DESCRIPTION
Hello @milas, @landism,

Please review the following commits I made in branch nicks/configs2:

0fbfb9701b233c56d9db5a343618fa8eab30676f (2021-09-02 20:22:46 -0400)
controllers: move all rebuild triggers to the tiltfile controller

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics