### PR TITLE
controllers: add `DisableSpec` and `DisableStatus` behavior to `KubernetesApply`

### DIFF
--- a/internal/controllers/core/filewatch/controller.go
+++ b/internal/controllers/core/filewatch/controller.go
@@ -109,6 +109,8 @@ func (c *Controller) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 			existing.cleanupWatch(ctx)
 			c.removeWatch(existing)
 		}
+
+		c.Store.Dispatch(filewatches.NewFileWatchDeleteAction(req.NamespacedName.Name))
 		return ctrl.Result{}, nil
 	}
 

--- a/internal/controllers/core/kubernetesapply/reconciler.go
+++ b/internal/controllers/core/kubernetesapply/reconciler.go
@@ -121,6 +121,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		return ctrl.Result{}, nil
 	}
 
+	// The apiserver is the source of truth, and will ensure the engine state is up to date.
+	r.st.Dispatch(kubernetesapplys.NewKubernetesApplyUpsertAction(&ka))
+
 	// Get configmap's disable status
 	disableStatus, err := configmap.MaybeNewDisableStatus(ctx, r.ctrlClient, ka.Spec.DisableSource, ka.Status.DisableStatus)
 	if err != nil {
@@ -145,9 +148,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		r.st.Dispatch(kubernetesapplys.NewKubernetesApplyUpsertAction(&ka))
 		return ctrl.Result{}, nil
 	}
-
-	// The apiserver is the source of truth, and will ensure the engine state is up to date.
-	r.st.Dispatch(kubernetesapplys.NewKubernetesApplyUpsertAction(&ka))
 
 	ctx = store.MustObjectLogHandler(ctx, r.st, &ka)
 	err = r.manageOwnedKubernetesDiscovery(ctx, nn, &ka)

