### PR TITLE
liveupdate: update status to reflect all containers, not just running containers

### DIFF
--- a/internal/controllers/core/liveupdate/reconciler.go
+++ b/internal/controllers/core/liveupdate/reconciler.go
@@ -518,11 +518,7 @@ func (r *Reconciler) maybeSync(ctx context.Context, lu *v1alpha1.LiveUpdate, mon
 		}
 
 		if cInfo.State.Running == nil {
-			// If we're missing any relevant info for this container, OR if the
-			// container isn't running, we can't update it in place.
-			// (Since we'll need to fully rebuild this image, we shouldn't bother
-			// in-place updating ANY containers on this pod -- they'll all
-			// be recreated when we image build. So don't return ANY Containers.)
+			// Mark the container as waiting, so we have a record of it.
 			status.Containers = append(status.Containers, v1alpha1.LiveUpdateContainerStatus{
 				ContainerName: cInfo.Name,
 				ContainerID:   cInfo.ID,
@@ -569,7 +565,7 @@ func (r *Reconciler) maybeSync(ctx context.Context, lu *v1alpha1.LiveUpdate, mon
 	//
 	// If we get to the end of this loop and haven't found any "live" pods,
 	// we assume we're in state (1) (to prevent waiting forever).
-	if status.Failed != nil && terminatedContainerPodName != "" &&
+	if status.Failed == nil && terminatedContainerPodName != "" &&
 		hasAnyFilesToSync && len(status.Containers) == 0 {
 		status.Failed = createFailedState(lu, "Terminated",
 			fmt.Sprintf("Container for live update is stopped. Pod name: %s", terminatedContainerPodName))

--- a/internal/controllers/core/liveupdate/reconciler_test.go
+++ b/internal/controllers/core/liveupdate/reconciler_test.go
@@ -180,6 +180,111 @@ func TestWaitingContainer(t *testing.T) {
 	assert.Equal(t, 1, len(f.cu.Calls))
 }
 
+func TestOneTerminatedContainer(t *testing.T) {
+	f := newFixture(t)
+
+	p, _ := os.Getwd()
+	nowMicro := apis.NowMicro()
+	txtPath := filepath.Join(p, "a.txt")
+	txtChangeTime := metav1.MicroTime{Time: nowMicro.Add(time.Second)}
+
+	f.setupFrontend()
+	f.kdUpdateStatus("frontend-discovery", v1alpha1.KubernetesDiscoveryStatus{
+		Pods: []v1alpha1.Pod{
+			{
+				Name:      "pod-1",
+				Namespace: "default",
+				Containers: []v1alpha1.Container{
+					{
+						Name:  "main",
+						ID:    "main",
+						Image: "frontend-image",
+						State: v1alpha1.ContainerState{
+							Terminated: &v1alpha1.ContainerStateTerminated{},
+						},
+					},
+				},
+			},
+		},
+	})
+
+	f.addFileEvent("frontend-fw", txtPath, txtChangeTime)
+	f.MustReconcile(types.NamespacedName{Name: "frontend-liveupdate"})
+
+	var lu v1alpha1.LiveUpdate
+	f.MustGet(types.NamespacedName{Name: "frontend-liveupdate"}, &lu)
+	if assert.NotNil(t, lu.Status.Failed) {
+		assert.Equal(t, "Terminated", lu.Status.Failed.Reason)
+	}
+
+	f.assertSteadyState(&lu)
+}
+
+func TestOneRunningOneTerminatedContainer(t *testing.T) {
+	f := newFixture(t)
+
+	p, _ := os.Getwd()
+	nowMicro := apis.NowMicro()
+	txtPath := filepath.Join(p, "a.txt")
+	txtChangeTime := metav1.MicroTime{Time: nowMicro.Add(time.Second)}
+
+	f.setupFrontend()
+	f.kdUpdateStatus("frontend-discovery", v1alpha1.KubernetesDiscoveryStatus{
+		Pods: []v1alpha1.Pod{
+			{
+				Name:      "pod-1",
+				Namespace: "default",
+				Containers: []v1alpha1.Container{
+					{
+						Name:  "main",
+						ID:    "main",
+						Image: "frontend-image",
+						State: v1alpha1.ContainerState{
+							Terminated: &v1alpha1.ContainerStateTerminated{},
+						},
+					},
+				},
+			},
+			{
+				Name:      "pod-2",
+				Namespace: "default",
+				Containers: []v1alpha1.Container{
+					{
+						Name:  "main",
+						ID:    "main",
+						Image: "frontend-image",
+						State: v1alpha1.ContainerState{
+							Running: &v1alpha1.ContainerStateRunning{},
+						},
+					},
+				},
+			},
+		},
+	})
+
+	// Trigger a file event, and make sure that the status reflects the sync.
+	f.addFileEvent("frontend-fw", txtPath, txtChangeTime)
+	f.MustReconcile(types.NamespacedName{Name: "frontend-liveupdate"})
+
+	var lu v1alpha1.LiveUpdate
+	f.MustGet(types.NamespacedName{Name: "frontend-liveupdate"}, &lu)
+	assert.Nil(t, lu.Status.Failed)
+	if assert.Equal(t, 1, len(lu.Status.Containers)) {
+		assert.Equal(t, txtChangeTime, lu.Status.Containers[0].LastFileTimeSynced)
+	}
+
+	// Also make sure the sync gets pulled into the monitor.
+	m, ok := f.r.monitors["frontend-liveupdate"]
+	require.True(t, ok)
+	assert.Equal(t, map[string]metav1.MicroTime{
+		txtPath: txtChangeTime,
+	}, m.sources["frontend-fw"].modTimeByPath)
+	assert.Equal(t, 1, len(f.cu.Calls))
+	assert.Equal(t, "pod-2", f.cu.Calls[0].ContainerInfo.PodID.String())
+
+	f.assertSteadyState(&lu)
+}
+
 type fixture struct {
 	*fake.ControllerFixture
 	r  *Reconciler
@@ -284,11 +389,15 @@ func (f *fixture) setupFrontend() {
 }
 
 func (f *fixture) assertSteadyState(lu *v1alpha1.LiveUpdate) {
+	startCalls := len(f.cu.Calls)
+
 	f.T().Helper()
 	f.MustReconcile(types.NamespacedName{Name: lu.Name})
 	var lu2 v1alpha1.LiveUpdate
 	f.MustGet(types.NamespacedName{Name: lu.Name}, &lu2)
 	assert.Equal(f.T(), lu.ResourceVersion, lu2.ResourceVersion)
+
+	assert.Equal(f.T(), startCalls, len(f.cu.Calls))
 }
 
 func (f *fixture) kdUpdateStatus(name string, status v1alpha1.KubernetesDiscoveryStatus) {


### PR DESCRIPTION
Hello @milas,

Please review the following commits I made in branch nicks/luwaiting2:

414b6d7d96ec9fc7e776128ffe2b1b78f5d90a8e (2021-10-26 18:45:31 -0400)
liveupdate: update status to reflect all containers, not just running containers

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics