### PR TITLE
docker-compose: log tailing robustness fixes

### DIFF
--- a/internal/dockercompose/fake_client.go
+++ b/internal/dockercompose/fake_client.go
@@ -11,6 +11,7 @@ import (
 	"unicode"
 
 	"github.com/compose-spec/compose-go/loader"
+	"github.com/stretchr/testify/require"
 
 	"github.com/compose-spec/compose-go/types"
 
@@ -65,12 +66,15 @@ func (c *FakeDCClient) Down(ctx context.Context, configPaths []string, stdout, s
 	return nil
 }
 
-func (c *FakeDCClient) StreamLogs(ctx context.Context, _ []string, serviceName model.TargetName) (io.ReadCloser, error) {
+func (c *FakeDCClient) StreamLogs(ctx context.Context, _ []string, serviceName model.TargetName) io.ReadCloser {
 	output := c.RunLogOutput[serviceName]
 	reader, writer := io.Pipe()
 	go func() {
+		c.t.Helper()
+
 		// docker-compose always logs an "Attaching to foo, bar" at the start of a log session
-		_, _ = writer.Write([]byte(fmt.Sprintf("Attaching to %s\n", serviceName)))
+		_, err := writer.Write([]byte(fmt.Sprintf("Attaching to %s\n", serviceName)))
+		require.NoError(c.t, err, "Failed to write to fake Docker Compose logs")
 
 		done := false
 		for !done {
@@ -84,18 +88,19 @@ func (c *FakeDCClient) StreamLogs(ctx context.Context, _ []string, serviceName m
 					logLine := fmt.Sprintf("%s %s\n",
 						time.Now().Format(time.RFC3339Nano),
 						strings.TrimRightFunc(s, unicode.IsSpace))
-					_, _ = writer.Write([]byte(logLine))
+					_, err = writer.Write([]byte(logLine))
+					require.NoError(c.t, err, "Failed to write to fake Docker Compose logs")
 				}
 			}
 		}
 
 		// we call docker-compose logs with --follow, so it only terminates (normally) when the container exits
 		// and it writes a message with the container exit code
-		_, _ = writer.Write([]byte(fmt.Sprintf("%s exited with code 0\n", serviceName)))
-
-		_ = writer.Close()
+		_, err = writer.Write([]byte(fmt.Sprintf("%s exited with code 0\n", serviceName)))
+		require.NoError(c.t, err, "Failed to write to fake Docker Compose logs")
+		require.NoError(c.t, writer.Close(), "Failed to close fake Docker Compose logs writer")
 	}()
-	return reader, nil
+	return reader
 }
 
 func (c *FakeDCClient) StreamEvents(ctx context.Context, configPaths []string) (<-chan string, error) {

--- a/internal/engine/dcwatch/event_watcher.go
+++ b/internal/engine/dcwatch/event_watcher.go
@@ -26,12 +26,12 @@ func NewEventWatcher(dcc dockercompose.DockerComposeClient, docker docker.LocalC
 	}
 }
 
-func (w *EventWatcher) OnChange(ctx context.Context, st store.RStore, _ store.ChangeSummary) error {
-	if !w.watching {
+func (w *EventWatcher) OnChange(ctx context.Context, st store.RStore, summary store.ChangeSummary) error {
+	// TODO(nick): This should respond dynamically if the path changes.
+	if summary.IsLogOnly() || w.watching {
 		return nil
 	}
 
-	// TODO(nick): This should respond dynamically if the path changes.
 	state := st.RLockState()
 	configPaths := state.DockerComposeConfigPath()
 	st.RUnlockState()

--- a/internal/engine/runtimelog/docker_compose_log_manager.go
+++ b/internal/engine/runtimelog/docker_compose_log_manager.go
@@ -127,18 +127,14 @@ func (m *DockerComposeLogManager) consumeLogs(watch dockerComposeLogWatch, st st
 	name := watch.name
 
 	for {
-		readCloser, err := m.dcc.StreamLogs(watch.ctx, watch.dc.ConfigPaths, watch.dc.Name)
-		if err != nil {
-			logger.Get(watch.ctx).Debugf("Error streaming %s logs: %v", name, err)
-			return
-		}
+		readCloser := m.dcc.StreamLogs(watch.ctx, watch.dc.ConfigPaths, watch.dc.Name)
 		actionWriter := &DockerComposeLogActionWriter{
 			store:        st,
 			manifestName: name,
 			since:        startTime,
 		}
 
-		_, err = io.Copy(actionWriter, readCloser)
+		_, err := io.Copy(actionWriter, readCloser)
 		_ = readCloser.Close()
 		if err == nil || watch.ctx.Err() != nil {
 			// stop tailing because either:

--- a/internal/engine/runtimelog/docker_compose_log_manager.go
+++ b/internal/engine/runtimelog/docker_compose_log_manager.go
@@ -160,12 +160,7 @@ type dockerComposeLogWatch struct {
 }
 
 func (w *dockerComposeLogWatch) Done() bool {
-	select {
-	case <-w.ctx.Done():
-		return true
-	default:
-		return false
-	}
+	return w.ctx.Err() != nil
 }
 
 type DockerComposeLogActionWriter struct {

--- a/internal/engine/runtimelog/docker_compose_log_manager.go
+++ b/internal/engine/runtimelog/docker_compose_log_manager.go
@@ -6,6 +6,9 @@ import (
 	"fmt"
 	"io"
 	"time"
+	"unicode"
+
+	"github.com/docker/docker/api/types"
 
 	"github.com/tilt-dev/tilt/internal/dockercompose"
 	"github.com/tilt-dev/tilt/internal/store"
@@ -51,29 +54,39 @@ func (m *DockerComposeLogManager) diff(ctx context.Context, st store.RStore) (se
 		if ms.CurrentBuild.StartTime.IsZero() && ms.LastBuild().StartTime.IsZero() {
 			continue
 		}
+		dcState := ms.DCRuntimeState()
+		if dcState.ContainerState.StartedAt == "" {
+			// wait for the container to start before attaching so that we can filter out old logs
+			// for job containers that can be re-used
+			continue
+		}
 
-		existing, isActive := m.watches[manifest.Name]
-		startWatchTime := time.Unix(0, 0)
-		if isActive {
-			select {
-			case termTime := <-existing.terminationTime:
-				// If we're receiving on this channel, it's because the previous watcher ended or
-				// died somehow; we need to create a new one that picks up where it left off.
-				startWatchTime = termTime
-			default:
-				// Watcher is still active, no action needed.
+		// Docker evidently records the container start time asynchronously, so it can actually be AFTER
+		// the first log timestamps (also reported by Docker), so we pad it by a second to reduce the
+		// number of potentially duplicative logs
+		startWatchTime := containerStartTime(dcState.ContainerState).Add(-time.Second)
+		existing, hasExisting := m.watches[manifest.Name]
+		if hasExisting {
+			if !existing.Done() {
+				// watcher is already running
+				continue
+			}
+
+			if !existing.startWatchTime.Before(startWatchTime) {
+				// watcher finished but the container hasn't started up again
+				// (N.B. we cannot compare on the container ID because containers can restart and be re-used
+				// 	after being stopped for jobs that run to completion but are re-triggered)
 				continue
 			}
 		}
 
 		ctx, cancel := context.WithCancel(ctx)
 		w := dockerComposeLogWatch{
-			ctx:             ctx,
-			cancel:          cancel,
-			name:            manifest.Name,
-			dc:              manifest.DockerComposeTarget(),
-			startWatchTime:  startWatchTime,
-			terminationTime: make(chan time.Time, 1),
+			ctx:            ctx,
+			cancel:         cancel,
+			name:           manifest.Name,
+			dc:             manifest.DockerComposeTarget(),
+			startWatchTime: startWatchTime,
 		}
 		m.watches[manifest.Name] = w
 		setup = append(setup, w)
@@ -91,7 +104,11 @@ func (m *DockerComposeLogManager) diff(ctx context.Context, st store.RStore) (se
 	return setup, teardown
 }
 
-func (m *DockerComposeLogManager) OnChange(ctx context.Context, st store.RStore, _ store.ChangeSummary) error {
+func (m *DockerComposeLogManager) OnChange(ctx context.Context, st store.RStore, summary store.ChangeSummary) error {
+	if summary.IsLogOnly() {
+		return nil
+	}
+
 	setup, teardown := m.diff(ctx, st)
 	for _, watch := range teardown {
 		watch.cancel()
@@ -104,100 +121,173 @@ func (m *DockerComposeLogManager) OnChange(ctx context.Context, st store.RStore,
 }
 
 func (m *DockerComposeLogManager) consumeLogs(watch dockerComposeLogWatch, st store.RStore) {
-	defer func() {
-		watch.terminationTime <- time.Now()
-	}()
+	defer watch.cancel()
 
+	startTime := watch.startWatchTime
 	name := watch.name
-	readCloser, err := m.dcc.StreamLogs(watch.ctx, watch.dc.ConfigPaths, watch.dc.Name)
-	if err != nil {
-		logger.Get(watch.ctx).Debugf("Error streaming %s logs: %v", name, err)
-		return
-	}
-	defer func() {
-		_ = readCloser.Close()
-	}()
 
-	actionWriter := &DockerComposeLogActionWriter{
-		store:             st,
-		manifestName:      name,
-		isStartingNewLine: true,
-	}
-	_, err = io.Copy(actionWriter, NewHardCancelReader(watch.ctx, readCloser))
-	if err != nil && watch.ctx.Err() == nil {
+	for {
+		readCloser, err := m.dcc.StreamLogs(watch.ctx, watch.dc.ConfigPaths, watch.dc.Name)
+		if err != nil {
+			logger.Get(watch.ctx).Debugf("Error streaming %s logs: %v", name, err)
+			return
+		}
+		actionWriter := &DockerComposeLogActionWriter{
+			store:        st,
+			manifestName: name,
+			since:        startTime,
+		}
+
+		_, err = io.Copy(actionWriter, readCloser)
+		_ = readCloser.Close()
+		if err == nil || watch.ctx.Err() != nil {
+			// stop tailing because either:
+			// 	* docker-compose logs exited naturally -> this means the container exited, so a new watcher will
+			// 	  be created once a new container is seen
+			//  * context was canceled -> manifest is no longer in engine & being torn-down
+			return
+		}
+
+		// something went wrong with docker-compose, log it and re-attach, starting from the last
+		// successfully logged timestamp
 		logger.Get(watch.ctx).Debugf("Error streaming %s logs: %v", name, err)
-		return
+		startTime = actionWriter.LastLogTime()
 	}
 }
 
 type dockerComposeLogWatch struct {
-	ctx             context.Context
-	cancel          func()
-	name            model.ManifestName
-	dc              model.DockerComposeTarget
-	startWatchTime  time.Time
-	terminationTime chan time.Time
+	ctx            context.Context
+	cancel         func()
+	name           model.ManifestName
+	dc             model.DockerComposeTarget
+	startWatchTime time.Time
+}
 
-	// TODO(maia): do we need to track these? (maybe if we implement with `docker logs <cID>`...)
-	// cID             container.ID
-	// cName           container.Name
+func (w *dockerComposeLogWatch) Done() bool {
+	select {
+	case <-w.ctx.Done():
+		return true
+	default:
+		return false
+	}
 }
 
 type DockerComposeLogActionWriter struct {
 	store        store.RStore
 	manifestName model.ManifestName
 
-	// If the next Write() call is on a new line. True when the writer is first
-	// created, or when the previous line ends with "\n".
-	isStartingNewLine bool
+	attachMessageSeen bool
+
+	since    time.Time
+	lastTime time.Time
 }
 
 var newlineAsBytes = []byte("\n")
-var dividerAsBytes = []byte(" | ")
 var attachingToLogAsBytes = []byte("Attaching to ")
+var spaceAsBytes = []byte(" ")
 
 func (w *DockerComposeLogActionWriter) Write(p []byte) (n int, err error) {
 	lines := bytes.Split(p, newlineAsBytes)
-	if w.shouldFilterDCLog(lines) {
-		lines = lines[1:]
-	}
-
-	start := 1
-	if w.isStartingNewLine {
-		start = 0
-	}
-
-	for i := start; i < len(lines); i++ {
-		indexOfDivider := bytes.Index(lines[i], dividerAsBytes)
-		if indexOfDivider >= 0 {
-			newStart := indexOfDivider + len(dividerAsBytes)
-			lines[i] = lines[i][newStart:]
+	if !w.attachMessageSeen {
+		if len(lines) != 0 && bytes.HasPrefix(lines[0], attachingToLogAsBytes) {
+			lines = lines[1:]
+			w.attachMessageSeen = true
 		}
 	}
 
-	if len(lines) == 0 {
+	linesToWrite := make([][]byte, 0, len(lines))
+	for _, line := range lines {
+		hasTimestamp, timestamp, logContent := splitDockerComposeLogLineTimestamp(line)
+		if hasTimestamp {
+			// use version of the log line w/o the timestamp
+			line = logContent
+			w.lastTime = timestamp
+			if !timestamp.After(w.since) {
+				continue
+			}
+		}
+		linesToWrite = append(linesToWrite, line)
+	}
+
+	if len(linesToWrite) == 0 {
 		return len(p), nil
 	}
 
-	// If the last line is empty, then we're starting a newline.
-	w.isStartingNewLine = len(lines[len(lines)-1]) == 0
-	newText := bytes.Join(lines, newlineAsBytes)
+	newText := bytes.Join(linesToWrite, newlineAsBytes)
+
 	w.store.Dispatch(store.NewLogAction(w.manifestName, SpanIDForDCService(w.manifestName), logger.InfoLvl, nil, newText))
 	return len(p), nil
 }
 
-var _ store.Subscriber = &DockerComposeLogManager{}
-
-func (w *DockerComposeLogActionWriter) shouldFilterDCLog(lines [][]byte) bool {
-	if !w.isStartingNewLine {
-		return false
-	}
-	if len(lines) == 0 {
-		return false
-	}
-	return bytes.HasPrefix(lines[0], attachingToLogAsBytes)
+// LastLogTime returns the timestamp of the last log message seen or zero time if none.
+//
+// The last log message seen timestamp might be before the `since` argument, so was discarded.
+//
+// This method is not goroutine-safe: it is intended to be used after the writer is done.
+func (w *DockerComposeLogActionWriter) LastLogTime() time.Time {
+	return w.lastTime
 }
+
+var _ store.Subscriber = &DockerComposeLogManager{}
 
 func SpanIDForDCService(mn model.ManifestName) logstore.SpanID {
 	return logstore.SpanID(fmt.Sprintf("dc:%s", mn))
+}
+
+func containerStartTime(cs types.ContainerState) time.Time {
+	if cs.StartedAt == "" {
+		return time.Time{}
+	}
+	startTime, err := time.Parse(time.RFC3339Nano, cs.StartedAt)
+	if err != nil {
+		return time.Time{}
+	}
+	return startTime
+}
+
+// splitDockerComposeLogLineTimestamp attempts to extract a timestamp from a Docker Compose log line.
+//
+// Tilt invokes `docker-compose logs` with `--timestamps`, which will output timestamps in the RFC3339Nano format
+// at the beginning of each log line with a single space as a divider afterwards. For example, if the container
+// logs "Hello World\n", the output would be:
+// 		2021-09-08T18:24:24.704836400Z Hello World
+//
+// Unfortunately, there are caveats:
+// 	* docker-compose v2 prepends whitespace _before_ the timestamp as well
+//  * Messages originating from docker-compose itself (e.g. container lifecycle messages) do NOT get a timestamp, e.g.
+// 		myproject_my-container_1 exited with code 0
+//
+// As a result, this function tries to be very conservative in extracting the timestamp.
+func splitDockerComposeLogLineTimestamp(line []byte) (bool, time.Time, []byte) {
+	if len(line) < 2 {
+		return false, time.Time{}, nil
+	}
+	// docker-compose v2 prepends a space to every log line
+	if unicode.IsSpace(rune(line[0])) {
+		line = bytes.TrimLeftFunc(line, unicode.IsSpace)
+		if len(line) == 0 {
+			// in case we trim the whole line
+			return false, time.Time{}, nil
+		}
+	}
+
+	// docker-compose emits meta-logs about container events that don't start with a timestamp
+	// N.B. it's actually possible for them to start with a number if the project name (typically dir name)
+	// 	starts with a number, but that's very unlikely so this is used as a short-circuit for the common
+	//  case to avoid attempting a parse that's guaranteed to fail, but it will still fail gracefully later
+	if !unicode.IsDigit(rune(line[0])) {
+		return false, time.Time{}, nil
+	}
+
+	index := bytes.Index(line, spaceAsBytes)
+	if index == -1 {
+		return false, time.Time{}, nil
+	}
+
+	logTimestamp, err := time.Parse(time.RFC3339Nano, string(line[:index]))
+	if err != nil {
+		return false, time.Time{}, nil
+	}
+
+	return true, logTimestamp, line[index+len(spaceAsBytes):]
 }

--- a/internal/engine/runtimelog/docker_compose_log_manager_test.go
+++ b/internal/engine/runtimelog/docker_compose_log_manager_test.go
@@ -2,23 +2,24 @@ package runtimelog
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/tilt-dev/tilt/internal/store"
+	"github.com/tilt-dev/tilt/internal/timecmp"
 )
 
-func TestSimpleWriter(t *testing.T) {
+func TestDockerComposeLogActionWriter_SimpleWriter(t *testing.T) {
 	st := store.NewTestingStore()
 	log := `Attaching to express-redis-docker_app_1, cache
-cache    | # oO0OoO0OoO0Oo Redis is starting oO0OoO0OoO0Oo
-cache    | # Redis version=5.0.7, bits=64, commit=00000000, modified=0, pid=1, just started
+2021-09-08T19:58:01.483005100Z # oO0OoO0OoO0Oo Redis is starting oO0OoO0OoO0Oo
+2021-09-08T19:58:01.483027300Z # Redis version=5.0.7, bits=64, commit=00000000, modified=0, pid=1, just started
 `
 
 	writer := &DockerComposeLogActionWriter{
-		store:             st,
-		isStartingNewLine: true,
+		store: st,
 	}
 	_, err := writer.Write([]byte(log))
 	require.NoError(t, err)
@@ -32,17 +33,16 @@ cache    | # Redis version=5.0.7, bits=64, commit=00000000, modified=0, pid=1, j
 	assert.Equal(t, expected, string(actions[0].(store.LogAction).Message()))
 }
 
-func TestBrokenLine(t *testing.T) {
+func TestDockerComposeLogActionWriter_BrokenLine(t *testing.T) {
 	st := store.NewTestingStore()
 	log1 := `Attaching to express-redis-docker_app_1, cache
-cache    | # oO0OoO0`
+2021-09-08T19:58:01.483005100Z # oO0OoO0`
 	log2 := `OoO0Oo Redis is starting oO0OoO0OoO0Oo
-cache    | # Redis version=5.0.7, bits=64, commit=00000000, modified=0, pid=1, just started
+2021-09-08T19:58:01.483027300Z # Redis version=5.0.7, bits=64, commit=00000000, modified=0, pid=1, just started
 `
 
 	writer := &DockerComposeLogActionWriter{
-		store:             st,
-		isStartingNewLine: true,
+		store: st,
 	}
 	_, err := writer.Write([]byte(log1))
 	require.NoError(t, err)
@@ -59,4 +59,54 @@ cache    | # Redis version=5.0.7, bits=64, commit=00000000, modified=0, pid=1, j
 # Redis version=5.0.7, bits=64, commit=00000000, modified=0, pid=1, just started
 `
 	assert.Equal(t, expected2, string(actions[1].(store.LogAction).Message()))
+}
+
+func TestDockerComposeLogActionWriter_SinceFilter(t *testing.T) {
+	st := store.NewTestingStore()
+	log := `Attaching to express-redis-docker_app_1, cache
+2021-09-08T19:58:01.483005100Z # oO0OoO0OoO0Oo Redis is starting oO0OoO0OoO0Oo
+2021-09-16T19:58:01.483027300Z # Redis version=5.0.7, bits=64, commit=00000000, modified=0, pid=1, just started
+`
+
+	writer := &DockerComposeLogActionWriter{
+		store: st,
+		// since is exclusive, so the first line should not appear
+		since: time.Date(2021, 9, 8, 19, 58, 1, 483005100, time.UTC),
+	}
+	_, err := writer.Write([]byte(log))
+	require.NoError(t, err)
+
+	actions := st.Actions()
+	require.Equal(t, 1, len(actions))
+
+	expected := "# Redis version=5.0.7, bits=64, commit=00000000, modified=0, pid=1, just started\n"
+	require.Equal(t, expected, string(actions[0].(store.LogAction).Message()))
+	timecmp.RequireTimeEqual(t,
+		time.Date(2021, 9, 16, 19, 58, 1, 483027300, time.UTC),
+		writer.LastLogTime())
+}
+
+func TestDockerComposeLogActionWriter_v2DateFormat(t *testing.T) {
+	st := store.NewTestingStore()
+	// N.B. there is a single space at the beginning of each _app_ log line before the timestamp w/ Compose v2
+	log := `Attaching to express-redis-docker_app_1
+ 2021-09-08T19:58:01.483005100Z # oO0OoO0OoO0Oo Redis is starting oO0OoO0OoO0Oo
+ 2021-09-16T19:58:01.483027300Z # Redis version=5.0.7, bits=64, commit=00000000, modified=0, pid=1, just started
+express-redis-docker_app_1 exited with code 0
+`
+
+	writer := &DockerComposeLogActionWriter{
+		store: st,
+	}
+	_, err := writer.Write([]byte(log))
+	require.NoError(t, err)
+
+	actions := st.Actions()
+	require.Equal(t, 1, len(actions))
+
+	expected := `# oO0OoO0OoO0Oo Redis is starting oO0OoO0OoO0Oo
+# Redis version=5.0.7, bits=64, commit=00000000, modified=0, pid=1, just started
+express-redis-docker_app_1 exited with code 0
+`
+	assert.Equal(t, expected, string(actions[0].(store.LogAction).Message()))
 }

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -2710,8 +2710,7 @@ func TestDockerComposeFiltersRunLogs(t *testing.T) {
 	fakeServiceLog := make(chan string)
 	close(fakeServiceLog)
 	f.dcc.RunLogOutput["fake-service"] = fakeServiceLog
-	r, err := f.dcc.StreamLogs(f.ctx, nil, "fake-service")
-	require.NoError(t, err, "Failed to set up fake Docker Compose log stream")
+	r := f.dcc.StreamLogs(f.ctx, nil, "fake-service")
 	sampleDCLogOutput, err := io.ReadAll(r)
 	require.NoError(t, err, "Failed to read fake Docker Compose log stream")
 	assert.Equal(t, string(sampleDCLogOutput),


### PR DESCRIPTION
The core issue this aims to solve is that for a stopped container,
`docker-compose logs` exits, and Tilt would continuously attempt
to re-launch it, resulting in high CPU usage due to repeatedly
invoking the command.

However, there were actually several intermingled issues that this
exposed/worsened. These mostly tie back to the behavior of
`docker-compose logs`: there is no built-in support for time
filtering (unlike `docker logs --since ...`), and since it exits
when a container stops, once invoked again, all the old logs will
be returned again. This means if a container crashes/restarts,
we'd re-emit all the old logs each time. Similarly, if there is
a "job" container that naturally runs to completion, whenever
re-triggered from the UI to run it, all the logs from prior
invocations would be re-logged. (This could also mean when attaching
on start up that you'd get a bunch of logs prior to the last
[re]start, which isn't super useful either.)

To solve this issue, `docker-compose logs` is now invoked with the
`--timestamps` argument, which prepends an RFC3339Nano timestamp
before each log line. Of course, there are caveats: first, Compose
v2 includes a whitespace before the timestamp and second, meta logs
from Compose itself about container events do NOT have a timestamp.
As a result, the attempt to parse/filter by the timestamp is _very_
forgiving. (There's an additional wrinkle which is that evidently
the `StartedAt` time reported by Docker for a container is not
precise, so you can actually get logs with earlier timestamps!)

Tying back to the original problem that once `docker-compose logs`
exits, Tilt tries to continuously re-invoke it, the watcher behavior
has been altered to more closely mirror the Pod log stream watcher.
When reading, if EOF is reached and/or the context is canceled,
it stops. The former case means that `docker-compose logs` exited
normally, indicating that the container is no longer running. The
latter case means the manifest is being torn down, so we no longer
want logs. Any errors during reading will cause it to retry, e.g.
if `docker-compose logs` crashes or is terminated abnormally.
(To support propagating process execution errors, the way that
logs are read has been adjusted slightly, which actually resolves
a race condition on reading logs and the `docker-compose logs`
process terminating, which ensures that short-lived containers
get all their logs!)

In the subscriber, when looking at already created watchers, if
the watcher has stopped running, a new one will only be created
if the corresponding container's start time is AFTER the last
time it started. This is the key to not continuously starting
up new `docker-compose logs` processes! (Finally.) We can't
key off container ID because that's consistent across restarts,
including both crashes and job containers that are run multiple
times without changes.

Finally, there is a fix for the Docker Compose event watcher
which was inadvertently broken (by yours truly) a while back.
It was not actually _ever_ running, so Tilt wouldn't notice
external changes (e.g. `docker-compose restart foo`), which
meant state was out of sync. This was not really noticeable
before since we were insanely aggressive about re-establishing
`docker-compose logs` sessions. After these fixes, however,
it meant that any container events _not_ initiated via Tilt
would go unnoticed, so the logs would not get resumed, as the
new container start time would never get picked up.

TL;DR Docker Compose logs should behave much nicer now both
      in terms of CPU usage as well as under various common
      scenarios like container restarts or job containers

Fixes #4904.