### PR TITLE
extension: set up filewatch triggers correctly

### DIFF
--- a/internal/controllers/core/extension/reconciler_test.go
+++ b/internal/controllers/core/extension/reconciler_test.go
@@ -26,6 +26,7 @@ func TestDefault(t *testing.T) {
 		Spec: v1alpha1.ExtensionSpec{
 			RepoName: "my-repo",
 			RepoPath: "my-ext",
+			Args:     []string{"--namespaces=foo"},
 		},
 	}
 	f.Create(&ext)
@@ -37,8 +38,12 @@ func TestDefault(t *testing.T) {
 
 	var tf v1alpha1.Tiltfile
 	f.MustGet(types.NamespacedName{Name: "my-repo:my-ext"}, &tf)
-	require.Equal(t, p, tf.Spec.Path)
-	require.Equal(t, map[string]string{"extension.my-repo_my-ext": "extension.my-repo_my-ext"}, tf.Spec.Labels)
+	require.Equal(t, tf.Spec, v1alpha1.TiltfileSpec{
+		Path:      p,
+		Labels:    map[string]string{"extension.my-repo_my-ext": "extension.my-repo_my-ext"},
+		RestartOn: &v1alpha1.RestartOnSpec{FileWatches: []string{"configs:my-repo:my-ext"}},
+		Args:      []string{"--namespaces=foo"},
+	})
 }
 
 func TestCleanupTiltfile(t *testing.T) {

--- a/internal/controllers/core/tiltfile/reconciler.go
+++ b/internal/controllers/core/tiltfile/reconciler.go
@@ -106,7 +106,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	ctx = store.MustObjectLogHandler(ctx, r.st, &tf)
 	run := r.runs[nn]
 	if run == nil {
-		// Initialize the UISession if this has never been initialized before.
+		// Initialize the UISession and filewatch if this has never been initialized before.
 		err := updateOwnedObjects(ctx, r.ctrlClient, nn, &tf, nil, r.engineMode)
 		if err != nil {
 			return ctrl.Result{}, err

--- a/internal/hud/webview/convert.go
+++ b/internal/hud/webview/convert.go
@@ -259,6 +259,8 @@ func toUIResource(mt *store.ManifestTarget, s store.EngineState) (*v1alpha1.UIRe
 	return r, nil
 }
 
+// TODO(nick): We should build this from the Tiltfile in the apiserver,
+// not the Tiltfile state in EngineState.
 func TiltfileResourceProtoView(name model.ManifestName, ms *store.ManifestState, logStore *logstore.LogStore) *v1alpha1.UIResource {
 	ltfb := ms.LastBuild()
 	ctfb := ms.CurrentBuild


### PR DESCRIPTION
Hello @milas,

Please review the following commits I made in branch nicks/tiltfile2:

e362ad9879a72e7c9825c3a90e23d16f9453a50e (2021-09-07 14:55:34 -0400)
extension: set up filewatch triggers correctly

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics