### PR TITLE
docker-compose: use .env when loading

### DIFF
--- a/internal/dockercompose/client.go
+++ b/internal/dockercompose/client.go
@@ -241,7 +241,7 @@ func (c *cmdDCClient) Version(ctx context.Context) (string, string, error) {
 func (c *cmdDCClient) loadProject(configPaths []string) (*types.Project, error) {
 	// NOTE: take care to keep relevant options in sync with FakeDCClient::Project() and cmdDCClient::loadProjectCLI()
 	// 	which work differently so cannot directly share options but need to behave similarly
-	opts, err := compose.NewProjectOptions(configPaths, compose.WithOsEnv, compose.WithResolvedPaths(true))
+	opts, err := compose.NewProjectOptions(configPaths, compose.WithOsEnv, compose.WithResolvedPaths(true), compose.WithDotEnv)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/dockercompose/client_test.go
+++ b/internal/dockercompose/client_test.go
@@ -146,6 +146,25 @@ OpenSSL version: OpenSSL 1.1.0l  10 Sep 2019
 	}
 }
 
+func TestLoadEnvFile(t *testing.T) {
+	if testing.Short() {
+		// remove this once the fallback to docker-compose CLI for YAML parse is eliminated
+		// (dependent upon compose-go upstream bugs being fixed)
+		t.Skip("skipping test that invokes docker-compose CLI in short mode")
+	}
+
+	f := newDCFixture(t)
+	f.tmpdir.WriteFile(".env", "COMMAND=foo")
+
+	dcYAML := `services:
+  foo:
+    command: ${COMMAND}
+    image: asdf
+`
+	proj := f.loadProject(dcYAML)
+	require.Equal(t, types.ShellCommand{"foo"}, proj.Services[0].Command)
+}
+
 type dcFixture struct {
 	t      testing.TB
 	ctx    context.Context

--- a/internal/dockercompose/fake_client.go
+++ b/internal/dockercompose/fake_client.go
@@ -10,6 +10,8 @@ import (
 	"time"
 	"unicode"
 
+	compose "github.com/compose-spec/compose-go/cli"
+
 	"github.com/compose-spec/compose-go/loader"
 	"github.com/stretchr/testify/require"
 
@@ -139,6 +141,14 @@ func (c *FakeDCClient) Config(_ context.Context, _ []string) (string, error) {
 }
 
 func (c *FakeDCClient) Project(_ context.Context, _ []string) (*types.Project, error) {
+	// this is a dummy ProjectOptions that lets us use compose's logic to apply options
+	// for consistency, but we have to then pull the data out ourselves since we're calling
+	// loader.Load ourselves
+	opts, err := compose.NewProjectOptions(nil, compose.WithDotEnv, compose.WithOsEnv)
+	if err != nil {
+		return nil, err
+	}
+
 	return loader.Load(types.ConfigDetails{
 		WorkingDir: c.WorkDir,
 		ConfigFiles: []types.ConfigFile{
@@ -146,6 +156,7 @@ func (c *FakeDCClient) Project(_ context.Context, _ []string) (*types.Project, e
 				Content: []byte(c.ConfigOutput),
 			},
 		},
+		Environment: opts.Environment,
 	}, func(options *loader.Options) {
 		options.ResolvePaths = true
 	})


### PR DESCRIPTION
Fixes #5020