### PR TITLE
web: fix rendering of disabled api buttons

### DIFF
--- a/web/src/GlobalNav.tsx
+++ b/web/src/GlobalNav.tsx
@@ -62,9 +62,8 @@ export const MenuButtonMixin = `
     fill: ${Color.grayDarker};
   }
 
-  &.is-disabled {
-    pointer-events: none;
-    cursor: default;
+  &:disabled {
+    opacity: 0.33;
   }
 `
 export const MenuButton = styled.button`

--- a/web/src/OverviewButton.tsx
+++ b/web/src/OverviewButton.tsx
@@ -34,8 +34,9 @@ export const OverviewButtonMixin = `
   }
 
   &:disabled {
-    cursor: not-allowed;
     opacity: 0.33;
+    border: 1px solid ${ColorRGBA(Color.grayLightest, 0.5)};
+    color: ${Color.gray7};
   }
 
   & .fillStd {


### PR DESCRIPTION
Fixes #4954 

### Problems
1. In the overview action bar, when a uibutton is disabled, its submit button is effectively invisible. Also, its options button gets no disabled styling.
2. In the nav bar, there's no visual indication that a button is disabled.
3. The UI was not showing the appropriate cursor on disabled buttons.

### Solutions
1. Fix the disabled styling for overview buttons and apply the same to the options button.
  1. I accomplished the latter by just disabling the options button, which is hacky, but was almost free and seems unlikely to have much user impact. If a user notices this we can spend the time to apply the styling without disabling the button, or if anyone thinks that's worth the time now, I'll do it.
2. Add some opacity to the disabled styling for nav bar buttons.
3. Apply the [mui workaround](https://material-ui.com/components/buttons/#cursor-not-allowed) to fix the cursor on disabled buttons.

Here's a screenshot with some disabled buttons:
![image](https://user-images.githubusercontent.com/7453991/132900656-c5c70418-09b6-4a4e-9ad6-72927c67173a.png)

