### PR TITLE
web: improve table sorting

### DIFF
--- a/web/src/OverviewTable.test.tsx
+++ b/web/src/OverviewTable.test.tsx
@@ -2,6 +2,7 @@ import { mount, ReactWrapper } from "enzyme"
 import { SnackbarProvider } from "notistack"
 import React from "react"
 import { MemoryRouter } from "react-router"
+import { HeaderGroup } from "react-table"
 import {
   cleanupMockAnalyticsCalls,
   mockAnalyticsCalls,
@@ -18,10 +19,12 @@ import OverviewTable, {
   resourcesToTableCells,
   ResourceTableData,
   ResourceTableHeader,
+  ResourceTableHeaderSortTriangle,
   ResourceTableRow,
   RowValues,
   Table,
   TableGroupedByLabels,
+  TableHeadRow,
   TableNameColumn,
   TableWithoutGroups,
 } from "./OverviewTable"
@@ -40,6 +43,7 @@ import {
 } from "./testdata"
 import { RuntimeStatus, UpdateStatus } from "./types"
 
+// Helpers
 const tableViewWithSettings = ({
   view,
   labelsEnabled,
@@ -60,6 +64,31 @@ const tableViewWithSettings = ({
     </MemoryRouter>
   )
 }
+
+const findTableColumnName = (
+  wrapper: ReactWrapper<any>,
+  columnName: string,
+  sortable = true
+) => {
+  const selector = sortable ? `Sort by ${columnName}` : columnName
+  return wrapper.find(ResourceTableHeader).filter(`[title="${selector}"]`)
+}
+
+const findTableColumn = (wrapper: ReactWrapper<any>, columnName: string) => {
+  const allTableHeaders = wrapper.find(TableHeadRow)
+  const allColumns = allTableHeaders.reduce(
+    (columns: HeaderGroup<RowValues>[], row) => {
+      const specificColumn = row
+        .prop("headerGroup")
+        .headers.filter((column) => column.Header === columnName)
+      return [...columns, ...specificColumn]
+    },
+    []
+  )
+
+  return allColumns
+}
+// End helpers
 
 it("shows buttons on the appropriate resources", () => {
   let view = nResourceView(3)
@@ -165,13 +194,50 @@ describe("when labels feature is not enabled", () => {
   })
 })
 
+describe("overview table without groups", () => {
+  let view: TestDataView
+  let wrapper: ReactWrapper<OverviewTableProps, typeof OverviewTable>
+
+  beforeEach(() => {
+    view = nResourceView(8)
+    wrapper = mount(tableViewWithSettings({ view, labelsEnabled: true }))
+  })
+
+  describe("sorting", () => {
+    it("table sorts when a column header is clicked", () => {
+      findTableColumnName(wrapper, "Pod ID").simulate("click")
+      const [podIdColumn] = findTableColumn(wrapper, "Pod ID")
+
+      expect(podIdColumn.isSorted).toBe(true)
+    })
+
+    it("table column header displays ascending arrow when sorted ascending", () => {
+      findTableColumnName(wrapper, "Pod ID").simulate("click")
+      const arrowIcon = findTableColumnName(wrapper, "Pod ID").find(
+        ResourceTableHeaderSortTriangle
+      )
+
+      expect(arrowIcon.hasClass("is-sorted-asc")).toBe(true)
+    })
+
+    it("table column header displays descending arrow when sorted descending", () => {
+      findTableColumnName(wrapper, "Pod ID").simulate("click").simulate("click")
+      const arrowIcon = findTableColumnName(wrapper, "Pod ID").find(
+        ResourceTableHeaderSortTriangle
+      )
+
+      expect(arrowIcon.hasClass("is-sorted-desc")).toBe(true)
+    })
+  })
+})
+
 describe("overview table with groups", () => {
   let view: TestDataView
   let wrapper: ReactWrapper<OverviewTableProps, typeof OverviewTable>
   let resources: GroupByLabelView<RowValues>
 
   beforeEach(() => {
-    view = nResourceWithLabelsView(5)
+    view = nResourceWithLabelsView(8)
     wrapper = mount(tableViewWithSettings({ view, labelsEnabled: true }))
     resources = resourcesToTableCells(
       view.uiResources,
@@ -362,6 +428,59 @@ describe("overview table with groups", () => {
 
       const updatedGroup = getResourceGroups().first()
       expect(updatedGroup.props().expanded).toBe(true)
+    })
+  })
+
+  describe("sorting", () => {
+    let firstTableNameColumn: ReactWrapper<any, typeof ResourceTableHeader>
+
+    beforeEach(() => {
+      // Find and click the "Resource Name" column on the first table group
+      firstTableNameColumn = wrapper
+        .find(ResourceTableHeader)
+        .filter('[title="Sort by Resource Name"]')
+        .first()
+      firstTableNameColumn.simulate("click")
+    })
+
+    it("all resource group tables are sorted by the same column when one table is sorted", () => {
+      const allTableHeaders = wrapper.find(TableHeadRow)
+      const allNameColumns = findTableColumn(wrapper, "Resource Name")
+
+      expect(allNameColumns.length).toBe(allTableHeaders.length)
+      expect(allNameColumns.every((column) => column.isSorted)).toBe(true)
+    })
+
+    it("tables sort by ascending values when clicked once", () => {
+      // Use the fourth resource group table, since it has multiple resources in the test data generator
+      const ascendingNames = wrapper.find(Table).at(3).find(TableNameColumn)
+      const expectedNames = ["_1", "_3", "_5", "_7", "a_failed_build"]
+      const actualNames = ascendingNames.map((name) => name.text())
+
+      expect(actualNames).toStrictEqual(expectedNames)
+    })
+
+    it("tables sort by descending values when clicked twice", () => {
+      firstTableNameColumn.simulate("click")
+
+      // Use the fourth resource group table, since it has multiple resources in the test data generator
+      const descendingNames = wrapper.find(Table).at(3).find(TableNameColumn)
+      const expectedNames = ["a_failed_build", "_7", "_5", "_3", "_1"]
+      const actualNames = descendingNames.map((name) => name.text())
+
+      expect(actualNames).toStrictEqual(expectedNames)
+    })
+
+    it("tables un-sort when clicked thrice", () => {
+      firstTableNameColumn.simulate("click")
+      firstTableNameColumn.simulate("click")
+
+      // Use the fourth resource group table, since it has multiple resources in the test data generator
+      const unsortedNames = wrapper.find(Table).at(3).find(TableNameColumn)
+      const expectedNames = ["_1", "_3", "_5", "_7", "a_failed_build"]
+      const actualNames = unsortedNames.map((name) => name.text())
+
+      expect(actualNames).toStrictEqual(expectedNames)
     })
   })
 })

--- a/web/src/OverviewTable.tsx
+++ b/web/src/OverviewTable.tsx
@@ -7,7 +7,12 @@ import React, { ChangeEvent, useMemo, useState } from "react"
 import {
   CellProps,
   Column,
+  HeaderGroup,
+  Row,
+  SortingRule,
+  TableHeaderProps,
   TableOptions,
+  TableState,
   useSortBy,
   useTable,
 } from "react-table"
@@ -76,6 +81,21 @@ import {
 export type OverviewTableProps = {
   view: Proto.webviewView
 }
+
+type TableGroupProps = {
+  label: string
+  setGlobalSortBy: (id: string) => void
+} & TableOptions<RowValues>
+
+type TableProps = {
+  isGroupView?: boolean
+  setGlobalSortBy?: (id: string) => void
+} & TableOptions<RowValues>
+
+type TableHeadRowProps = {
+  headerGroup: HeaderGroup<RowValues>
+  setGlobalSortBy?: (id: string) => void
+} & TableHeaderProps
 
 export type RowValues = {
   lastDeployTime: string
@@ -619,6 +639,47 @@ function ResourceTableHeaderTip(props: { name?: string }) {
   )
 }
 
+const FIRST_SORT_STATE = false
+const SECOND_SORT_STATE = true
+
+// This helper function manually implements the toggle sorting
+// logic used by react-table, so we can keep the sorting state
+// globally and sort multiple tables by the same column.
+//    Click once to sort by ascending values
+//    Click twice to sort by descending values
+//    Click thrice to remove sort
+// Note: unlike react-table, this function does NOT support
+// sorting by multiple columns right now.
+function calculateNextSort(
+  id: string,
+  sortByState: SortingRule<RowValues>[] | undefined
+): SortingRule<RowValues>[] {
+  if (!sortByState || sortByState.length === 0) {
+    return [{ id, desc: FIRST_SORT_STATE }]
+  }
+
+  // If the current sort is the same column as next sort,
+  // determine its next value
+  const [currentSort] = sortByState
+  if (currentSort.id === id) {
+    const { desc } = currentSort
+
+    if (desc === undefined) {
+      return [{ id, desc: FIRST_SORT_STATE }]
+    }
+
+    if (desc === FIRST_SORT_STATE) {
+      return [{ id, desc: SECOND_SORT_STATE }]
+    }
+
+    if (desc === SECOND_SORT_STATE) {
+      return []
+    }
+  }
+
+  return [{ id, desc: FIRST_SORT_STATE }]
+}
+
 async function copyTextToClipboard(text: string, cb: () => void) {
   await navigator.clipboard.writeText(text)
   cb()
@@ -726,70 +787,101 @@ export function resourcesToTableCells(
   return { labels, labelsToResources, tiltfile, unlabeled }
 }
 
-export function Table(
-  props: TableOptions<RowValues> & { isGroupView?: boolean }
-) {
+function TableHeadRow({ headerGroup, setGlobalSortBy }: TableHeadRowProps) {
+  const calculateToggleProps = (column: HeaderGroup<RowValues>) => {
+    // Warning! Toggle props are not typed or documented well within react-table.
+    // Modify toggle props with caution.
+    // See https://react-table.tanstack.com/docs/api/useSortBy#column-properties
+    const toggleProps: { [key: string]: any } = {
+      title: column.canSort
+        ? `Sort by ${column.render("Header")}`
+        : column.render("Header"),
+    }
+
+    if (setGlobalSortBy) {
+      // If the sort state is global, rather than individual to each table,
+      // pass a click handler to the sort toggle that changes the global state
+      toggleProps.onClick = () => setGlobalSortBy(column.id)
+    }
+
+    return toggleProps
+  }
+
+  const calculateHeaderProps = (column: HeaderGroup<RowValues>) => {
+    const headerProps: Partial<TableHeaderProps> = {
+      style: { width: column.width },
+    }
+
+    if (column.isSorted) {
+      headerProps.className = "isSorted"
+    }
+
+    return headerProps
+  }
+
+  return (
+    <ResourceTableRow>
+      {headerGroup.headers.map((column) => (
+        <ResourceTableHeader
+          {...column.getHeaderProps([
+            calculateHeaderProps(column),
+            column.getSortByToggleProps(calculateToggleProps(column)),
+          ])}
+        >
+          <ResourceTableHeaderLabel>
+            {column.render("Header")}
+            <ResourceTableHeaderTip name={String(column.Header)} />
+            {column.canSort && (
+              <ResourceTableHeaderSortTriangle
+                className={
+                  column.isSorted
+                    ? column.isSortedDesc
+                      ? "is-sorted-desc"
+                      : "is-sorted-asc"
+                    : ""
+                }
+              />
+            )}
+          </ResourceTableHeaderLabel>
+        </ResourceTableHeader>
+      ))}
+    </ResourceTableRow>
+  )
+}
+
+export function Table(props: TableProps) {
   const {
     getTableProps,
     getTableBodyProps,
     headerGroups,
     rows,
     prepareRow,
-    columns,
   } = useTable(
     {
       columns: columnDefs,
       data: props.data,
       autoResetSortBy: false,
+      useControlledState: props.useControlledState,
     },
     useSortBy
   )
 
   const isGroupClass = props.isGroupView ? "isGroup" : ""
 
-  // TODO (lizz): Consider adding `aria-sort` properties and markup to table
-  // to improve accessibility
+  // TODO (lizz): Consider adding `aria-sort` markup to table headings
   return (
     <ResourceTable {...getTableProps()} className={isGroupClass}>
       <ResourceTableHead>
-        {headerGroups.map((headerGroup) => (
-          <ResourceTableRow {...headerGroup.getHeaderGroupProps()}>
-            {headerGroup.headers.map((column) => (
-              <ResourceTableHeader
-                {...column.getHeaderProps([
-                  {
-                    style: { width: column.width },
-                    className: column.isSorted ? "isSorted" : "",
-                  },
-                  column.getSortByToggleProps({
-                    title: column.canSort
-                      ? `Sort by ${column.render("Header")}`
-                      : column.render("Header"),
-                  }),
-                ])}
-              >
-                <ResourceTableHeaderLabel>
-                  {column.render("Header")}
-                  <ResourceTableHeaderTip name={String(column.Header)} />
-                  {column.canSort && (
-                    <ResourceTableHeaderSortTriangle
-                      className={
-                        column.isSorted
-                          ? column.isSortedDesc
-                            ? "is-sorted-desc"
-                            : "is-sorted-asc"
-                          : ""
-                      }
-                    />
-                  )}
-                </ResourceTableHeaderLabel>
-              </ResourceTableHeader>
-            ))}
-          </ResourceTableRow>
+        {headerGroups.map((headerGroup: HeaderGroup<RowValues>) => (
+          <TableHeadRow
+            {...headerGroup.getHeaderGroupProps()}
+            headerGroup={headerGroup}
+            setGlobalSortBy={props.setGlobalSortBy}
+          />
         ))}
       </ResourceTableHead>
       <tbody {...getTableBodyProps()}>
-        {rows.map((row, i) => {
+        {rows.map((row: Row<RowValues>) => {
           prepareRow(row)
           return (
             <ResourceTableRow {...row.getRowProps()}>
@@ -810,19 +902,20 @@ export function Table(
   )
 }
 
-function TableGroup(props: { label: string; data: RowValues[] }) {
-  if (props.data.length === 0) {
+function TableGroup(props: TableGroupProps) {
+  const { label, ...tableProps } = props
+
+  if (tableProps.data.length === 0) {
     return null
   }
 
-  const formattedLabel =
-    props.label === UNLABELED_LABEL ? <em>{props.label}</em> : props.label
-  const labelNameId = `tableOverview-${props.label}`
+  const formattedLabel = label === UNLABELED_LABEL ? <em>{label}</em> : label
+  const labelNameId = `tableOverview-${label}`
 
   const { getGroup, toggleGroupExpanded } = useResourceGroups()
-  const { expanded } = getGroup(props.label)
+  const { expanded } = getGroup(label)
   const handleChange = (_e: ChangeEvent<{}>) =>
-    toggleGroupExpanded(props.label, AnalyticsType.Grid)
+    toggleGroupExpanded(label, AnalyticsType.Grid)
 
   return (
     <OverviewGroup expanded={expanded} onChange={handleChange}>
@@ -830,12 +923,12 @@ function TableGroup(props: { label: string; data: RowValues[] }) {
         <ResourceGroupSummaryIcon role="presentation" />
         <OverviewGroupName>{formattedLabel}</OverviewGroupName>
         <TableGroupStatusSummary
-          aria-label={`Status summary for ${props.label} group`}
-          resources={props.data}
+          aria-label={`Status summary for ${label} group`}
+          resources={tableProps.data}
         />
       </OverviewGroupSummary>
       <OverviewGroupDetails>
-        <Table columns={columnDefs} data={props.data} isGroupView />
+        <Table {...tableProps} isGroupView />
       </OverviewGroupDetails>
     </OverviewGroup>
   )
@@ -852,6 +945,24 @@ export function TableGroupedByLabels(props: OverviewTableProps) {
       ),
     [props.view.uiResources, props.view.uiButtons]
   )
+
+  // Global table settings are currently used to sort multiple
+  // tables by the same column
+  // See: https://react-table.tanstack.com/docs/faq#how-can-i-manually-control-the-table-state
+  const [globalTableSettings, setGlobalTableSettings] = useState<
+    TableState<RowValues>
+  >()
+
+  const useControlledState = (state: TableState<RowValues>) =>
+    useMemo(() => {
+      return { ...state, ...globalTableSettings }
+    }, [state, globalTableSettings])
+
+  const setGlobalSortBy = (columnId: string) => {
+    const sortBy = calculateNextSort(columnId, globalTableSettings?.sortBy)
+    setGlobalTableSettings({ sortBy })
+  }
+
   return (
     <>
       {data.labels.map((label) => (
@@ -859,10 +970,25 @@ export function TableGroupedByLabels(props: OverviewTableProps) {
           key={label}
           label={label}
           data={data.labelsToResources[label]}
+          columns={columnDefs}
+          useControlledState={useControlledState}
+          setGlobalSortBy={setGlobalSortBy}
         />
       ))}
-      <TableGroup label={UNLABELED_LABEL} data={data.unlabeled} />
-      <TableGroup label={TILTFILE_LABEL} data={data.tiltfile} />
+      <TableGroup
+        label={UNLABELED_LABEL}
+        data={data.unlabeled}
+        columns={columnDefs}
+        useControlledState={useControlledState}
+        setGlobalSortBy={setGlobalSortBy}
+      />
+      <TableGroup
+        label={TILTFILE_LABEL}
+        data={data.tiltfile}
+        columns={columnDefs}
+        useControlledState={useControlledState}
+        setGlobalSortBy={setGlobalSortBy}
+      />
     </>
   )
 }

--- a/web/src/OverviewTable.tsx
+++ b/web/src/OverviewTable.tsx
@@ -190,7 +190,7 @@ const ResourceTableHeaderLabel = styled.div`
   user-select: none;
 `
 
-const ResourceTableHeaderSortTriangle = styled.div`
+export const ResourceTableHeaderSortTriangle = styled.div`
   display: inline-block;
   margin-left: ${SizeUnit(0.25)};
   width: 0;
@@ -787,7 +787,10 @@ export function resourcesToTableCells(
   return { labels, labelsToResources, tiltfile, unlabeled }
 }
 
-function TableHeadRow({ headerGroup, setGlobalSortBy }: TableHeadRowProps) {
+export function TableHeadRow({
+  headerGroup,
+  setGlobalSortBy,
+}: TableHeadRowProps) {
   const calculateToggleProps = (column: HeaderGroup<RowValues>) => {
     // Warning! Toggle props are not typed or documented well within react-table.
     // Modify toggle props with caution.
@@ -1018,13 +1021,13 @@ export default function OverviewTable(props: OverviewTableProps) {
 
   if (labelsEnabled && resourcesHaveLabels) {
     return (
-      <OverviewTableRoot title="Resources overview">
+      <OverviewTableRoot aria-label="Resources overview">
         <TableGroupedByLabels {...props} />
       </OverviewTableRoot>
     )
   } else {
     return (
-      <OverviewTableRoot title="Resources overview">
+      <OverviewTableRoot aria-label="Resources overview">
         {displayLabelGroupsTip && (
           <ResourceGroupsInfoTip idForIcon={GROUP_INFO_TOOLTIP_ID} />
         )}

--- a/web/src/OverviewTable.tsx
+++ b/web/src/OverviewTable.tsx
@@ -126,7 +126,8 @@ const ResourceTable = styled.table`
   }
 
   td + td {
-    padding-right: ${SizeUnit(1 / 2)};
+    padding-left: ${SizeUnit(1 / 4)};
+    padding-right: ${SizeUnit(1 / 4)};
   }
 
   &.isGroup {
@@ -145,6 +146,10 @@ export const ResourceTableData = styled.td`
   font-size: ${FontSize.small};
   color: ${Color.gray6};
   box-sizing: border-box;
+
+  &.isSorted {
+    background-color: ${Color.gray};
+  }
 `
 export const ResourceTableHeader = styled(ResourceTableData)`
   color: ${Color.gray7};
@@ -153,6 +158,10 @@ export const ResourceTableHeader = styled(ResourceTableData)`
   padding-bottom: ${SizeUnit(0.5)};
   box-sizing: border-box;
   white-space: nowrap;
+
+  &.isSorted {
+    background-color: ${Color.grayDark};
+  }
 `
 
 const ResourceTableHeaderLabel = styled.div`
@@ -166,8 +175,8 @@ const ResourceTableHeaderSortTriangle = styled.div`
   margin-left: ${SizeUnit(0.25)};
   width: 0;
   height: 0;
-  border-left: 4px solid transparent;
-  border-right: 4px solid transparent;
+  border-left: 5px solid transparent;
+  border-right: 5px solid transparent;
   border-bottom: 6px solid ${Color.grayLight};
 
   &.is-sorted-asc {
@@ -738,6 +747,8 @@ export function Table(
 
   const isGroupClass = props.isGroupView ? "isGroup" : ""
 
+  // TODO (lizz): Consider adding `aria-sort` properties and markup to table
+  // to improve accessibility
   return (
     <ResourceTable {...getTableProps()} className={isGroupClass}>
       <ResourceTableHead>
@@ -746,9 +757,14 @@ export function Table(
             {headerGroup.headers.map((column) => (
               <ResourceTableHeader
                 {...column.getHeaderProps([
-                  { style: { width: column.width } },
+                  {
+                    style: { width: column.width },
+                    className: column.isSorted ? "isSorted" : "",
+                  },
                   column.getSortByToggleProps({
-                    title: `Sort by ${column.render("Header")}`,
+                    title: column.canSort
+                      ? `Sort by ${column.render("Header")}`
+                      : column.render("Header"),
                   }),
                 ])}
               >
@@ -778,7 +794,11 @@ export function Table(
           return (
             <ResourceTableRow {...row.getRowProps()}>
               {row.cells.map((cell) => (
-                <ResourceTableData {...cell.getCellProps()}>
+                <ResourceTableData
+                  {...cell.getCellProps({
+                    className: cell.column.isSorted ? "isSorted" : "",
+                  })}
+                >
                   {cell.render("Cell")}
                 </ResourceTableData>
               ))}

--- a/web/src/StarredResourceBar.tsx
+++ b/web/src/StarredResourceBar.tsx
@@ -200,7 +200,7 @@ export function StarredResource(props: {
 
 export default function StarredResourceBar(props: StarredResourceBarProps) {
   return (
-    <StarredResourceBarRoot title="Starred resources">
+    <StarredResourceBarRoot aria-label="Starred resources">
       {props.resources.map((r) => (
         <StarredResource
           resource={r}


### PR DESCRIPTION
This PR adds a global sort state for Table View, so that when there are multiple resource group tables, they can all be sorted by the same column. Clicking on one sortable header will sort all the tables at once. It also adds a highlight to the sorted column, so it's clearer to the user that the tables are sorted.

The interface that `react-table` exposes for manually managing table state is not super intuitive. 🙃 (I haven't seen any examples of handling sort state outside of the component itself.) This approach consists of:
* using the `useControlledState` hook, which can override any `react-table`-tracked state
* manually implementing the default sort behavior of `react-table` so we can track the global sort state ourselves
* passing a click handler to columns through the `getSortByToggleProps` to set the global sort state

You can test in any project (like `storybook.tiltfile`) that has resource groups and toggle the resource groups in table view by enabling and disabling the `labels` feature from the Tiltfile.

![2021-09-07 13 36 17](https://user-images.githubusercontent.com/23283986/132387527-498aa443-c43d-4a05-9d8a-2694e6bd49c5.gif)

Closes [ch12497](https://app.clubhouse.io/windmill/story/12497/highlight-sorted-column-s-in-table-view).