--- a/internal/controllers/core/kubernetesapply/reconciler.go
+++ b/internal/controllers/core/kubernetesapply/reconciler.go
@@ -269,14 +269,13 @@ func (r *Reconciler) ForceApply(
 	nn types.NamespacedName,
 	spec v1alpha1.KubernetesApplySpec,
 	imageMaps map[types.NamespacedName]*v1alpha1.ImageMap) (v1alpha1.KubernetesApplyStatus, error) {
+	forceApplyStatus, appliedObjects := r.forceApplyHelper(ctx, spec, imageMaps)
 
 	var ka v1alpha1.KubernetesApply
 	err := r.ctrlClient.Get(ctx, nn, &ka)
 	if err != nil {
 		return v1alpha1.KubernetesApplyStatus{}, err
 	}
-
-	forceApplyStatus, appliedObjects := r.forceApplyHelper(ctx, spec, imageMaps)
 
 	// Copy over status information from `forceApplyHelper`
 	// so other existing status information isn't overwritten

--- a/internal/controllers/core/kubernetesapply/reconciler.go
+++ b/internal/controllers/core/kubernetesapply/reconciler.go
@@ -112,7 +112,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	}
 
 	if apierrors.IsNotFound(err) || !ka.ObjectMeta.DeletionTimestamp.IsZero() {
-		err := r.bestEffortDeleteWithRelatedObjects(ctx, nn)
+		err := r.deleteCreatedObjects(ctx, nn)
 		if err != nil {
 			return ctrl.Result{}, err
 		}
@@ -137,7 +137,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	// Delete kubernetesapply if it's disabled
 	if disableStatus.Disabled {
-		err := r.bestEffortDeleteWithRelatedObjects(ctx, nn)
+		err := r.deleteCreatedObjects(ctx, nn)
 		if err != nil {
 			return ctrl.Result{}, err
 		}
@@ -602,7 +602,7 @@ func (r *Reconciler) updateResult(nn types.NamespacedName, result *Result) delet
 
 // A helper that deletes all kubernetesapply objects and the
 // related kubernetesdiscovery objects it owns
-func (r *Reconciler) bestEffortDeleteWithRelatedObjects(
+func (r *Reconciler) deleteCreatedObjects(
 	ctx context.Context,
 	nn types.NamespacedName,
 ) error {

--- a/internal/controllers/core/kubernetesapply/reconciler_test.go
+++ b/internal/controllers/core/kubernetesapply/reconciler_test.go
@@ -4,17 +4,18 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"strconv"
 	"testing"
 	"time"
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/google/uuid"
-	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/tilt-dev/tilt/internal/build"
 	"github.com/tilt-dev/tilt/internal/controllers/fake"
@@ -28,6 +29,10 @@ import (
 	"github.com/tilt-dev/tilt/pkg/apis"
 	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
 )
+
+// Test constants
+const timeout = time.Second * 10
+const interval = 5 * time.Millisecond
 
 func TestImageIndexing(t *testing.T) {
 	f := newFixture(t)
@@ -44,7 +49,7 @@ func TestImageIndexing(t *testing.T) {
 	// Verify we can index one image map.
 	reqs := f.r.indexer.Enqueue(&v1alpha1.ImageMap{ObjectMeta: metav1.ObjectMeta{Name: "image-a"}})
 	assert.ElementsMatch(t, []reconcile.Request{
-		reconcile.Request{NamespacedName: types.NamespacedName{Name: "a"}},
+		{NamespacedName: types.NamespacedName{Name: "a"}},
 	}, reqs)
 
 	kb := v1alpha1.KubernetesApply{
@@ -60,17 +65,21 @@ func TestImageIndexing(t *testing.T) {
 	// Verify we can index one image map to two applies.
 	reqs = f.r.indexer.Enqueue(&v1alpha1.ImageMap{ObjectMeta: metav1.ObjectMeta{Name: "image-c"}})
 	assert.ElementsMatch(t, []reconcile.Request{
-		reconcile.Request{NamespacedName: types.NamespacedName{Name: "a"}},
-		reconcile.Request{NamespacedName: types.NamespacedName{Name: "b"}},
+		{NamespacedName: types.NamespacedName{Name: "a"}},
+		{NamespacedName: types.NamespacedName{Name: "b"}},
 	}, reqs)
 
+	// Get the latest ka, since resource version numbers
+	// may have changed since its creation and mismatched
+	// versions will throw an error on update
+	f.MustGet(types.NamespacedName{Name: "a"}, &ka)
 	ka.Spec.ImageMaps = []string{"image-a"}
 	f.Update(&ka)
 
 	// Verify we can remove an image map.
 	reqs = f.r.indexer.Enqueue(&v1alpha1.ImageMap{ObjectMeta: metav1.ObjectMeta{Name: "image-c"}})
 	assert.ElementsMatch(t, []reconcile.Request{
-		reconcile.Request{NamespacedName: types.NamespacedName{Name: "b"}},
+		{NamespacedName: types.NamespacedName{Name: "b"}},
 	}, reqs)
 }
 
@@ -432,6 +441,68 @@ func TestIgnoreManagedObjects(t *testing.T) {
 
 	f.MustGet(nn, &ka)
 	assert.Equal(f.T(), result, ka.Status)
+}
+
+func TestDisableByConfigmap(t *testing.T) {
+	f := newFixture(t)
+	ka := v1alpha1.KubernetesApply{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test",
+		},
+		Spec: v1alpha1.KubernetesApplySpec{
+			YAML: testyaml.SanchoYAML,
+			DisableSource: &v1alpha1.DisableSource{
+				ConfigMap: &v1alpha1.ConfigMapDisableSource{
+					Name: "test-disable",
+					Key:  "isDisabled",
+				},
+			},
+		},
+	}
+	f.Create(&ka)
+
+	f.setDisabled(ka.GetObjectMeta().Name, true)
+
+	f.setDisabled(ka.GetObjectMeta().Name, false)
+
+	f.setDisabled(ka.GetObjectMeta().Name, true)
+}
+
+func (f *fixture) requireKaMatchesInApi(name string, matcher func(ka *v1alpha1.KubernetesApply) bool) *v1alpha1.KubernetesApply {
+	ka := v1alpha1.KubernetesApply{}
+
+	require.Eventually(f.T(), func() bool {
+		f.MustGet(types.NamespacedName{Name: name}, &ka)
+		return matcher(&ka)
+	}, timeout, interval)
+
+	return &ka
+}
+
+func (f *fixture) setDisabled(name string, isDisabled bool) {
+	ka := v1alpha1.KubernetesApply{}
+	f.MustGet(types.NamespacedName{Name: name}, &ka)
+
+	require.NotNil(f.T(), ka.Spec.DisableSource)
+	require.NotNil(f.T(), ka.Spec.DisableSource.ConfigMap)
+
+	cm := v1alpha1.ConfigMap{}
+	cmExists := f.Get(types.NamespacedName{Name: ka.Spec.DisableSource.ConfigMap.Name}, &cm)
+	if !cmExists {
+		cm.ObjectMeta.Name = ka.Spec.DisableSource.ConfigMap.Name
+		cm.Data = map[string]string{ka.Spec.DisableSource.ConfigMap.Key: strconv.FormatBool(isDisabled)}
+		f.Client.Create(f.Context(), &cm)
+	} else {
+		cm.Data[ka.Spec.DisableSource.ConfigMap.Key] = strconv.FormatBool(isDisabled)
+		f.Client.Update(f.Context(), &cm)
+	}
+
+	_, err := f.Reconcile(types.NamespacedName{Name: name})
+	require.NoError(f.T(), err)
+
+	f.requireKaMatchesInApi(name, func(ka *v1alpha1.KubernetesApply) bool {
+		return ka.Status.DisableStatus != nil && ka.Status.DisableStatus.Disabled == isDisabled
+	})
 }
 
 type fixture struct {

--- a/internal/controllers/core/kubernetesapply/reconciler_test.go
+++ b/internal/controllers/core/kubernetesapply/reconciler_test.go
@@ -491,10 +491,12 @@ func (f *fixture) setDisabled(name string, isDisabled bool) {
 	if !cmExists {
 		cm.ObjectMeta.Name = ka.Spec.DisableSource.ConfigMap.Name
 		cm.Data = map[string]string{ka.Spec.DisableSource.ConfigMap.Key: strconv.FormatBool(isDisabled)}
-		f.Client.Create(f.Context(), &cm)
+		err := f.Client.Create(f.Context(), &cm)
+		require.NoError(f.T(), err)
 	} else {
 		cm.Data[ka.Spec.DisableSource.ConfigMap.Key] = strconv.FormatBool(isDisabled)
-		f.Client.Update(f.Context(), &cm)
+		err := f.Client.Update(f.Context(), &cm)
+		require.NoError(f.T(), err)
 	}
 
 	_, err := f.Reconcile(types.NamespacedName{Name: name})

--- a/internal/controllers/core/kubernetesapply/reconciler_test.go
+++ b/internal/controllers/core/kubernetesapply/reconciler_test.go
@@ -505,6 +505,19 @@ func (f *fixture) setDisabled(name string, isDisabled bool) {
 	f.requireKaMatchesInApi(name, func(ka *v1alpha1.KubernetesApply) bool {
 		return ka.Status.DisableStatus != nil && ka.Status.DisableStatus.Disabled == isDisabled
 	})
+
+	kd := v1alpha1.KubernetesDiscovery{}
+	kdExists := f.Get(types.NamespacedName{Name: name}, &kd)
+
+	if isDisabled {
+		require.False(f.T(), kdExists)
+
+		require.Contains(f.T(), f.kClient.DeletedYaml, "name: sancho")
+		// Reset the deletedYaml so it doesn't interfere with other tests
+		f.kClient.DeletedYaml = ""
+	} else {
+		require.True(f.T(), kdExists)
+	}
 }
 
 type fixture struct {

--- a/internal/engine/buildcontrol/image_build_and_deployer.go
+++ b/internal/engine/buildcontrol/image_build_and_deployer.go
@@ -309,6 +309,9 @@ func (ibd *ImageBuildAndDeployer) deploy(
 	ps.StartBuildStep(ctx, "Injecting images into Kubernetes YAML")
 
 	kTargetNN := types.NamespacedName{Name: kTargetID.Name.String()}
+	// Note: `KubernetesApply` object may not exist yet when this `ForceApply` is called
+	// and may cause a race-condition-related "Not found" error here.
+	// https://github.com/tilt-dev/tilt/issues/5125
 	status, err := ibd.r.ForceApply(ctx, kTargetNN, spec, imageMaps)
 	if err != nil {
 		return store.K8sBuildResult{}, fmt.Errorf("applying %s: %v", kTargetID, err)


### PR DESCRIPTION
Add logic to watch the `configmap` specified in a `KubernetesApply`'s `DisableSpec` and update its `DisableStatus`, plus delete any of its managed objects when it's disabled.

Note: there's a `ForceApply` that runs during a `Reconcile` when a `KubernetesApply` isn't disabled. It will overwrite any `DisableStatus` that's been updated earlier in the reconciling, so I added a couple lines to make sure that status gets written properly. If there's a better way to handle this, lmk!

Closes [CH12731](https://app.shortcut.com/windmill/story/12731/rest-of-api-controllers-other-than-cmd-s-deal-with-disablesource-status)