### PR TITLE
script: fix local codegen

### DIFF
--- a/scripts/update-codegen.sh
+++ b/scripts/update-codegen.sh
@@ -22,4 +22,4 @@ docker run --rm -v "$(pwd)":/go/src/github.com/tilt-dev/tilt \
 docker run --rm -e "CODEGEN_USER=$USER" -v "$(pwd)":/go/src/github.com/tilt-dev/tilt \
    --workdir /go/src/github.com/tilt-dev/tilt \
    --entrypoint ./scripts/update-codegen-helper.sh \
-   golang:1.15
+   golang:1.17


### PR DESCRIPTION
Use Go 1.17 so the build tags match what is expected when CI
re-runs generation to ensure things are up-to-date.