### PR TITLE
cli: add a convenience function over extension repos

### DIFF
--- a/internal/cli/create.go
+++ b/internal/cli/create.go
@@ -84,6 +84,7 @@ func (c *createCmd) register() *cobra.Command {
 
 	addCommand(cmd, newCreateFileWatchCmd())
 	addCommand(cmd, newCreateCmdCmd())
+	addCommand(cmd, newCreateRepoCmd())
 
 	return cmd
 }

--- a/internal/cli/create_cmd.go
+++ b/internal/cli/create_cmd.go
@@ -37,7 +37,7 @@ func newCreateCmdCmd() *createCmdCmd {
 	}
 }
 
-func (c *createCmdCmd) name() model.TiltSubcommand { return "cmd" }
+func (c *createCmdCmd) name() model.TiltSubcommand { return "create" }
 
 func (c *createCmdCmd) register() *cobra.Command {
 	cmd := &cobra.Command{

--- a/internal/cli/create_filewatch.go
+++ b/internal/cli/create_filewatch.go
@@ -34,7 +34,7 @@ func newCreateFileWatchCmd() *createFileWatchCmd {
 	}
 }
 
-func (c *createFileWatchCmd) name() model.TiltSubcommand { return "filewatch" }
+func (c *createFileWatchCmd) name() model.TiltSubcommand { return "create" }
 
 func (c *createFileWatchCmd) register() *cobra.Command {
 	cmd := &cobra.Command{

--- a/internal/cli/create_repo.go
+++ b/internal/cli/create_repo.go
@@ -1,0 +1,85 @@
+package cli
+
+import (
+	"context"
+	"time"
+
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/tilt-dev/tilt/internal/analytics"
+	engineanalytics "github.com/tilt-dev/tilt/internal/engine/analytics"
+	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
+	"github.com/tilt-dev/tilt/pkg/model"
+)
+
+// A human-friendly CLI for creating extension repos.
+type createRepoCmd struct {
+	helper *createHelper
+
+	ref string
+}
+
+var _ tiltCmd = &createRepoCmd{}
+
+func newCreateRepoCmd() *createRepoCmd {
+	helper := newCreateHelper()
+	return &createRepoCmd{
+		helper: helper,
+	}
+}
+
+func (c *createRepoCmd) name() model.TiltSubcommand { return "create" }
+
+func (c *createRepoCmd) register() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:                   "repo NAME URL [ARG...]",
+		DisableFlagsInUseLine: true,
+		Short:                 "Register an extension repository.",
+		Long: `Register a repository for loading Tilt extensions.
+
+Tilt supports both git-hosted and local filesystem repositories.
+`,
+		Args: cobra.MinimumNArgs(2),
+		Example: `
+tilt create repo default https://github.com/tilt-dev/tilt-extensions
+tilt create repo default file:///home/user/src/tilt-extensions
+tilt create repo default https://github.com/tilt-dev/tilt-extensions --ref=SHA
+`,
+	}
+
+	cmd.Flags().StringVar(&c.ref, "ref", "",
+		"Git reference to sync the repository to.")
+
+	c.helper.addFlags(cmd)
+
+	return cmd
+}
+
+func (c *createRepoCmd) run(ctx context.Context, args []string) error {
+	a := analytics.Get(ctx)
+	cmdTags := engineanalytics.CmdTags(map[string]string{})
+	a.Incr("cmd.create-repo", cmdTags.AsMap())
+	defer a.Flush(time.Second)
+
+	err := c.helper.interpretFlags(ctx)
+	if err != nil {
+		return err
+	}
+
+	return c.helper.create(ctx, c.object(args))
+}
+
+func (c *createRepoCmd) object(args []string) *v1alpha1.ExtensionRepo {
+	name := args[0]
+	url := args[1]
+	return &v1alpha1.ExtensionRepo{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Spec: v1alpha1.ExtensionRepoSpec{
+			URL: url,
+			Ref: c.ref,
+		},
+	}
+}

--- a/internal/cli/create_repo_test.go
+++ b/internal/cli/create_repo_test.go
@@ -1,0 +1,38 @@
+package cli
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
+)
+
+func TestCreateRepo(t *testing.T) {
+	f := newServerFixture(t)
+	defer f.TearDown()
+
+	out := bytes.NewBuffer(nil)
+
+	cmd := newCreateRepoCmd()
+	cmd.helper.streams.Out = out
+	c := cmd.register()
+	err := c.Flags().Parse([]string{
+		"--ref", "FAKE_SHA",
+	})
+	require.NoError(t, err)
+
+	err = cmd.run(f.ctx, []string{"default", "https://github.com/tilt-dev/tilt-extensions"})
+	require.NoError(t, err)
+	assert.Contains(t, out.String(), `extensionrepo.tilt.dev/default created`)
+
+	var obj v1alpha1.ExtensionRepo
+	err = f.client.Get(f.ctx, types.NamespacedName{Name: "default"}, &obj)
+	require.NoError(t, err)
+
+	assert.Equal(t, "https://github.com/tilt-dev/tilt-extensions", obj.Spec.URL)
+	assert.Equal(t, "FAKE_SHA", obj.Spec.Ref)
+}

--- a/pkg/apis/core/v1alpha1/extensionrepo_types.go
+++ b/pkg/apis/core/v1alpha1/extensionrepo_types.go
@@ -83,6 +83,10 @@ func (in *ExtensionRepo) NamespaceScoped() bool {
 	return false
 }
 
+func (in *ExtensionRepo) ShortNames() []string {
+	return []string{"repo", "extrepo"}
+}
+
 func (in *ExtensionRepo) New() runtime.Object {
 	return &ExtensionRepo{}
 }


### PR DESCRIPTION
Hello @milas,

Please review the following commits I made in branch nicks/generator:

e3220afe93feb6a3dd3c69f3e2eb0eb2bf2a4bd5 (2021-09-03 13:45:49 -0400)
cli: add a convenience function over extension repos

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics