### PR TITLE
cmd: reconciler uses DisableSource/Status

### DIFF
--- a/internal/controllers/apis/configmap/disable.go
+++ b/internal/controllers/apis/configmap/disable.go
@@ -1,0 +1,65 @@
+package configmap
+
+import (
+	"context"
+	"fmt"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
+)
+
+func disableStatus(ctx context.Context, client client.Client, disableSource *v1alpha1.DisableSource) (isDisabled bool, reason string, err error) {
+	if disableSource == nil {
+		return false, "object does not specify a DisableSource", nil
+	}
+
+	if disableSource.ConfigMap == nil {
+		return false, "DisableSource specifies no ConfigMap", nil
+	}
+
+	cm := &v1alpha1.ConfigMap{}
+	err = client.Get(ctx, types.NamespacedName{Name: disableSource.ConfigMap.Name}, cm)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, fmt.Sprintf("ConfigMap %q does not exist", disableSource.ConfigMap.Name), nil
+		}
+		return false, fmt.Sprintf("error reading ConfigMap %q", disableSource.ConfigMap.Name), err
+	}
+
+	cmVal, ok := cm.Data[disableSource.ConfigMap.Key]
+	if !ok {
+		return false, fmt.Sprintf("ConfigMap %q has no key %q", disableSource.ConfigMap.Name, disableSource.ConfigMap.Key), nil
+	}
+	// TODO(matt)
+	// checking `== "true"` rather than strconv.ParseBool because we lack a good way to surface errors
+	// maybe once we have something like k8s events, we should use that?
+	isDisabled = cmVal == "true"
+	var verb string
+	if isDisabled {
+		verb = "is"
+	} else {
+		verb = "is not"
+	}
+	return isDisabled, fmt.Sprintf("ConfigMap/key %q/%q %s \"true\"", disableSource.ConfigMap.Name, disableSource.ConfigMap.Key, verb), nil
+}
+
+// Returns a new DisableStatus if the disable status has changed, or the prev status if it hasn't.
+func MaybeNewDisableStatus(ctx context.Context, client client.Client, disableSource *v1alpha1.DisableSource, prevStatus *v1alpha1.DisableStatus) (*v1alpha1.DisableStatus, error) {
+	isDisabled, reason, err := disableStatus(ctx, client, disableSource)
+	if err != nil {
+		return nil, err
+	}
+	statusDiffers := prevStatus == nil || prevStatus.Disabled != isDisabled || prevStatus.Reason != reason
+	if statusDiffers {
+		return &v1alpha1.DisableStatus{
+			Disabled:       isDisabled,
+			LastUpdateTime: metav1.Now(),
+			Reason:         reason,
+		}, nil
+	}
+	return prevStatus, nil
+}

--- a/internal/controllers/apis/configmap/disable_test.go
+++ b/internal/controllers/apis/configmap/disable_test.go
@@ -1,0 +1,163 @@
+package configmap
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/pointer"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/tilt-dev/tilt/internal/controllers/fake"
+	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
+)
+
+const configMapName = "fe-disable"
+const key = "isDisabled"
+
+func TestMaybeNewDisableStatusNoSource(t *testing.T) {
+	f := newDisableFixture(t)
+	newStatus, err := MaybeNewDisableStatus(f.ctx, f.fc, nil, nil)
+	require.NoError(t, err)
+	require.NotNil(t, newStatus)
+	require.Equal(t, false, newStatus.Disabled)
+	require.Contains(t, newStatus.Reason, "does not specify a DisableSource")
+}
+
+func TestMaybeNewDisableStatusNoConfigMapDisableSource(t *testing.T) {
+	f := newDisableFixture(t)
+	newStatus, err := MaybeNewDisableStatus(f.ctx, f.fc, &v1alpha1.DisableSource{}, nil)
+	require.NoError(t, err)
+	require.NotNil(t, newStatus)
+	require.Equal(t, false, newStatus.Disabled)
+	require.Contains(t, newStatus.Reason, "specifies no ConfigMap")
+}
+
+func TestMaybeNewDisableStatusNoConfigMap(t *testing.T) {
+	f := newDisableFixture(t)
+	newStatus, err := MaybeNewDisableStatus(f.ctx, f.fc, disableSource(), nil)
+	require.NoError(t, err)
+	require.NotNil(t, newStatus)
+	require.Equal(t, false, newStatus.Disabled)
+	require.Contains(t, newStatus.Reason, "ConfigMap \"fe-disable\" does not exist")
+}
+
+func TestMaybeNewDisableStatusNoKey(t *testing.T) {
+	f := newDisableFixture(t)
+	f.createConfigMap(nil)
+	newStatus, err := MaybeNewDisableStatus(f.ctx, f.fc, disableSource(), nil)
+	require.NoError(t, err)
+	require.NotNil(t, newStatus)
+	require.Equal(t, false, newStatus.Disabled)
+	require.Contains(t, newStatus.Reason, "has no key")
+}
+
+func TestMaybeNewDisableStatusTrue(t *testing.T) {
+	f := newDisableFixture(t)
+	f.createConfigMap(pointer.StringPtr("true"))
+	newStatus, err := MaybeNewDisableStatus(f.ctx, f.fc, disableSource(), nil)
+	require.NoError(t, err)
+	require.NotNil(t, newStatus)
+	require.Equal(t, true, newStatus.Disabled)
+	require.Contains(t, newStatus.Reason, "is \"true\"")
+}
+
+func TestMaybeNewDisableStatusFalse(t *testing.T) {
+	f := newDisableFixture(t)
+	f.createConfigMap(pointer.StringPtr("false"))
+	newStatus, err := MaybeNewDisableStatus(f.ctx, f.fc, disableSource(), nil)
+	require.NoError(t, err)
+	require.NotNil(t, newStatus)
+	require.Equal(t, false, newStatus.Disabled)
+	require.Contains(t, newStatus.Reason, "is not \"true\"")
+}
+
+func TestMaybeNewDisableStatusGobbledygookValue(t *testing.T) {
+	f := newDisableFixture(t)
+	f.createConfigMap(pointer.StringPtr("asdf"))
+	newStatus, err := MaybeNewDisableStatus(f.ctx, f.fc, disableSource(), nil)
+	require.NoError(t, err)
+	require.NotNil(t, newStatus)
+	require.Equal(t, false, newStatus.Disabled)
+	require.Contains(t, newStatus.Reason, "is not \"true\"")
+}
+
+func TestMaybeNewDisableStatusNoChange(t *testing.T) {
+	f := newDisableFixture(t)
+	f.createConfigMap(pointer.StringPtr("false"))
+	status, err := MaybeNewDisableStatus(f.ctx, f.fc, disableSource(), nil)
+	require.NoError(t, err)
+	newStatus, err := MaybeNewDisableStatus(f.ctx, f.fc, disableSource(), status)
+	require.Same(t, status, newStatus)
+}
+
+func TestMaybeNewDisableStatusChange(t *testing.T) {
+	f := newDisableFixture(t)
+	f.createConfigMap(pointer.StringPtr("false"))
+	status, err := MaybeNewDisableStatus(
+		f.ctx,
+		f.fc,
+		disableSource(),
+		nil,
+	)
+	require.NoError(t, err)
+	f.updateConfigMap(pointer.StringPtr("true"))
+	newStatus, err := MaybeNewDisableStatus(f.ctx, f.fc, disableSource(), status)
+	require.NotSame(t, status, newStatus)
+}
+
+type disableFixture struct {
+	t   *testing.T
+	fc  ctrlclient.Client
+	ctx context.Context
+}
+
+func (f *disableFixture) createConfigMap(isDisabled *string) {
+	m := make(map[string]string)
+	if isDisabled != nil {
+		m[key] = *isDisabled
+	}
+	err := f.fc.Create(f.ctx, &v1alpha1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: configMapName,
+		},
+		Data: m,
+	})
+
+	require.NoError(f.t, err)
+}
+
+func (f *disableFixture) updateConfigMap(isDisabled *string) {
+	m := make(map[string]string)
+	if isDisabled != nil {
+		m[key] = *isDisabled
+	}
+	var cm v1alpha1.ConfigMap
+	err := f.fc.Get(f.ctx, types.NamespacedName{Name: configMapName}, &cm)
+	require.NoError(f.t, err)
+
+	cm.Data = m
+	err = f.fc.Update(f.ctx, &cm)
+	require.NoError(f.t, err)
+}
+
+func disableSource() *v1alpha1.DisableSource {
+	return &v1alpha1.DisableSource{
+		ConfigMap: &v1alpha1.ConfigMapDisableSource{
+			Name: configMapName,
+			Key:  key,
+		},
+	}
+}
+
+func newDisableFixture(t *testing.T) *disableFixture {
+	fc := fake.NewFakeTiltClient()
+	ctx := context.Background()
+	return &disableFixture{
+		t:   t,
+		fc:  fc,
+		ctx: ctx,
+	}
+}

--- a/internal/controllers/apis/configmap/disable_test.go
+++ b/internal/controllers/apis/configmap/disable_test.go
@@ -61,7 +61,7 @@ func TestMaybeNewDisableStatusTrue(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, newStatus)
 	require.Equal(t, true, newStatus.Disabled)
-	require.Contains(t, newStatus.Reason, "is \"true\"")
+	require.Contains(t, newStatus.Reason, "is true")
 }
 
 func TestMaybeNewDisableStatusFalse(t *testing.T) {
@@ -71,7 +71,7 @@ func TestMaybeNewDisableStatusFalse(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, newStatus)
 	require.Equal(t, false, newStatus.Disabled)
-	require.Contains(t, newStatus.Reason, "is not \"true\"")
+	require.Contains(t, newStatus.Reason, "is false")
 }
 
 func TestMaybeNewDisableStatusGobbledygookValue(t *testing.T) {
@@ -81,7 +81,7 @@ func TestMaybeNewDisableStatusGobbledygookValue(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, newStatus)
 	require.Equal(t, false, newStatus.Disabled)
-	require.Contains(t, newStatus.Reason, "is not \"true\"")
+	require.Contains(t, newStatus.Reason, "strconv.ParseBool: parsing \"asdf\"")
 }
 
 func TestMaybeNewDisableStatusNoChange(t *testing.T) {

--- a/internal/controllers/apis/configmap/disable_test.go
+++ b/internal/controllers/apis/configmap/disable_test.go
@@ -90,6 +90,7 @@ func TestMaybeNewDisableStatusNoChange(t *testing.T) {
 	status, err := MaybeNewDisableStatus(f.ctx, f.fc, disableSource(), nil)
 	require.NoError(t, err)
 	newStatus, err := MaybeNewDisableStatus(f.ctx, f.fc, disableSource(), status)
+	require.NoError(t, err)
 	require.Same(t, status, newStatus)
 }
 
@@ -105,6 +106,7 @@ func TestMaybeNewDisableStatusChange(t *testing.T) {
 	require.NoError(t, err)
 	f.updateConfigMap(pointer.StringPtr("true"))
 	newStatus, err := MaybeNewDisableStatus(f.ctx, f.fc, disableSource(), status)
+	require.NoError(t, err)
 	require.NotSame(t, status, newStatus)
 }
 

--- a/internal/controllers/core/cmd/types.go
+++ b/internal/controllers/core/cmd/types.go
@@ -13,6 +13,7 @@ type CmdSpec = v1alpha1.CmdSpec
 type CmdStateWaiting = v1alpha1.CmdStateWaiting
 type CmdStateTerminated = v1alpha1.CmdStateTerminated
 type CmdStateRunning = v1alpha1.CmdStateRunning
+type ConfigMap = v1alpha1.ConfigMap
 type ObjectMeta = metav1.ObjectMeta
 type FileWatch = v1alpha1.FileWatch
 type FileWatchSpec = v1alpha1.FileWatchSpec


### PR DESCRIPTION
When a `Cmd`'s disable `ConfigMap` is set, the `Cmd` will disable/enable and set its `Status.DisableStatus` as appropriate.
