### PR TITLE
web: fix sidebar card display bug that shrinks starred resource button

### DIFF
--- a/web/src/StarResourceButton.tsx
+++ b/web/src/StarResourceButton.tsx
@@ -15,6 +15,7 @@ export const StarResourceButtonRoot = styled(InstrumentedButton)`
   padding: 0;
   background-color: transparent;
   align-items: center;
+  flex-shrink: 0;
 `
 let StarIcon = styled(StarSvg)`
   width: ${SizeUnit(1.0 / 3)};

--- a/web/src/testdata.tsx
+++ b/web/src/testdata.tsx
@@ -429,7 +429,7 @@ export const nResourceWithLabelsView = (n: number) => {
     javascript: "javascript",
     backend: "frontend",
   }
-  crashedStart.metadata!.name = "crash_on_start"
+  crashedStart.metadata!.name = "crash_on_start_and_wont_restart"
   view.uiResources.push(crashedStart)
 
   return view


### PR DESCRIPTION
When the resource name is long enough that the text overflow gets hidden, the sidebar card expands a tiny bit and shrinks the starred resource button. This PR prevents the starred resource button from shrinking. You can test the fix in [storybook](http://localhost:9009/?path=/story/new-ui-overviewresourcepane--ten-resources-with-labels).