### PR TITLE
apis: add some API docs that were missing

### DIFF
--- a/pkg/apis/core/v1alpha1/filewatch_types.go
+++ b/pkg/apis/core/v1alpha1/filewatch_types.go
@@ -68,6 +68,7 @@ type FileWatchSpec struct {
 	DisableSource *DisableSource `json:"disableSource,omitempty" protobuf:"bytes,3,opt,name=disableSource"`
 }
 
+// Describes sets of file paths that the FileWatch should ignore.
 type IgnoreDef struct {
 	// BasePath is the base path for the patterns. It cannot be empty.
 	//

--- a/pkg/apis/core/v1alpha1/generated.proto
+++ b/pkg/apis/core/v1alpha1/generated.proto
@@ -628,6 +628,7 @@ message Handler {
   optional TCPSocketAction tcpSocket = 3;
 }
 
+// Describes sets of file paths that the FileWatch should ignore.
 message IgnoreDef {
   // BasePath is the base path for the patterns. It cannot be empty.
   //
@@ -1554,7 +1555,7 @@ message PortForwardTemplateSpec {
   repeated Forward forwards = 1;
 }
 
-// Probe describes a health check to be performed o determine whether it is
+// Probe describes a health check to be performed to determine whether it is
 // alive or ready to receive traffic.
 message Probe {
   // The action taken to determine the health of a container
@@ -1956,6 +1957,7 @@ message ToggleButtonStatus {
   optional string error = 1;
 }
 
+// Describes a boolean checkbox input field attached to a button.
 message UIBoolInputSpec {
   // Whether the input is initially true or false.
   // +optional
@@ -2127,6 +2129,8 @@ message UIFeatureFlag {
   optional bool value = 2;
 }
 
+// Describes a hidden input field attached to a button,
+// with a value to pass on any submit.
 message UIHiddenInputSpec {
   optional string value = 1;
 }
@@ -2493,6 +2497,7 @@ message UISessionStatus {
   optional string tiltfileKey = 11;
 }
 
+// Describes a text input field attached to a button.
 message UITextInputSpec {
   // Initial value for this field.
   //

--- a/pkg/apis/core/v1alpha1/probe.go
+++ b/pkg/apis/core/v1alpha1/probe.go
@@ -79,7 +79,7 @@ type ExecAction struct {
 	Command []string `json:"command,omitempty" protobuf:"bytes,1,rep,name=command"`
 }
 
-// Probe describes a health check to be performed o determine whether it is
+// Probe describes a health check to be performed to determine whether it is
 // alive or ready to receive traffic.
 type Probe struct {
 	// The action taken to determine the health of a container

--- a/pkg/apis/core/v1alpha1/uibutton_types.go
+++ b/pkg/apis/core/v1alpha1/uibutton_types.go
@@ -198,6 +198,7 @@ func (in *UIButtonList) GetListMeta() *metav1.ListMeta {
 	return &in.ListMeta
 }
 
+// Describes a text input field attached to a button.
 type UITextInputSpec struct {
 	// Initial value for this field.
 	//
@@ -215,6 +216,7 @@ type UITextInputStatus struct {
 	Value string `json:"value" protobuf:"bytes,1,opt,name=value"`
 }
 
+// Describes a boolean checkbox input field attached to a button.
 type UIBoolInputSpec struct {
 	// Whether the input is initially true or false.
 	// +optional
@@ -235,6 +237,8 @@ type UIBoolInputStatus struct {
 	Value bool `json:"value" protobuf:"varint,1,opt,name=value"`
 }
 
+// Describes a hidden input field attached to a button,
+// with a value to pass on any submit.
 type UIHiddenInputSpec struct {
 	Value string `json:"value" protobuf:"bytes,1,opt,name=value"`
 }

--- a/pkg/openapi/zz_generated.openapi.go
+++ b/pkg/openapi/zz_generated.openapi.go
@@ -1900,7 +1900,8 @@ func schema_pkg_apis_core_v1alpha1_IgnoreDef(ref common.ReferenceCallback) commo
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Type: []string{"object"},
+				Description: "Describes sets of file paths that the FileWatch should ignore.",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"basePath": {
 						SchemaProps: spec.SchemaProps{
@@ -3979,7 +3980,7 @@ func schema_pkg_apis_core_v1alpha1_Probe(ref common.ReferenceCallback) common.Op
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "Probe describes a health check to be performed o determine whether it is alive or ready to receive traffic.",
+				Description: "Probe describes a health check to be performed to determine whether it is alive or ready to receive traffic.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"exec": {
@@ -5099,7 +5100,8 @@ func schema_pkg_apis_core_v1alpha1_UIBoolInputSpec(ref common.ReferenceCallback)
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Type: []string{"object"},
+				Description: "Describes a boolean checkbox input field attached to a button.",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"defaultValue": {
 						SchemaProps: spec.SchemaProps{
@@ -5528,7 +5530,8 @@ func schema_pkg_apis_core_v1alpha1_UIHiddenInputSpec(ref common.ReferenceCallbac
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Type: []string{"object"},
+				Description: "Describes a hidden input field attached to a button, with a value to pass on any submit.",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"value": {
 						SchemaProps: spec.SchemaProps{
@@ -6380,7 +6383,8 @@ func schema_pkg_apis_core_v1alpha1_UITextInputSpec(ref common.ReferenceCallback)
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Type: []string{"object"},
+				Description: "Describes a text input field attached to a button.",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"defaultValue": {
 						SchemaProps: spec.SchemaProps{

--- a/pkg/webview/view.swagger.json
+++ b/pkg/webview/view.swagger.json
@@ -420,7 +420,8 @@
           "type": "string",
           "title": "If the input's value is converted to a string, use this when the value is false.\nIf unspecified, its string value will be `\"false\"`\n+optional"
         }
-      }
+      },
+      "description": "Describes a boolean checkbox input field attached to a button."
     },
     "v1alpha1UIBoolInputStatus": {
       "type": "object",
@@ -581,7 +582,8 @@
         "value": {
           "type": "string"
         }
-      }
+      },
+      "description": "Describes a hidden input field attached to a button,\nwith a value to pass on any submit."
     },
     "v1alpha1UIHiddenInputStatus": {
       "type": "object",
@@ -956,7 +958,8 @@
           "type": "string",
           "description": "A short hint that describes the expected input of this field.\n\n+optional"
         }
-      }
+      },
+      "description": "Describes a text input field attached to a button."
     },
     "v1alpha1UITextInputStatus": {
       "type": "object",


### PR DESCRIPTION
Hello @hyu, @milas,

Please review the following commits I made in branch nicks/docs:

e3d3b0d658c18b36f0bd18dd3852e82f1461cbe9 (2021-10-28 17:04:36 -0400)
apis: add some API docs that were missing
We noticed these because Sphinx no longer generates documentation
for objects that don't have docstrings.

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics