### PR TITLE
engine: infer liveupdate pods from KubernetesApply+KubernetesDiscovery

### DIFF
--- a/internal/engine/buildcontroller_test.go
+++ b/internal/engine/buildcontroller_test.go
@@ -722,6 +722,9 @@ func TestFullBuildTriggerClearsLiveUpdate(t *testing.T) {
 	f.WaitUntilManifestState("foobar loaded", "foobar", func(ms store.ManifestState) bool {
 		return len(ms.K8sRuntimeState().Pods) == 1
 	})
+	f.WaitUntil("foobar k8sresource loaded", func(s store.EngineState) bool {
+		return s.KubernetesResources["foobar"] != nil && len(s.KubernetesResources["foobar"].FilteredPods) == 1
+	})
 	f.withManifestState("foobar", func(ms store.ManifestState) {
 		ms.LiveUpdatedContainerIDs["containerID"] = true
 	})

--- a/internal/store/engine_state.go
+++ b/internal/store/engine_state.go
@@ -116,6 +116,10 @@ type EngineState struct {
 	// 4) ConfigsController dispatches a TiltfileCreateAction, to copy the apiserver data into the EngineState
 	DesiredTiltfilePath string
 
+	// KubernetesResources by name.
+	// Updated to match KubernetesApply + KubernetesDiscovery
+	KubernetesResources map[string]*k8sconv.KubernetesResource `json:"-"`
+
 	// API-server-based data models. Stored in EngineState
 	// to assist in migration.
 	Cmds                 map[string]*Cmd                          `json:"-"`
@@ -521,6 +525,7 @@ func NewState() *EngineState {
 	ret.FileWatches = make(map[string]*v1alpha1.FileWatch)
 	ret.KubernetesApplys = make(map[string]*v1alpha1.KubernetesApply)
 	ret.KubernetesDiscoverys = make(map[string]*v1alpha1.KubernetesDiscovery)
+	ret.KubernetesResources = make(map[string]*k8sconv.KubernetesResource)
 
 	return ret
 }

--- a/internal/store/kubernetesapplys/reducers.go
+++ b/internal/store/kubernetesapplys/reducers.go
@@ -2,13 +2,16 @@ package kubernetesapplys
 
 import (
 	"github.com/tilt-dev/tilt/internal/store"
+	"github.com/tilt-dev/tilt/internal/store/kubernetesdiscoverys"
 )
 
 func HandleKubernetesApplyUpsertAction(state *store.EngineState, action KubernetesApplyUpsertAction) {
 	n := action.KubernetesApply.Name
 	state.KubernetesApplys[n] = action.KubernetesApply
+	kubernetesdiscoverys.RefreshKubernetesResource(state, n)
 }
 
 func HandleKubernetesApplyDeleteAction(state *store.EngineState, action KubernetesApplyDeleteAction) {
 	delete(state.KubernetesApplys, action.Name)
+	kubernetesdiscoverys.RefreshKubernetesResource(state, action.Name)
 }

--- a/internal/store/kubernetesdiscoverys/reducers.go
+++ b/internal/store/kubernetesdiscoverys/reducers.go
@@ -2,13 +2,35 @@ package kubernetesdiscoverys
 
 import (
 	"github.com/tilt-dev/tilt/internal/store"
+	"github.com/tilt-dev/tilt/internal/store/k8sconv"
+	"github.com/tilt-dev/tilt/internal/store/liveupdates"
+	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
 )
 
 func HandleKubernetesDiscoveryUpsertAction(state *store.EngineState, action KubernetesDiscoveryUpsertAction) {
 	n := action.KubernetesDiscovery.Name
 	state.KubernetesDiscoverys[n] = action.KubernetesDiscovery
+	RefreshKubernetesResource(state, n)
+	liveupdates.CheckForContainerCrash(state, n)
 }
 
 func HandleKubernetesDiscoveryDeleteAction(state *store.EngineState, action KubernetesDiscoveryDeleteAction) {
 	delete(state.KubernetesDiscoverys, action.Name)
+	RefreshKubernetesResource(state, action.Name)
+	liveupdates.CheckForContainerCrash(state, action.Name)
+}
+
+func RefreshKubernetesResource(state *store.EngineState, name string) {
+	var aStatus *v1alpha1.KubernetesApplyStatus
+	a := state.KubernetesApplys[name]
+	if a != nil {
+		aStatus = &(a.Status)
+	}
+
+	d := state.KubernetesDiscoverys[name]
+	r, err := k8sconv.NewKubernetesResource(d, aStatus)
+	if err != nil {
+		return
+	}
+	state.KubernetesResources[name] = r
 }

--- a/internal/store/kubernetesdiscoverys/reducers.go
+++ b/internal/store/kubernetesdiscoverys/reducers.go
@@ -1,6 +1,7 @@
 package kubernetesdiscoverys
 
 import (
+	"github.com/tilt-dev/tilt/internal/controllers/apicmp"
 	"github.com/tilt-dev/tilt/internal/store"
 	"github.com/tilt-dev/tilt/internal/store/k8sconv"
 	"github.com/tilt-dev/tilt/internal/store/liveupdates"
@@ -9,15 +10,34 @@ import (
 
 func HandleKubernetesDiscoveryUpsertAction(state *store.EngineState, action KubernetesDiscoveryUpsertAction) {
 	n := action.KubernetesDiscovery.Name
+	oldState := state.KubernetesDiscoverys[n]
 	state.KubernetesDiscoverys[n] = action.KubernetesDiscovery
-	RefreshKubernetesResource(state, n)
-	liveupdates.CheckForContainerCrash(state, n)
+
+	// We only refresh when the K8sDiscovery is changed.
+	//
+	// This is really only needed for tests - we have tests that wait until we've
+	// reached a steady state, then change some fields on EngineState.
+	//
+	// K8s controllers assume everything is idempotent, and will wipe out our changes
+	// later with duplicate events.
+	isChanged := oldState == nil ||
+		!apicmp.DeepEqual(oldState.Status, action.KubernetesDiscovery.Status) ||
+		!apicmp.DeepEqual(oldState.Spec, action.KubernetesDiscovery.Spec)
+	if isChanged {
+		RefreshKubernetesResource(state, n)
+		liveupdates.CheckForContainerCrash(state, n)
+	}
 }
 
 func HandleKubernetesDiscoveryDeleteAction(state *store.EngineState, action KubernetesDiscoveryDeleteAction) {
+	oldState := state.KubernetesDiscoverys[action.Name]
 	delete(state.KubernetesDiscoverys, action.Name)
-	RefreshKubernetesResource(state, action.Name)
-	liveupdates.CheckForContainerCrash(state, action.Name)
+
+	isChanged := oldState != nil
+	if isChanged {
+		RefreshKubernetesResource(state, action.Name)
+		liveupdates.CheckForContainerCrash(state, action.Name)
+	}
 }
 
 func RefreshKubernetesResource(state *store.EngineState, name string) {

--- a/internal/store/liveupdates/reducers.go
+++ b/internal/store/liveupdates/reducers.go
@@ -1,0 +1,57 @@
+package liveupdates
+
+import (
+	"fmt"
+
+	"github.com/tilt-dev/tilt/internal/container"
+	"github.com/tilt-dev/tilt/internal/store"
+	"github.com/tilt-dev/tilt/pkg/logger"
+	"github.com/tilt-dev/tilt/pkg/model"
+)
+
+// If a container crashes, and it's been live-updated in the past,
+// then it needs to enter a special state to indicate that it
+// needs to be rebuilt (because the file system has been reset to the original image).
+//
+// Eventually, this will be represented by a special state on the LiveUpdateStatus.
+func CheckForContainerCrash(state *store.EngineState, name string) {
+	mt, ok := state.ManifestTargets[model.ManifestName(name)]
+	if !ok {
+		return
+	}
+
+	ms := mt.State
+	if ms.NeedsRebuildFromCrash {
+		// We're already aware the pod is crashing.
+		return
+	}
+
+	runningContainers := store.AllRunningContainers(mt, state)
+	if len(runningContainers) == 0 {
+		// If there are no running containers, it might mean the containers are
+		// being deleted. We don't need to intervene yet.
+		return
+	}
+
+	hitList := make(map[container.ID]bool, len(ms.LiveUpdatedContainerIDs))
+	for cID := range ms.LiveUpdatedContainerIDs {
+		hitList[cID] = true
+	}
+	for _, c := range runningContainers {
+		delete(hitList, c.ContainerID)
+	}
+
+	if len(hitList) == 0 {
+		// The pod is what we expect it to be.
+		return
+	}
+
+	// There are new running containers that don't match
+	// what we live-updated!
+	ms.NeedsRebuildFromCrash = true
+	ms.LiveUpdatedContainerIDs = container.NewIDSet()
+
+	msg := fmt.Sprintf("Detected a container change for %s. We could be running stale code. Rebuilding and deploying a new image.", ms.Name)
+	le := store.NewLogAction(ms.Name, ms.LastBuild().SpanID, logger.WarnLvl, nil, []byte(msg+"\n"))
+	state.LogStore.Append(le, state.Secrets)
+}

--- a/internal/store/runtime_state.go
+++ b/internal/store/runtime_state.go
@@ -191,16 +191,6 @@ func (s K8sRuntimeState) MostRecentPod() v1alpha1.Pod {
 	return s.Pods.MostRecentPod()
 }
 
-// podCompare is a stable sort order for pods.
-func podCompare(p1 v1alpha1.Pod, p2 v1alpha1.Pod) bool {
-	if p1.CreatedAt.After(p2.CreatedAt.Time) {
-		return true
-	} else if p2.CreatedAt.After(p1.CreatedAt.Time) {
-		return false
-	}
-	return p1.Name > p2.Name
-}
-
 func AllPodContainers(p v1alpha1.Pod) []v1alpha1.Container {
 	var result []v1alpha1.Container
 	result = append(result, p.InitContainers...)
@@ -252,7 +242,7 @@ func (ps PodSet) MostRecentPod() v1alpha1.Pod {
 	found := false
 
 	for _, v := range ps {
-		if !found || podCompare(*v, bestPod) {
+		if !found || k8sconv.PodCompare(*v, bestPod) {
 			bestPod = *v
 			found = true
 		}


### PR DESCRIPTION
Hello @milas, @landism,

Please review the following commits I made in branch nicks/lu11:

c3f5735ac54a10d43e528b0aaedc4fd57137817f (2021-10-01 13:01:00 -0400)
engine: infer liveupdate pods from KubernetesApply+KubernetesDiscovery

247f0fd7ac42aab89120eb51af1ddcf9e04ba17c (2021-10-01 12:30:36 -0400)
test: improve how we infer pod template hashes

d80e6ee232c4c1e4919a547fce266deee8798412 (2021-09-30 16:42:25 -0400)
store: create helper objects for summarizing Discovery+Apply
Right now, we decide which pods to LiveUpdate based on a complex
set of information from Discovery+Apply. We want to move all the relevant
info into its own object, separate from the old K8sRuntimeState

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics