### PR TITLE
tiltfile: clarify unexpected positional args error

### DIFF
--- a/internal/tiltfile/config/config_def.go
+++ b/internal/tiltfile/config/config_def.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	"strings"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
@@ -119,7 +120,9 @@ func (cd ConfigDef) parseArgs(args []string) (ret configMap, output string, err 
 
 	if len(fs.Args()) > 0 {
 		if cd.positionalSettingName == "" {
-			return nil, w.String(), errors.New("positional args were specified, but none were expected (no setting defined with args=True)")
+			return nil, w.String(), fmt.Errorf(
+				"invalid tiltfile config args: positional CLI args (%q) were specified, but none were expected.\n"+
+					"See https://docs.tilt.dev/tiltfile_config.html#positional-arguments for examples.", strings.Join(fs.Args(), " "))
 		} else {
 			for _, arg := range fs.Args() {
 				err := ret[cd.positionalSettingName].Set(arg)

--- a/internal/tiltfile/config/config_test.go
+++ b/internal/tiltfile/config/config_test.go
@@ -242,7 +242,10 @@ cfg = config.parse()
 
 	_, err := f.ExecFile("Tiltfile")
 	require.Error(t, err)
-	require.Equal(t, "positional args were specified, but none were expected (no setting defined with args=True)", err.Error())
+	require.Equal(t,
+		"invalid tiltfile config args: positional CLI args (\"do re mi\") were specified, but none were expected.\n"+
+			"See https://docs.tilt.dev/tiltfile_config.html#positional-arguments for examples.",
+		err.Error())
 }
 
 func TestUsage(t *testing.T) {


### PR DESCRIPTION
This sounds like a Starlark syntax error, but it's actually about
the CLI args passed to `tilt up` if there's no Tiltfile config
positional option defined.

The text has been adjusted slightly to explicilty refer to "CLI
args" and links to a (new) section in the docs (see
tilt-dev/tilt.build#941).

No behavior has changed.