### PR TITLE
extension: propagate extension arg changes correctly

### DIFF
--- a/internal/controllers/core/extension/reconciler_test.go
+++ b/internal/controllers/core/extension/reconciler_test.go
@@ -89,6 +89,33 @@ func TestMissing(t *testing.T) {
 		fmt.Sprintf("no extension tiltfile found at %s", p), ext.Status.Error)
 }
 
+// Verify that args are propagated to the tiltfile when changed.
+func TestChangeArgs(t *testing.T) {
+	f := newFixture(t)
+	f.setupRepo()
+
+	ext := v1alpha1.Extension{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "ext",
+		},
+		Spec: v1alpha1.ExtensionSpec{
+			RepoName: "my-repo",
+			RepoPath: "my-ext",
+			Args:     []string{"--namespace=bar"},
+		},
+	}
+	f.Create(&ext)
+
+	f.MustGet(types.NamespacedName{Name: "ext"}, &ext)
+
+	ext.Spec.Args = []string{"--namespace=foo"}
+	f.Update(&ext)
+
+	var tf v1alpha1.Tiltfile
+	f.MustGet(types.NamespacedName{Name: "ext"}, &tf)
+	require.Equal(t, []string{"--namespace=foo"}, tf.Spec.Args)
+}
+
 type fixture struct {
 	*fake.ControllerFixture
 	*tempdir.TempDirFixture


### PR DESCRIPTION
Hello @milas,

Please review the following commits I made in branch nicks/args:

211609a6b33bfeb0195d334f45c0d07f22897aab (2021-09-08 10:37:07 -0400)
extension: propagate extension arg changes correctly

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics