### PR TITLE
web: enable trigger button when pod rolling out

### DIFF
--- a/web/src/OverviewTableTriggerButton.tsx
+++ b/web/src/OverviewTableTriggerButton.tsx
@@ -89,8 +89,7 @@ function OverviewTableTriggerButton(props: TriggerButtonProps) {
   let isDisabled =
     props.isQueued || // already queued for manual run
     props.isBuilding || // currently building
-    (!isManualTriggerIncludingInitial && !props.hasBuilt) || // waiting to perform its initial build
-    (props.hasPendingChanges && !isManualTriggerMode) // waiting to perform an auto-triggered build in response to a change
+    (!isManualTriggerIncludingInitial && !props.hasBuilt) // waiting to perform its initial build
 
   let shouldBeClicked = false
   if (!isDisabled) {

--- a/web/src/SidebarTriggerButton.test.tsx
+++ b/web/src/SidebarTriggerButton.test.tsx
@@ -224,15 +224,16 @@ describe("SidebarTriggerButton", () => {
     expectIsSelected(buttons.at(1), false) // Non-selected resource
   })
 
-  it("never shows clickMe trigger button for automatic resources", () => {
+  // A pending resource may mean that a pod is being rolled out, but is not
+  // ready yet. In that case, the trigger button will delete the pod (cancelling
+  // the rollout) and rebuild.
+  it("shows clickMe trigger button when pending", () => {
     let items = twoResourceView().uiResources.map(
       (r: UIResource, i: number) => {
         let res = r.status!
         res.currentBuild = {} // not currently building
 
         if (i == 0) {
-          // first resource has pending changes -- but is automatic, should NOT
-          // have a clickMe button (and button should be !clickable)
           res.hasPendingChanges = true
           res.pendingBuildSince = new Date(Date.now()).toISOString()
         } else {
@@ -260,10 +261,10 @@ describe("SidebarTriggerButton", () => {
     let b0 = buttons.at(0) // Automatic resource with pending changes
     let b1 = buttons.at(1) // Automatic resource, no pending changes
 
-    expectClickable(b0, false)
+    expectClickable(b0, true)
     expectManualTriggerIcon(b0, false)
     expectIsQueued(b0, false)
-    expectWithTooltip(b0, TriggerButtonTooltip.UpdateInProgOrPending)
+    expectWithTooltip(b0, TriggerButtonTooltip.Default)
 
     expectClickable(b1, true)
     expectManualTriggerIcon(b1, false)

--- a/web/src/SidebarTriggerButton.tsx
+++ b/web/src/SidebarTriggerButton.tsx
@@ -115,8 +115,7 @@ function SidebarTriggerButton(props: SidebarTriggerButtonProps) {
   let clickable =
     !props.isQueued && // already queued for manual run
     !props.isBuilding && // currently building
-    !(!isManualTriggerIncludingInitial && !props.hasBuilt) && // waiting to perform its initial build
-    !(props.hasPendingChanges && !isManualTriggerMode) // waiting to perform an auto-triggered build in response to a change
+    !(!isManualTriggerIncludingInitial && !props.hasBuilt) // waiting to perform its initial build
 
   let clickMe = false
   if (clickable) {


### PR DESCRIPTION
Hello @lizzthabet, @hyu,

Please review the following commits I made in branch nicks/triggers:

c15081fd12874a1d7cca68308b1939625b57426c (2021-11-01 14:34:34 -0400)
web: enable trigger button when pod rolling out
We want to be able to cancel the rollout and rebuild.

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics