### PR TITLE
web: fix navbar button styling

### DIFF
--- a/web/src/ApiButton.tsx
+++ b/web/src/ApiButton.tsx
@@ -41,6 +41,8 @@ export const ApiButtonRoot = styled(ButtonGroup)`
   ${ApiIconRoot} + ${ApiButtonLabel} {
     margin-left: ${SizeUnit(0.25)};
   }
+
+  align-items: center;
 `
 export const LogLink = styled(Link)`
   font-size: ${FontSize.smallest};
@@ -282,9 +284,6 @@ export function ApiButton(props: React.PropsWithChildren<ApiButtonProps>) {
   const { setError } = useHudErrorContext()
 
   const onClick = async (e: React.MouseEvent<HTMLElement>) => {
-    if ((e.target as Element).classList.contains("ignoreClick")) {
-      return true
-    }
     // TODO(milas): currently the loading state just disables the button for the duration of
     //  the AJAX request to avoid duplicate clicks - there is no progress tracking at the
     //  moment, so there's no fancy spinner animation or propagation of result of action(s)

--- a/web/src/ApiButton.tsx
+++ b/web/src/ApiButton.tsx
@@ -41,8 +41,6 @@ export const ApiButtonRoot = styled(ButtonGroup)`
   ${ApiIconRoot} + ${ApiButtonLabel} {
     margin-left: ${SizeUnit(0.25)};
   }
-
-  align-items: center;
 `
 export const LogLink = styled(Link)`
   font-size: ${FontSize.smallest};
@@ -173,6 +171,7 @@ function ApiButtonWithOptions(props: ApiButtonWithOptionsProps) {
             setOpen((prevOpen) => !prevOpen)
           }}
           analyticsName="ui.web.uiButton.inputMenu"
+          aria-label={`Open ${props.uiButton.spec?.text} options`}
           {...props.buttonProps}
         >
           <ArrowDropDownIcon />
@@ -283,7 +282,7 @@ export function ApiButton(props: React.PropsWithChildren<ApiButtonProps>) {
 
   const { setError } = useHudErrorContext()
 
-  const onClick = async (e: React.MouseEvent<HTMLElement>) => {
+  const onClick = async () => {
     // TODO(milas): currently the loading state just disables the button for the duration of
     //  the AJAX request to avoid duplicate clicks - there is no progress tracking at the
     //  moment, so there's no fancy spinner animation or propagation of result of action(s)
@@ -324,6 +323,7 @@ export function ApiButton(props: React.PropsWithChildren<ApiButtonProps>) {
       analyticsName={"ui.web.uibutton"}
       onClick={onClick}
       disabled={loading || uiButton.spec?.disabled}
+      aria-label={`Trigger ${uiButton.spec?.text}`}
       {...buttonProps}
     >
       {props.children || (
@@ -353,11 +353,16 @@ export function ApiButton(props: React.PropsWithChildren<ApiButtonProps>) {
         setInputValue={setInputValue}
         getInputValue={getInputValue}
         buttonProps={buttonProps}
+        aria-label={uiButton.spec?.text}
       />
     )
   } else {
     return (
-      <ApiButtonRoot className={className} disableRipple={true}>
+      <ApiButtonRoot
+        className={className}
+        disableRipple={true}
+        aria-label={uiButton.spec?.text}
+      >
         {button}
       </ApiButtonRoot>
     )

--- a/web/src/ApiButton.tsx
+++ b/web/src/ApiButton.tsx
@@ -281,7 +281,10 @@ export function ApiButton(props: React.PropsWithChildren<ApiButtonProps>) {
 
   const { setError } = useHudErrorContext()
 
-  const onClick = async () => {
+  const onClick = async (e: React.MouseEvent<HTMLElement>) => {
+    if ((e.target as Element).classList.contains("ignoreClick")) {
+      return true
+    }
     // TODO(milas): currently the loading state just disables the button for the duration of
     //  the AJAX request to avoid duplicate clicks - there is no progress tracking at the
     //  moment, so there's no fancy spinner animation or propagation of result of action(s)

--- a/web/src/CustomNav.tsx
+++ b/web/src/CustomNav.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import styled from "styled-components"
 import { ApiButton, ApiIcon, buttonsForComponent } from "./ApiButton"
-import { MenuButtonLabel, MenuButtonMixin } from "./GlobalNav"
+import { MenuButtonLabeled, MenuButtonMixin } from "./GlobalNav"
 import { Color, SizeUnit } from "./style-helpers"
 
 type CustomNavProps = {
@@ -46,19 +46,18 @@ export function CustomNav(props: CustomNavProps) {
   return (
     <React.Fragment>
       {buttons.map((b) => (
-        <CustomNavButton
-          key={b.metadata?.name}
-          uiButton={b}
-          variant="contained"
-        >
-          <ApiIcon
-            iconName={b.spec?.iconName || "smart_button"}
-            iconSVG={b.spec?.iconSVG}
-          />
-          <MenuButtonLabel className="ignoreClick">
-            {b.spec?.text}
-          </MenuButtonLabel>
-        </CustomNavButton>
+        <MenuButtonLabeled label={b.spec?.text}>
+          <CustomNavButton
+            key={b.metadata?.name}
+            uiButton={b}
+            variant="contained"
+          >
+            <ApiIcon
+              iconName={b.spec?.iconName || "smart_button"}
+              iconSVG={b.spec?.iconSVG}
+            />
+          </CustomNavButton>
+        </MenuButtonLabeled>
       ))}
     </React.Fragment>
   )

--- a/web/src/CustomNav.tsx
+++ b/web/src/CustomNav.tsx
@@ -2,17 +2,29 @@ import React from "react"
 import styled from "styled-components"
 import { ApiButton, ApiIcon, buttonsForComponent } from "./ApiButton"
 import { MenuButtonLabel, MenuButtonMixin } from "./GlobalNav"
-import { SizeUnit } from "./style-helpers"
+import { Color, SizeUnit } from "./style-helpers"
 
 type CustomNavProps = {
   view: Proto.webviewView
 }
 
 const CustomNavButton = styled(ApiButton)`
-  align-items: center;
+  height: 100%;
 
   button {
     ${MenuButtonMixin};
+    height: 100%;
+    box-shadow: none;
+    justify-content: center;
+
+    &:hover {
+      box-shadow: none;
+    }
+  }
+
+  .MuiButton-contained.Mui-disabled {
+    color: ${Color.blue};
+    background: transparent;
   }
   // If there is an options toggle, remove padding between the submit
   // button and the options button.
@@ -21,7 +33,7 @@ const CustomNavButton = styled(ApiButton)`
   }
   // If there is no options toggle, then restore the default padding.
   button:only-child {
-    ${SizeUnit(0.5)};
+    padding-right: ${SizeUnit(0.5)};
   }
   .apibtn-label {
     display: none;
@@ -43,7 +55,9 @@ export function CustomNav(props: CustomNavProps) {
             iconName={b.spec?.iconName || "smart_button"}
             iconSVG={b.spec?.iconSVG}
           />
-          <MenuButtonLabel>{b.spec?.text}</MenuButtonLabel>
+          <MenuButtonLabel className="ignoreClick">
+            {b.spec?.text}
+          </MenuButtonLabel>
         </CustomNavButton>
       ))}
     </React.Fragment>

--- a/web/src/CustomNav.tsx
+++ b/web/src/CustomNav.tsx
@@ -10,15 +10,17 @@ type CustomNavProps = {
 
 const CustomNavButton = styled(ApiButton)`
   height: 100%;
+  align-items: center;
 
   button {
     ${MenuButtonMixin};
     height: 100%;
-    box-shadow: none;
+    box-shadow: unset;
     justify-content: center;
 
-    &:hover {
-      box-shadow: none;
+    &:hover,
+    &:active {
+      box-shadow: unset;
     }
   }
 
@@ -51,6 +53,7 @@ export function CustomNav(props: CustomNavProps) {
             key={b.metadata?.name}
             uiButton={b}
             variant="contained"
+            aria-label={b.spec?.text}
           >
             <ApiIcon
               iconName={b.spec?.iconName || "smart_button"}

--- a/web/src/GlobalNav.tsx
+++ b/web/src/GlobalNav.tsx
@@ -40,7 +40,7 @@ export const MenuButtonMixin = `
   ${mixinResetButtonStyle};
   display: flex;
   flex-direction: column;
-  justify-content: flex-end;
+  justify-content: center;
   align-items: center;
   transition: color ${AnimDuration.default} ease;
   padding-top: ${SizeUnit(0.5)};
@@ -49,6 +49,7 @@ export const MenuButtonMixin = `
   padding-bottom: ${SizeUnit(0.5)};
   font-size: ${FontSize.smallest};
   color: ${Color.blue};
+  height: 100%;
 
   & .fillStd {
     fill: ${Color.blue};
@@ -67,11 +68,14 @@ export const MenuButtonMixin = `
   }
 `
 export const MenuButton = styled.button`
-  ${MenuButtonMixin}
+  ${MenuButtonMixin};
 `
 export const MenuButtonLabeledRoot = styled.div`
   position: relative; // Anchor MenuButtonLabel, which shouldn't affect this element's width
-  &:hover ${MenuButtonLabel}, button[data-open="true"] + ${MenuButtonLabel} {
+  &:is(:hover, :focus, :active)
+    ${MenuButtonLabel},
+    button[data-open="true"]
+    + ${MenuButtonLabel} {
     opacity: 1;
   }
 `
@@ -212,13 +216,16 @@ export function GlobalNav(props: GlobalNavProps) {
     </MenuButtonLabeled>
   ) : null
 
+  const versionButtonLabel = props.showUpdate ? "Get Update" : "Version"
+
   return (
     <GlobalNavRoot>
-      <MenuButtonLabeled label={props.showUpdate ? "Get Update" : "Version"}>
+      <MenuButtonLabeled label={versionButtonLabel}>
         <MenuButton
           ref={updateButton}
           onClick={() => toggleUpdateDialog(AnalyticsAction.Click)}
           data-open={updateDialogOpen}
+          aria-label={versionButtonLabel}
         >
           <div>v{props.runningBuild?.version || "?"}</div>
 
@@ -230,11 +237,12 @@ export function GlobalNav(props: GlobalNavProps) {
 
       {snapshotButton}
 
-      <MenuButtonLabeled label={"Help"}>
+      <MenuButtonLabeled label="Help">
         <MenuButton
           ref={shortcutButton}
           onClick={() => toggleShortcutsDialog(AnalyticsAction.Click)}
           data-open={shortcutsDialogOpen}
+          aria-label="Help"
         >
           <HelpIcon width="24" height="24" />
         </MenuButton>
@@ -244,6 +252,7 @@ export function GlobalNav(props: GlobalNavProps) {
           ref={accountButton}
           onClick={() => toggleAccountMenu(AnalyticsAction.Click)}
           data-open={accountMenuOpen}
+          aria-label="Account"
         >
           <AccountIcon width="24" height="24" />
         </MenuButton>

--- a/web/src/GlobalNav.tsx
+++ b/web/src/GlobalNav.tsx
@@ -33,6 +33,8 @@ export const MenuButtonLabel = styled.div`
   transition: opacity ${AnimDuration.default} ease;
   opacity: 0;
   white-space: nowrap;
+  width: 100%;
+  text-align: center;
 `
 export const MenuButtonMixin = `
   ${mixinResetButtonStyle};
@@ -41,7 +43,6 @@ export const MenuButtonMixin = `
   justify-content: flex-end;
   align-items: center;
   transition: color ${AnimDuration.default} ease;
-  position: relative; // Anchor MenuButtonLabel, which shouldn't affect this element's width
   padding-top: ${SizeUnit(0.5)};
   padding-left: ${SizeUnit(0.5)};
   padding-right: ${SizeUnit(0.5)};
@@ -64,13 +65,15 @@ export const MenuButtonMixin = `
     pointer-events: none;
     cursor: default;
   }
-  
-  &:hover ${MenuButtonLabel}, &[data-open="true"] ${MenuButtonLabel} {
-    opacity: 1;
-  }
 `
 export const MenuButton = styled.button`
   ${MenuButtonMixin}
+`
+export const MenuButtonLabeledRoot = styled.div`
+  position: relative; // Anchor MenuButtonLabel, which shouldn't affect this element's width
+  &:hover ${MenuButtonLabel}, button[data-open="true"] + ${MenuButtonLabel} {
+    opacity: 1;
+  }
 `
 const UpdateAvailableFloatIcon = styled(UpdateAvailableIcon)`
   display: none;
@@ -126,6 +129,17 @@ class GlobalNavShortcuts extends Component<GlobalNavShortcutsProps> {
   render() {
     return <span></span>
   }
+}
+
+export function MenuButtonLabeled(
+  props: React.PropsWithChildren<{ label?: string }>
+) {
+  return (
+    <MenuButtonLabeledRoot>
+      {props.children}
+      {props.label && <MenuButtonLabel>{props.label}</MenuButtonLabel>}
+    </MenuButtonLabeledRoot>
+  )
 }
 
 type GlobalNavProps = {
@@ -191,47 +205,49 @@ export function GlobalNav(props: GlobalNavProps) {
   let accountMenuHeader = <AccountMenuHeader {...props} />
   let accountMenuContent = <AccountMenuContent {...props} />
   let snapshotButton = props.snapshot.enabled ? (
-    <MenuButton onClick={props.snapshot.openModal}>
-      <SnapshotIcon width="24" height="24" />
-      <MenuButtonLabel>Snapshot</MenuButtonLabel>
-    </MenuButton>
+    <MenuButtonLabeled label="Snapshot">
+      <MenuButton onClick={props.snapshot.openModal}>
+        <SnapshotIcon width="24" height="24" />
+      </MenuButton>
+    </MenuButtonLabeled>
   ) : null
 
   return (
     <GlobalNavRoot>
-      <MenuButton
-        ref={updateButton}
-        onClick={() => toggleUpdateDialog(AnalyticsAction.Click)}
-        data-open={updateDialogOpen}
-      >
-        <div>v{props.runningBuild?.version || "?"}</div>
+      <MenuButtonLabeled label={props.showUpdate ? "Get Update" : "Version"}>
+        <MenuButton
+          ref={updateButton}
+          onClick={() => toggleUpdateDialog(AnalyticsAction.Click)}
+          data-open={updateDialogOpen}
+        >
+          <div>v{props.runningBuild?.version || "?"}</div>
 
-        <UpdateAvailableFloatIcon
-          className={props.showUpdate ? "is-visible" : ""}
-        />
-        <MenuButtonLabel>
-          {props.showUpdate ? "Get Update" : "Version"}
-        </MenuButtonLabel>
-      </MenuButton>
+          <UpdateAvailableFloatIcon
+            className={props.showUpdate ? "is-visible" : ""}
+          />
+        </MenuButton>
+      </MenuButtonLabeled>
 
       {snapshotButton}
 
-      <MenuButton
-        ref={shortcutButton}
-        onClick={() => toggleShortcutsDialog(AnalyticsAction.Click)}
-        data-open={shortcutsDialogOpen}
-      >
-        <HelpIcon width="24" height="24" />
-        <MenuButtonLabel>Help</MenuButtonLabel>
-      </MenuButton>
-      <MenuButton
-        ref={accountButton}
-        onClick={() => toggleAccountMenu(AnalyticsAction.Click)}
-        data-open={accountMenuOpen}
-      >
-        <AccountIcon width="24" height="24" />
-        <MenuButtonLabel>Account</MenuButtonLabel>
-      </MenuButton>
+      <MenuButtonLabeled label={"Help"}>
+        <MenuButton
+          ref={shortcutButton}
+          onClick={() => toggleShortcutsDialog(AnalyticsAction.Click)}
+          data-open={shortcutsDialogOpen}
+        >
+          <HelpIcon width="24" height="24" />
+        </MenuButton>
+      </MenuButtonLabeled>
+      <MenuButtonLabeled label="Account">
+        <MenuButton
+          ref={accountButton}
+          onClick={() => toggleAccountMenu(AnalyticsAction.Click)}
+          data-open={accountMenuOpen}
+        >
+          <AccountIcon width="24" height="24" />
+        </MenuButton>
+      </MenuButtonLabeled>
 
       <FloatDialog
         id="accountMenu"


### PR DESCRIPTION
Fixes navbar issues from this [PR's comment](https://github.com/tilt-dev/tilt/pull/4898#pullrequestreview-742973668):
1. title display on hover overlaps and can lead the user to click the wrong button
2. (very subtle) drop shadow on buttons that shouldn't be there
3. ripple displays on click and shouldn't be there
4. icon and button seems to darken/flicker on click, though this could be related to the disabled/loading state
5. the click area is a little strange for the button groups. the click area is large for the command button itself, but small for the dropdown button. i think we could solve this by making the size of the command button / button group smaller and centering the button title display, but i didn't play around with this solution!