### PR TITLE
web: fix borders on table view api buttons

### DIFF
--- a/web/src/OverviewButton.tsx
+++ b/web/src/OverviewButton.tsx
@@ -1,6 +1,7 @@
 import {
   AnimDuration,
   Color,
+  ColorRGBA,
   Font,
   mixinResetButtonStyle,
 } from "./style-helpers"
@@ -13,9 +14,9 @@ export const OverviewButtonMixin = `
   padding: 8px 12px;
   margin: 0;
 
-  background: ${Color.grayDark};
+  background: transparent;
 
-  border: 1px solid ${Color.grayLighter};
+  border: 1px solid ${ColorRGBA(Color.grayLightest, 0.5)};
   box-sizing: border-box;
   border-radius: 4px;
   cursor: pointer;
@@ -59,9 +60,6 @@ export const OverviewButtonMixin = `
   &:hover {
     color: ${Color.blue};
     border-color: ${Color.blue};
-    // When in a ButtonGroup, adjacent buttons share a border.
-    // Force this button to the front so that its highlighted border shows.
-    z-index: 10;
   }
   &:hover .fillStd {
     fill: ${Color.blue};


### PR DESCRIPTION
Fix the focus/hover border weirdness spotted in [this PR comment](https://github.com/tilt-dev/tilt/pull/4898#pullrequestreview-742973668)

MUI is kind of annoying for this:
In a button group, each line between buttons is on the same 1px from each neighbor button. MUI does this by adding `margin-left: 1px;` to each button in the group other than the first.
Button 2's left border gets rendered on top of button 1's right border.
My understanding of the way this works in normal MUI is:
1. give the buttons a transparent background, so button 2's background doesn't wipe out button 1's right border
2. make the normal border color transparent, so that when button 2's left border is rendered on top of button 1's right border, you still see most of button 1's right border.

I'd previously tried to solve this with z-index, but then the transition on the right border is wonky.

> ripple displays on click and shouldn't be there

I wasn't able to observe this, which maybe means it's not worth worrying about? Or maybe my eyes are going bad and/or I wasn't looking at the right place.

> icon and button seems to darken/flicker on click, though this could be related to the disabled/loading state

I think I'm fine leaving this as-is, if you don't feel strongly about it.