### PR TITLE
tiltfile: add built-in for filewatch

### DIFF
--- a/internal/controllers/apiset/apiset.go
+++ b/internal/controllers/apiset/apiset.go
@@ -9,6 +9,16 @@ import (
 // A set of API Objects of different types.
 type ObjectSet map[schema.GroupVersionResource]TypedObjectSet
 
+func (s ObjectSet) GetOrCreateTypedSet(o Object) TypedObjectSet {
+	gvk := o.GetGroupVersionResource()
+	set := s[gvk]
+	if set == nil {
+		set = TypedObjectSet{}
+		s[gvk] = set
+	}
+	return set
+}
+
 // A set of API Objects of the same type.
 type TypedObjectSet map[string]Object
 

--- a/internal/controllers/core/tiltfile/api.go
+++ b/internal/controllers/core/tiltfile/api.go
@@ -131,12 +131,12 @@ func propagateAnnotations(tf *v1alpha1.Tiltfile, obj apiset.Object) {
 var typesWithTiltfileBuiltins = []apiset.Object{
 	&v1alpha1.ExtensionRepo{},
 	&v1alpha1.Extension{},
+	&v1alpha1.FileWatch{},
 }
 
 var typesToReconcile = append([]apiset.Object{
 	&v1alpha1.KubernetesApply{},
 	&v1alpha1.ImageMap{},
-	&v1alpha1.FileWatch{},
 	&v1alpha1.Cmd{},
 	&v1alpha1.UIResource{},
 	&v1alpha1.ConfigMap{},
@@ -205,7 +205,10 @@ func toAPIObjects(nn types.NamespacedName, tf *v1alpha1.Tiltfile, tlr *tiltfile.
 		watchInputs.TiltfilePath = tf.Spec.Path
 	}
 
-	result[(&v1alpha1.FileWatch{}).GetGroupVersionResource()] = ToFileWatchObjects(watchInputs, disableSources)
+	fwMap := result.GetOrCreateTypedSet(&v1alpha1.FileWatch{})
+	for k, fw := range ToFileWatchObjects(watchInputs, disableSources) {
+		fwMap[k] = fw
+	}
 
 	return result
 }

--- a/internal/tiltfile/v1alpha1/plugin.go
+++ b/internal/tiltfile/v1alpha1/plugin.go
@@ -43,17 +43,11 @@ func (p Plugin) register(t *starlark.Thread, obj apiset.Object) (starlark.Value,
 	}
 
 	err := starkit.SetState(t, func(set apiset.ObjectSet) (apiset.ObjectSet, error) {
-		gvr := obj.GetGroupVersionResource()
-		typedSet, ok := set[gvr]
-		if !ok {
-			typedSet = apiset.TypedObjectSet{}
-			set[gvr] = typedSet
-		}
-
+		typedSet := set.GetOrCreateTypedSet(obj)
 		name := obj.GetName()
 		_, exists := typedSet[name]
 		if exists {
-			return set, fmt.Errorf("%s %q already registered", gvr.Resource, name)
+			return set, fmt.Errorf("%s %q already registered", obj.GetGroupVersionResource().Resource, name)
 		}
 
 		typedSet[name] = obj

--- a/pkg/apis/core/v1alpha1/filewatch_types.go
+++ b/pkg/apis/core/v1alpha1/filewatch_types.go
@@ -35,6 +35,7 @@ import (
 
 // FileWatch
 // +k8s:openapi-gen=true
+// +tilt:starlark-gen=true
 type FileWatch struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
@@ -55,7 +56,10 @@ type FileWatchList struct {
 // FileWatchSpec defines the desired state of FileWatch
 type FileWatchSpec struct {
 	// WatchedPaths are paths of directories or files to watch for changes to. It cannot be empty.
+	//
+	// +tilt:local-path=true
 	WatchedPaths []string `json:"watchedPaths" protobuf:"bytes,1,rep,name=watchedPaths"`
+
 	// Ignores are optional rules to filter out a subset of changes matched by WatchedPaths.
 	Ignores []IgnoreDef `json:"ignores,omitempty" protobuf:"bytes,2,rep,name=ignores"`
 	// Specifies how to disable this.
@@ -68,7 +72,10 @@ type IgnoreDef struct {
 	// BasePath is the base path for the patterns. It cannot be empty.
 	//
 	// If no patterns are specified, everything under it will be recursively ignored.
+	//
+	// +tilt:local-path=true
 	BasePath string `json:"basePath" protobuf:"bytes,1,opt,name=basePath"`
+
 	// Patterns are dockerignore style rules. Absolute-style patterns will be rooted to the BasePath.
 	//
 	// See https://docs.docker.com/engine/reference/builder/#dockerignore-file.


### PR DESCRIPTION
Hello @milas,

Please review the following commits I made in branch nicks/filewatchcodegen:

22cc7165582aa74fa81b01cdf32a745632594941 (2021-09-20 16:33:30 -0400)
tiltfile: add built-in for filewatch

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics