### PR TITLE
docker: add image pull method

### DIFF
--- a/internal/docker/client.go
+++ b/internal/docker/client.go
@@ -453,6 +453,10 @@ func (c *Cli) ImagePull(ctx context.Context, ref reference.Named) (reference.Can
 		return nil, fmt.Errorf("failed to inspect after pull for image %q: %v", image, err)
 	}
 
+	// NOTE: the value in RepoDigests is NOT canonical, so we need to grab the digest and attach it to the original ref
+	// 	for example, the value from the image inspect for `docker.io/nginx:1.21.3` will be `nginx@sha256:<hash>`,
+	// 	which loses the repo and tag; by grabbing the digest and re-attaching it, we end up with something like
+	//	`docker.io/nginx:1.21.3@sha256:<hash>`
 	digestInfo := strings.SplitN(imgInspect.RepoDigests[0], "@", 2)
 	if len(digestInfo) != 2 {
 		return nil, fmt.Errorf("invalid digest %q for image %q: missing @", imgInspect.RepoDigests[0], image)

--- a/internal/docker/exploding.go
+++ b/internal/docker/exploding.go
@@ -50,6 +50,9 @@ func (c explodingClient) ContainerRestartNoWait(ctx context.Context, containerID
 func (c explodingClient) ExecInContainer(ctx context.Context, cID container.ID, cmd model.Cmd, in io.Reader, out io.Writer) error {
 	return c.err
 }
+func (c explodingClient) ImagePull(_ context.Context, _ reference.Named) (reference.Canonical, error) {
+	return nil, c.err
+}
 func (c explodingClient) ImagePush(ctx context.Context, ref reference.NamedTagged) (io.ReadCloser, error) {
 	return nil, c.err
 }

--- a/internal/docker/fake_client.go
+++ b/internal/docker/fake_client.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/docker/go-units"
+	"github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
 
 	"github.com/docker/distribution/reference"
@@ -133,6 +134,8 @@ type FakeClient struct {
 	ContainersPruned       []string
 }
 
+var _ Client = &FakeClient{}
+
 func NewFakeClient() *FakeClient {
 	return &FakeClient{
 		PushOutput:          ExamplePushOutput1,
@@ -226,6 +229,12 @@ func (c *FakeClient) ExecInContainer(ctx context.Context, cID container.ID, cmd 
 	}
 
 	return err
+}
+
+func (c *FakeClient) ImagePull(_ context.Context, ref reference.Named) (reference.Canonical, error) {
+	// fake digest is the reference itself hashed
+	// i.e. docker.io/library/_/nginx -> sha256sum(docker.io/library/_/nginx) -> 2ca21a92e8ee99f672764b7619a413019de5ffc7f06dbc7422d41eca17705802
+	return reference.WithDigest(ref, digest.FromString(ref.String()))
 }
 
 func (c *FakeClient) ImagePush(ctx context.Context, ref reference.NamedTagged) (io.ReadCloser, error) {

--- a/internal/docker/switch.go
+++ b/internal/docker/switch.go
@@ -23,6 +23,8 @@ type switchCli struct {
 	mu         sync.Mutex
 }
 
+var _ Client = &switchCli{}
+
 func ProvideSwitchCli(clusterCli ClusterClient, localCli LocalClient) *switchCli {
 	return &switchCli{
 		localCli:   localCli,
@@ -68,6 +70,9 @@ func (c *switchCli) ContainerRestartNoWait(ctx context.Context, containerID stri
 }
 func (c *switchCli) ExecInContainer(ctx context.Context, cID container.ID, cmd model.Cmd, in io.Reader, out io.Writer) error {
 	return c.client().ExecInContainer(ctx, cID, cmd, in, out)
+}
+func (c *switchCli) ImagePull(ctx context.Context, ref reference.Named) (reference.Canonical, error) {
+	return c.client().ImagePull(ctx, ref)
 }
 func (c *switchCli) ImagePush(ctx context.Context, ref reference.NamedTagged) (io.ReadCloser, error) {
 	return c.client().ImagePush(ctx, ref)


### PR DESCRIPTION
This is in preparation for directly creating+running containers
with Docker, where it's necessary to do a pull first to ensure
the image exists before creating the container (this is automatic
behavior from the CLI but not when using the API).

(This was split out of #4988.)