### PR TITLE
tiltfile: kubecontext protection shouldn't apply when loading extensions

### DIFF
--- a/internal/controllers/apis/tiltfile/main.go
+++ b/internal/controllers/apis/tiltfile/main.go
@@ -2,13 +2,31 @@ package tiltfile
 
 import (
 	"fmt"
+	"path/filepath"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/tilt-dev/tilt/internal/ospath"
 	"github.com/tilt-dev/tilt/pkg/apis"
 	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
 	"github.com/tilt-dev/tilt/pkg/model"
 )
+
+// Resolve a filename to its "best" version.
+// On any error, just return the original filename.
+func ResolveFilename(filename string) string {
+	resolved, err := ospath.RealAbs(filename)
+	if err == nil {
+		return resolved
+	}
+
+	resolved, err = filepath.Abs(filename)
+	if err == nil {
+		return resolved
+	}
+
+	return filename
+}
 
 func MainTiltfile(filename string, args []string) *v1alpha1.Tiltfile {
 	name := model.MainTiltfileManifestName.String()
@@ -16,7 +34,7 @@ func MainTiltfile(filename string, args []string) *v1alpha1.Tiltfile {
 	return &v1alpha1.Tiltfile{
 		ObjectMeta: metav1.ObjectMeta{Name: name},
 		Spec: v1alpha1.TiltfileSpec{
-			Path: filename,
+			Path: ResolveFilename(filename),
 			Args: args,
 			RestartOn: &v1alpha1.RestartOnSpec{
 				FileWatches: []string{fwName},

--- a/internal/engine/configs/configs_controller_test.go
+++ b/internal/engine/configs/configs_controller_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/types"
 
+	"github.com/tilt-dev/tilt/internal/controllers/apis/tiltfile"
 	"github.com/tilt-dev/tilt/internal/controllers/fake"
 	"github.com/tilt-dev/tilt/internal/store"
 	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
@@ -28,7 +29,7 @@ func TestCreateTiltfile(t *testing.T) {
 	var tf v1alpha1.Tiltfile
 	require.NoError(t, client.Get(ctx, types.NamespacedName{Name: model.MainTiltfileManifestName.String()}, &tf))
 	assert.Equal(t, tf.Spec, v1alpha1.TiltfileSpec{
-		Path: "./fake-tiltfile-path",
+		Path: tiltfile.ResolveFilename("fake-tiltfile-path"),
 		Args: []string{"arg1", "arg2"},
 		RestartOn: &v1alpha1.RestartOnSpec{
 			FileWatches: []string{"configs:(Tiltfile)"},

--- a/internal/tiltfile/config/config_test.go
+++ b/internal/tiltfile/config/config_test.go
@@ -61,7 +61,7 @@ config.parse()`
 			require.NoError(t, err)
 
 			manifests := []model.Manifest{{Name: "a"}, {Name: "b"}}
-			actual, err := MustState(result).EnabledResources(manifests)
+			actual, err := MustState(result).EnabledResources(f.Tiltfile(), manifests)
 			require.NoError(t, err)
 
 			expectedResourcesByName := make(map[model.ManifestName]bool)
@@ -201,7 +201,7 @@ config.parse()
 
 	expected := `invalid Tiltfile config args: unknown flag: --bar
 Usage:
-      --foo list[string]   
+      --foo list[string]   ` + `
 `
 
 	_, err := f.ExecFile("Tiltfile")
@@ -286,7 +286,7 @@ config.set_enabled_resources(config.parse()['resources'])
 	require.NoError(t, err)
 
 	manifests := []model.Manifest{{Name: "foo"}, {Name: "bar"}, {Name: "baz"}}
-	actual, err := MustState(result).EnabledResources(manifests)
+	actual, err := MustState(result).EnabledResources(f.Tiltfile(), manifests)
 	require.NoError(t, err)
 	require.Equal(t, manifests[:2], actual)
 }
@@ -510,9 +510,10 @@ print(config.main_dir)
 
 func NewFixture(tb testing.TB, userConfigState model.UserConfigState, tiltSubcommand model.TiltSubcommand) *starkit.Fixture {
 	ext := NewPlugin(tiltSubcommand)
-	ext.UserConfigState = userConfigState
+
 	ret := starkit.NewFixture(tb, ext, io.NewPlugin(), include.IncludeFn{})
 	ret.UseRealFS()
+	ret.Tiltfile().Spec.Args = userConfigState.Args
 	return ret
 }
 

--- a/internal/tiltfile/config/resources.go
+++ b/internal/tiltfile/config/resources.go
@@ -9,6 +9,7 @@ import (
 	"github.com/tilt-dev/tilt/internal/sliceutils"
 	"github.com/tilt-dev/tilt/internal/tiltfile/starkit"
 	"github.com/tilt-dev/tilt/internal/tiltfile/value"
+	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
 	"github.com/tilt-dev/tilt/pkg/model"
 )
 
@@ -44,13 +45,13 @@ func setEnabledResources(thread *starlark.Thread, fn *starlark.Builtin, args sta
 }
 
 // for the given args and list of full manifests, figure out which manifests the user actually selected
-func (s Settings) EnabledResources(manifests []model.Manifest) ([]model.Manifest, error) {
+func (s Settings) EnabledResources(tf *v1alpha1.Tiltfile, manifests []model.Manifest) ([]model.Manifest, error) {
 	// if the user called set_enabled_resources, that trumps everything
 	if s.enabledResources != nil {
 		return match(manifests, s.enabledResources)
 	}
 
-	args := s.userConfigState.Args
+	args := tf.Spec.Args
 
 	// if the user has not called config.parse and has specified args, use those to select which resources
 	if args != nil && !s.configParseCalled {

--- a/internal/tiltfile/k8scontext/k8scontext_test.go
+++ b/internal/tiltfile/k8scontext/k8scontext_test.go
@@ -17,11 +17,24 @@ allow_k8s_contexts('gke-blorg')
 	model, err := f.ExecFile("Tiltfile")
 	assert.NoError(t, err)
 	assert.Equal(t, []k8s.KubeContext{"gke-blorg"}, MustState(model).allowed)
-	assert.True(t, MustState(model).IsAllowed())
+	assert.True(t, MustState(model).IsAllowed(f.Tiltfile()))
 
 	model, err = f.ExecFile("Tiltfile")
 	assert.NoError(t, err)
 	assert.Equal(t, []k8s.KubeContext{"gke-blorg"}, MustState(model).allowed)
+}
+
+func TestForbidK8sContext(t *testing.T) {
+	f := NewFixture(t, "gke-blorg", k8s.EnvGKE)
+	f.File("Tiltfile", `
+`)
+	model, err := f.ExecFile("Tiltfile")
+	assert.NoError(t, err)
+	assert.False(t, MustState(model).IsAllowed(f.Tiltfile()))
+
+	// All k8s contexts are allowed in extensions.
+	f.Tiltfile().ObjectMeta.Name = "my-ext"
+	assert.True(t, MustState(model).IsAllowed(f.Tiltfile()))
 }
 
 func NewFixture(tb testing.TB, ctx k8s.KubeContext, env k8s.Env) *starkit.Fixture {

--- a/internal/tiltfile/starkit/model.go
+++ b/internal/tiltfile/starkit/model.go
@@ -6,6 +6,8 @@ import (
 	"reflect"
 
 	"go.starlark.net/starlark"
+
+	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
 )
 
 type Model struct {
@@ -62,4 +64,13 @@ func ContextFromThread(t *starlark.Thread) (context.Context, error) {
 	}
 
 	return ctx, nil
+}
+
+func StartTiltfileFromThread(t *starlark.Thread) (*v1alpha1.Tiltfile, error) {
+	tf, ok := t.Local(startTfKey).(*v1alpha1.Tiltfile)
+	if !ok {
+		return nil, fmt.Errorf("Internal error Starlark not initialized correctly: start tiltfile not found")
+	}
+
+	return tf, nil
 }

--- a/internal/tiltfile/tiltfile.go
+++ b/internal/tiltfile/tiltfile.go
@@ -161,7 +161,7 @@ func (tfl tiltfileLoader) Load(ctx context.Context, tf *corev1alpha1.Tiltfile) T
 	s := newTiltfileState(ctx, tfl.dcCli, tfl.webHost, tfl.localEnv, tfl.k8sContextExt, tfl.versionExt,
 		tfl.configExt, localRegistry, feature.FromDefaults(tfl.fDefaults))
 
-	manifests, result, err := s.loadManifests(absFilename, tf.Spec.Args)
+	manifests, result, err := s.loadManifests(tf)
 
 	tlr.BuiltinCalls = result.BuiltinCalls
 

--- a/pkg/webview/view.pb.go
+++ b/pkg/webview/view.pb.go
@@ -7,6 +7,7 @@ import (
 	context "context"
 	fmt "fmt"
 	math "math"
+
 	v1alpha1 "github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
 
 	proto "github.com/golang/protobuf/proto"


### PR DESCRIPTION
Hello @landism,

Please review the following commits I made in branch nicks/allowed:

af810d6f5d1412cc361a7f5731662e08f573ca10 (2021-09-20 19:54:41 -0400)
tiltfile: kubecontext protection shouldn't apply when loading extensions
Fixes https://github.com/tilt-dev/tilt-extensions/issues/253

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics