### PR TITLE
liveupdate: add a flag for liveupdatev2

### DIFF
--- a/internal/controllers/core/tiltfile/api.go
+++ b/internal/controllers/core/tiltfile/api.go
@@ -308,13 +308,18 @@ func toLiveUpdateObjects(tlr *tiltfile.TiltfileLoadResult) apiset.TypedObjectSet
 				continue
 			}
 
+			managedBy := ""
+			if !iTarget.LiveUpdateReconciler {
+				managedBy = "buildcontrol"
+			}
+
 			obj := &v1alpha1.LiveUpdate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: luName,
 					Annotations: map[string]string{
 						v1alpha1.AnnotationManifest:  m.Name.String(),
 						v1alpha1.AnnotationSpanID:    fmt.Sprintf("liveupdate:%s", luName),
-						v1alpha1.AnnotationManagedBy: "buildcontrol",
+						v1alpha1.AnnotationManagedBy: managedBy,
 					},
 				},
 				Spec: luSpec,

--- a/internal/feature/flags.go
+++ b/internal/feature/flags.go
@@ -24,6 +24,7 @@ const Snapshots = "snapshots"
 const UpdateHistory = "update_history"
 const Facets = "facets"
 const Labels = "labels"
+const LiveUpdateV2 = "live_update_v2"
 
 // The Value a flag can have. Status should never be changed.
 type Value struct {
@@ -59,6 +60,10 @@ var MainDefaults = Defaults{
 	},
 	Labels: Value{
 		Enabled: true,
+		Status:  Active,
+	},
+	LiveUpdateV2: Value{
+		Enabled: false,
 		Status:  Active,
 	},
 }

--- a/internal/tiltfile/tiltfile_state.go
+++ b/internal/tiltfile/tiltfile_state.go
@@ -1074,6 +1074,15 @@ func (s *tiltfileState) translateK8s(resources []*k8sResource, updateSettings mo
 			return nil, errors.Wrapf(err, "getting image build info for %s", r.name)
 		}
 
+		// Currently, only Kubernetes ImageTargets support the reconciler,
+		// and only if the user has flagged it on.
+		if s.features.Get(feature.LiveUpdateV2) {
+			for i, iTarget := range iTargets {
+				iTarget.LiveUpdateReconciler = true
+				iTargets[i] = iTarget
+			}
+		}
+
 		m = m.WithImageTargets(iTargets)
 
 		k8sTarget, err := k8s.NewTarget(mn.TargetName(), r.entities,

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -5915,10 +5915,11 @@ type fixture struct {
 func (f *fixture) newTiltfileLoader() TiltfileLoader {
 	dcc := dockercompose.NewDockerComposeClient(docker.LocalEnv{})
 	features := feature.Defaults{
-		"testflag_disabled": feature.Value{Enabled: false},
-		"testflag_enabled":  feature.Value{Enabled: true},
-		"obsoleteflag":      feature.Value{Status: feature.Obsolete, Enabled: true},
-		feature.Snapshots:   feature.Value{Enabled: true},
+		"testflag_disabled":  feature.Value{Enabled: false},
+		"testflag_enabled":   feature.Value{Enabled: true},
+		"obsoleteflag":       feature.Value{Status: feature.Obsolete, Enabled: true},
+		feature.Snapshots:    feature.Value{Enabled: true},
+		feature.LiveUpdateV2: feature.Value{Enabled: false},
 	}
 
 	k8sContextExt := k8scontext.NewPlugin(f.k8sContext, f.k8sEnv)

--- a/pkg/model/image_target.go
+++ b/pkg/model/image_target.go
@@ -16,8 +16,9 @@ type ImageTarget struct {
 	v1alpha1.ImageMapSpec
 
 	// An apiserver-driven data model for live-updating containers.
-	LiveUpdateName string
-	LiveUpdateSpec v1alpha1.LiveUpdateSpec
+	LiveUpdateName       string
+	LiveUpdateSpec       v1alpha1.LiveUpdateSpec
+	LiveUpdateReconciler bool
 
 	Refs         container.RefSet
 	BuildDetails BuildDetails


### PR DESCRIPTION
Hello @milas, @landism,

Please review the following commits I made in branch nicks/flags:

395a057dd9d9baa0c1895308170b2d93db05c230 (2021-10-25 17:58:57 -0400)
liveupdate: add a flag for liveupdatev2

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics