### PR TITLE
web: fix a couple UIButton hidden input bugs

### DIFF
--- a/pkg/apis/core/v1alpha1/uibutton_types.go
+++ b/pkg/apis/core/v1alpha1/uibutton_types.go
@@ -273,6 +273,9 @@ func (in *UIInputSpec) Validate(_ context.Context, path *field.Path) field.Error
 	if in.Bool != nil {
 		numInputTypes += 1
 	}
+	if in.Hidden != nil {
+		numInputTypes += 1
+	}
 
 	if numInputTypes != 1 {
 		fieldErrors = append(fieldErrors, field.Invalid(path, in, "must specify exactly one input type"))

--- a/web/src/ApiButton.test.tsx
+++ b/web/src/ApiButton.test.tsx
@@ -78,6 +78,14 @@ describe("ApiButton", () => {
     ).toEqual(1)
   })
 
+  it("doesn't render an options button when the button has only hidden inputs", () => {
+    const inputs = [1, 2, 3].map((i) => hiddenField(`hidden${i}`, `value${i}`))
+    const root = mountButton(makeUIButton({ inputSpecs: inputs }))
+    expect(
+      root.find(ApiButton).find(ApiButtonInputsToggleButton).length
+    ).toEqual(0)
+  })
+
   it("shows the options form when the options button is clicked", () => {
     const inputs = [1, 2, 3].map((i) => textField(`text${i}`))
     const root = mountButton(makeUIButton({ inputSpecs: inputs }))

--- a/web/src/ApiButton.tsx
+++ b/web/src/ApiButton.tsx
@@ -367,7 +367,8 @@ export function ApiButton(props: React.PropsWithChildren<ApiButtonProps>) {
     </InstrumentedButton>
   )
 
-  if (uiButton.spec?.inputs?.length) {
+  // show the options button if there are any non-hidden inputs
+  if (uiButton.spec?.inputs?.filter((i) => !i.hidden)?.length) {
     const setInputValue = (name: string, value: any) => {
       // Copy to a new object so that the reference changes to force a rerender.
       setInputValues({ ...inputValues, [name]: value })


### PR DESCRIPTION
In #4992, I relied only on unit tests, which missed a couple bugs:
1. UIInput validation fails since it's unaware of the 'hidden' input type
2. If a button has only hidden fields, it shows the arrow button to toggle the options form, which is then empty. instead, we should not show the arrow.