### PR TITLE
docker-compose: version detection logic

### DIFF
--- a/.circleci/Dockerfile.integration
+++ b/.circleci/Dockerfile.integration
@@ -3,7 +3,7 @@ FROM golang:1.16
 # Install docker
 # Adapted from https://github.com/circleci/circleci-images/blob/staging/shared/images/Dockerfile-basic.template
 # Check https://download.docker.com/linux/static/stable/x86_64/ for latest versions
-ENV DOCKER_VERSION=19.03.5
+ENV DOCKER_VERSION=20.10.6
 RUN set -exu \
   && DOCKER_URL="https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_VERSION}.tgz" \
   && echo Docker URL: $DOCKER_URL \
@@ -16,7 +16,7 @@ RUN set -exu \
   && (docker version || true)
 
 # Install docker-compose
-RUN curl -fL "https://github.com/docker/compose/releases/download/1.23.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose \
+RUN curl -fL "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose \
   && chmod a+x /usr/local/bin/docker-compose \
   && docker-compose version
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,7 +88,7 @@ jobs:
   build-integration:
     resource_class: medium+
     docker:
-      - image: gcr.io/windmill-public-containers/tilt-integration-ci@sha256:d41a891455a232a865c7abc1e2ffe25b1a78a207a6ea00feeb1a0c26c58f1eeb
+      - image: gcr.io/windmill-public-containers/tilt-integration-ci@sha256:5bd1575a8c47e52607a490b9498c112e616e43d90811b068811f796cb88add99
     steps:
       - checkout
       - run: echo 'export PATH=/go/bin:$PATH' >> $BASH_ENV
@@ -146,7 +146,7 @@ jobs:
           path: test-results
       - slack/notify-on-failure:
           only_for_branches: master
-          
+
   deploy-storybook:
     docker:
       - image: cimg/base:2020.01
@@ -167,7 +167,7 @@ jobs:
       - run: ./configs/storybook/deploy.sh
       - slack/notify-on-failure:
           only_for_branches: master
-          
+
   release:
     resource_class: medium+
     docker:
@@ -195,9 +195,8 @@ workflows:
       - shellcheck/check:
           dir: scripts
           exclude: SC2001
-          
+
   build:
-        
     # The linux job is cheaper than the others, so run that first.
     jobs:
       - build-linux
@@ -229,16 +228,16 @@ workflows:
           filters:
             branches:
               only: master
-              
+
   release:
     jobs:
       - release:
           context:
-          - Tilt Slack Context
-          - Tilt Release CLI Context
-          - Tilt Docker Login Context
-          - Tilt Cloud Login Context
-          - Tilt Deploy Context
+            - Tilt Slack Context
+            - Tilt Release CLI Context
+            - Tilt Docker Login Context
+            - Tilt Cloud Login Context
+            - Tilt Deploy Context
           filters:
             branches:
               only: never-release-on-a-branch

--- a/go.mod
+++ b/go.mod
@@ -77,6 +77,7 @@ require (
 	go.opencensus.io v0.22.4
 	go.opentelemetry.io/otel v0.2.0
 	go.starlark.net v0.0.0-20200615180055-61b64bc45990
+	golang.org/x/mod v0.3.1-0.20200828183125-ce943fd02449
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	google.golang.org/genproto v0.0.0-20201110150050-8816d57aaa9a
 	google.golang.org/grpc v1.29.1

--- a/internal/dockercompose/client.go
+++ b/internal/dockercompose/client.go
@@ -235,7 +235,7 @@ func (c *cmdDCClient) Version(ctx context.Context) (string, error) {
 	if err != nil {
 		return "", FormatError(cmd, stdout, err)
 	}
-	return ParseComposeVersionOutput(stdout)
+	return parseComposeVersionOutput(stdout)
 }
 
 func (c *cmdDCClient) loadProject(configPaths []string) (*types.Project, error) {
@@ -320,9 +320,9 @@ func (c *cmdDCClient) dcOutput(ctx context.Context, configPaths []string, args .
 	return strings.TrimSpace(string(output)), err
 }
 
-// ParseComposeVersionOutput parses the raw output of `docker-compose --version` (v1) or `docker-compose version` (v2)
+// parseComposeVersionOutput parses the raw output of `docker-compose version` for both v1.x + v2.x Compose
 // and returns the semver or an error.
-func ParseComposeVersionOutput(stdout []byte) (string, error) {
+func parseComposeVersionOutput(stdout []byte) (string, error) {
 	// match 0: raw output
 	// match 1: version w/o leading v (required)
 	// match 2: build (optional - unused)

--- a/internal/dockercompose/client_test.go
+++ b/internal/dockercompose/client_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/compose-spec/compose-go/types"
@@ -72,7 +73,11 @@ func TestVariableInterpolation(t *testing.T) {
 func TestPreferComposeV1(t *testing.T) {
 	t.Run("v1 Symlink Exists", func(t *testing.T) {
 		tmpdir := t.TempDir()
-		binPath := filepath.Join(tmpdir, "docker-compose-v1")
+		v1Name := "docker-compose-v1"
+		if runtime.GOOS == "windows" {
+			v1Name += ".exe"
+		}
+		binPath := filepath.Join(tmpdir, v1Name)
 		require.NoError(t, os.WriteFile(binPath, nil, 0777),
 			"Failed to create fake docker-compose-v1 binary")
 

--- a/internal/dockercompose/client_test.go
+++ b/internal/dockercompose/client_test.go
@@ -1,7 +1,9 @@
-package dockercompose_test
+package dockercompose
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/compose-spec/compose-go/types"
@@ -9,7 +11,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/tilt-dev/tilt/internal/docker"
-	"github.com/tilt-dev/tilt/internal/dockercompose"
 	"github.com/tilt-dev/tilt/internal/testutils"
 	"github.com/tilt-dev/tilt/internal/testutils/tempdir"
 )
@@ -68,10 +69,69 @@ func TestVariableInterpolation(t *testing.T) {
 	}
 }
 
+func TestPreferComposeV1(t *testing.T) {
+	t.Run("v1 Symlink Exists", func(t *testing.T) {
+		tmpdir := t.TempDir()
+		binPath := filepath.Join(tmpdir, "docker-compose-v1")
+		require.NoError(t, os.WriteFile(binPath, nil, 0777),
+			"Failed to create fake docker-compose-v1 binary")
+
+		testutils.Setenv(t, "PATH", tmpdir)
+		cli, ok := NewDockerComposeClient(docker.LocalEnv{}).(*cmdDCClient)
+		require.True(t, ok, "Unexpected type for Compose client: %T", cli)
+		assert.Equal(t, binPath, cli.composePath)
+	})
+
+	t.Run("No v1 Symlink Exists", func(t *testing.T) {
+		testutils.Unsetenv(t, "PATH")
+		cli, ok := NewDockerComposeClient(docker.LocalEnv{}).(*cmdDCClient)
+		require.True(t, ok, "Unexpected type for Compose client: %T", cli)
+		// if docker-compose-v1 isn't in path, we just set the path to the unqualified binary name and let it get
+		// resolved at exec time
+		assert.Equal(t, "docker-compose", cli.composePath)
+	})
+}
+
+func TestParseComposeVersionOutput(t *testing.T) {
+	type tc struct {
+		version string
+		output  []byte
+	}
+	tcs := []tc{
+		{
+			version: "v1.4.0",
+			output: []byte(`docker-compose version: 1.4.0
+docker-py version: 1.3.1
+CPython version: 2.7.9
+OpenSSL version: OpenSSL 1.0.1e 11 Feb 2013
+`),
+		},
+		{
+			version: "v1.29.2",
+			output: []byte(`docker-compose version 1.29.2, build 5becea4c
+docker-py version: 5.0.0
+CPython version: 3.7.10
+OpenSSL version: OpenSSL 1.1.0l  10 Sep 2019
+`),
+		},
+		{
+			version: "v2.0.0-rc.3",
+			output:  []byte("Docker Compose version v2.0.0-rc.3\n"),
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.version, func(t *testing.T) {
+			version, err := ParseComposeVersionOutput(tc.output)
+			require.NoError(t, err)
+			require.Equal(t, tc.version, version)
+		})
+	}
+}
+
 type dcFixture struct {
 	t      testing.TB
 	ctx    context.Context
-	cli    dockercompose.DockerComposeClient
+	cli    DockerComposeClient
 	tmpdir *tempdir.TempDirFixture
 }
 
@@ -84,7 +144,7 @@ func newDCFixture(t testing.TB) *dcFixture {
 	return &dcFixture{
 		t:      t,
 		ctx:    ctx,
-		cli:    dockercompose.NewDockerComposeClient(docker.LocalEnv{}),
+		cli:    NewDockerComposeClient(docker.LocalEnv{}),
 		tmpdir: tmpdir,
 	}
 }

--- a/internal/dockercompose/client_test.go
+++ b/internal/dockercompose/client_test.go
@@ -126,7 +126,7 @@ OpenSSL version: OpenSSL 1.1.0l  10 Sep 2019
 	}
 	for _, tc := range tcs {
 		t.Run(tc.version, func(t *testing.T) {
-			version, err := ParseComposeVersionOutput(tc.output)
+			version, err := parseComposeVersionOutput(tc.output)
 			require.NoError(t, err)
 			require.Equal(t, tc.version, version)
 		})

--- a/internal/dockercompose/fake_client.go
+++ b/internal/dockercompose/fake_client.go
@@ -27,6 +27,7 @@ type FakeDCClient struct {
 	ContainerIdOutput container.ID
 	eventJson         chan string
 	ConfigOutput      string
+	VersionOutput     string
 
 	UpCalls   []UpCall
 	DownError error
@@ -152,4 +153,12 @@ func (c *FakeDCClient) Project(_ context.Context, _ []string) (*types.Project, e
 
 func (c *FakeDCClient) ContainerID(ctx context.Context, configPaths []string, serviceName model.TargetName) (container.ID, error) {
 	return c.ContainerIdOutput, nil
+}
+
+func (c *FakeDCClient) Version(_ context.Context) (string, error) {
+	if c.VersionOutput != "" {
+		return c.VersionOutput, nil
+	}
+	// default to a "known good" version that won't produce warnings
+	return "v1.29.2", nil
 }

--- a/internal/tiltfile/docker_compose_test.go
+++ b/internal/tiltfile/docker_compose_test.go
@@ -6,9 +6,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/tilt-dev/tilt/internal/testutils"
-
 	"github.com/tilt-dev/tilt/internal/dockercompose"
+	"github.com/tilt-dev/tilt/internal/testutils"
 )
 
 // ParseConfig must return services topologically sorted wrt dependencies.

--- a/internal/tiltfile/tiltfile_docker_compose_test.go
+++ b/internal/tiltfile/tiltfile_docker_compose_test.go
@@ -794,7 +794,7 @@ func TestDockerComposeVersionWarnings(t *testing.T) {
 		error   string
 	}
 	tcs := []tc{
-		{version: "v1.28.0", error: "Tilt requires a Docker Compose v1.28.3+ (you have v1.28.0). Please upgrade and re-launch Tilt."},
+		{version: "v1.28.0", error: "Tilt requires Docker Compose v1.28.3+ (you have v1.28.0). Please upgrade and re-launch Tilt."},
 		{version: "v2.0.0-rc.3", warning: "Tilt has known issues with Docker Compose v2."},
 		{version: "v1.29.2" /* no errors or warnings */},
 	}

--- a/internal/tiltfile/tiltfile_docker_compose_test.go
+++ b/internal/tiltfile/tiltfile_docker_compose_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/mod/semver"
 
 	ctrltiltfile "github.com/tilt-dev/tilt/internal/controllers/apis/tiltfile"
 	"github.com/tilt-dev/tilt/internal/dockercompose"
@@ -795,8 +796,11 @@ func TestDockerComposeVersionWarnings(t *testing.T) {
 	}
 	tcs := []tc{
 		{version: "v1.28.0", error: "Tilt requires Docker Compose v1.28.3+ (you have v1.28.0). Please upgrade and re-launch Tilt."},
-		{version: "v2.0.0-rc.3", warning: "Tilt has known issues with Docker Compose v2."},
+		{version: "v2.0.0-rc.3", warning: "Support for Docker Compose v2.x is experimental, and you might encounter errors or broken functionality.\n" +
+			"For best results, we recommend using Docker Compose v1.x with Tilt."},
 		{version: "v1.29.2" /* no errors or warnings */},
+		{version: "v1.99.0-beta.4", warning: "You are running a pre-release version of Docker Compose (v1.99.0-beta.4), which is unsupported.\n" +
+			"You might encounter errors or broken functionality."},
 	}
 
 	for _, tc := range tcs {
@@ -814,7 +818,7 @@ func TestDockerComposeVersionWarnings(t *testing.T) {
 			if tl, ok := loader.(tiltfileLoader); ok {
 				dcCli := dockercompose.NewFakeDockerComposeClient(t, f.ctx)
 				dcCli.ConfigOutput = simpleConfig
-				dcCli.VersionOutput = tc.version
+				dcCli.VersionOutput = semver.Canonical(tc.version)
 				tl.dcCli = dcCli
 				loader = tl
 			} else {

--- a/internal/tiltfile/tiltfile_state.go
+++ b/internal/tiltfile/tiltfile_state.go
@@ -1230,7 +1230,11 @@ func (s *tiltfileState) validateDockerComposeVersion() error {
 			// maintain compatibility with existing tooling
 			downgradeInstructions = "Ensure `docker-compose` in your PATH points to Compose v1 and re-launch Tilt.\n"
 		}
-		logger.Get(s.ctx).Warnf("Tilt has known issues with Docker Compose v2.\n%s", downgradeInstructions)
+		logger.Get(s.ctx).Warnf("Support for Docker Compose v2.x is experimental, and you might encounter errors or broken functionality.\n"+
+			"For best results, we recommend using Docker Compose v1.x with Tilt.\n%s", downgradeInstructions)
+	} else if semver.Prerelease(dcVersion) != "" {
+		logger.Get(s.ctx).Warnf("You are running a pre-release version of Docker Compose (%s), which is unsupported.\n"+
+			"You might encounter errors or broken functionality.", dcVersion)
 	}
 	return nil
 }

--- a/internal/tiltfile/tiltfile_state.go
+++ b/internal/tiltfile/tiltfile_state.go
@@ -1215,7 +1215,7 @@ func (s *tiltfileState) validateDockerComposeVersion() error {
 		logger.Get(s.ctx).Debugf("Failed to determine Docker Compose version: %v", err)
 	} else if semver.Compare(dcVersion, minimumDockerComposeVersion) == -1 {
 		return fmt.Errorf(
-			"Tilt requires a Docker Compose %s+ (you have %s). Please upgrade and re-launch Tilt.",
+			"Tilt requires Docker Compose %s+ (you have %s). Please upgrade and re-launch Tilt.",
 			minimumDockerComposeVersion,
 			dcVersion)
 	} else if semver.Major(dcVersion) == "v2" {

--- a/internal/tiltfile/tiltfile_state.go
+++ b/internal/tiltfile/tiltfile_state.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/docker/distribution/reference"
@@ -11,10 +12,11 @@ import (
 	"github.com/pkg/errors"
 	"go.starlark.net/starlark"
 	"go.starlark.net/syntax"
+	"golang.org/x/mod/semver"
 
 	"github.com/tilt-dev/tilt/internal/controllers/apiset"
 	"github.com/tilt-dev/tilt/internal/localexec"
-	links "github.com/tilt-dev/tilt/internal/tiltfile/links"
+	"github.com/tilt-dev/tilt/internal/tiltfile/links"
 	"github.com/tilt-dev/tilt/internal/tiltfile/print"
 	"github.com/tilt-dev/tilt/internal/tiltfile/probe"
 	"github.com/tilt-dev/tilt/internal/tiltfile/sys"
@@ -262,6 +264,12 @@ If you're sure you want to deploy there, add:
 to your Tiltfile. Otherwise, switch k8s contexts and restart Tilt.`, kubeContext, kubeContext)
 		}
 	} else {
+		if !resources.dc.Empty() {
+			if err := s.validateDockerComposeVersion(); err != nil {
+				return nil, result, err
+			}
+		}
+
 		manifests, err = s.translateDC(resources.dc)
 		if err != nil {
 			return nil, result, err
@@ -1196,6 +1204,34 @@ func (s *tiltfileState) validateLiveUpdate(iTarget model.ImageTarget, g model.Ta
 		}
 	}
 
+	return nil
+}
+
+func (s *tiltfileState) validateDockerComposeVersion() error {
+	const minimumDockerComposeVersion = "v1.28.3"
+
+	dcVersion, err := s.dcCli.Version(s.ctx)
+	if err != nil {
+		logger.Get(s.ctx).Debugf("Failed to determine Docker Compose version: %v", err)
+	} else if semver.Compare(dcVersion, minimumDockerComposeVersion) == -1 {
+		return fmt.Errorf(
+			"Tilt requires a Docker Compose %s+ (you have %s). Please upgrade and re-launch Tilt.",
+			minimumDockerComposeVersion,
+			dcVersion)
+	} else if semver.Major(dcVersion) == "v2" {
+		var downgradeInstructions string
+		if runtime.GOOS == "windows" || runtime.GOOS == "darwin" {
+			// `docker-compose` on Docker Desktop is a shim that conditionally execs either v1 or v2
+			downgradeInstructions = "Run `docker-compose disable-v2` and re-launch Tilt."
+		} else {
+			// Compose v2 on Linux is a Docker plugin, used by running "docker compose" (notice the lack of hyphen -
+			// it's a subcommand found by searching `~/.docker/cli-plugins`), so if `docker-compose` points to v2,
+			// there must be a custom symlink; this will likely become more common over time as users want to
+			// maintain compatibility with existing tooling
+			downgradeInstructions = "Ensure `docker-compose` in your PATH points to Compose v1 and re-launch Tilt.\n"
+		}
+		logger.Get(s.ctx).Warnf("Tilt has known issues with Docker Compose v2.\n%s", downgradeInstructions)
+	}
 	return nil
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -642,6 +642,7 @@ golang.org/x/crypto/ssh
 golang.org/x/crypto/ssh/agent
 golang.org/x/crypto/ssh/terminal
 # golang.org/x/mod v0.3.1-0.20200828183125-ce943fd02449
+## explicit
 golang.org/x/mod/module
 golang.org/x/mod/semver
 # golang.org/x/net v0.0.0-20210428140749-89ef3d95e781


### PR DESCRIPTION
There's two parts here:
 1. Look for the `docker-compose-v1` binary in the path and prefer
    that (fall back to `docker-compose` if it does not exist) until
    Compose v2 is stable and does not have issues with Tilt

 2. Add `DockerComposeClient::Version()` method and use it during
    Tiltfile load to either error if a minimum version is not met
    or warn if v2 is being used; the latter check can be adjusted
    to only warn for v2 under a minimum version once it's stable
    and known issues with Tilt have been addressed