### PR TITLE
api: share RestartOn/StartOn logic

### DIFF
--- a/internal/controllers/apis/restarton/restarton_test.go
+++ b/internal/controllers/apis/restarton/restarton_test.go
@@ -1,0 +1,134 @@
+package restarton
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/tilt-dev/tilt/internal/controllers/fake"
+	"github.com/tilt-dev/tilt/internal/controllers/indexer"
+	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
+)
+
+func TestExtractKeysForIndexer(t *testing.T) {
+	const ns = "fake-ns"
+
+	key := func(name string, kind string) indexer.Key {
+		return indexer.Key{
+			Name: types.NamespacedName{Namespace: ns, Name: name},
+			GVK: schema.GroupVersionKind{
+				Group:   "tilt.dev",
+				Version: "v1alpha1",
+				Kind:    kind,
+			},
+		}
+	}
+
+	fwKey := func(name string) indexer.Key {
+		return key(name, "FileWatch")
+	}
+
+	btnKey := func(name string) indexer.Key {
+		return key(name, "UIButton")
+	}
+
+	type tc struct {
+		restartOn *v1alpha1.RestartOnSpec
+		startOn   *v1alpha1.StartOnSpec
+		expected  []indexer.Key
+	}
+
+	tcs := []tc{
+		{nil, nil, []indexer.Key(nil)},
+		{
+			&v1alpha1.RestartOnSpec{FileWatches: []string{"foo"}},
+			nil,
+			[]indexer.Key{fwKey("foo")},
+		},
+		{
+			nil,
+			&v1alpha1.StartOnSpec{UIButtons: []string{"btn"}},
+			[]indexer.Key{btnKey("btn")},
+		},
+		{
+			&v1alpha1.RestartOnSpec{FileWatches: []string{"foo"}, UIButtons: []string{"bar"}},
+			&v1alpha1.StartOnSpec{UIButtons: []string{"baz"}},
+			[]indexer.Key{fwKey("foo"), btnKey("bar"), btnKey("baz")},
+		},
+	}
+
+	for _, tc := range tcs {
+		keys := ExtractKeysForIndexer(ns, tc.restartOn, tc.startOn)
+		assert.ElementsMatchf(t, tc.expected, keys,
+			"Indexer keys did not match\nRestartOnSpec: %s\nStartOnSpec: %s",
+			strings.TrimSpace(spew.Sdump(tc.restartOn)),
+			spew.Sdump(tc.startOn))
+	}
+}
+
+func TestFetchObjects(t *testing.T) {
+	f := fake.NewControllerFixtureBuilder(t).Build(noopController{})
+
+	f.Create(&v1alpha1.FileWatch{ObjectMeta: metav1.ObjectMeta{Name: "fw1"}})
+	f.Create(&v1alpha1.FileWatch{ObjectMeta: metav1.ObjectMeta{Name: "fw2"}})
+	f.Create(&v1alpha1.UIButton{ObjectMeta: metav1.ObjectMeta{Name: "btn1"}})
+	f.Create(&v1alpha1.UIButton{ObjectMeta: metav1.ObjectMeta{Name: "btn2"}})
+
+	restartObjs, err := FetchObjects(f.Context(), f.Client,
+		&v1alpha1.RestartOnSpec{
+			FileWatches: []string{"fw1", "fw2", "fw3"},
+			UIButtons:   []string{"btn1"},
+		},
+		&v1alpha1.StartOnSpec{
+			UIButtons: []string{"btn2", "btn3"},
+		})
+	require.NoError(t, err)
+	assert.NotNil(t, restartObjs.FileWatches["fw1"])
+	assert.NotNil(t, restartObjs.FileWatches["fw2"])
+	// fw3 doesn't exist but should have been silently ignored
+	assert.Nil(t, restartObjs.FileWatches["fw3"])
+
+	assert.NotNil(t, restartObjs.UIButtons["btn1"])
+	assert.NotNil(t, restartObjs.UIButtons["btn2"])
+	// btn3 doesn't exist but should have been silently ignored
+	assert.Nil(t, restartObjs.UIButtons["btn3"])
+}
+
+func TestFetchObjects_Error(t *testing.T) {
+	cli := &explodingReader{err: errors.New("oh no")}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	restartObjs, err := FetchObjects(ctx, cli, &v1alpha1.RestartOnSpec{FileWatches: []string{"fw"}}, nil)
+	require.Error(t, err, "FetchObjects should have failed with an error")
+	require.Empty(t, restartObjs.FileWatches)
+	require.Empty(t, restartObjs.UIButtons)
+}
+
+type noopController struct{}
+
+func (n noopController) Reconcile(_ context.Context, _ reconcile.Request) (reconcile.Result, error) {
+	return reconcile.Result{}, nil
+}
+
+type explodingReader struct {
+	err error
+}
+
+func (e explodingReader) Get(_ context.Context, _ ctrlclient.ObjectKey, _ ctrlclient.Object) error {
+	return e.err
+}
+
+func (e explodingReader) List(_ context.Context, _ ctrlclient.ObjectList, _ ...ctrlclient.ListOption) error {
+	return e.err
+}

--- a/internal/controllers/core/tiltfile/reconciler.go
+++ b/internal/controllers/core/tiltfile/reconciler.go
@@ -121,23 +121,18 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	// If the tiltfile isn't being run, check to see if anything has triggered a run.
 	if step == runStepNone || step == runStepDone {
-		buttons, err := restarton.Buttons(ctx, r.ctrlClient, tf.Spec.RestartOn, nil)
+		restartObjs, err := restarton.FetchObjects(ctx, r.ctrlClient, tf.Spec.RestartOn, nil)
 		if err != nil {
 			return ctrl.Result{}, err
 		}
 
-		fileWatches, err := restarton.FileWatches(ctx, r.ctrlClient, tf.Spec.RestartOn)
-		if err != nil {
-			return ctrl.Result{}, err
-		}
-
-		lastRestartEventTime, _ := restarton.LastRestartEvent(tf.Spec.RestartOn, fileWatches, buttons)
+		lastRestartEventTime, _ := restarton.LastRestartEvent(tf.Spec.RestartOn, restartObjs)
 		queue, err := configmap.TriggerQueue(ctx, r.ctrlClient)
 		if err != nil {
 			return ctrl.Result{}, err
 		}
 
-		be := r.needsBuild(ctx, nn, &tf, run, fileWatches, queue, lastRestartEventTime)
+		be := r.needsBuild(ctx, nn, &tf, run, restartObjs.FileWatches, queue, lastRestartEventTime)
 		if be != nil {
 			r.startRunAsync(ctx, nn, &tf, be)
 		}
@@ -359,26 +354,8 @@ func (r *Reconciler) deleteExistingRun(nn types.NamespacedName) {
 // Find all the objects we need to watch based on the tiltfile model.
 func indexTiltfile(obj client.Object) []indexer.Key {
 	result := []indexer.Key{}
-	tiltfile := obj.(*v1alpha1.Tiltfile)
-	if tiltfile.Spec.RestartOn != nil {
-		fwGVK := v1alpha1.SchemeGroupVersion.WithKind("FileWatch")
-
-		for _, name := range tiltfile.Spec.RestartOn.FileWatches {
-			result = append(result, indexer.Key{
-				Name: types.NamespacedName{Name: name},
-				GVK:  fwGVK,
-			})
-		}
-
-		bGVK := v1alpha1.SchemeGroupVersion.WithKind("UIButton")
-
-		for _, name := range tiltfile.Spec.RestartOn.UIButtons {
-			result = append(result, indexer.Key{
-				Name: types.NamespacedName{Name: name},
-				GVK:  bGVK,
-			})
-		}
-	}
+	tf := obj.(*v1alpha1.Tiltfile)
+	result = append(result, restarton.ExtractKeysForIndexer(tf.Namespace, tf.Spec.RestartOn, nil)...)
 	return result
 }
 

--- a/pkg/apis/core/v1alpha1/cmd_types.go
+++ b/pkg/apis/core/v1alpha1/cmd_types.go
@@ -234,27 +234,3 @@ var _ resource.StatusSubResource = &CmdStatus{}
 func (in CmdStatus) CopyTo(parent resource.ObjectWithStatusSubResource) {
 	parent.(*Cmd).Status = in
 }
-
-// RestartOnSpec indicates the set of objects that can trigger a restart of this object.
-type RestartOnSpec struct {
-	// A list of file watches that can trigger a restart.
-	// +optional
-	FileWatches []string `json:"fileWatches,omitempty" protobuf:"bytes,1,rep,name=fileWatches"`
-
-	// A list of ui buttons that can trigger a restart.
-	// +optional
-	UIButtons []string `json:"uiButtons,omitempty" protobuf:"bytes,2,rep,name=uiButtons"`
-}
-
-// StartOnSpec indicates the set of objects that can trigger a start/restart of this object.
-type StartOnSpec struct {
-	// Any events that predate this time will be ignored.
-	//
-	// +optional
-	StartAfter metav1.Time `json:"startAfter,omitempty" protobuf:"bytes,1,opt,name=startAfter"`
-	// A list of ui buttons that can trigger a run.
-	//
-	// When a button triggers a run, any UIInputs on that button will be added
-	// to the cmd's env.
-	UIButtons []string `json:"uiButtons" protobuf:"bytes,2,rep,name=uiButtons"`
-}

--- a/pkg/apis/core/v1alpha1/generated.proto
+++ b/pkg/apis/core/v1alpha1/generated.proto
@@ -1589,11 +1589,11 @@ message Probe {
 
 // RestartOnSpec indicates the set of objects that can trigger a restart of this object.
 message RestartOnSpec {
-  // A list of file watches that can trigger a restart.
+  // FileWatches that can trigger a restart.
   // +optional
   repeated string fileWatches = 1;
 
-  // A list of ui buttons that can trigger a restart.
+  // UIButtons that can trigger a restart.
   // +optional
   repeated string uiButtons = 2;
 }
@@ -1651,15 +1651,12 @@ message SessionStatus {
 
 // StartOnSpec indicates the set of objects that can trigger a start/restart of this object.
 message StartOnSpec {
-  // Any events that predate this time will be ignored.
+  // StartAfter indicates that events before this time should be ignored.
   //
   // +optional
   optional k8s.io.apimachinery.pkg.apis.meta.v1.Time startAfter = 1;
 
-  // A list of ui buttons that can trigger a run.
-  //
-  // When a button triggers a run, any UIInputs on that button will be added
-  // to the cmd's env.
+  // UIButtons that can trigger a start/restart.
   repeated string uiButtons = 2;
 }
 

--- a/pkg/apis/core/v1alpha1/restarton_types.go
+++ b/pkg/apis/core/v1alpha1/restarton_types.go
@@ -1,0 +1,25 @@
+package v1alpha1
+
+import v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+// RestartOnSpec indicates the set of objects that can trigger a restart of this object.
+type RestartOnSpec struct {
+	// FileWatches that can trigger a restart.
+	// +optional
+	FileWatches []string `json:"fileWatches,omitempty" protobuf:"bytes,1,rep,name=fileWatches"`
+
+	// UIButtons that can trigger a restart.
+	// +optional
+	UIButtons []string `json:"uiButtons,omitempty" protobuf:"bytes,2,rep,name=uiButtons"`
+}
+
+// StartOnSpec indicates the set of objects that can trigger a start/restart of this object.
+type StartOnSpec struct {
+	// StartAfter indicates that events before this time should be ignored.
+	//
+	// +optional
+	StartAfter v1.Time `json:"startAfter,omitempty" protobuf:"bytes,1,opt,name=startAfter"`
+
+	// UIButtons that can trigger a start/restart.
+	UIButtons []string `json:"uiButtons" protobuf:"bytes,2,rep,name=uiButtons"`
+}

--- a/pkg/openapi/zz_generated.openapi.go
+++ b/pkg/openapi/zz_generated.openapi.go
@@ -4052,7 +4052,7 @@ func schema_pkg_apis_core_v1alpha1_RestartOnSpec(ref common.ReferenceCallback) c
 				Properties: map[string]spec.Schema{
 					"fileWatches": {
 						SchemaProps: spec.SchemaProps{
-							Description: "A list of file watches that can trigger a restart.",
+							Description: "FileWatches that can trigger a restart.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -4067,7 +4067,7 @@ func schema_pkg_apis_core_v1alpha1_RestartOnSpec(ref common.ReferenceCallback) c
 					},
 					"uiButtons": {
 						SchemaProps: spec.SchemaProps{
-							Description: "A list of ui buttons that can trigger a restart.",
+							Description: "UIButtons that can trigger a restart.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -4281,14 +4281,14 @@ func schema_pkg_apis_core_v1alpha1_StartOnSpec(ref common.ReferenceCallback) com
 				Properties: map[string]spec.Schema{
 					"startAfter": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Any events that predate this time will be ignored.",
+							Description: "StartAfter indicates that events before this time should be ignored.",
 							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Time"),
 						},
 					},
 					"uiButtons": {
 						SchemaProps: spec.SchemaProps{
-							Description: "A list of ui buttons that can trigger a run.\n\nWhen a button triggers a run, any UIInputs on that button will be added to the cmd's env.",
+							Description: "UIButtons that can trigger a start/restart.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{


### PR DESCRIPTION
Moved some duplicated logic from the reconcilers to the `restarton`
package and made some tests. Since `KubernetesApply` is about to get
restart support, it made sense to start sharing this.

There's also a new `restarton.Objects` container that just holds the
maps of relevant objects (currently `FileWatch` / `UIButton`), which
makes the method signatures shorter and will reduce the amount of
tedious refactoring needed in the future if/when we add another type
to one of the (re)startOn specs.

The `v1alpha1.RestartOnSpec` and `v1alpha1.StartOnSpec` objects were
also moved into their own file to make it clearer that they're shared
types and don't just belong to `v1alpha1.Cmd`.

API regen changes are just doc strings because I cleaned up the
comments on them slightly.