### PR TITLE
web: don't highlight header titles on multiple clicks

### DIFF
--- a/web/src/OverviewTable.tsx
+++ b/web/src/OverviewTable.tsx
@@ -158,6 +158,7 @@ const ResourceTableHeader = styled(ResourceTableData)`
 const ResourceTableHeaderLabel = styled.div`
   display: flex;
   align-items: center;
+  user-select: none;
 `
 
 const ResourceTableHeaderSortTriangle = styled.div`


### PR DESCRIPTION
### Problem
Clicking on a header column multiple times to cycle through sort orders annoyingly results in the titles being selected
![image](https://user-images.githubusercontent.com/7453991/132415554-57154920-74f3-4155-b6bf-71dc3bd6c13d.png)

### Solution
Make the headers unselectable. Maybe this will be slightly annoying to someone who wants to copy a header title, but the highlighting feels pretty broken as-is.

NB: FWIW, the text inside a header's info tooltip is still selectable after this change