### PR TITLE
store: create helper objects for summarizing Discovery+Apply

### DIFF
--- a/internal/cli/wire_gen.go
+++ b/internal/cli/wire_gen.go
@@ -7,8 +7,16 @@ package cli
 
 import (
 	"context"
+	"time"
+
 	"github.com/google/wire"
 	"github.com/jonboulle/clockwork"
+	"github.com/tilt-dev/wmclient/pkg/dirs"
+	"go.opentelemetry.io/otel/sdk/trace"
+	version2 "k8s.io/apimachinery/pkg/version"
+	"k8s.io/client-go/tools/clientcmd/api"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	"github.com/tilt-dev/tilt/internal/analytics"
 	"github.com/tilt-dev/tilt/internal/build"
 	client2 "github.com/tilt-dev/tilt/internal/cli/client"
@@ -67,12 +75,6 @@ import (
 	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
 	"github.com/tilt-dev/tilt/pkg/logger"
 	"github.com/tilt-dev/tilt/pkg/model"
-	"github.com/tilt-dev/wmclient/pkg/dirs"
-	"go.opentelemetry.io/otel/sdk/trace"
-	version2 "k8s.io/apimachinery/pkg/version"
-	"k8s.io/client-go/tools/clientcmd/api"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"time"
 )
 
 // Injectors from wire.go:

--- a/internal/engine/buildcontrol/image_build_and_deployer_test.go
+++ b/internal/engine/buildcontrol/image_build_and_deployer_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/tilt-dev/tilt/internal/k8s"
 	"github.com/tilt-dev/tilt/internal/k8s/testyaml"
 	"github.com/tilt-dev/tilt/internal/store"
+	"github.com/tilt-dev/tilt/internal/store/k8sconv"
 	"github.com/tilt-dev/tilt/internal/testutils"
 	"github.com/tilt-dev/tilt/internal/testutils/bufsync"
 	"github.com/tilt-dev/tilt/internal/testutils/manifestbuilder"
@@ -695,7 +696,7 @@ func TestDeployInjectsPodTemplateSpecHash(t *testing.T) {
 
 	hash := f.firstPodTemplateSpecHash()
 
-	require.True(t, resultSet.DeployedPodTemplateSpecHashes().Contains(hash))
+	require.True(t, k8sconv.ContainsHash(resultSet.ApplyFilter(), hash))
 }
 
 func TestDeployPodTemplateSpecHashChangesWhenImageChanges(t *testing.T) {
@@ -868,9 +869,9 @@ func TestIBDDeployUIDs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	deployed := result.DeployedEntities()
-	assert.Equal(t, 1, len(deployed))
-	assert.True(t, deployed.ContainsUID(f.k8s.LastUpsertResult[0].UID()))
+	filter := result.ApplyFilter()
+	assert.Equal(t, 1, len(filter.DeployedRefs))
+	assert.True(t, k8sconv.ContainsUID(filter, f.k8s.LastUpsertResult[0].UID()))
 }
 
 func TestDockerBuildTargetStage(t *testing.T) {

--- a/internal/engine/buildcontrol/wire_gen.go
+++ b/internal/engine/buildcontrol/wire_gen.go
@@ -7,7 +7,11 @@ package buildcontrol
 
 import (
 	"context"
+
 	"github.com/google/wire"
+	"github.com/tilt-dev/wmclient/pkg/dirs"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	"github.com/tilt-dev/tilt/internal/analytics"
 	"github.com/tilt-dev/tilt/internal/build"
 	"github.com/tilt-dev/tilt/internal/containerupdate"
@@ -19,8 +23,6 @@ import (
 	"github.com/tilt-dev/tilt/internal/store"
 	"github.com/tilt-dev/tilt/internal/tracer"
 	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
-	"github.com/tilt-dev/wmclient/pkg/dirs"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // Injectors from wire.go:

--- a/internal/engine/k8swatch/event_watch_manager_test.go
+++ b/internal/engine/k8swatch/event_watch_manager_test.go
@@ -15,6 +15,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/tilt-dev/tilt/internal/k8s/testyaml"
+	"github.com/tilt-dev/tilt/internal/store/k8sconv"
 	"github.com/tilt-dev/tilt/internal/testutils"
 	"github.com/tilt-dev/tilt/internal/testutils/manifestbuilder"
 	"github.com/tilt-dev/tilt/internal/testutils/podbuilder"
@@ -309,7 +310,9 @@ func (f *ewmFixture) addDeployedEntity(m model.Manifest, entity k8s.K8sEntity) {
 		f.t.Fatalf("Unknown manifest: %s", m.Name)
 	}
 	runtimeState := mState.K8sRuntimeState()
-	runtimeState.DeployedEntities = k8s.ObjRefList{entity.ToObjectReference()}
+	runtimeState.ApplyFilter = &k8sconv.KubernetesApplyFilter{
+		DeployedRefs: k8s.ObjRefList{entity.ToObjectReference()},
+	}
 	mState.RuntimeState = runtimeState
 }
 

--- a/internal/engine/k8swatch/reducers.go
+++ b/internal/engine/k8swatch/reducers.go
@@ -13,6 +13,7 @@ import (
 	"github.com/tilt-dev/tilt/internal/container"
 	"github.com/tilt-dev/tilt/internal/k8s"
 	"github.com/tilt-dev/tilt/internal/store"
+	"github.com/tilt-dev/tilt/internal/store/k8sconv"
 	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
 	"github.com/tilt-dev/tilt/pkg/logger"
 	"github.com/tilt-dev/tilt/pkg/model"
@@ -67,7 +68,7 @@ func maybeUpdateStateForPod(ms *store.ManifestState, pod *v1alpha1.Pod) bool {
 	podID := k8s.PodID(pod.Name)
 	runtime := ms.K8sRuntimeState()
 
-	if !runtime.HasOKPodTemplateSpecHash(pod) {
+	if !k8sconv.HasOKPodTemplateSpecHash(pod, runtime.ApplyFilter) {
 		// If this is from an outdated deploy but the pod is still being tracked, we
 		// will still update it; if it's outdated and untracked, just ignore
 		if _, alreadyTracked := runtime.Pods[podID]; alreadyTracked {

--- a/internal/engine/k8swatch/service_watch_test.go
+++ b/internal/engine/k8swatch/service_watch_test.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/tilt-dev/tilt/internal/k8s/testyaml"
+	"github.com/tilt-dev/tilt/internal/store/k8sconv"
 	"github.com/tilt-dev/tilt/internal/testutils"
 	"github.com/tilt-dev/tilt/internal/testutils/manifestbuilder"
 	"github.com/tilt-dev/tilt/internal/testutils/servicebuilder"
@@ -104,8 +105,8 @@ func (f *swFixture) addDeployedService(m model.Manifest, svc *v1.Service) {
 		f.t.Fatalf("Unknown manifest: %s", m.Name)
 	}
 	runtimeState := mState.K8sRuntimeState()
-	runtimeState.DeployedEntities = k8s.ObjRefList{
-		k8s.NewK8sEntity(svc).ToObjectReference(),
+	runtimeState.ApplyFilter = &k8sconv.KubernetesApplyFilter{
+		DeployedRefs: k8s.ObjRefList{k8s.NewK8sEntity(svc).ToObjectReference()},
 	}
 	mState.RuntimeState = runtimeState
 }

--- a/internal/engine/k8swatch/watcher.go
+++ b/internal/engine/k8swatch/watcher.go
@@ -63,24 +63,27 @@ func (ks *watcherKnownState) createTaskList(state store.EngineState) watcherTask
 		}
 
 		// Collect all the new UIDs
-		for _, ref := range mt.State.K8sRuntimeState().DeployedEntities {
-			// Our data model allows people to have the same resource defined in
-			// multiple manifests, and so we can have the same deployed UID in
-			// multiple manifests.
-			//
-			// This check protects us from infinite loops where the diff keeps flipping
-			// between the two manifests.
-			//
-			// Ideally, our data model would prevent this from happening entirely.
-			id := ref.UID
-			if seenUIDs[id] {
-				continue
-			}
-			seenUIDs[id] = true
+		applyFilter := mt.State.K8sRuntimeState().ApplyFilter
+		if applyFilter != nil {
+			for _, ref := range applyFilter.DeployedRefs {
+				// Our data model allows people to have the same resource defined in
+				// multiple manifests, and so we can have the same deployed UID in
+				// multiple manifests.
+				//
+				// This check protects us from infinite loops where the diff keeps flipping
+				// between the two manifests.
+				//
+				// Ideally, our data model would prevent this from happening entirely.
+				id := ref.UID
+				if seenUIDs[id] {
+					continue
+				}
+				seenUIDs[id] = true
 
-			oldName := ks.knownDeployedUIDs[id]
-			if name != oldName {
-				newUIDs[id] = name
+				oldName := ks.knownDeployedUIDs[id]
+				if name != oldName {
+					newUIDs[id] = name
+				}
 			}
 		}
 	}

--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -428,14 +428,10 @@ func handleBuildCompleted(ctx context.Context, engineState *store.EngineState, c
 	manifest := mt.Manifest
 	if manifest.IsK8s() {
 		state := ms.K8sRuntimeState()
-		deployedEntities := cb.Result.DeployedEntities()
-		if len(deployedEntities) > 0 {
-			state.DeployedEntities = deployedEntities
-		}
 
-		deployedPodTemplateSpecHashSet := cb.Result.DeployedPodTemplateSpecHashes()
-		if len(deployedPodTemplateSpecHashSet) > 0 {
-			state.DeployedPodTemplateSpecHashSet = deployedPodTemplateSpecHashSet
+		applyFilter := cb.Result.ApplyFilter()
+		if applyFilter != nil && len(applyFilter.DeployedRefs) > 0 {
+			state.ApplyFilter = applyFilter
 		}
 
 		if err == nil {

--- a/internal/engine/wire_gen.go
+++ b/internal/engine/wire_gen.go
@@ -7,8 +7,13 @@ package engine
 
 import (
 	"context"
+
 	"github.com/google/wire"
 	"github.com/jonboulle/clockwork"
+	"github.com/tilt-dev/wmclient/pkg/dirs"
+	"go.opentelemetry.io/otel/sdk/trace"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	"github.com/tilt-dev/tilt/internal/analytics"
 	"github.com/tilt-dev/tilt/internal/build"
 	"github.com/tilt-dev/tilt/internal/container"
@@ -24,9 +29,6 @@ import (
 	"github.com/tilt-dev/tilt/internal/store"
 	"github.com/tilt-dev/tilt/internal/tracer"
 	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
-	"github.com/tilt-dev/wmclient/pkg/dirs"
-	"go.opentelemetry.io/otel/sdk/trace"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // Injectors from wire.go:

--- a/internal/store/json_test.go
+++ b/internal/store/json_test.go
@@ -8,9 +8,9 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/tilt-dev/tilt/internal/k8s/testyaml"
+	"github.com/tilt-dev/tilt/internal/store/k8sconv"
 	"github.com/tilt-dev/tilt/internal/testutils/manifestbuilder"
 	"github.com/tilt-dev/tilt/internal/testutils/tempdir"
-	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
 	"github.com/tilt-dev/tilt/pkg/model"
 )
 
@@ -25,7 +25,7 @@ func TestToJSON(t *testing.T) {
 
 	mState, _ := state.ManifestState("fe")
 	mState.MutableBuildStatus(m.K8sTarget().ID()).LastResult = NewK8sDeployResult(
-		m.K8sTarget().ID(), v1alpha1.KubernetesApplyStatus{}, nil, nil)
+		m.K8sTarget().ID(), &k8sconv.KubernetesApplyFilter{})
 
 	buf := bytes.NewBuffer(nil)
 	encoder := CreateEngineStateEncoder(buf)

--- a/internal/store/k8sconv/resource.go
+++ b/internal/store/k8sconv/resource.go
@@ -1,0 +1,122 @@
+package k8sconv
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/tilt-dev/tilt/internal/k8s"
+	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
+)
+
+// A KubernetesResource exposes a high-level status that summarizes
+// the Pods we care about in a KubernetesDiscovery.
+//
+// If we have a KubernetesApply, KubernetesResource will use that
+// to narrow down the list of pods to only the pods we care about
+// for the current Apply.
+//
+// KubernetesResource is intended to be a non-stateful object (i.e., it is
+// immutable and its status can be inferred from the state of child
+// objects.)
+//
+// Long-term, this may become an explicit API server object, but
+// for now it's intended to provide an API-server compatible
+// layer around KubernetesDiscovery + KubernetesApply.
+type KubernetesResource struct {
+	Discovery   *v1alpha1.KubernetesDiscovery
+	ApplyStatus *v1alpha1.KubernetesApplyStatus
+
+	// A set of properties we use to determine which pods in Discovery
+	// belong to the current Apply.
+	ApplyFilter *KubernetesApplyFilter
+}
+
+func NewKubernetesResource(discovery *v1alpha1.KubernetesDiscovery, status *v1alpha1.KubernetesApplyStatus) (*KubernetesResource, error) {
+	var filter *KubernetesApplyFilter
+	var err error
+	if status != nil {
+		filter, err = NewKubernetesApplyFilter(status)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &KubernetesResource{Discovery: discovery, ApplyStatus: status, ApplyFilter: filter}, nil
+
+}
+
+// Filter to determine whether a pod or resource belongs to the current
+// KubernetesApply. Used to filter out pods from previous applys
+// when looking at a KubernetesDiscovery object.
+//
+// Considered immutable once created.
+type KubernetesApplyFilter struct {
+	// DeployedRefs are references to the objects that we deployed to a Kubernetes cluster.
+	DeployedRefs []v1.ObjectReference
+
+	// Hashes of the pod template specs that we deployed to a Kubernetes cluster.
+	PodTemplateSpecHashes []k8s.PodTemplateSpecHash
+}
+
+func NewKubernetesApplyFilter(status *v1alpha1.KubernetesApplyStatus) (*KubernetesApplyFilter, error) {
+	deployed, err := k8s.ParseYAMLFromString(status.ResultYAML)
+	if err != nil {
+		return nil, err
+	}
+
+	podTemplateSpecHashes := []k8s.PodTemplateSpecHash{}
+	for _, entity := range deployed {
+		if entity.UID() == "" {
+			return nil, fmt.Errorf("Entity not deployed correctly: %v", entity)
+		}
+		hs, err := k8s.ReadPodTemplateSpecHashes(entity)
+		if err != nil {
+			return nil, errors.Wrap(err, "reading pod template spec hashes")
+		}
+		podTemplateSpecHashes = append(podTemplateSpecHashes, hs...)
+	}
+	return &KubernetesApplyFilter{
+		DeployedRefs:          k8s.ToRefList(deployed),
+		PodTemplateSpecHashes: podTemplateSpecHashes,
+	}, nil
+}
+
+func ContainsHash(filter *KubernetesApplyFilter, hash k8s.PodTemplateSpecHash) bool {
+	if filter == nil {
+		return false
+	}
+
+	for _, h := range filter.PodTemplateSpecHashes {
+		if h == hash {
+			return true
+		}
+	}
+	return false
+}
+
+func ContainsUID(filter *KubernetesApplyFilter, uid types.UID) bool {
+	if filter == nil {
+		return false
+	}
+
+	for _, ref := range filter.DeployedRefs {
+		if ref.UID == uid {
+			return true
+		}
+	}
+	return false
+}
+
+// Checks to see if the given pod is allowed by the current filter.
+func HasOKPodTemplateSpecHash(pod *v1alpha1.Pod, filter *KubernetesApplyFilter) bool {
+	// if it doesn't have a label, just let it through - maybe it's from a CRD w/ no pod template spec
+	hash := k8s.PodTemplateSpecHash(pod.PodTemplateSpecHash)
+	if hash == "" {
+		return true
+	}
+
+	return ContainsHash(filter, hash)
+}

--- a/internal/store/runtime_state.go
+++ b/internal/store/runtime_state.go
@@ -72,10 +72,10 @@ type K8sRuntimeState struct {
 	// In many cases, this will be a Deployment UID.
 	PodAncestorUID types.UID
 
-	Pods                           PodSet
-	LBs                            map[k8s.ServiceName]*url.URL
-	DeployedEntities               k8s.ObjRefList         // for the most recent successful deploy
-	DeployedPodTemplateSpecHashSet PodTemplateSpecHashSet // for the most recent successful deploy
+	Pods PodSet
+	LBs  map[k8s.ServiceName]*url.URL
+
+	ApplyFilter *k8sconv.KubernetesApplyFilter
 
 	LastReadyOrSucceededTime    time.Time
 	HasEverDeployedSuccessfully bool
@@ -105,12 +105,11 @@ func NewK8sRuntimeStateWithPods(m model.Manifest, pods ...v1alpha1.Pod) K8sRunti
 
 func NewK8sRuntimeState(m model.Manifest) K8sRuntimeState {
 	return K8sRuntimeState{
-		PodReadinessMode:               m.PodReadinessMode(),
-		Pods:                           PodSet{},
-		LBs:                            make(map[k8s.ServiceName]*url.URL),
-		DeployedPodTemplateSpecHashSet: NewPodTemplateSpecHashSet(),
-		UpdateStartTime:                make(map[k8s.PodID]time.Time),
-		BaselineRestarts:               make(map[k8s.PodID]int32),
+		PodReadinessMode: m.PodReadinessMode(),
+		Pods:             PodSet{},
+		LBs:              make(map[k8s.ServiceName]*url.URL),
+		UpdateStartTime:  make(map[k8s.PodID]time.Time),
+		BaselineRestarts: make(map[k8s.PodID]int32),
 	}
 }
 
@@ -192,24 +191,6 @@ func (s K8sRuntimeState) MostRecentPod() v1alpha1.Pod {
 	return s.Pods.MostRecentPod()
 }
 
-func (s K8sRuntimeState) HasOKPodTemplateSpecHash(pod *v1alpha1.Pod) bool {
-	// if it doesn't have a label, just let it through - maybe it's from a CRD w/ no pod template spec
-	hash := k8s.PodTemplateSpecHash(pod.PodTemplateSpecHash)
-	if hash == "" {
-		return true
-	}
-
-	return s.DeployedPodTemplateSpecHashSet.Contains(hash)
-}
-
-func (s K8sRuntimeState) DeployedUIDSet() k8s.UIDSet {
-	uids := k8s.NewUIDSet()
-	for _, ref := range s.DeployedEntities {
-		uids.Add(ref.UID)
-	}
-	return uids
-}
-
 // podCompare is a stable sort order for pods.
 func podCompare(p1 v1alpha1.Pod, p2 v1alpha1.Pod) bool {
 	if p1.CreatedAt.After(p2.CreatedAt.Time) {
@@ -262,22 +243,6 @@ func AllPodContainerPorts(p v1alpha1.Pod) []int32 {
 		result = append(result, c.Ports...)
 	}
 	return result
-}
-
-type PodTemplateSpecHashSet map[k8s.PodTemplateSpecHash]bool
-
-func NewPodTemplateSpecHashSet() PodTemplateSpecHashSet {
-	return make(map[k8s.PodTemplateSpecHash]bool)
-}
-
-func (s PodTemplateSpecHashSet) Add(hashes ...k8s.PodTemplateSpecHash) {
-	for _, hash := range hashes {
-		s[hash] = true
-	}
-}
-
-func (s PodTemplateSpecHashSet) Contains(hash k8s.PodTemplateSpecHash) bool {
-	return s[hash]
 }
 
 type PodSet map[k8s.PodID]*v1alpha1.Pod

--- a/pkg/webview/view.pb.go
+++ b/pkg/webview/view.pb.go
@@ -7,6 +7,7 @@ import (
 	context "context"
 	fmt "fmt"
 	math "math"
+
 	v1alpha1 "github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
 
 	proto "github.com/golang/protobuf/proto"


### PR DESCRIPTION
Hello @milas, @landism,

Please review the following commits I made in branch nicks/lu10:

6ef1e4c198ea19816930c3cf1be5731a82a6a6e8 (2021-09-30 16:39:01 -0400)
store: create helper objects for summarizing Discovery+Apply
Right now, we decide which pods to LiveUpdate based on a complex
set of information from Discovery+Apply. We want to move all the relevant
info into its own object, separate from the old K8sRuntimeState

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics