### PR TITLE
docker: ignore changes to Tiltfile

### DIFF
--- a/internal/ignore/path_matcher.go
+++ b/internal/ignore/path_matcher.go
@@ -77,6 +77,10 @@ func IgnoresToMatcher(ignores []v1alpha1.IgnoreDef) (model.PathMatcher, error) {
 
 // Pull the FileWatch Ignores out of the old manifest target data model.
 func TargetToFileWatchIgnores(t IgnorableTarget) (ignores []v1alpha1.IgnoreDef) {
+	if iTarget, ok := t.(model.ImageTarget); ok && iTarget.TiltFilename() != "" {
+		ignores = append(ignores, v1alpha1.IgnoreDef{BasePath: iTarget.TiltFilename()})
+	}
+
 	for _, r := range t.LocalRepos() {
 		ignores = append(ignores, v1alpha1.IgnoreDef{
 			BasePath: filepath.Join(r.LocalPath, ".git"),

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -1286,7 +1286,7 @@ k8s_yaml('foo.yaml')
 		buildFilters(".git"),
 		fileChangeFilters(".git"),
 		buildFilters("Tiltfile"),
-		fileChangeMatches("Tiltfile"),
+		fileChangeFilters("Tiltfile"),
 		buildMatches("foo.yaml"),
 		fileChangeMatches("foo.yaml"),
 	)


### PR DESCRIPTION
This is already excluded from the build context (see #5024) and
is in preparation for making the ignore logic for Live Update
driven by the FileWatch object.