### PR TITLE
engine: don't treat Jobs as "OK" until they complete

### DIFF
--- a/integration/job/Tiltfile
+++ b/integration/job/Tiltfile
@@ -4,3 +4,6 @@ include('../Tiltfile')
 k8s_yaml('job.yaml')
 docker_build('job', '.')
 k8s_resource('job', port_forwards=31234)
+
+# to test that resource_deps on jobs wait for succeeded, not running
+local_resource('foo', 'echo hi', allow_parallel=True, resource_deps=['job'])

--- a/integration/job_test.go
+++ b/integration/job_test.go
@@ -6,6 +6,8 @@ import (
 	"context"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 )
 
 // Replacing a job often exercises very different codepaths
@@ -26,4 +28,8 @@ func TestJob(t *testing.T) {
 	ctx, cancel = context.WithTimeout(f.ctx, time.Minute)
 	defer cancel()
 	f.CurlUntil(ctx, "http://localhost:31234/message.txt", "🍄 Two-Up! 🍄")
+
+	target := f.TargetStatus("foo:update")
+	require.NotNil(t, target.State.Waiting)
+	require.Equal(t, "waiting-for-dep", target.State.Waiting.WaitReason)
 }

--- a/internal/store/engine_state_test.go
+++ b/internal/store/engine_state_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/docker/go-connections/nat"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
 
 	"github.com/tilt-dev/tilt/internal/container"
 	"github.com/tilt-dev/tilt/internal/hud/view"
@@ -154,6 +155,41 @@ func TestRuntimeStateNonWorkload(t *testing.T) {
 	runtimeState.HasEverDeployedSuccessfully = true
 
 	assert.Equal(t, v1alpha1.RuntimeStatusOK, runtimeState.RuntimeStatus())
+}
+
+func TestRuntimeStateJob(t *testing.T) {
+	for _, tc := range []struct {
+		phase                 v1.PodPhase
+		expectedRuntimeStatus v1alpha1.RuntimeStatus
+	}{
+		{v1.PodRunning, v1alpha1.RuntimeStatusPending},
+		{v1.PodSucceeded, v1alpha1.RuntimeStatusOK},
+		{v1.PodFailed, v1alpha1.RuntimeStatusError},
+	} {
+		t.Run(string(tc.phase), func(t *testing.T) {
+			f := tempdir.NewTempDirFixture(t)
+			defer f.TearDown()
+
+			m := manifestbuilder.New(f, "foo").
+				WithK8sYAML(testyaml.JobYAML).
+				WithK8sPodReadiness(model.PodReadinessComplete).
+				Build()
+			state := newState([]model.Manifest{m})
+			runtimeState := state.ManifestTargets[m.Name].State.K8sRuntimeState()
+			assert.Equal(t, v1alpha1.RuntimeStatusPending, runtimeState.RuntimeStatus())
+
+			runtimeState.HasEverDeployedSuccessfully = true
+
+			pod := &v1alpha1.Pod{
+				Name:      "pod",
+				CreatedAt: apis.Now(),
+				Phase:     string(tc.phase),
+			}
+			runtimeState.Pods[k8s.PodID(pod.Name)] = pod
+
+			assert.Equal(t, tc.expectedRuntimeStatus, runtimeState.RuntimeStatus())
+		})
+	}
 }
 
 func TestStateToViewUnresourcedYAMLManifest(t *testing.T) {

--- a/internal/store/runtime_state.go
+++ b/internal/store/runtime_state.go
@@ -135,7 +135,7 @@ func (s K8sRuntimeState) RuntimeStatus() v1alpha1.RuntimeStatus {
 
 	switch v1.PodPhase(pod.Phase) {
 	case v1.PodRunning:
-		if AllPodContainersReady(pod) {
+		if AllPodContainersReady(pod) && s.PodReadinessMode != model.PodReadinessComplete {
 			return v1alpha1.RuntimeStatusOK
 		}
 		return v1alpha1.RuntimeStatusPending

--- a/internal/tiltfile/k8s/readiness.go
+++ b/internal/tiltfile/k8s/readiness.go
@@ -20,19 +20,16 @@ func (m *PodReadinessMode) Unpack(v starlark.Value) error {
 		return fmt.Errorf("Must be a string. Got: %s", v.Type())
 	}
 
-	if s == string(model.PodReadinessIgnore) {
-		m.Value = model.PodReadinessIgnore
-		return nil
-	}
-
-	if s == string(model.PodReadinessWait) {
-		m.Value = model.PodReadinessWait
-		return nil
-	}
-
-	if s == "" {
-		m.Value = model.PodReadinessNone
-		return nil
+	for _, mode := range []model.PodReadinessMode{
+		model.PodReadinessIgnore,
+		model.PodReadinessWait,
+		model.PodReadinessComplete,
+		model.PodReadinessNone,
+	} {
+		if s == string(mode) {
+			m.Value = mode
+			return nil
+		}
 	}
 
 	return fmt.Errorf("Invalid value. Allowed: {%s, %s}. Got: %s", model.PodReadinessIgnore, model.PodReadinessWait, s)

--- a/internal/tiltfile/k8s/resource.go
+++ b/internal/tiltfile/k8s/resource.go
@@ -9,3 +9,13 @@ type KindInfo struct {
 	ImageLocators    []k8s.ImageLocator
 	PodReadinessMode model.PodReadinessMode
 }
+
+func InitialKinds() map[k8s.ObjectSelector]*KindInfo {
+	sel, err := k8s.NewPartialMatchObjectSelector("batch/v1", "Job", "", "")
+	if err != nil {
+		panic(err)
+	}
+	return map[k8s.ObjectSelector]*KindInfo{
+		sel: {PodReadinessMode: model.PodReadinessComplete},
+	}
+}

--- a/internal/tiltfile/tiltfile_state.go
+++ b/internal/tiltfile/tiltfile_state.go
@@ -171,7 +171,7 @@ func newTiltfileState(
 		features:                  features,
 		secretSettings:            model.DefaultSecretSettings(),
 		apiObjects:                apiset.ObjectSet{},
-		k8sKinds:                  make(map[k8s.ObjectSelector]*tiltfile_k8s.KindInfo),
+		k8sKinds:                  tiltfile_k8s.InitialKinds(),
 	}
 }
 
@@ -1008,7 +1008,7 @@ func (s *tiltfileState) decideRegistry() container.Registry {
 // if it should wait for the pods to be complete before building the next resource (e.g., jobs)
 // and it's complicated a bit by the fact that there are both normal CRDs where the image shows up in the same place each time, and more meta CRDs (like HelmRelease) where it might appear in different places
 //
-// feels like wer're still doing this very ad-hoc rather than holistically
+// feels like we're still doing this very ad-hoc rather than holistically
 func (s *tiltfileState) inferPodReadinessMode(r *k8sResource) model.PodReadinessMode {
 	// The mode set directly on the resource has highest priority.
 	if r.podReadinessMode != model.PodReadinessNone {
@@ -1016,28 +1016,20 @@ func (s *tiltfileState) inferPodReadinessMode(r *k8sResource) model.PodReadiness
 	}
 
 	// Next, check if any of the k8s kinds have a mode.
-	hasWaitMode := false
-	hasIgnoreMode := false
+	hasMode := make(map[model.PodReadinessMode]bool)
 	for _, e := range r.entities {
 		for sel, info := range s.k8sKinds {
 			if sel.Matches(e) {
-				if info.PodReadinessMode == model.PodReadinessWait {
-					hasWaitMode = true
-				}
-
-				if info.PodReadinessMode == model.PodReadinessIgnore {
-					hasIgnoreMode = true
-				}
+				hasMode[info.PodReadinessMode] = true
 			}
 		}
 	}
 
-	if hasWaitMode {
-		return model.PodReadinessWait
-	}
-
-	if hasIgnoreMode {
-		return model.PodReadinessIgnore
+	modes := []model.PodReadinessMode{model.PodReadinessWait, model.PodReadinessIgnore, model.PodReadinessComplete}
+	for _, m := range modes {
+		if hasMode[m] {
+			return m
+		}
 	}
 
 	// Auto-infer based on context

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -1767,6 +1767,25 @@ k8s_resource(new_name='config', objects=['config'])
 	)
 }
 
+func TestPodReadinessDefaultJob(t *testing.T) {
+	f := newFixture(t)
+	defer f.TearDown()
+
+	f.file("job.yaml", `apiVersion: batch/v1
+kind: Job
+metadata:
+  name: myjob
+`)
+	f.file("Tiltfile", `
+k8s_yaml('job.yaml')
+`)
+
+	f.load("myjob")
+	f.assertNextManifest("myjob",
+		podReadiness(model.PodReadinessComplete),
+	)
+}
+
 func TestK8sDiscoveryStrategy(t *testing.T) {
 	f := newFixture(t)
 	defer f.TearDown()

--- a/pkg/model/k8s_target.go
+++ b/pkg/model/k8s_target.go
@@ -10,11 +10,7 @@ import (
 	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
 )
 
-// Whether or not to wait for pods to become ready before
-// marking the k8s resource healthy.
-//
-// TODO(nick): I strongly suspect we will at least want a separate mode
-// for jobs that waits until they become complete, as we do in `tilt ci`
+// Specifies how a Pod's state factors into determining whether a resource is ready
 type PodReadinessMode string
 
 // Pod readiness isn't applicable to this resource
@@ -25,6 +21,9 @@ const PodReadinessWait PodReadinessMode = "wait"
 
 // Don't even wait for pods to appear.
 const PodReadinessIgnore PodReadinessMode = "ignore"
+
+// wait until the pod has completed
+const PodReadinessComplete PodReadinessMode = "complete"
 
 type K8sTarget struct {
 	// An apiserver-driven data model for applying Kubernetes YAML.


### PR DESCRIPTION
Fixes #4809 

1. Jobs now have a runtime status of "pending" until the pod completes (they are currently "ok" as soon as the pod is ready)
2. A resource that has a resource_dep on a Job resource will now start only once the job's pod succeeds (it currently starts as soon as the job's pod is ready)