### PR TITLE
docker: pass the correct path to Tiltfile

### DIFF
--- a/internal/tiltfile/docker.go
+++ b/internal/tiltfile/docker.go
@@ -68,6 +68,9 @@ type dockerImage struct {
 	outputsImageRefTo string
 
 	liveUpdate v1alpha1.LiveUpdateSpec
+
+	// TODO(milas): we should have a better way of passing the Tiltfile path around during resource assembly
+	tiltfilePath string
 }
 
 func (d *dockerImage) ID() model.TargetID {
@@ -247,6 +250,7 @@ func (s *tiltfileState) dockerBuild(thread *starlark.Thread, fn *starlark.Builti
 		cacheFrom:        cacheFrom.Values,
 		pullParent:       pullParent,
 		platform:         platform.Value,
+		tiltfilePath:     starkit.CurrentExecPath(thread),
 	}
 	err = s.buildIndex.addImage(r)
 	if err != nil {
@@ -367,6 +371,7 @@ func (s *tiltfileState) customBuild(thread *starlark.Thread, fn *starlark.Builti
 		entrypoint:        entrypointCmd,
 		overrideArgs:      overrideArgs,
 		outputsImageRefTo: outputsImageRefTo.Value,
+		tiltfilePath:      starkit.CurrentExecPath(thread),
 	}
 
 	err = s.buildIndex.addImage(img)

--- a/internal/tiltfile/tiltfile_state.go
+++ b/internal/tiltfile/tiltfile_state.go
@@ -1369,7 +1369,7 @@ func (s *tiltfileState) imgTargetsForDependencyIDsHelper(ids []model.TargetID, c
 		iTarget = iTarget.
 			WithRepos(s.reposForImage(image)).
 			WithDockerignores(dIgnores). // used even for custom build
-			WithTiltFilename(image.workDir).
+			WithTiltFilename(image.tiltfilePath).
 			WithDependencyIDs(image.dependencyIDs)
 
 		depTargets, err := s.imgTargetsForDependencyIDsHelper(image.dependencyIDs, claimStatus, reg)


### PR DESCRIPTION
This was using the workdir rather than the Tiltfile path. The
only thing it's used for is setting up an ignore for the Tiltfile.

In practice, this should have meant that image builds would be
totally broken - it'd ignore the _entire_ build context directory.
However, there's an extra bit of logic when actually tar'ing things
for the build context that explicitly prevents you from ignoring
the root directory (`localPath` is the root build context dir):
https://github.com/tilt-dev/tilt/blob/84b41dbe96dbdbc51ebeaf0d40d84a55cbce566c/internal/build/tar.go#L149-L158

This will now prevent `Tiltfile`s from being included in build
contexts, and shortly the corresponding `FileWatch` for an image
will ignore changes to the `Tiltfile` so that it doesn't spuriously
trigger.