### PR TITLE
cli: use XDG_HOME for headless cert generation

### DIFF
--- a/internal/cli/openapi.go
+++ b/internal/cli/openapi.go
@@ -17,6 +17,7 @@ import (
 	engineanalytics "github.com/tilt-dev/tilt/internal/engine/analytics"
 	"github.com/tilt-dev/tilt/internal/hud/server"
 	"github.com/tilt-dev/tilt/internal/store"
+	"github.com/tilt-dev/tilt/internal/xdg"
 	"github.com/tilt-dev/tilt/pkg/assets"
 	"github.com/tilt-dev/tilt/pkg/model"
 )
@@ -94,7 +95,7 @@ type headlessServer struct {
 
 func newHeadlessServer(ctx context.Context) (*headlessServer, error) {
 	memconn := server.ProvideMemConn()
-	serverOptions, err := server.ProvideTiltServerOptionsForHeadless(ctx, memconn, tiltInfo())
+	serverOptions, err := server.ProvideTiltServerOptionsForHeadless(ctx, xdg.NewTiltDevBase(), memconn, tiltInfo())
 	if err != nil {
 		return nil, err
 	}

--- a/internal/hud/server/apiserver.go
+++ b/internal/hud/server/apiserver.go
@@ -17,6 +17,7 @@ import (
 	"github.com/tilt-dev/tilt-apiserver/pkg/server/builder"
 	"github.com/tilt-dev/tilt-apiserver/pkg/server/options"
 	"github.com/tilt-dev/tilt-apiserver/pkg/server/testdata"
+	"github.com/tilt-dev/tilt/internal/xdg"
 	"github.com/tilt-dev/tilt/pkg/logger"
 	"github.com/tilt-dev/tilt/pkg/model"
 
@@ -188,9 +189,15 @@ func ProvideTiltServerOptionsForTesting(ctx context.Context) (*APIServerConfig, 
 
 // Generate the server config, removing options that are not needed for headless mode
 // (where we don't open up any webserver or apiserver).
-func ProvideTiltServerOptionsForHeadless(ctx context.Context, memconn apiserver.ConnProvider, version model.TiltBuild) (*APIServerConfig, error) {
+func ProvideTiltServerOptionsForHeadless(ctx context.Context, base xdg.Base, memconn apiserver.ConnProvider, version model.TiltBuild) (*APIServerConfig, error) {
+	exampleCert, err := base.CacheFile(filepath.Join("certs", "headless", "example.crt"))
+	if err != nil {
+		return nil, err
+	}
+
+	keyCert := options.GeneratableKeyCert{FixtureDirectory: filepath.Dir(exampleCert)}
 	config, err := ProvideTiltServerOptions(ctx,
-		version, memconn, "corgi-charge", testdata.CertKey(), 0)
+		version, memconn, "corgi-charge", keyCert, 0)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Hello @milas,

Please review the following commits I made in branch nicks/ch12774:

b2159dc4a539e0b69e3b96d508b2c6c09dc09651 (2021-09-23 20:08:38 -0400)
cli: use XDG_HOME for headless cert generation

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics