### PR TITLE
engine: temporarily replicate FileWatch, KubernetesApply, and KubernetesDiscovery back to the EngineState

### DIFF
--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -27,6 +27,9 @@ import (
 	"github.com/tilt-dev/tilt/internal/hud/server"
 	"github.com/tilt-dev/tilt/internal/k8s"
 	"github.com/tilt-dev/tilt/internal/store"
+	"github.com/tilt-dev/tilt/internal/store/filewatches"
+	"github.com/tilt-dev/tilt/internal/store/kubernetesapplys"
+	"github.com/tilt-dev/tilt/internal/store/kubernetesdiscoverys"
 	"github.com/tilt-dev/tilt/internal/store/tiltfiles"
 	"github.com/tilt-dev/tilt/internal/timecmp"
 	"github.com/tilt-dev/tilt/internal/token"
@@ -123,10 +126,14 @@ func upperReducerFn(ctx context.Context, state *store.EngineState, action store.
 		state.FatalError = action.Error
 	case hud.ExitAction:
 		handleHudExitAction(state, action)
+
+	// TODO(nick): Delete these handlers in favor of the bog-standard ones that copy
+	// the api models directly.
 	case filewatch.FileWatchUpdateStatusAction:
 		filewatch.HandleFileWatchUpdateStatusEvent(ctx, state, action)
 	case k8swatch.KubernetesDiscoveryUpdateStatusAction:
 		k8swatch.HandleKubernetesDiscoveryUpdateStatusAction(ctx, state, action)
+
 	case k8swatch.ServiceChangeAction:
 		handleServiceEvent(ctx, state, action)
 	case store.K8sEventAction:
@@ -175,6 +182,18 @@ func upperReducerFn(ctx context.Context, state *store.EngineState, action store.
 		tiltfiles.HandleTiltfileUpsertAction(state, action)
 	case tiltfiles.TiltfileDeleteAction:
 		tiltfiles.HandleTiltfileDeleteAction(state, action)
+	case filewatches.FileWatchUpsertAction:
+		filewatches.HandleFileWatchUpsertAction(state, action)
+	case filewatches.FileWatchDeleteAction:
+		filewatches.HandleFileWatchDeleteAction(state, action)
+	case kubernetesapplys.KubernetesApplyUpsertAction:
+		kubernetesapplys.HandleKubernetesApplyUpsertAction(state, action)
+	case kubernetesapplys.KubernetesApplyDeleteAction:
+		kubernetesapplys.HandleKubernetesApplyDeleteAction(state, action)
+	case kubernetesdiscoverys.KubernetesDiscoveryUpsertAction:
+		kubernetesdiscoverys.HandleKubernetesDiscoveryUpsertAction(state, action)
+	case kubernetesdiscoverys.KubernetesDiscoveryDeleteAction:
+		kubernetesdiscoverys.HandleKubernetesDiscoveryDeleteAction(state, action)
 	default:
 		state.FatalError = fmt.Errorf("unrecognized action: %T", action)
 	}

--- a/internal/store/engine_state.go
+++ b/internal/store/engine_state.go
@@ -118,8 +118,11 @@ type EngineState struct {
 
 	// API-server-based data models. Stored in EngineState
 	// to assist in migration.
-	Cmds      map[string]*Cmd               `json:"-"`
-	Tiltfiles map[string]*v1alpha1.Tiltfile `json:"-"`
+	Cmds                 map[string]*Cmd                          `json:"-"`
+	Tiltfiles            map[string]*v1alpha1.Tiltfile            `json:"-"`
+	FileWatches          map[string]*v1alpha1.FileWatch           `json:"-"`
+	KubernetesApplys     map[string]*v1alpha1.KubernetesApply     `json:"-"`
+	KubernetesDiscoverys map[string]*v1alpha1.KubernetesDiscovery `json:"-"`
 }
 
 type CloudStatus struct {
@@ -515,6 +518,9 @@ func NewState() *EngineState {
 
 	ret.Cmds = make(map[string]*Cmd)
 	ret.Tiltfiles = make(map[string]*v1alpha1.Tiltfile)
+	ret.FileWatches = make(map[string]*v1alpha1.FileWatch)
+	ret.KubernetesApplys = make(map[string]*v1alpha1.KubernetesApply)
+	ret.KubernetesDiscoverys = make(map[string]*v1alpha1.KubernetesDiscovery)
 
 	return ret
 }

--- a/internal/store/filewatches/actions.go
+++ b/internal/store/filewatches/actions.go
@@ -1,0 +1,23 @@
+package filewatches
+
+import "github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
+
+type FileWatchUpsertAction struct {
+	FileWatch *v1alpha1.FileWatch
+}
+
+func NewFileWatchUpsertAction(obj *v1alpha1.FileWatch) FileWatchUpsertAction {
+	return FileWatchUpsertAction{FileWatch: obj}
+}
+
+func (FileWatchUpsertAction) Action() {}
+
+type FileWatchDeleteAction struct {
+	Name string
+}
+
+func NewFileWatchDeleteAction(n string) FileWatchDeleteAction {
+	return FileWatchDeleteAction{Name: n}
+}
+
+func (FileWatchDeleteAction) Action() {}

--- a/internal/store/filewatches/reducers.go
+++ b/internal/store/filewatches/reducers.go
@@ -1,0 +1,14 @@
+package filewatches
+
+import (
+	"github.com/tilt-dev/tilt/internal/store"
+)
+
+func HandleFileWatchUpsertAction(state *store.EngineState, action FileWatchUpsertAction) {
+	n := action.FileWatch.Name
+	state.FileWatches[n] = action.FileWatch
+}
+
+func HandleFileWatchDeleteAction(state *store.EngineState, action FileWatchDeleteAction) {
+	delete(state.FileWatches, action.Name)
+}

--- a/internal/store/kubernetesapplys/actions.go
+++ b/internal/store/kubernetesapplys/actions.go
@@ -1,0 +1,23 @@
+package kubernetesapplys
+
+import "github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
+
+type KubernetesApplyUpsertAction struct {
+	KubernetesApply *v1alpha1.KubernetesApply
+}
+
+func NewKubernetesApplyUpsertAction(obj *v1alpha1.KubernetesApply) KubernetesApplyUpsertAction {
+	return KubernetesApplyUpsertAction{KubernetesApply: obj}
+}
+
+func (KubernetesApplyUpsertAction) Action() {}
+
+type KubernetesApplyDeleteAction struct {
+	Name string
+}
+
+func NewKubernetesApplyDeleteAction(n string) KubernetesApplyDeleteAction {
+	return KubernetesApplyDeleteAction{Name: n}
+}
+
+func (KubernetesApplyDeleteAction) Action() {}

--- a/internal/store/kubernetesapplys/reducers.go
+++ b/internal/store/kubernetesapplys/reducers.go
@@ -1,0 +1,14 @@
+package kubernetesapplys
+
+import (
+	"github.com/tilt-dev/tilt/internal/store"
+)
+
+func HandleKubernetesApplyUpsertAction(state *store.EngineState, action KubernetesApplyUpsertAction) {
+	n := action.KubernetesApply.Name
+	state.KubernetesApplys[n] = action.KubernetesApply
+}
+
+func HandleKubernetesApplyDeleteAction(state *store.EngineState, action KubernetesApplyDeleteAction) {
+	delete(state.KubernetesApplys, action.Name)
+}

--- a/internal/store/kubernetesdiscoverys/actions.go
+++ b/internal/store/kubernetesdiscoverys/actions.go
@@ -1,0 +1,23 @@
+package kubernetesdiscoverys
+
+import "github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
+
+type KubernetesDiscoveryUpsertAction struct {
+	KubernetesDiscovery *v1alpha1.KubernetesDiscovery
+}
+
+func NewKubernetesDiscoveryUpsertAction(obj *v1alpha1.KubernetesDiscovery) KubernetesDiscoveryUpsertAction {
+	return KubernetesDiscoveryUpsertAction{KubernetesDiscovery: obj}
+}
+
+func (KubernetesDiscoveryUpsertAction) Action() {}
+
+type KubernetesDiscoveryDeleteAction struct {
+	Name string
+}
+
+func NewKubernetesDiscoveryDeleteAction(n string) KubernetesDiscoveryDeleteAction {
+	return KubernetesDiscoveryDeleteAction{Name: n}
+}
+
+func (KubernetesDiscoveryDeleteAction) Action() {}

--- a/internal/store/kubernetesdiscoverys/reducers.go
+++ b/internal/store/kubernetesdiscoverys/reducers.go
@@ -1,0 +1,14 @@
+package kubernetesdiscoverys
+
+import (
+	"github.com/tilt-dev/tilt/internal/store"
+)
+
+func HandleKubernetesDiscoveryUpsertAction(state *store.EngineState, action KubernetesDiscoveryUpsertAction) {
+	n := action.KubernetesDiscovery.Name
+	state.KubernetesDiscoverys[n] = action.KubernetesDiscovery
+}
+
+func HandleKubernetesDiscoveryDeleteAction(state *store.EngineState, action KubernetesDiscoveryDeleteAction) {
+	delete(state.KubernetesDiscoverys, action.Name)
+}


### PR DESCRIPTION
Hello @landism, @milas,

Please review the following commits I made in branch nicks/liveupdate7:

b14c6bd5c60f73e0c40f5416159581b1a3b4e943 (2021-09-29 13:19:02 -0400)
engine: temporarily replicate FileWatch, KubernetesApply, and KubernetesDiscovery back to the EngineState
This will help enable the tried-and-true pattern of
"let's make everything use API models before moving them to the reconciler"

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics