### PR TITLE
engine: fix flaky Docker Compose test

### DIFF
--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -2731,6 +2731,12 @@ fake-service exited with code 0
 	f.loadAndStart()
 	f.waitForCompletedBuildCount(2)
 
+	f.WaitUntil("wait until manifest state has a log", func(state store.EngineState) bool {
+		ms, _ := state.ManifestState(m.ManifestName())
+		spanID := ms.DCRuntimeState().SpanID
+		return spanID != "" && state.LogStore.SpanLog(spanID) != ""
+	})
+
 	// recorded on manifest state
 	f.withState(func(es store.EngineState) {
 		ms, _ := es.ManifestState(m.ManifestName())


### PR DESCRIPTION
This is not the result of any behavior changes from the recent
Docker Compose changes. This test is a negative test case to
ensure we filter out the "Attaching to foo" message Docker Compose
emits at the beginning of every log session. Previously, it was
only checking that it hadn't seen that exact message. In attempt
to tighten it up, it now asserts that it hasn't seen that message
AND that it HAS seen a message that _should_ be output.

Turns out that there was a race in the test, so it was looking at
the logs while they were still empty sometimes. It would pass
before but fails now due to being stricter.

The solution is a copy-paste from another DC test that relies
on logs.