### PR TITLE
test: improve how we infer pod template hashes

### DIFF
--- a/internal/k8s/pod_template.go
+++ b/internal/k8s/pod_template.go
@@ -36,6 +36,10 @@ func InjectPodTemplateSpecHashes(entity K8sEntity) (K8sEntity, error) {
 	}
 
 	for _, ts := range templateSpecs {
+		if ts.Labels == nil {
+			ts.Labels = map[string]string{}
+		}
+
 		h, err := HashPodTemplateSpec(ts)
 		if err != nil {
 			return K8sEntity{}, errors.Wrap(err, "calculating hash")


### PR DESCRIPTION
Hello @landism,

Please review the following commits I made in branch nicks/lu12:

247f0fd7ac42aab89120eb51af1ddcf9e04ba17c (2021-10-01 12:30:36 -0400)
test: improve how we infer pod template hashes

d80e6ee232c4c1e4919a547fce266deee8798412 (2021-09-30 16:42:25 -0400)
store: create helper objects for summarizing Discovery+Apply
Right now, we decide which pods to LiveUpdate based on a complex
set of information from Discovery+Apply. We want to move all the relevant
info into its own object, separate from the old K8sRuntimeState

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics