### PR TITLE
ci: bump Brew cache version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,7 +120,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - homebrew_cache_v13
+            - homebrew_cache_v14
       # Bump cache version when changing this.
       - run: echo 'export HOMEBREW_PACKAGES="go@1.17"' >> $BASH_ENV
       # Only update when brew doesn't know about some of the packages because:
@@ -131,9 +131,9 @@ jobs:
       - save_cache:
           paths:
             - /usr/local/Homebrew
-          key: homebrew_cache_v13
+          key: homebrew_cache_v14
       - run: echo 'export PATH="/usr/local/opt/go@1.17/bin:$PATH"' >> $BASH_ENV
-      - run: curl -fsSL "https://github.com/gotestyourself/gotestsum/releases/download/v0.3.3/gotestsum_0.3.3_darwin_amd64.tar.gz" | sudo tar -xz -C /usr/local/bin gotestsum
+      - run: curl -fsSL "https://github.com/gotestyourself/gotestsum/releases/download/v1.7.0/gotestsum_1.7.0_darwin_amd64.tar.gz" | sudo tar -xz -C /usr/local/bin gotestsum
       # We can't run the container tests on macos because nested
       # VMs don't work on circleci.
       - run: mkdir -p test-results


### PR DESCRIPTION
Looks like Homebrew made some change, so make a new cache version.