### PR TITLE
cli: add a convenience function for installing extensions

### DIFF
--- a/internal/cli/apply_test.go
+++ b/internal/cli/apply_test.go
@@ -31,7 +31,7 @@ spec:
 	err := c.Flags().Parse([]string{"-f", f.JoinPath("sleep.yaml")})
 	require.NoError(t, err)
 
-	err = cmd.run(f.ctx, nil)
+	err = cmd.run(f.ctx, c.Flags().Args())
 	require.NoError(t, err)
 	assert.Contains(t, out.String(), `cmd.tilt.dev/my-sleep created`)
 

--- a/internal/cli/create.go
+++ b/internal/cli/create.go
@@ -85,6 +85,7 @@ func (c *createCmd) register() *cobra.Command {
 	addCommand(cmd, newCreateFileWatchCmd())
 	addCommand(cmd, newCreateCmdCmd())
 	addCommand(cmd, newCreateRepoCmd())
+	addCommand(cmd, newCreateExtCmd())
 
 	return cmd
 }

--- a/internal/cli/create_cmd_test.go
+++ b/internal/cli/create_cmd_test.go
@@ -24,10 +24,11 @@ func TestCreateCmd(t *testing.T) {
 	err := c.Flags().Parse([]string{
 		"--env", "COLOR=1",
 		"-e", "USER=nick",
+		"my-cmd", "echo", "hello", "world",
 	})
 	require.NoError(t, err)
 
-	err = cmd.run(f.ctx, []string{"my-cmd", "echo", "hello", "world"})
+	err = cmd.run(f.ctx, c.Flags().Args())
 	require.NoError(t, err)
 	assert.Contains(t, out.String(), `cmd.tilt.dev/my-cmd created`)
 

--- a/internal/cli/create_ext.go
+++ b/internal/cli/create_ext.go
@@ -1,0 +1,112 @@
+package cli
+
+import (
+	"context"
+	"time"
+
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/tilt-dev/tilt/internal/analytics"
+	engineanalytics "github.com/tilt-dev/tilt/internal/engine/analytics"
+	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
+	"github.com/tilt-dev/tilt/pkg/model"
+)
+
+// A human-friendly CLI for creating extensions.
+type createExtCmd struct {
+	helper *createHelper
+	cmd    *cobra.Command
+
+	repoName string
+	repoPath string
+}
+
+var _ tiltCmd = &createExtCmd{}
+
+func newCreateExtCmd() *createExtCmd {
+	helper := newCreateHelper()
+	return &createExtCmd{
+		helper: helper,
+	}
+}
+
+func (c *createExtCmd) name() model.TiltSubcommand { return "create" }
+
+func (c *createExtCmd) register() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:                   "ext NAME [ARG...]",
+		DisableFlagsInUseLine: true,
+		Short:                 "Register an extension.",
+		Long: `Register an extension with a running Tilt instance.
+
+An extension will load a set of services into your dev environment.
+
+These might be services you need to run your app, or servers
+that add functionality to Tilt itself.
+
+Assumes that an extension repo has already been registered
+with 'tilt create repo' or in the Tiltfile.
+`,
+		Args: cobra.MinimumNArgs(1),
+		Example: `
+# Installs the extension from the extension repo 'default' under the path './cancel'.
+tilt create ext cancel
+
+# Installs the extension from the extension repo 'default' under
+# and with custom argument '--namespaces=default' passed to the extension.
+tilt create ext my-kubefwd --path=./kubefwd -- --namespaces=default
+
+# Installs the extension from the extension repo 'dev' under the path './cancel'
+tilt create ext cancel --repo=dev
+`,
+	}
+
+	cmd.Flags().StringVar(&c.repoName, "repo", "default",
+		"The name of the extension repo (list existing repos with 'tilt get repo')")
+	cmd.Flags().StringVar(&c.repoPath, "path", "",
+		"The path of the extension. If not specified, defaults to the extension name.")
+
+	c.helper.addFlags(cmd)
+	c.cmd = cmd
+
+	return cmd
+}
+
+func (c *createExtCmd) run(ctx context.Context, args []string) error {
+	a := analytics.Get(ctx)
+	cmdTags := engineanalytics.CmdTags(map[string]string{})
+	a.Incr("cmd.create-ext", cmdTags.AsMap())
+	defer a.Flush(time.Second)
+
+	err := c.helper.interpretFlags(ctx)
+	if err != nil {
+		return err
+	}
+
+	name := args[0]
+	extArgs := []string{}
+	if c.cmd.ArgsLenAtDash() != -1 {
+		extArgs = args[c.cmd.ArgsLenAtDash():]
+	}
+
+	return c.helper.create(ctx, c.object(name, extArgs))
+}
+
+func (c *createExtCmd) object(name string, extArgs []string) *v1alpha1.Extension {
+	repoName := c.repoName
+	repoPath := c.repoPath
+	if repoPath == "" {
+		repoPath = name
+	}
+	return &v1alpha1.Extension{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Spec: v1alpha1.ExtensionSpec{
+			RepoName: repoName,
+			RepoPath: repoPath,
+			Args:     extArgs,
+		},
+	}
+}

--- a/internal/cli/create_filewatch_test.go
+++ b/internal/cli/create_filewatch_test.go
@@ -24,10 +24,11 @@ func TestCreateFileWatch(t *testing.T) {
 	c := cmd.register()
 	err := c.Flags().Parse([]string{
 		"--ignore", "web/node_modules",
+		"my-watch", "src", "web",
 	})
 	require.NoError(t, err)
 
-	err = cmd.run(f.ctx, []string{"my-watch", "src", "web"})
+	err = cmd.run(f.ctx, c.Flags().Args())
 	require.NoError(t, err)
 	assert.Contains(t, out.String(), `filewatch.tilt.dev/my-watch created`)
 
@@ -53,10 +54,10 @@ func TestCreateFileWatchNoIgnore(t *testing.T) {
 	cmd := newCreateFileWatchCmd()
 	cmd.helper.streams.Out = out
 	c := cmd.register()
-	err := c.Flags().Parse([]string{})
+	err := c.Flags().Parse([]string{"my-watch", "src"})
 	require.NoError(t, err)
 
-	err = cmd.run(f.ctx, []string{"my-watch", "src"})
+	err = cmd.run(f.ctx, c.Flags().Args())
 	require.NoError(t, err)
 	assert.Contains(t, out.String(), `filewatch.tilt.dev/my-watch created`)
 

--- a/pkg/apis/core/v1alpha1/extension_types.go
+++ b/pkg/apis/core/v1alpha1/extension_types.go
@@ -90,6 +90,10 @@ func (in *Extension) NamespaceScoped() bool {
 	return false
 }
 
+func (in *Extension) ShortNames() []string {
+	return []string{"ext"}
+}
+
 func (in *Extension) New() runtime.Object {
 	return &Extension{}
 }


### PR DESCRIPTION
Hello @milas,

Please review the following commits I made in branch nicks/generator2:

dea70380f1a2f0329df620736e77d16e6d7397f3 (2021-09-03 14:58:01 -0400)
cli: add a convenience function for installing extensions

e3220afe93feb6a3dd3c69f3e2eb0eb2bf2a4bd5 (2021-09-03 13:45:49 -0400)
cli: add a convenience function over extension repos

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics