### PR TITLE
engine: create links for dynamically allocated Docker Compose ports

### DIFF
--- a/internal/cli/wire_gen.go
+++ b/internal/cli/wire_gen.go
@@ -7,8 +7,16 @@ package cli
 
 import (
 	"context"
+	"time"
+
 	"github.com/google/wire"
 	"github.com/jonboulle/clockwork"
+	"github.com/tilt-dev/wmclient/pkg/dirs"
+	"go.opentelemetry.io/otel/sdk/trace"
+	version2 "k8s.io/apimachinery/pkg/version"
+	"k8s.io/client-go/tools/clientcmd/api"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	"github.com/tilt-dev/tilt/internal/analytics"
 	"github.com/tilt-dev/tilt/internal/build"
 	client2 "github.com/tilt-dev/tilt/internal/cli/client"
@@ -67,12 +75,6 @@ import (
 	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
 	"github.com/tilt-dev/tilt/pkg/logger"
 	"github.com/tilt-dev/tilt/pkg/model"
-	"github.com/tilt-dev/wmclient/pkg/dirs"
-	"go.opentelemetry.io/otel/sdk/trace"
-	version2 "k8s.io/apimachinery/pkg/version"
-	"k8s.io/client-go/tools/clientcmd/api"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"time"
 )
 
 // Injectors from wire.go:

--- a/internal/dockercompose/state.go
+++ b/internal/dockercompose/state.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/go-connections/nat"
 
 	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
 	"github.com/tilt-dev/tilt/pkg/model"
@@ -32,6 +33,8 @@ type State struct {
 	LastReadyTime time.Time
 
 	SpanID model.LogSpanID
+
+	Ports nat.PortMap
 }
 
 func (State) RuntimeState() {}
@@ -69,6 +72,11 @@ func (s State) RuntimeStatusError() error {
 
 func (s State) WithContainerState(state types.ContainerState) State {
 	s.ContainerState = state
+	return s
+}
+
+func (s State) WithPorts(ports nat.PortMap) State {
+	s.Ports = ports
 	return s
 }
 

--- a/internal/engine/buildcontrol/docker_compose_build_and_deployer.go
+++ b/internal/engine/buildcontrol/docker_compose_build_and_deployer.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/api/types"
+	"github.com/docker/go-connections/nat"
 
 	"github.com/tilt-dev/tilt/internal/analytics"
 
@@ -159,7 +160,12 @@ func (bd *DockerComposeBuildAndDeployer) BuildAndDeploy(ctx context.Context, st 
 		containerState = containerJSON.ContainerJSONBase.State
 	}
 
-	newResults[dcTarget.ID()] = store.NewDockerComposeDeployResult(dcTarget.ID(), cid, containerState)
+	var ports nat.PortMap
+	if containerJSON.NetworkSettings != nil {
+		ports = containerJSON.NetworkSettings.NetworkSettingsBase.Ports
+	}
+
+	newResults[dcTarget.ID()] = store.NewDockerComposeDeployResult(dcTarget.ID(), cid, containerState, ports)
 	return newResults, nil
 }
 

--- a/internal/engine/buildcontrol/wire_gen.go
+++ b/internal/engine/buildcontrol/wire_gen.go
@@ -7,7 +7,11 @@ package buildcontrol
 
 import (
 	"context"
+
 	"github.com/google/wire"
+	"github.com/tilt-dev/wmclient/pkg/dirs"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	"github.com/tilt-dev/tilt/internal/analytics"
 	"github.com/tilt-dev/tilt/internal/build"
 	"github.com/tilt-dev/tilt/internal/containerupdate"
@@ -19,8 +23,6 @@ import (
 	"github.com/tilt-dev/tilt/internal/store"
 	"github.com/tilt-dev/tilt/internal/tracer"
 	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
-	"github.com/tilt-dev/wmclient/pkg/dirs"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // Injectors from wire.go:

--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -458,6 +458,7 @@ func handleBuildCompleted(ctx context.Context, engineState *store.EngineState, c
 		cState := dcResult.ContainerState
 		if cState != nil {
 			state = state.WithContainerState(*cState)
+			state = state.WithPorts(dcResult.Ports)
 
 			if docker.HasStarted(*cState) {
 				if state.StartTime.IsZero() {

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -349,7 +349,7 @@ func (b *fakeBuildAndDeployer) BuildAndDeploy(ctx context.Context, st store.RSto
 
 		dcContainerState := b.nextDockerComposeContainerState
 		result[call.dc().ID()] = store.NewDockerComposeDeployResult(
-			call.dc().ID(), dcContainerID, dcContainerState)
+			call.dc().ID(), dcContainerID, dcContainerState, nil)
 	}
 
 	if kTarg := call.k8s(); !kTarg.Empty() {

--- a/internal/engine/wire_gen.go
+++ b/internal/engine/wire_gen.go
@@ -7,8 +7,13 @@ package engine
 
 import (
 	"context"
+
 	"github.com/google/wire"
 	"github.com/jonboulle/clockwork"
+	"github.com/tilt-dev/wmclient/pkg/dirs"
+	"go.opentelemetry.io/otel/sdk/trace"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	"github.com/tilt-dev/tilt/internal/analytics"
 	"github.com/tilt-dev/tilt/internal/build"
 	"github.com/tilt-dev/tilt/internal/container"
@@ -24,9 +29,6 @@ import (
 	"github.com/tilt-dev/tilt/internal/store"
 	"github.com/tilt-dev/tilt/internal/tracer"
 	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
-	"github.com/tilt-dev/wmclient/pkg/dirs"
-	"go.opentelemetry.io/otel/sdk/trace"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // Injectors from wire.go:

--- a/internal/store/build_result.go
+++ b/internal/store/build_result.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/docker/distribution/reference"
 	dockertypes "github.com/docker/docker/api/types"
+	"github.com/docker/go-connections/nat"
 
 	"github.com/tilt-dev/tilt/internal/container"
 	"github.com/tilt-dev/tilt/internal/dockercompose"
@@ -117,17 +118,21 @@ type DockerComposeBuildResult struct {
 
 	// The initial state of the container.
 	ContainerState *dockertypes.ContainerState
+
+	// Runtime port bindings
+	Ports nat.PortMap
 }
 
 func (r DockerComposeBuildResult) TargetID() model.TargetID   { return r.id }
 func (r DockerComposeBuildResult) BuildType() model.BuildType { return model.BuildTypeDockerCompose }
 
 // For docker compose deploy targets.
-func NewDockerComposeDeployResult(id model.TargetID, containerID container.ID, state *dockertypes.ContainerState) DockerComposeBuildResult {
+func NewDockerComposeDeployResult(id model.TargetID, containerID container.ID, state *dockertypes.ContainerState, ports nat.PortMap) DockerComposeBuildResult {
 	return DockerComposeBuildResult{
 		id:                       id,
 		DockerComposeContainerID: containerID,
 		ContainerState:           state,
+		Ports:                    ports,
 	}
 }
 

--- a/internal/store/engine_state.go
+++ b/internal/store/engine_state.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"sort"
+	"strconv"
 	"sync"
 	"time"
 
@@ -813,14 +814,34 @@ func ManifestTargetEndpoints(mt *ManifestTarget) (endpoints []model.Link) {
 		return localResourceLinks
 	}
 
-	publishedPorts := mt.Manifest.DockerComposeTarget().PublishedPorts()
-	if len(publishedPorts) > 0 {
+	if mt.Manifest.IsDC() {
+		hostPorts := make(map[int]bool)
+		publishedPorts := mt.Manifest.DockerComposeTarget().PublishedPorts()
 		for _, p := range publishedPorts {
+			if p == 0 || hostPorts[p] {
+				continue
+			}
+			hostPorts[p] = true
 			endpoints = append(endpoints, model.MustNewLink(fmt.Sprintf("http://localhost:%d/", p), ""))
 		}
+
+		for _, bindings := range mt.State.DCRuntimeState().Ports {
+			// Docker usually contains multiple bindings for each port - one for ipv4 (0.0.0.0)
+			// and one for ipv6 (::1).
+			for _, binding := range bindings {
+				pstring := binding.HostPort
+				p, err := strconv.Atoi(pstring)
+				if err != nil || p == 0 || hostPorts[p] {
+					continue
+				}
+				hostPorts[p] = true
+				endpoints = append(endpoints, model.MustNewLink(fmt.Sprintf("http://localhost:%d/", p), ""))
+			}
+		}
+
+		endpoints = append(endpoints, mt.Manifest.DockerComposeTarget().Links...)
 	}
 
-	endpoints = append(endpoints, mt.Manifest.DockerComposeTarget().Links...)
 	return endpoints
 }
 

--- a/pkg/webview/view.pb.go
+++ b/pkg/webview/view.pb.go
@@ -7,6 +7,7 @@ import (
 	context "context"
 	fmt "fmt"
 	math "math"
+
 	v1alpha1 "github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
 
 	proto "github.com/golang/protobuf/proto"


### PR DESCRIPTION
Hello @landism, @lizzthabet,

Please review the following commits I made in branch nicks/ch12807:

a144c3df5d065ef7aa56382c472d2e596e75351e (2021-10-01 17:35:57 -0400)
engine: create links for dynamically allocated Docker Compose ports
Fixes https://github.com/tilt-dev/tilt/issues/4998

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics