### PR TITLE
web: add resource name filter to Table View

### DIFF
--- a/web/src/HUD.tsx
+++ b/web/src/HUD.tsx
@@ -21,7 +21,7 @@ import OverviewResourcePane from "./OverviewResourcePane"
 import OverviewTablePane from "./OverviewTablePane"
 import PathBuilder, { PathBuilderProvider } from "./PathBuilder"
 import { ResourceGroupsContextProvider } from "./ResourceGroupsContext"
-import { ResourceListOptionsContextProvider } from "./ResourceListOptionsContext"
+import { ResourceListOptionsProvider } from "./ResourceListOptionsContext"
 import { ResourceNavProvider } from "./ResourceNav"
 import ShareSnapshotModal from "./ShareSnapshotModal"
 import { TiltSnackbarProvider } from "./Snackbar"
@@ -258,7 +258,7 @@ export default class HUD extends Component<HudProps, HudState> {
             <PathBuilderProvider value={this.pathBuilder}>
               <LogStoreProvider value={this.state.logStore || new LogStore()}>
                 <ResourceGroupsContextProvider>
-                  <ResourceListOptionsContextProvider>
+                  <ResourceListOptionsProvider>
                     <Switch>
                       <Route
                         path={this.path("/r/:name/overview")}
@@ -272,7 +272,7 @@ export default class HUD extends Component<HudProps, HudState> {
                         )}
                       />
                     </Switch>
-                  </ResourceListOptionsContextProvider>
+                  </ResourceListOptionsProvider>
                 </ResourceGroupsContextProvider>
               </LogStoreProvider>
             </PathBuilderProvider>

--- a/web/src/OverviewResourcePane.stories.tsx
+++ b/web/src/OverviewResourcePane.stories.tsx
@@ -5,7 +5,7 @@ import Features, { FeaturesProvider, Flag } from "./feature"
 import LogStore, { LogStoreProvider } from "./LogStore"
 import OverviewResourcePane from "./OverviewResourcePane"
 import { ResourceGroupsContextProvider } from "./ResourceGroupsContext"
-import { ResourceListOptionsContextProvider } from "./ResourceListOptionsContext"
+import { ResourceListOptionsProvider } from "./ResourceListOptionsContext"
 import { ResourceNavProvider } from "./ResourceNav"
 import { TiltSnackbarProvider } from "./Snackbar"
 import { StarredResourceMemoryProvider } from "./StarredResourcesContext"
@@ -29,7 +29,7 @@ export default {
           <TiltSnackbarProvider>
             <FeaturesProvider value={features}>
               <ResourceGroupsContextProvider>
-                <ResourceListOptionsContextProvider>
+                <ResourceListOptionsProvider>
                   <StarredResourceMemoryProvider>
                     <div style={{ margin: "-1rem", height: "80vh" }}>
                       <StylesProvider injectFirst>
@@ -37,7 +37,7 @@ export default {
                       </StylesProvider>
                     </div>
                   </StarredResourceMemoryProvider>
-                </ResourceListOptionsContextProvider>
+                </ResourceListOptionsProvider>
               </ResourceGroupsContextProvider>
             </FeaturesProvider>
           </TiltSnackbarProvider>

--- a/web/src/OverviewResourceSidebar.stories.tsx
+++ b/web/src/OverviewResourceSidebar.stories.tsx
@@ -5,7 +5,7 @@ import Features, { FeaturesProvider, Flag } from "./feature"
 import LogStore, { LogStoreProvider } from "./LogStore"
 import OverviewResourceSidebar from "./OverviewResourceSidebar"
 import { ResourceGroupsContextProvider } from "./ResourceGroupsContext"
-import { ResourceListOptionsContextProvider } from "./ResourceListOptionsContext"
+import { ResourceListOptionsProvider } from "./ResourceListOptionsContext"
 import { Width } from "./style-helpers"
 import {
   nResourceView,
@@ -123,9 +123,9 @@ export function TestsWithErrors() {
   let view = { uiResources: all, tiltfileKey: "test" }
   return (
     <LogStoreProvider value={logStore}>
-      <ResourceListOptionsContextProvider>
+      <ResourceListOptionsProvider>
         <OverviewResourceSidebar name={""} view={view} />
-      </ResourceListOptionsContextProvider>
+      </ResourceListOptionsProvider>
     </LogStoreProvider>
   )
 }

--- a/web/src/OverviewSidebarOptions.test.tsx
+++ b/web/src/OverviewSidebarOptions.test.tsx
@@ -17,7 +17,7 @@ import {
 import {
   DEFAULT_OPTIONS,
   ResourceListOptions,
-  ResourceListOptionsContextProvider,
+  ResourceListOptionsProvider,
   RESOURCE_LIST_OPTIONS_KEY,
 } from "./ResourceListOptionsContext"
 import { ResourceNameFilterTextField } from "./ResourceNameFilter"
@@ -83,11 +83,11 @@ describe("overview sidebar options", () => {
     const root = mount(
       <MemoryRouter>
         <tiltfileKeyContext.Provider value="test">
-          <ResourceListOptionsContextProvider>
+          <ResourceListOptionsProvider>
             <StarredResourcesContextProvider>
               {TwoResourcesTwoTests()}
             </StarredResourcesContextProvider>
-          </ResourceListOptionsContextProvider>
+          </ResourceListOptionsProvider>
         </tiltfileKeyContext.Provider>
       </MemoryRouter>
     )
@@ -108,11 +108,11 @@ describe("overview sidebar options", () => {
     const root = mount(
       <MemoryRouter>
         <tiltfileKeyContext.Provider value="test">
-          <ResourceListOptionsContextProvider>
+          <ResourceListOptionsProvider>
             <StarredResourcesContextProvider>
               {TwoResourcesTwoTests()}
             </StarredResourcesContextProvider>
-          </ResourceListOptionsContextProvider>
+          </ResourceListOptionsProvider>
         </tiltfileKeyContext.Provider>
       </MemoryRouter>
     )

--- a/web/src/OverviewTable.stories.tsx
+++ b/web/src/OverviewTable.stories.tsx
@@ -4,6 +4,7 @@ import Features, { FeaturesProvider, Flag } from "./feature"
 import LogStore, { LogStoreProvider } from "./LogStore"
 import OverviewTable from "./OverviewTable"
 import { ResourceGroupsContextProvider } from "./ResourceGroupsContext"
+import { ResourceListOptionsProvider } from "./ResourceListOptionsContext"
 import { TiltSnackbarProvider } from "./Snackbar"
 import {
   nButtonView,
@@ -27,9 +28,11 @@ export default {
           <TiltSnackbarProvider>
             <FeaturesProvider value={features}>
               <ResourceGroupsContextProvider>
-                <div style={{ margin: "-1rem" }}>
-                  <Story />
-                </div>
+                <ResourceListOptionsProvider>
+                  <div style={{ margin: "-1rem" }}>
+                    <Story />
+                  </div>
+                </ResourceListOptionsProvider>
               </ResourceGroupsContextProvider>
             </FeaturesProvider>
           </TiltSnackbarProvider>

--- a/web/src/OverviewTable.test.tsx
+++ b/web/src/OverviewTable.test.tsx
@@ -12,11 +12,11 @@ import Features, { FeaturesProvider, Flag } from "./feature"
 import { GroupByLabelView, TILTFILE_LABEL, UNLABELED_LABEL } from "./labels"
 import LogStore from "./LogStore"
 import OverviewTable, {
+  labeledResourcesToTableCells,
   OverviewGroup,
   OverviewGroupName,
   OverviewGroupSummary,
   OverviewTableProps,
-  resourcesToTableCells,
   ResourceTableData,
   ResourceTableHeader,
   ResourceTableHeaderSortTriangle,
@@ -242,7 +242,7 @@ describe("overview table with groups", () => {
   beforeEach(() => {
     view = nResourceWithLabelsView(8)
     wrapper = mount(tableViewWithSettings({ view, labelsEnabled: true }))
-    resources = resourcesToTableCells(
+    resources = labeledResourcesToTableCells(
       view.uiResources,
       view.uiButtons,
       new LogStore()
@@ -381,7 +381,10 @@ describe("overview table with groups", () => {
       // Re-mount the component with the initial groups context values
       wrapper = mount(
         <ResourceGroupsContextProvider initialValuesForTesting={testData}>
-          <TableGroupedByLabels view={view} />
+          <TableGroupedByLabels
+            resources={view.uiResources}
+            buttons={view.uiButtons}
+          />
         </ResourceGroupsContextProvider>
       )
 

--- a/web/src/OverviewTable.test.tsx
+++ b/web/src/OverviewTable.test.tsx
@@ -26,6 +26,8 @@ import OverviewTable, {
   Table,
   TableGroupedByLabels,
   TableNameColumn,
+  TableNoMatchesFound,
+  TableResourceResultCount,
   TableWithoutGroups,
 } from "./OverviewTable"
 import { ResourceGroupsInfoTip } from "./ResourceGroups"
@@ -34,6 +36,14 @@ import {
   GroupsState,
   ResourceGroupsContextProvider,
 } from "./ResourceGroupsContext"
+import {
+  ResourceListOptions,
+  ResourceListOptionsProvider,
+} from "./ResourceListOptionsContext"
+import {
+  matchesResourceName,
+  ResourceNameFilterTextField,
+} from "./ResourceNameFilter"
 import { TableGroupStatusSummary } from "./ResourceStatusSummary"
 import {
   nResourceView,
@@ -47,9 +57,11 @@ import { RuntimeStatus, UpdateStatus } from "./types"
 const tableViewWithSettings = ({
   view,
   labelsEnabled,
+  resourceListOptions,
 }: {
   view: TestDataView
   labelsEnabled?: boolean
+  resourceListOptions?: ResourceListOptions
 }) => {
   const features = new Features({ [Flag.Labels]: labelsEnabled ?? true })
   return (
@@ -57,7 +69,11 @@ const tableViewWithSettings = ({
       <SnackbarProvider>
         <FeaturesProvider value={features}>
           <ResourceGroupsContextProvider>
-            <OverviewTable view={view} />
+            <ResourceListOptionsProvider
+              initialValuesForTesting={resourceListOptions}
+            >
+              <OverviewTable view={view} />
+            </ResourceListOptionsProvider>
           </ResourceGroupsContextProvider>
         </FeaturesProvider>
       </SnackbarProvider>
@@ -90,6 +106,10 @@ const findTableColumnByName = (
   return matchingColumns
 }
 // End helpers
+
+afterEach(() => {
+  localStorage.clear()
+})
 
 it("shows buttons on the appropriate resources", () => {
   let view = nResourceView(3)
@@ -145,6 +165,72 @@ it("sorts by status", () => {
   expect(expectedResources).toEqual(actualResources)
 })
 
+describe("resource name filter", () => {
+  describe("when a filter is applied", () => {
+    let view: TestDataView
+    let wrapper: ReactWrapper<OverviewTableProps, typeof OverviewTable>
+
+    beforeEach(() => {
+      view = nResourceView(100)
+      wrapper = mount(
+        tableViewWithSettings({
+          view,
+          resourceListOptions: { resourceNameFilter: "1", alertsOnTop: false },
+        })
+      )
+    })
+
+    it("displays an accurate result count", () => {
+      const resultCount = wrapper.find(TableResourceResultCount)
+      expect(resultCount).toBeDefined()
+      // Expect 19 results because test data names resources with their index number
+      expect(resultCount.text()).toMatch(/19/)
+    })
+
+    it("displays only matching resources if there are matches", () => {
+      const matchingResources =
+        wrapper.find(TableWithoutGroups).prop("resources") || []
+
+      // Expect 19 results because test data names resources with their index number
+      expect(matchingResources.length).toBe(19)
+
+      const displayedResourceNames = wrapper
+        .find(TableNameColumn)
+        .map((nameCell) => nameCell.text())
+      const everyNameMatchesFilterTerm = displayedResourceNames.every((name) =>
+        matchesResourceName(name, "1")
+      )
+
+      expect(everyNameMatchesFilterTerm).toBe(true)
+    })
+
+    it("displays a `no matches` message if there are no matches", () => {
+      wrapper
+        .find(`${ResourceNameFilterTextField} input`)
+        .simulate("change", { target: { value: "eek no matches!" } })
+      wrapper.update()
+
+      expect(wrapper.find(TableNoMatchesFound)).toBeDefined()
+    })
+  })
+
+  describe("when a filter is NOT applied", () => {
+    it("displays all resources", () => {
+      const wrapper = mount(
+        tableViewWithSettings({
+          view: nResourceView(10),
+          resourceListOptions: { resourceNameFilter: "", alertsOnTop: false },
+        })
+      )
+
+      const resourceListProp =
+        wrapper.find(TableWithoutGroups).prop("resources") || []
+      expect(resourceListProp.length).toBe(10)
+      expect(wrapper.find(`tbody ${ResourceTableRow}`).length).toBe(10)
+    })
+  })
+})
+
 describe("when labels feature is enabled", () => {
   it("it displays tables grouped by labels if resources have labels", () => {
     const wrapper = mount(
@@ -173,7 +259,7 @@ describe("when labels feature is enabled", () => {
   })
 })
 
-describe("when labels feature is not enabled", () => {
+describe("when labels feature is NOT enabled", () => {
   let wrapper: ReactWrapper<OverviewTableProps, typeof OverviewTable>
 
   beforeEach(() => {
@@ -490,6 +576,19 @@ describe("overview table with groups", () => {
       const actualNames = unsortedNames.map((name) => name.text())
 
       expect(actualNames).toStrictEqual(expectedNames)
+    })
+  })
+
+  describe("resource name filter", () => {
+    it("does not display tables in groups when a resource filter is applied", () => {
+      expect(wrapper.find(TableGroupedByLabels).length).toBeGreaterThan(0)
+
+      wrapper
+        .find(`${ResourceNameFilterTextField} input`)
+        .simulate("change", { target: { value: "filtering!" } })
+      wrapper.update()
+
+      expect(wrapper.find(TableGroupedByLabels).length).toBe(0)
     })
   })
 })

--- a/web/src/OverviewTable.tsx
+++ b/web/src/OverviewTable.tsx
@@ -99,7 +99,6 @@ type TableGroupProps = {
 } & TableOptions<RowValues>
 
 type TableProps = {
-  isGroupView?: boolean
   setGlobalSortBy?: (id: string) => void
 } & TableOptions<RowValues>
 
@@ -137,7 +136,6 @@ type OverviewTableStatus = {
 
 // Resource name filter styles
 const OverviewTableResourceNameFilter = styled(ResourceNameFilter)`
-  margin-left: ${SizeUnit(1 / 2)};
   margin-right: ${SizeUnit(1 / 2)};
   min-width: ${Width.sidebarDefault}px;
 `
@@ -159,11 +157,15 @@ const NoMatchesFound = styled.p`
 // Table styles
 const OverviewTableRoot = styled.section`
   margin-bottom: ${SizeUnit(1 / 2)};
+  margin-left: ${SizeUnit(1 / 2)};
+  margin-right: ${SizeUnit(1 / 2)};
 `
 
 const ResourceTable = styled.table`
   margin-top: ${SizeUnit(0.5)};
   border-collapse: collapse;
+  border: 1px ${Color.grayLighter} solid;
+  border-radius: 0 ${SizeUnit(1 / 4)};
   width: 100%;
 
   td:first-child {
@@ -180,11 +182,6 @@ const ResourceTable = styled.table`
   td + td {
     padding-left: ${SizeUnit(1 / 4)};
     padding-right: ${SizeUnit(1 / 4)};
-  }
-
-  &.isGroup {
-    border: 1px ${Color.grayLighter} solid;
-    border-radius: 0 ${SizeUnit(1 / 4)};
   }
 `
 const ResourceTableHead = styled.thead`
@@ -328,11 +325,9 @@ const WidgetCell = styled.span`
 export const OverviewGroup = styled(Accordion)`
   ${AccordionStyleResetMixin}
 
-  /* Set specific margins for table view */
   &.MuiAccordion-root,
-  &.MuiAccordion-root.Mui-expanded,
-  &.MuiAccordion-root.Mui-expanded:first-child {
-    margin: ${SizeUnit(1 / 2)};
+  &.MuiAccordion-root.Mui-expanded {
+    margin-top: ${SizeUnit(1 / 2)};
   }
 `
 
@@ -359,7 +354,7 @@ export const OverviewGroupDetails = styled(AccordionDetails)`
 
 const GROUP_INFO_TOOLTIP_ID = "table-groups-info"
 
-function TableResourceResultCount(props: { resources?: UIResource[] }) {
+export function TableResourceResultCount(props: { resources?: UIResource[] }) {
   const { options } = useResourceListOptions()
 
   if (
@@ -378,7 +373,7 @@ function TableResourceResultCount(props: { resources?: UIResource[] }) {
   )
 }
 
-function TableNoMatchesFound(props: { resources?: UIResource[] }) {
+export function TableNoMatchesFound(props: { resources?: UIResource[] }) {
   const { options } = useResourceListOptions()
 
   if (props.resources?.length === 0 && options.resourceNameFilter.length > 0) {
@@ -952,11 +947,9 @@ export function Table(props: TableProps) {
     useSortBy
   )
 
-  const isGroupClass = props.isGroupView ? "isGroup" : ""
-
   // TODO (lizz): Consider adding `aria-sort` markup to table headings
   return (
-    <ResourceTable {...getTableProps()} className={isGroupClass}>
+    <ResourceTable {...getTableProps()}>
       <ResourceTableHead>
         {headerGroups.map((headerGroup: HeaderGroup<RowValues>) => (
           <ResourceTableHeadRow
@@ -1013,7 +1006,7 @@ function TableGroup(props: TableGroupProps) {
         />
       </OverviewGroupSummary>
       <OverviewGroupDetails>
-        <Table {...tableProps} isGroupView />
+        <Table {...tableProps} />
       </OverviewGroupDetails>
     </OverviewGroup>
   )

--- a/web/src/OverviewTable.tsx
+++ b/web/src/OverviewTable.tsx
@@ -53,6 +53,11 @@ import {
   ResourceGroupSummaryMixin,
 } from "./ResourceGroups"
 import { useResourceGroups } from "./ResourceGroupsContext"
+import {
+  ResourceListOptions,
+  useResourceListOptions,
+} from "./ResourceListOptionsContext"
+import { matchesResourceName, ResourceNameFilter } from "./ResourceNameFilter"
 import { useResourceNav } from "./ResourceNav"
 import { TableGroupStatusSummary } from "./ResourceStatusSummary"
 import { useStarredResources } from "./StarredResourcesContext"
@@ -63,6 +68,7 @@ import {
   FontSize,
   mixinResetButtonStyle,
   SizeUnit,
+  Width,
 } from "./style-helpers"
 import { isZeroTime, timeDiff } from "./time"
 import { timeAgoFormatter } from "./timeFormatters"
@@ -80,6 +86,11 @@ import {
 
 export type OverviewTableProps = {
   view: Proto.webviewView
+}
+
+type TableWrapperProps = {
+  resources?: UIResource[]
+  buttons?: UIButton[]
 }
 
 type TableGroupProps = {
@@ -123,6 +134,27 @@ type OverviewTableStatus = {
   runtimeStatus: ResourceStatus
   runtimeAlertCount: number
 }
+
+// Resource name filter styles
+const OverviewTableResourceNameFilter = styled(ResourceNameFilter)`
+  margin-left: ${SizeUnit(1 / 2)};
+  margin-right: ${SizeUnit(1 / 2)};
+  min-width: ${Width.sidebarDefault}px;
+`
+
+const ResourceResultCount = styled.p`
+  color: ${Color.grayLight};
+  font-size: ${FontSize.small};
+  margin-top: ${SizeUnit(0.5)};
+  margin-left: ${SizeUnit(0.5)};
+  text-transform: uppercase;
+`
+
+const NoMatchesFound = styled.p`
+  color: ${Color.grayLightest};
+  margin-left: ${SizeUnit(0.5)};
+  margin-top: ${SizeUnit(1 / 4)};
+`
 
 // Table styles
 const OverviewTableRoot = styled.section`
@@ -326,6 +358,35 @@ export const OverviewGroupDetails = styled(AccordionDetails)`
 `
 
 const GROUP_INFO_TOOLTIP_ID = "table-groups-info"
+
+function TableResourceResultCount(props: { resources?: UIResource[] }) {
+  const { options } = useResourceListOptions()
+
+  if (
+    props.resources === undefined ||
+    options.resourceNameFilter.length === 0
+  ) {
+    return null
+  }
+
+  const count = props.resources.length
+
+  return (
+    <ResourceResultCount>
+      {count} result{count !== 1 ? "s" : ""}
+    </ResourceResultCount>
+  )
+}
+
+function TableNoMatchesFound(props: { resources?: UIResource[] }) {
+  const { options } = useResourceListOptions()
+
+  if (props.resources?.length === 0 && options.resourceNameFilter.length > 0) {
+    return <NoMatchesFound>No matching resources</NoMatchesFound>
+  }
+
+  return null
+}
 
 function TableStarColumn({ row }: CellProps<RowValues>) {
   let ctx = useStarredResources()
@@ -684,6 +745,23 @@ async function copyTextToClipboard(text: string, cb: () => void) {
   cb()
 }
 
+function applyOptionsToResources(
+  resources: UIResource[] | undefined,
+  options: ResourceListOptions
+): UIResource[] {
+  if (!resources) {
+    return []
+  }
+
+  if (options.resourceNameFilter.length === 0) {
+    return resources
+  }
+
+  return resources.filter((r) =>
+    matchesResourceName(r.metadata?.name || "", options.resourceNameFilter)
+  )
+}
+
 function uiResourceToCell(
   r: UIResource,
   allButtons: UIButton[] | undefined,
@@ -748,7 +826,7 @@ function resourceTypeLabel(r: UIResource): string {
   return "Unknown"
 }
 
-export function resourcesToTableCells(
+export function labeledResourcesToTableCells(
   resources: UIResource[] | undefined,
   buttons: UIButton[] | undefined,
   logAlertIndex: LogAlertIndex
@@ -854,6 +932,10 @@ export function ResourceTableHeadRow({
 }
 
 export function Table(props: TableProps) {
+  if (props.data.length === 0) {
+    return null
+  }
+
   const {
     getTableProps,
     getTableBodyProps,
@@ -937,16 +1019,14 @@ function TableGroup(props: TableGroupProps) {
   )
 }
 
-export function TableGroupedByLabels(props: OverviewTableProps) {
+export function TableGroupedByLabels({
+  resources,
+  buttons,
+}: TableWrapperProps) {
   const logAlertIndex = useLogAlertIndex()
   const data = useMemo(
-    () =>
-      resourcesToTableCells(
-        props.view.uiResources,
-        props.view.uiButtons,
-        logAlertIndex
-      ),
-    [props.view.uiResources, props.view.uiButtons]
+    () => labeledResourcesToTableCells(resources, buttons, logAlertIndex),
+    [resources, buttons]
   )
 
   // Global table settings are currently used to sort multiple
@@ -996,48 +1076,69 @@ export function TableGroupedByLabels(props: OverviewTableProps) {
   )
 }
 
-export function TableWithoutGroups(props: OverviewTableProps) {
+export function TableWithoutGroups({ resources, buttons }: TableWrapperProps) {
   const logAlertIndex = useLogAlertIndex()
   const data = useMemo(() => {
     return (
-      props.view.uiResources?.map((r) =>
-        uiResourceToCell(r, props.view.uiButtons, logAlertIndex)
-      ) || []
+      resources?.map((r) => uiResourceToCell(r, buttons, logAlertIndex)) || []
     )
-  }, [props.view.uiResources, props.view.uiButtons])
+  }, [resources, buttons])
 
   return <Table columns={columnDefs} data={data} />
 }
 
-export default function OverviewTable(props: OverviewTableProps) {
+function OverviewTableContent(props: OverviewTableProps) {
   const features = useFeatures()
   const labelsEnabled = features.isEnabled(Flag.Labels)
   const resourcesHaveLabels =
     props.view.uiResources?.some((r) => getResourceLabels(r).length > 0) ||
     false
 
-  // The label group tip is only displayed if labels are enabled but not used
-  const displayLabelGroupsTip = labelsEnabled && !resourcesHaveLabels
+  const { options } = useResourceListOptions()
+  const resourceFilterApplied = options.resourceNameFilter.length > 0
 
-  if (labelsEnabled && resourcesHaveLabels) {
+  // Table groups are displayed when feature is enabled, resources have labels,
+  // and no resource name filter is applied
+  const displayResourceGroups =
+    labelsEnabled && resourcesHaveLabels && !resourceFilterApplied
+
+  if (displayResourceGroups) {
     return (
-      <OverviewTableRoot aria-label="Resources overview">
-        <TableGroupedByLabels {...props} />
-      </OverviewTableRoot>
+      <TableGroupedByLabels
+        resources={props.view.uiResources}
+        buttons={props.view.uiButtons}
+      />
     )
   } else {
+    // The label group tip is only displayed if labels are enabled but not used
+    const displayLabelGroupsTip = labelsEnabled && !resourcesHaveLabels
+
+    // Apply any display filters or options to resources
+    const resources = applyOptionsToResources(props.view.uiResources, options)
     return (
-      <OverviewTableRoot aria-label="Resources overview">
+      <>
         {displayLabelGroupsTip && (
           <ResourceGroupsInfoTip idForIcon={GROUP_INFO_TOOLTIP_ID} />
         )}
+        <TableResourceResultCount resources={resources} />
+        <TableNoMatchesFound resources={resources} />
         <TableWithoutGroups
           aria-describedby={
             displayLabelGroupsTip ? GROUP_INFO_TOOLTIP_ID : undefined
           }
-          {...props}
+          resources={resources}
+          buttons={props.view.uiButtons}
         />
-      </OverviewTableRoot>
+      </>
     )
   }
+}
+
+export default function OverviewTable(props: OverviewTableProps) {
+  return (
+    <OverviewTableRoot aria-label="Resources overview">
+      <OverviewTableResourceNameFilter />
+      <OverviewTableContent {...props} />
+    </OverviewTableRoot>
+  )
 }

--- a/web/src/OverviewTablePane.stories.tsx
+++ b/web/src/OverviewTablePane.stories.tsx
@@ -2,6 +2,7 @@ import React from "react"
 import { MemoryRouter } from "react-router"
 import Features, { FeaturesProvider, Flag } from "./feature"
 import OverviewTablePane from "./OverviewTablePane"
+import { ResourceListOptionsProvider } from "./ResourceListOptionsContext"
 import { StarredResourceMemoryProvider } from "./StarredResourcesContext"
 import {
   nResourceView,
@@ -9,6 +10,7 @@ import {
   tenResourceView,
   twoResourceView,
 } from "./testdata"
+
 
 export default {
   title: "New UI/OverviewTablePane",
@@ -20,11 +22,13 @@ export default {
       return (
         <MemoryRouter initialEntries={["/"]}>
           <FeaturesProvider value={features}>
-            <StarredResourceMemoryProvider>
-              <div style={{ margin: "-1rem", height: "80vh" }}>
-                <Story />
-              </div>
-            </StarredResourceMemoryProvider>
+            <ResourceListOptionsProvider>
+              <StarredResourceMemoryProvider>
+                <div style={{ margin: "-1rem", height: "80vh" }}>
+                  <Story />
+                </div>
+              </StarredResourceMemoryProvider>
+            </ResourceListOptionsProvider>
           </FeaturesProvider>
         </MemoryRouter>
       )

--- a/web/src/OverviewTablePane.stories.tsx
+++ b/web/src/OverviewTablePane.stories.tsx
@@ -11,7 +11,6 @@ import {
   twoResourceView,
 } from "./testdata"
 
-
 export default {
   title: "New UI/OverviewTablePane",
   decorators: [

--- a/web/src/ResourceListOptionsContext.tsx
+++ b/web/src/ResourceListOptionsContext.tsx
@@ -48,7 +48,7 @@ export function useResourceListOptions(): ResourceListOptionsContext {
   return useContext(ResourceListOptionsContext)
 }
 
-export function ResourceListOptionsContextProvider(
+export function ResourceListOptionsProvider(
   props: PropsWithChildren<{ initialValuesForTesting?: ResourceListOptions }>
 ) {
   const defaultPersistentValue = props.initialValuesForTesting ?? {

--- a/web/src/ResourceNameFilter.test.tsx
+++ b/web/src/ResourceNameFilter.test.tsx
@@ -11,7 +11,7 @@ import { accessorsForTesting, tiltfileKeyContext } from "./LocalStorage"
 import {
   DEFAULT_OPTIONS,
   ResourceListOptions,
-  ResourceListOptionsContextProvider,
+  ResourceListOptionsProvider,
   RESOURCE_LIST_OPTIONS_KEY,
 } from "./ResourceListOptionsContext"
 import {
@@ -27,9 +27,9 @@ const resourceListOptionsAccessor = accessorsForTesting<ResourceListOptions>(
 const ResourceNameFilterTestWrapper = () => (
   <MemoryRouter>
     <tiltfileKeyContext.Provider value="test">
-      <ResourceListOptionsContextProvider>
+      <ResourceListOptionsProvider>
         <ResourceNameFilter />
-      </ResourceListOptionsContextProvider>
+      </ResourceListOptionsProvider>
     </tiltfileKeyContext.Provider>
   </MemoryRouter>
 )

--- a/web/src/SidebarResources.test.tsx
+++ b/web/src/SidebarResources.test.tsx
@@ -15,7 +15,7 @@ import PathBuilder from "./PathBuilder"
 import {
   DEFAULT_OPTIONS,
   ResourceListOptions,
-  ResourceListOptionsContextProvider,
+  ResourceListOptionsProvider,
   RESOURCE_LIST_OPTIONS_KEY,
 } from "./ResourceListOptionsContext"
 import SidebarItem from "./SidebarItem"
@@ -62,7 +62,7 @@ describe("SidebarResources", () => {
       <MemoryRouter>
         <tiltfileKeyContext.Provider value="test">
           <StarredResourcesContextProvider>
-            <ResourceListOptionsContextProvider>
+            <ResourceListOptionsProvider>
               <SidebarResources
                 items={items}
                 selected={""}
@@ -70,7 +70,7 @@ describe("SidebarResources", () => {
                 pathBuilder={pathBuilder}
                 resourceListOptions={DEFAULT_OPTIONS}
               />
-            </ResourceListOptionsContextProvider>
+            </ResourceListOptionsProvider>
           </StarredResourcesContextProvider>
         </tiltfileKeyContext.Provider>
       </MemoryRouter>
@@ -105,7 +105,7 @@ describe("SidebarResources", () => {
       <MemoryRouter>
         <tiltfileKeyContext.Provider value="test">
           <StarredResourcesContextProvider>
-            <ResourceListOptionsContextProvider>
+            <ResourceListOptionsProvider>
               <SidebarResources
                 items={items}
                 selected={""}
@@ -113,7 +113,7 @@ describe("SidebarResources", () => {
                 pathBuilder={pathBuilder}
                 resourceListOptions={DEFAULT_OPTIONS}
               />
-            </ResourceListOptionsContextProvider>
+            </ResourceListOptionsProvider>
           </StarredResourcesContextProvider>
         </tiltfileKeyContext.Provider>
       </MemoryRouter>
@@ -166,7 +166,7 @@ describe("SidebarResources", () => {
       const root = mount(
         <MemoryRouter>
           <tiltfileKeyContext.Provider value="test">
-            <ResourceListOptionsContextProvider>
+            <ResourceListOptionsProvider>
               <SidebarResources
                 items={items}
                 selected={""}
@@ -174,7 +174,7 @@ describe("SidebarResources", () => {
                 pathBuilder={pathBuilder}
                 resourceListOptions={options}
               />
-            </ResourceListOptionsContextProvider>
+            </ResourceListOptionsProvider>
           </tiltfileKeyContext.Provider>
         </MemoryRouter>
       )
@@ -205,7 +205,7 @@ describe("SidebarResources", () => {
       const root = mount(
         <MemoryRouter>
           <tiltfileKeyContext.Provider value="test">
-            <ResourceListOptionsContextProvider>
+            <ResourceListOptionsProvider>
               <SidebarResources
                 items={items}
                 selected={""}
@@ -213,7 +213,7 @@ describe("SidebarResources", () => {
                 pathBuilder={pathBuilder}
                 resourceListOptions={DEFAULT_OPTIONS}
               />
-            </ResourceListOptionsContextProvider>
+            </ResourceListOptionsProvider>
           </tiltfileKeyContext.Provider>
         </MemoryRouter>
       )


### PR DESCRIPTION
This PR adds the resource name filter to Table View. I have a couple detail-oriented design questions for Surbhi, though those questions aren't blockers for review.

Example of resource filtering with labels:
![2021-09-17 11 06 11](https://user-images.githubusercontent.com/23283986/133828325-e5968406-f89f-4acc-80c0-4d735b9b0f66.gif)

Closes [ch12500](https://app.shortcut.com/windmill/story/12500/add-resource-name-filter-to-table-view)

