### PR TITLE
server: disable websocket protection to fix macos monterey safari

### DIFF
--- a/internal/hud/server/websocket.go
+++ b/internal/hud/server/websocket.go
@@ -26,9 +26,16 @@ import (
 )
 
 var upgrader = websocket.Upgrader{
-	ReadBufferSize:    1024,
-	WriteBufferSize:   1024,
-	EnableCompression: true,
+	ReadBufferSize:  1024,
+	WriteBufferSize: 1024,
+
+	// Disable compression due to safari bugs in websockets, see:
+	// https://github.com/tilt-dev/tilt/issues/4746
+	//
+	// Though, frankly, we probably don't need compression
+	// anyway, since it's not like you're using Tilt over
+	// a mobile network.
+	EnableCompression: false,
 }
 
 type WebsocketSubscriber struct {


### PR DESCRIPTION
Hello @landism,

Please review the following commits I made in branch nicks/websocket:

67fbc6f325e115a4d3f3ef219ba6098e9ae8accc (2021-10-27 11:33:16 -0400)
server: disable websocket compression to fix macos monterey safari
Fixes https://github.com/tilt-dev/tilt/issues/4746

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics