### PR TITLE
web: add enable/disable button to resource view

### DIFF
--- a/internal/feature/flags.go
+++ b/internal/feature/flags.go
@@ -24,6 +24,7 @@ const Snapshots = "snapshots"
 const UpdateHistory = "update_history"
 const Facets = "facets"
 const Labels = "labels"
+const DisableResources = "disable_resources"
 
 // The Value a flag can have. Status should never be changed.
 type Value struct {
@@ -59,6 +60,10 @@ var MainDefaults = Defaults{
 	},
 	Labels: Value{
 		Enabled: true,
+		Status:  Active,
+	},
+	DisableResources: Value{
+		Enabled: false,
 		Status:  Active,
 	},
 }

--- a/web/src/feature.ts
+++ b/web/src/feature.ts
@@ -15,6 +15,7 @@ export enum Flag {
   UpdateHistory = "update_history",
   Facets = "facets",
   Labels = "labels",
+  DisableResources = "disable_resources",
 }
 
 export default class Features {


### PR DESCRIPTION
The button currently doesn't actually do anything other than cycle through enable/disable/confirm.

It's hidden behind a disabled feature flag for now, so users won't see it.

![image](https://user-images.githubusercontent.com/7453991/132698815-fe57693e-2462-4ded-be44-e8242e267413.png)
