### PR TITLE
engine: Pass KubernetesResource and KubernetesSelector to BuildState

### DIFF
--- a/internal/containerupdate/container_updater.go
+++ b/internal/containerupdate/container_updater.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"io"
 
-	"github.com/tilt-dev/tilt/internal/store"
+	"github.com/tilt-dev/tilt/internal/store/liveupdates"
 	"github.com/tilt-dev/tilt/pkg/model"
 )
 
 type ContainerUpdater interface {
-	UpdateContainer(ctx context.Context, cInfo store.ContainerInfo,
+	UpdateContainer(ctx context.Context, cInfo liveupdates.Container,
 		archiveToCopy io.Reader, filesToDelete []string, cmds []model.Cmd, hotReload bool) error
 }

--- a/internal/containerupdate/docker_container_updater.go
+++ b/internal/containerupdate/docker_container_updater.go
@@ -12,7 +12,7 @@ import (
 	"github.com/tilt-dev/tilt/internal/container"
 	"github.com/tilt-dev/tilt/internal/docker"
 	"github.com/tilt-dev/tilt/internal/k8s"
-	"github.com/tilt-dev/tilt/internal/store"
+	"github.com/tilt-dev/tilt/internal/store/liveupdates"
 	"github.com/tilt-dev/tilt/pkg/logger"
 	"github.com/tilt-dev/tilt/pkg/model"
 )
@@ -31,7 +31,7 @@ func (cu *DockerUpdater) WillBuildToKubeContext(kctx k8s.KubeContext) bool {
 	return cu.dCli.Env().WillBuildToKubeContext(kctx)
 }
 
-func (cu *DockerUpdater) UpdateContainer(ctx context.Context, cInfo store.ContainerInfo,
+func (cu *DockerUpdater) UpdateContainer(ctx context.Context, cInfo liveupdates.Container,
 	archiveToCopy io.Reader, filesToDelete []string, cmds []model.Cmd, hotReload bool) error {
 	l := logger.Get(ctx)
 

--- a/internal/containerupdate/docker_container_updater_test.go
+++ b/internal/containerupdate/docker_container_updater_test.go
@@ -8,16 +8,16 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/tilt-dev/tilt/internal/store/liveupdates"
 	"github.com/tilt-dev/tilt/internal/testutils"
 
 	"github.com/tilt-dev/tilt/internal/build"
-	"github.com/tilt-dev/tilt/internal/store"
 
 	"github.com/tilt-dev/tilt/internal/docker"
 	"github.com/tilt-dev/tilt/pkg/model"
 )
 
-var TestContainerInfo = store.ContainerInfo{
+var TestContainerInfo = liveupdates.Container{
 	PodID:         "somepod",
 	ContainerID:   docker.TestContainer,
 	ContainerName: "my-container",

--- a/internal/containerupdate/exec_updater.go
+++ b/internal/containerupdate/exec_updater.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/tilt-dev/tilt/internal/build"
 	"github.com/tilt-dev/tilt/internal/k8s"
-	"github.com/tilt-dev/tilt/internal/store"
+	"github.com/tilt-dev/tilt/internal/store/liveupdates"
 	"github.com/tilt-dev/tilt/pkg/logger"
 	"github.com/tilt-dev/tilt/pkg/model"
 )
@@ -24,7 +24,7 @@ func NewExecUpdater(kCli k8s.Client) *ExecUpdater {
 	return &ExecUpdater{kCli: kCli}
 }
 
-func (cu *ExecUpdater) UpdateContainer(ctx context.Context, cInfo store.ContainerInfo,
+func (cu *ExecUpdater) UpdateContainer(ctx context.Context, cInfo liveupdates.Container,
 	archiveToCopy io.Reader, filesToDelete []string, cmds []model.Cmd, hotReload bool) error {
 	if !hotReload {
 		return fmt.Errorf("ExecUpdater does not support `restart_container()` step. If you ran Tilt " +

--- a/internal/containerupdate/fake_container_updater.go
+++ b/internal/containerupdate/fake_container_updater.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/tilt-dev/tilt/internal/store"
+	"github.com/tilt-dev/tilt/internal/store/liveupdates"
 	"github.com/tilt-dev/tilt/pkg/model"
 )
 
@@ -15,7 +15,7 @@ type FakeContainerUpdater struct {
 }
 
 type UpdateContainerCall struct {
-	ContainerInfo store.ContainerInfo
+	ContainerInfo liveupdates.Container
 	Archive       io.Reader
 	ToDelete      []string
 	Cmds          []model.Cmd
@@ -26,7 +26,7 @@ func (cu *FakeContainerUpdater) SetUpdateErr(err error) {
 	cu.UpdateErrs = []error{err}
 }
 
-func (cu *FakeContainerUpdater) UpdateContainer(ctx context.Context, cInfo store.ContainerInfo,
+func (cu *FakeContainerUpdater) UpdateContainer(ctx context.Context, cInfo liveupdates.Container,
 	archiveToCopy io.Reader, filesToDelete []string, cmds []model.Cmd, hotReload bool) error {
 	cu.Calls = append(cu.Calls, UpdateContainerCall{
 		ContainerInfo: cInfo,

--- a/internal/engine/build_and_deployer_live_update_test.go
+++ b/internal/engine/build_and_deployer_live_update_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/tilt-dev/tilt/internal/engine/buildcontrol"
 	"github.com/tilt-dev/tilt/internal/k8s/testyaml"
+	"github.com/tilt-dev/tilt/internal/store/liveupdates"
 
 	"github.com/tilt-dev/tilt/internal/docker"
 
@@ -84,15 +85,16 @@ func runTestCase(t *testing.T, f *bdFixture, tCase testCase) {
 	require.True(t, manifest.IsImageDeployed(iTarg))
 
 	for targID, cIDs := range tCase.runningContainersByTarget {
-		cInfos := make([]store.ContainerInfo, len(cIDs))
+		containers := make([]liveupdates.Container, len(cIDs))
 		for i, id := range cIDs {
-			cInfos[i] = store.ContainerInfo{
+			containers[i] = liveupdates.Container{
 				PodID:         testPodID,
 				ContainerID:   id,
 				ContainerName: container.Name(fmt.Sprintf("container %s", id)),
 			}
 		}
-		bs[targID] = bs[targID].WithRunningContainers(cInfos)
+		imageName := string(targID.Name)
+		bs[targID] = liveupdates.WithFakeContainers(bs[targID], imageName, containers)
 	}
 
 	targets := buildcontrol.BuildTargets(manifest)

--- a/internal/engine/buildcontrol/build_control.go
+++ b/internal/engine/buildcontrol/build_control.go
@@ -9,6 +9,7 @@ import (
 	"github.com/tilt-dev/tilt/internal/controllers/apis/liveupdate"
 	"github.com/tilt-dev/tilt/internal/store"
 	"github.com/tilt-dev/tilt/internal/store/k8sconv"
+	"github.com/tilt-dev/tilt/internal/store/liveupdates"
 	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
 	"github.com/tilt-dev/tilt/pkg/model"
 )
@@ -412,7 +413,7 @@ func IsLiveUpdateTargetWaitingOnDeploy(state store.EngineState, mt *store.Manife
 				return true // Wait for the k8s resource to appear.
 			}
 
-			cInfos, err := store.RunningContainersForOnePod(
+			cInfos, err := liveupdates.RunningContainersForOnePod(
 				iTarget.LiveUpdateSpec.Selector.Kubernetes, kResource)
 			if err != nil {
 				return false
@@ -439,7 +440,7 @@ func IsLiveUpdateTargetWaitingOnDeploy(state store.EngineState, mt *store.Manife
 			}
 
 		} else if mt.Manifest.IsDC() {
-			cInfos := store.RunningContainersForDC(mt.State.DCRuntimeState())
+			cInfos := liveupdates.RunningContainersForDC(mt.State.DockerResource())
 			if len(cInfos) != 0 {
 				return false
 			}

--- a/internal/engine/buildcontrol/live_update_state_tree.go
+++ b/internal/engine/buildcontrol/live_update_state_tree.go
@@ -3,6 +3,7 @@ package buildcontrol
 import (
 	"github.com/tilt-dev/tilt/internal/container"
 	"github.com/tilt-dev/tilt/internal/store"
+	"github.com/tilt-dev/tilt/internal/store/liveupdates"
 	"github.com/tilt-dev/tilt/pkg/model"
 )
 
@@ -11,17 +12,16 @@ import (
 type liveUpdateStateTree struct {
 	iTarget           model.ImageTarget
 	filesChanged      []string
-	iTargetState      store.BuildState
+	containers        []liveupdates.Container
 	hasFileChangesIDs []model.TargetID
 }
 
 // Create a successful build result if the live update deploys successfully.
 func (t liveUpdateStateTree) createResultSet() store.BuildResultSet {
 	iTargetID := t.iTarget.ID()
-	state := t.iTargetState
 
 	liveUpdatedContainerIDs := []container.ID{}
-	for _, c := range state.RunningContainers {
+	for _, c := range t.containers {
 		liveUpdatedContainerIDs = append(liveUpdatedContainerIDs, c.ContainerID)
 	}
 

--- a/internal/engine/buildcontroller.go
+++ b/internal/engine/buildcontroller.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/tilt-dev/tilt/internal/engine/buildcontrol"
 	"github.com/tilt-dev/tilt/internal/store"
+	"github.com/tilt-dev/tilt/internal/store/dcconv"
 	"github.com/tilt-dev/tilt/internal/store/k8sconv"
 	"github.com/tilt-dev/tilt/pkg/logger"
 	"github.com/tilt-dev/tilt/pkg/model"
@@ -188,16 +189,12 @@ func buildStateSet(ctx context.Context, manifest model.Manifest,
 			if ok {
 				selector := iTarget.LiveUpdateSpec.Selector
 				if manifest.IsK8s() && selector.Kubernetes != nil {
-					cInfos, err := store.RunningContainersForOnePod(selector.Kubernetes, kresource)
-					if err != nil {
-						buildState = buildState.WithRunningContainerError(err)
-					} else {
-						buildState = buildState.WithRunningContainers(cInfos)
-					}
+					buildState.KubernetesSelector = selector.Kubernetes
+					buildState.KubernetesResource = kresource
 				}
 
 				if manifest.IsDC() {
-					buildState = buildState.WithRunningContainers(store.RunningContainersForDC(ms.DCRuntimeState()))
+					buildState.DockerResource = &dcconv.DockerResource{ContainerID: string(ms.DCRuntimeState().ContainerID)}
 				}
 			}
 		}

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -2951,7 +2951,8 @@ func TestWatchManifestsWithCommonAncestor(t *testing.T) {
 
 	id := m2.ImageTargets[0].ID()
 	result := f.b.resultsByID[id]
-	assert.Equal(t, store.NewBuildState(result, nil, nil), call.state[id])
+	assert.Equal(t, result, call.state[id].LastResult)
+	assert.Equal(t, 0, len(call.state[id].FilesChangedSet))
 
 	id = m2.ImageTargets[1].ID()
 	result = f.b.resultsByID[id]

--- a/internal/store/dcconv/resource.go
+++ b/internal/store/dcconv/resource.go
@@ -1,0 +1,9 @@
+package dcconv
+
+// A DockerResource exposes a high-level status that summarizes
+// the containers we care about in a DockerCompose session.
+//
+// Long-term, this may become an explicit API server object.
+type DockerResource struct {
+	ContainerID string
+}

--- a/internal/store/engine_state.go
+++ b/internal/store/engine_state.go
@@ -8,21 +8,19 @@ import (
 	"sync"
 	"time"
 
-	"github.com/tilt-dev/tilt/internal/timecmp"
-
-	"github.com/tilt-dev/tilt/internal/store/k8sconv"
-
 	"github.com/tilt-dev/wmclient/pkg/analytics"
-
-	"github.com/tilt-dev/tilt/internal/k8s"
-	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
 
 	tiltanalytics "github.com/tilt-dev/tilt/internal/analytics"
 	"github.com/tilt-dev/tilt/internal/container"
 	"github.com/tilt-dev/tilt/internal/dockercompose"
 	"github.com/tilt-dev/tilt/internal/hud/view"
+	"github.com/tilt-dev/tilt/internal/k8s"
 	"github.com/tilt-dev/tilt/internal/ospath"
+	"github.com/tilt-dev/tilt/internal/store/dcconv"
+	"github.com/tilt-dev/tilt/internal/store/k8sconv"
+	"github.com/tilt-dev/tilt/internal/timecmp"
 	"github.com/tilt-dev/tilt/internal/token"
+	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
 	"github.com/tilt-dev/tilt/pkg/model"
 	"github.com/tilt-dev/tilt/pkg/model/logstore"
 )
@@ -577,6 +575,14 @@ func (ms *ManifestState) MutableBuildStatus(id model.TargetID) *BuildStatus {
 func (ms *ManifestState) DCRuntimeState() dockercompose.State {
 	ret, _ := ms.RuntimeState.(dockercompose.State)
 	return ret
+}
+
+func (ms *ManifestState) DockerResource() *dcconv.DockerResource {
+	ret, ok := ms.RuntimeState.(dockercompose.State)
+	if !ok {
+		return nil
+	}
+	return &dcconv.DockerResource{ContainerID: string(ret.ContainerID)}
 }
 
 func (ms *ManifestState) IsDC() bool {

--- a/internal/store/liveupdates/containers.go
+++ b/internal/store/liveupdates/containers.go
@@ -1,0 +1,128 @@
+package liveupdates
+
+import (
+	"fmt"
+
+	"github.com/docker/distribution/reference"
+	v1 "k8s.io/api/core/v1"
+
+	"github.com/tilt-dev/tilt/internal/container"
+	"github.com/tilt-dev/tilt/internal/k8s"
+	"github.com/tilt-dev/tilt/internal/store"
+	"github.com/tilt-dev/tilt/internal/store/dcconv"
+	"github.com/tilt-dev/tilt/internal/store/k8sconv"
+	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
+)
+
+func AllRunningContainers(mt *store.ManifestTarget, state *store.EngineState) []Container {
+	if mt.Manifest.IsDC() {
+		return RunningContainersForDC(mt.State.DockerResource())
+	}
+
+	var result []Container
+	for _, iTarget := range mt.Manifest.ImageTargets {
+		selector := iTarget.LiveUpdateSpec.Selector
+		if mt.Manifest.IsK8s() && selector.Kubernetes != nil {
+			cInfos, err := RunningContainersForOnePod(
+				selector.Kubernetes,
+				state.KubernetesResources[mt.Manifest.Name.String()])
+			if err != nil {
+				// HACK(maia): just don't collect container info for targets running
+				// more than one pod -- we don't support LiveUpdating them anyway,
+				// so no need to monitor those containers for crashes.
+				continue
+			}
+			result = append(result, cInfos...)
+		}
+	}
+	return result
+}
+
+func RunningContainers(selector *v1alpha1.LiveUpdateKubernetesSelector, k8sResource *k8sconv.KubernetesResource, dResource *dcconv.DockerResource) ([]Container, error) {
+	if selector != nil && k8sResource != nil {
+		return RunningContainersForOnePod(selector, k8sResource)
+	}
+	if dResource != nil {
+		return RunningContainersForDC(dResource), nil
+	}
+	return nil, nil
+}
+
+// If all containers running the given image are ready, returns info for them.
+// (If this image is running on multiple pods, return an error.)
+func RunningContainersForOnePod(selector *v1alpha1.LiveUpdateKubernetesSelector, resource *k8sconv.KubernetesResource) ([]Container, error) {
+	if selector == nil || resource == nil {
+		return nil, nil
+	}
+
+	activePods := []v1alpha1.Pod{}
+	for _, p := range resource.FilteredPods {
+		// Ignore completed pods.
+		if p.Phase == string(v1.PodSucceeded) || p.Phase == string(v1.PodFailed) {
+			continue
+		}
+		activePods = append(activePods, p)
+	}
+
+	if len(activePods) == 0 {
+		return nil, nil
+	}
+	if len(activePods) > 1 {
+		return nil, fmt.Errorf("can only get container info for a single pod; image target %s has %d pods", selector.Image, len(resource.FilteredPods))
+	}
+
+	pod := activePods[0]
+	var containers []Container
+	for _, c := range pod.Containers {
+		// Only return containers matching our image
+		imageRef, err := container.ParseNamed(c.Image)
+		if err != nil || imageRef == nil || selector.Image != reference.FamiliarName(imageRef) {
+			continue
+		}
+		if c.ID == "" || c.Name == "" || c.State.Running == nil {
+			// If we're missing any relevant info for this container, OR if the
+			// container isn't running, we can't update it in place.
+			// (Since we'll need to fully rebuild this image, we shouldn't bother
+			// in-place updating ANY containers on this pod -- they'll all
+			// be recreated when we image build. So don't return ANY Containers.)
+			return nil, nil
+		}
+		containers = append(containers, Container{
+			PodID:         k8s.PodID(pod.Name),
+			ContainerID:   container.ID(c.ID),
+			ContainerName: container.Name(c.Name),
+			Namespace:     k8s.Namespace(pod.Namespace),
+		})
+	}
+
+	return containers, nil
+}
+
+func RunningContainersForDC(dr *dcconv.DockerResource) []Container {
+	if dr == nil || dr.ContainerID == "" {
+		return nil
+	}
+	return []Container{
+		Container{ContainerID: container.ID(dr.ContainerID)},
+	}
+}
+
+// Information describing a single running & ready container
+type Container struct {
+	PodID         k8s.PodID
+	ContainerID   container.ID
+	ContainerName container.Name
+	Namespace     k8s.Namespace
+}
+
+func (c Container) Empty() bool {
+	return c == Container{}
+}
+
+func IDsForContainers(infos []Container) []container.ID {
+	ids := make([]container.ID, len(infos))
+	for i, info := range infos {
+		ids[i] = info.ContainerID
+	}
+	return ids
+}

--- a/internal/store/liveupdates/fake.go
+++ b/internal/store/liveupdates/fake.go
@@ -1,0 +1,64 @@
+package liveupdates
+
+import (
+	"sort"
+
+	"github.com/tilt-dev/tilt/internal/store"
+	"github.com/tilt-dev/tilt/internal/store/k8sconv"
+	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
+)
+
+func WithFakeContainers(s store.BuildState, imageName string, containers []Container) store.BuildState {
+	s.KubernetesSelector = &v1alpha1.LiveUpdateKubernetesSelector{Image: imageName}
+	s.KubernetesResource = FakeKubernetesResource(imageName, containers)
+	return s
+}
+
+func FakeKubernetesResource(image string, containers []Container) *k8sconv.KubernetesResource {
+	r, err := k8sconv.NewKubernetesResource(FakeKubernetesDiscovery(image, containers), nil)
+	if err != nil {
+		panic(err)
+	}
+	return r
+}
+
+// Given the set of containers we want, create a fake KubernetesDiscovery
+// with those containers running.
+func FakeKubernetesDiscovery(image string, containers []Container) *v1alpha1.KubernetesDiscovery {
+	podMap := map[string]*v1alpha1.Pod{}
+	for _, c := range containers {
+		pod, ok := podMap[string(c.PodID)]
+		if !ok {
+			pod = &v1alpha1.Pod{
+				Name:      string(c.PodID),
+				Namespace: string(c.Namespace),
+				Phase:     "Running",
+			}
+			podMap[string(c.PodID)] = pod
+		}
+
+		pod.Containers = append(pod.Containers, v1alpha1.Container{
+			ID:    string(c.ContainerID),
+			Name:  string(c.ContainerName),
+			Ready: true,
+			Image: image,
+			State: v1alpha1.ContainerState{
+				Running: &v1alpha1.ContainerStateRunning{},
+			},
+		})
+	}
+
+	pods := []v1alpha1.Pod{}
+	for _, p := range podMap {
+		pods = append(pods, *p)
+	}
+	sort.Slice(pods, func(i, j int) bool {
+		return pods[i].Name < pods[j].Name
+	})
+
+	return &v1alpha1.KubernetesDiscovery{
+		Status: v1alpha1.KubernetesDiscoveryStatus{
+			Pods: pods,
+		},
+	}
+}

--- a/internal/store/liveupdates/reducers.go
+++ b/internal/store/liveupdates/reducers.go
@@ -26,7 +26,7 @@ func CheckForContainerCrash(state *store.EngineState, name string) {
 		return
 	}
 
-	runningContainers := store.AllRunningContainers(mt, state)
+	runningContainers := AllRunningContainers(mt, state)
 	if len(runningContainers) == 0 {
 		// If there are no running containers, it might mean the containers are
 		// being deleted. We don't need to intervene yet.


### PR DESCRIPTION
Hello @milas, @landism,

Please review the following commits I made in branch nicks/lu13:

aabc42555e5756b7075071330df46fa4123341a0 (2021-10-04 20:05:26 -0400)
engine: Pass KubernetesResource and KubernetesSelector to BuildState
This is mostly a giant yak shave. Getting both data and testdata
into the format that the LiveUpdate API expects.

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics