### PR TITLE
api: propagate image hold targets

### DIFF
--- a/internal/engine/buildcontrol/build_control_test.go
+++ b/internal/engine/buildcontrol/build_control_test.go
@@ -214,6 +214,8 @@ func TestTwoK8sTargetsWithBaseImage(t *testing.T) {
 	sanchoOne.State.CurrentBuild = model.BuildRecord{StartTime: time.Now()}
 
 	f.assertNoTargetNextToBuild()
+	f.assertHold("sancho-two", store.HoldReasonBuildingComponent, baseImage.ID())
+
 	sanchoOne.State.CurrentBuild = model.BuildRecord{}
 	sanchoOne.State.AddCompletedBuild(model.BuildRecord{
 		StartTime:  time.Now(),


### PR DESCRIPTION
Populate `Hold.HoldOn` for dependent/shared image targets.
The logic to map image target IDs to an `ImageMap` at the API
layer already exists; this populates them in the `HoldSet`
itself.