### PR TITLE
filewatch: use `DisableStatus` and `Spec` to enable and disable filewatches

### DIFF
--- a/internal/cli/wire_gen.go
+++ b/internal/cli/wire_gen.go
@@ -224,7 +224,7 @@ func wireCmdUp(ctx context.Context, analytics3 *analytics.TiltAnalytics, cmdTags
 	}
 	watcherMaker := fsevent.ProvideWatcherMaker()
 	timerMaker := fsevent.ProvideTimerMaker()
-	controller := filewatch.NewController(deferredClient, storeStore, watcherMaker, timerMaker)
+	controller := filewatch.NewController(deferredClient, storeStore, watcherMaker, timerMaker, scheme)
 	env := localexec.DefaultEnv(webPort, webHost)
 	execer := cmd.ProvideExecer(env)
 	proberManager := cmd.ProvideProberManager()
@@ -425,7 +425,7 @@ func wireCmdCI(ctx context.Context, analytics3 *analytics.TiltAnalytics, subcomm
 	}
 	watcherMaker := fsevent.ProvideWatcherMaker()
 	timerMaker := fsevent.ProvideTimerMaker()
-	controller := filewatch.NewController(deferredClient, storeStore, watcherMaker, timerMaker)
+	controller := filewatch.NewController(deferredClient, storeStore, watcherMaker, timerMaker, scheme)
 	env := localexec.DefaultEnv(webPort, webHost)
 	execer := cmd.ProvideExecer(env)
 	proberManager := cmd.ProvideProberManager()
@@ -623,7 +623,7 @@ func wireCmdUpdog(ctx context.Context, analytics3 *analytics.TiltAnalytics, cmdT
 	}
 	watcherMaker := fsevent.ProvideWatcherMaker()
 	timerMaker := fsevent.ProvideTimerMaker()
-	controller := filewatch.NewController(deferredClient, storeStore, watcherMaker, timerMaker)
+	controller := filewatch.NewController(deferredClient, storeStore, watcherMaker, timerMaker, scheme)
 	env := localexec.DefaultEnv(webPort, webHost)
 	execer := cmd.ProvideExecer(env)
 	proberManager := cmd.ProvideProberManager()

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -3922,7 +3922,7 @@ func newTestFixture(t *testing.T, options ...fixtureOptions) *testFixture {
 	tcum := cloud.NewStatusManager(httptest.NewFakeClientEmptyJSON(), clock)
 	fe := cmd.NewFakeExecer()
 	fpm := cmd.NewFakeProberManager()
-	fwc := filewatch.NewController(cdc, st, watcher.NewSub, timerMaker.Maker())
+	fwc := filewatch.NewController(cdc, st, watcher.NewSub, timerMaker.Maker(), v1alpha1.NewScheme())
 	cmds := cmd.NewController(ctx, fe, fpm, cdc, st, clock, v1alpha1.NewScheme())
 	lsc := local.NewServerController(cdc)
 	sessionController := session.NewController(cdc, engineMode)


### PR DESCRIPTION
This PR enables and disables `filewatch` API objects based on the corresponding `configmap`.

If the `configmap` gets enabled or disabled, the `filewatch` should get enabled or disabled accordingly. I tested locally by editing the `configmap` directly and inspecting the `filewatch` objects. If there are other ways I should be testling, lmk!