### PR TITLE
ci: fix Windows + Javascript jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ jobs:
 
   build-js:
     docker:
-      - image: circleci/node:16
+      - image: cimg/node:16.8
     steps:
       - checkout
       - run: make check-js

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,7 +75,7 @@ jobs:
       size: "large"
     steps:
       - run: choco install make kustomize kubernetes-helm docker-compose
-      - run: choco update golang --version=1.16.2
+      - run: choco upgrade -y --allow-downgrade golang --version=1.16.2
       - run: go get -u gotest.tools/gotestsum
       - checkout
       # Check to make sure Windows binaries compile


### PR DESCRIPTION
# test-windows
Temporarily allow downgrading to Go 1.16 until we upgrade all
OSes to 1.17 for test/release.

# build-js
NodeJS v16.9.0 has a regression causing a crash:
```
Check failed: !holder_map.has_named_interceptor().
```

Temporarily pin to v16.8.
