### PR TITLE
store: infer ChangeSummary.Log

### DIFF
--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -151,6 +151,8 @@ func (s *Store) Loop(ctx context.Context) error {
 		case actions := <-s.actionCh:
 			s.stateMu.Lock()
 
+			logCheckpoint := s.state.LogStore.Checkpoint()
+
 			for _, action := range actions {
 				var oldState EngineState
 				if s.logActions {
@@ -174,6 +176,12 @@ func (s *Store) Loop(ctx context.Context) error {
 						}
 					}()
 				}
+			}
+
+			// if one of the actions logged, but didn't report it via Summarizer,
+			// include it in the summary anyway
+			if logCheckpoint != s.state.LogStore.Checkpoint() {
+				summary.Log = true
 			}
 
 			s.stateMu.Unlock()


### PR DESCRIPTION
### Problem

A couple action handlers in the upper reducer [append directly to the logstore](https://github.com/tilt-dev/tilt/blob/688f5dfb982ce68de84977dc26e3d12b7f486355/internal/engine/upper.go#L352), but don't implement `Summarizer`, so they do not set `Summary.Log` when they are handled.

The WebSocketSubscriber only passes log updates to the frontend when [`summary.Log` is true](https://github.com/tilt-dev/tilt/blob/13c9bb803c8cfe08b51beaaa32788c565f3b69bd/internal/hud/server/websocket.go#L122). When one of these messages is logged: 1) at the time, it shows up in the TUI but not the web ui 2) the next time something is logged (properly), it shows up in the web ui. This can be quite some time later.

AFAIK this problem hasn't been affecting prod, because these logs happen to precede other logging that flushes them. I ran into this when killing builds in a disable resource branch.

### Solution

If the log checkpoint changes while running the reducer, set summary.Log = true. AFAICT there isn't much reason to give the summarizer the responsibility of reporting whether anything was logged anyway, but it's also probably not worth declaring a separate type to take that field out.

Alternative approach: add a ChangeSummary.HasLogs() method that returns `Log || Legacy` and have WebSocketSubscriber use that instead (since if it's legacy, we have to assume it might contain logs). I like that less since it leaves callers room to iincorrectly check Log instead of HasLogs.