### PR TITLE
goreleaser: arm builds no longer in alpha

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -36,8 +36,8 @@ archives:
     linux: linux
     386: i386
     amd64: x86_64
-    arm: arm_ALPHA
-    arm64: arm64_ALPHA
+    arm: arm
+    arm64: arm64
   format_overrides:
     - goos: windows
       format: zip


### PR DESCRIPTION
Hello @milas,

Please review the following commits I made in branch nicks/alpha:

eb6b0217e9a0f2b590f39e259a5aa89ff13d578c (2021-10-26 11:17:03 -0400)
goreleaser: arm builds no longer in alpha

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics