### PR TITLE
docker: platform argument to customize image arch

### DIFF
--- a/internal/build/options.go
+++ b/internal/build/options.go
@@ -21,6 +21,7 @@ func Options(archive io.Reader, db model.DockerBuild) docker.BuildOptions {
 		SecretSpecs: db.SecretSpecs,
 		CacheFrom:   db.CacheFrom,
 		PullParent:  db.PullParent,
+		Platform:    db.Platform,
 	}
 }
 

--- a/internal/docker/client.go
+++ b/internal/docker/client.go
@@ -469,6 +469,7 @@ func (c *Cli) ImageBuild(ctx context.Context, buildContext io.Reader, options Bu
 	opts.NetworkMode = options.Network
 	opts.CacheFrom = options.CacheFrom
 	opts.PullParent = options.PullParent
+	opts.Platform = options.Platform
 
 	opts.Labels = BuiltByTiltLabel // label all images as built by us
 

--- a/internal/docker/options.go
+++ b/internal/docker/options.go
@@ -13,6 +13,7 @@ type BuildOptions struct {
 	Network            string
 	CacheFrom          []string
 	PullParent         bool
+	Platform           string
 	ExtraTags          []string
 	ForceLegacyBuilder bool
 }

--- a/internal/testutils/env.go
+++ b/internal/testutils/env.go
@@ -1,0 +1,43 @@
+package testutils
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Setenv sets an environment variable for the duration of the test and restores the original value afterwards.
+func Setenv(t testing.TB, key, value string) {
+	t.Helper()
+	captureAndRestoreEnv(t, key)
+	require.NoError(t, os.Setenv(key, value))
+}
+
+// Unsetenv unsets an environment variable for the duration of the test and restores the original value afterwards.
+func Unsetenv(t testing.TB, key string) {
+	t.Helper()
+	captureAndRestoreEnv(t, key)
+	require.NoError(t, os.Unsetenv(key))
+}
+
+func captureAndRestoreEnv(t testing.TB, key string) {
+	t.Helper()
+	if curVal, ok := os.LookupEnv(key); ok {
+		t.Cleanup(
+			func() {
+				if err := os.Setenv(key, curVal); err != nil {
+					t.Errorf("Failed to restore env var %q: %v", key, err)
+				}
+			},
+		)
+	} else {
+		t.Cleanup(
+			func() {
+				if err := os.Unsetenv(key); err != nil {
+					t.Errorf("Failed to restore env var %q: %v", key, err)
+				}
+			},
+		)
+	}
+}

--- a/internal/tiltfile/tiltfile_state.go
+++ b/internal/tiltfile/tiltfile_state.go
@@ -1296,6 +1296,7 @@ func (s *tiltfileState) imgTargetsForDependencyIDsHelper(ids []model.TargetID, c
 				Network:     image.network,
 				CacheFrom:   image.cacheFrom,
 				PullParent:  image.pullParent,
+				Platform:    image.platform,
 				ExtraTags:   image.extraTags,
 			})
 		case CustomBuild:

--- a/pkg/model/image_target.go
+++ b/pkg/model/image_target.go
@@ -282,6 +282,10 @@ type DockerBuild struct {
 	PullParent bool
 	CacheFrom  []string
 
+	// Platform specifies architecture information for target image.
+	// https://docs.docker.com/desktop/multi-arch/
+	Platform string
+
 	// By default, Tilt creates a new temporary image reference for each build.
 	// The user can also specify their own reference, to integrate with other tooling
 	// (like build IDs for Jenkins build pipelines)


### PR DESCRIPTION
Docker CLI has a `--platform` argument and `DOCKER_DEFAULT_PLATFORM`
environment variable for default.

This is useful when dealing with multi-architecture images in
different scenarios, e.g. using an M1-based macOS machine.

This adds a `platform` argument to `docker_build` which will get
passed through to Docker/BuildKit. Similar to the Docker CLI, if
not specified, `DOCKER_DEFAULT_PLATFORM` will be used as a default
if set.

Fixes #4932.