### PR TITLE
buildcontrol: triggered builds shouldn't ignore scheduling rules

### DIFF
--- a/internal/engine/buildcontrol/build_control.go
+++ b/internal/engine/buildcontrol/build_control.go
@@ -73,10 +73,9 @@ func NextTargetToBuild(state store.EngineState) (*store.ManifestTarget, HoldSet)
 	}
 
 	// Next prioritize builds that have been manually triggered.
-	if len(state.TriggerQueue) > 0 {
-		mn := state.TriggerQueue[0]
+	for _, mn := range state.TriggerQueue {
 		mt, ok := state.ManifestTargets[mn]
-		if ok {
+		if ok && holds.IsEligible(mt) {
 			return mt, holds
 		}
 	}


### PR DESCRIPTION
I hit this when trying to use holds to prevent triggers on disabled resources.

Presumably we haven't noticed because under most conditions, it doesn't matter:
* The UI trigger button is disabled for currently building resources
* We have a couple [short-circuits](https://github.com/tilt-dev/tilt/blob/6cfbd14d3a1211e03ca2eb3eb22a14c3e4049019/internal/engine/buildcontrol/build_control.go#L28-L40) where we bail before we check the trigger queue
* if all build slots are full, we don't even check the next target to build

"local1 is building, local2 is non-parallelizable, trigger local2" does repro buggy behavior in the actual product, though.