### PR TITLE
api: inject localexec.Excer into KubernetesApply reconciler

### DIFF
--- a/internal/cli/wire_gen.go
+++ b/internal/cli/wire_gen.go
@@ -269,7 +269,8 @@ func wireCmdUp(ctx context.Context, analytics3 *analytics.TiltAnalytics, cmdTags
 	labels := _wireLabelsValue
 	dockerImageBuilder := build.NewDockerImageBuilder(switchCli, labels)
 	dockerBuilder := build.DefaultDockerBuilder(dockerImageBuilder)
-	kubernetesapplyReconciler := kubernetesapply.NewReconciler(deferredClient, client, scheme, dockerBuilder, kubeContext, storeStore, namespace)
+	processExecer := localexec.NewProcessExecer(env)
+	kubernetesapplyReconciler := kubernetesapply.NewReconciler(deferredClient, client, scheme, dockerBuilder, kubeContext, storeStore, namespace, processExecer)
 	uisessionReconciler := uisession.NewReconciler(deferredClient, websocketList)
 	uiresourceReconciler := uiresource.NewReconciler(deferredClient, websocketList, storeStore)
 	uibuttonReconciler := uibutton.NewReconciler(deferredClient, websocketList)
@@ -278,7 +279,6 @@ func wireCmdUp(ctx context.Context, analytics3 *analytics.TiltAnalytics, cmdTags
 	versionPlugin := version.NewPlugin(tiltBuild)
 	configPlugin := config.NewPlugin(subcommand)
 	dockerComposeClient := dockercompose.NewDockerComposeClient(localEnv)
-	processExecer := localexec.NewProcessExecer(env)
 	defaults := _wireDefaultsValue
 	tiltfileLoader := tiltfile.ProvideTiltfileLoader(analytics3, client, plugin, versionPlugin, configPlugin, dockerComposeClient, webHost, processExecer, defaults, k8sEnv)
 	buildSource := tiltfile2.NewBuildSource()
@@ -473,7 +473,8 @@ func wireCmdCI(ctx context.Context, analytics3 *analytics.TiltAnalytics, subcomm
 	labels := _wireLabelsValue
 	dockerImageBuilder := build.NewDockerImageBuilder(switchCli, labels)
 	dockerBuilder := build.DefaultDockerBuilder(dockerImageBuilder)
-	kubernetesapplyReconciler := kubernetesapply.NewReconciler(deferredClient, client, scheme, dockerBuilder, kubeContext, storeStore, namespace)
+	processExecer := localexec.NewProcessExecer(env)
+	kubernetesapplyReconciler := kubernetesapply.NewReconciler(deferredClient, client, scheme, dockerBuilder, kubeContext, storeStore, namespace, processExecer)
 	uisessionReconciler := uisession.NewReconciler(deferredClient, websocketList)
 	uiresourceReconciler := uiresource.NewReconciler(deferredClient, websocketList, storeStore)
 	uibuttonReconciler := uibutton.NewReconciler(deferredClient, websocketList)
@@ -482,7 +483,6 @@ func wireCmdCI(ctx context.Context, analytics3 *analytics.TiltAnalytics, subcomm
 	versionPlugin := version.NewPlugin(tiltBuild)
 	configPlugin := config.NewPlugin(subcommand)
 	dockerComposeClient := dockercompose.NewDockerComposeClient(localEnv)
-	processExecer := localexec.NewProcessExecer(env)
 	defaults := _wireDefaultsValue
 	tiltfileLoader := tiltfile.ProvideTiltfileLoader(analytics3, client, plugin, versionPlugin, configPlugin, dockerComposeClient, webHost, processExecer, defaults, k8sEnv)
 	buildSource := tiltfile2.NewBuildSource()
@@ -674,7 +674,8 @@ func wireCmdUpdog(ctx context.Context, analytics3 *analytics.TiltAnalytics, cmdT
 	labels := _wireLabelsValue
 	dockerImageBuilder := build.NewDockerImageBuilder(switchCli, labels)
 	dockerBuilder := build.DefaultDockerBuilder(dockerImageBuilder)
-	kubernetesapplyReconciler := kubernetesapply.NewReconciler(deferredClient, k8sClient, scheme, dockerBuilder, kubeContext, storeStore, namespace)
+	processExecer := localexec.NewProcessExecer(env)
+	kubernetesapplyReconciler := kubernetesapply.NewReconciler(deferredClient, k8sClient, scheme, dockerBuilder, kubeContext, storeStore, namespace, processExecer)
 	uisessionReconciler := uisession.NewReconciler(deferredClient, websocketList)
 	uiresourceReconciler := uiresource.NewReconciler(deferredClient, websocketList, storeStore)
 	uibuttonReconciler := uibutton.NewReconciler(deferredClient, websocketList)
@@ -683,7 +684,6 @@ func wireCmdUpdog(ctx context.Context, analytics3 *analytics.TiltAnalytics, cmdT
 	versionPlugin := version.NewPlugin(tiltBuild)
 	configPlugin := config.NewPlugin(subcommand)
 	dockerComposeClient := dockercompose.NewDockerComposeClient(localEnv)
-	processExecer := localexec.NewProcessExecer(env)
 	defaults := _wireDefaultsValue
 	tiltfileLoader := tiltfile.ProvideTiltfileLoader(analytics3, k8sClient, plugin, versionPlugin, configPlugin, dockerComposeClient, webHost, processExecer, defaults, k8sEnv)
 	buildSource := tiltfile2.NewBuildSource()

--- a/internal/controllers/core/kubernetesapply/reconciler.go
+++ b/internal/controllers/core/kubernetesapply/reconciler.go
@@ -26,6 +26,7 @@ import (
 	"github.com/tilt-dev/tilt/internal/controllers/apis/restarton"
 	"github.com/tilt-dev/tilt/internal/controllers/indexer"
 	"github.com/tilt-dev/tilt/internal/k8s"
+	"github.com/tilt-dev/tilt/internal/localexec"
 	"github.com/tilt-dev/tilt/internal/store"
 	"github.com/tilt-dev/tilt/internal/store/kubernetesapplys"
 	"github.com/tilt-dev/tilt/internal/timecmp"
@@ -43,6 +44,7 @@ type Reconciler struct {
 	cfgNS       k8s.Namespace
 	ctrlClient  ctrlclient.Client
 	indexer     *indexer.Indexer
+	execer      localexec.Execer
 
 	mu sync.Mutex
 
@@ -60,11 +62,12 @@ func (r *Reconciler) CreateBuilder(mgr ctrl.Manager) (*builder.Builder, error) {
 	return b, nil
 }
 
-func NewReconciler(ctrlClient ctrlclient.Client, k8sClient k8s.Client, scheme *runtime.Scheme, dkc build.DockerKubeConnection, kubeContext k8s.KubeContext, st store.RStore, cfgNS k8s.Namespace) *Reconciler {
+func NewReconciler(ctrlClient ctrlclient.Client, k8sClient k8s.Client, scheme *runtime.Scheme, dkc build.DockerKubeConnection, kubeContext k8s.KubeContext, st store.RStore, cfgNS k8s.Namespace, execer localexec.Execer) *Reconciler {
 	return &Reconciler{
 		ctrlClient:  ctrlClient,
 		k8sClient:   k8sClient,
 		indexer:     indexer.NewIndexer(scheme, indexImageMap),
+		execer:      execer,
 		dkc:         dkc,
 		kubeContext: kubeContext,
 		st:          st,

--- a/internal/controllers/core/kubernetesapply/reconciler_test.go
+++ b/internal/controllers/core/kubernetesapply/reconciler_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/tilt-dev/tilt/internal/dockerfile"
 	"github.com/tilt-dev/tilt/internal/k8s"
 	"github.com/tilt-dev/tilt/internal/k8s/testyaml"
+	"github.com/tilt-dev/tilt/internal/localexec"
 	"github.com/tilt-dev/tilt/internal/store"
 	"github.com/tilt-dev/tilt/internal/timecmp"
 	"github.com/tilt-dev/tilt/pkg/apis"
@@ -257,6 +258,7 @@ type fixture struct {
 	*fake.ControllerFixture
 	r       *Reconciler
 	kClient *k8s.FakeK8sClient
+	execer  *localexec.FakeExecer
 }
 
 func newFixture(t *testing.T) *fixture {
@@ -270,12 +272,15 @@ func newFixture(t *testing.T) *fixture {
 	// when testing the reconciler
 	dockerClient.ImageAlwaysExists = true
 
+	execer := localexec.NewFakeExecer(t)
+
 	db := build.NewDockerImageBuilder(dockerClient, dockerfile.Labels{})
-	r := NewReconciler(cfb.Client, kClient, v1alpha1.NewScheme(), db, kubeContext, st, "default")
+	r := NewReconciler(cfb.Client, kClient, v1alpha1.NewScheme(), db, kubeContext, st, "default", execer)
 
 	return &fixture{
 		ControllerFixture: cfb.Build(r),
 		r:                 r,
 		kClient:           kClient,
+		execer:            execer,
 	}
 }

--- a/internal/engine/build_and_deployer_test.go
+++ b/internal/engine/build_and_deployer_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/tilt-dev/tilt/internal/controllers/apis/liveupdate"
 	"github.com/tilt-dev/tilt/internal/controllers/fake"
 	"github.com/tilt-dev/tilt/internal/engine/buildcontrol"
+	"github.com/tilt-dev/tilt/internal/localexec"
 	"github.com/tilt-dev/tilt/internal/store/liveupdates"
 
 	"github.com/tilt-dev/wmclient/pkg/dirs"
@@ -803,8 +804,9 @@ func newBDFixtureWithUpdateMode(t *testing.T, env k8s.Env, runtime container.Run
 	kl := &fakeKINDLoader{}
 	ctrlClient := fake.NewFakeTiltClient()
 	st := NewTestingStore(logs)
+	execer := localexec.NewFakeExecer(t)
 	bd, err := provideFakeBuildAndDeployer(ctx, dockerClient, k8s, dir, env, mode, dcc,
-		fakeClock{now: time.Unix(1551202573, 0)}, kl, ta, ctrlClient, st)
+		fakeClock{now: time.Unix(1551202573, 0)}, kl, ta, ctrlClient, st, execer)
 	require.NoError(t, err)
 
 	return &bdFixture{

--- a/internal/engine/buildcontrol/image_build_and_deployer_test.go
+++ b/internal/engine/buildcontrol/image_build_and_deployer_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/api/types"
-	digest "github.com/opencontainers/go-digest"
+	"github.com/opencontainers/go-digest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tilt-dev/wmclient/pkg/dirs"
@@ -26,6 +26,7 @@ import (
 	"github.com/tilt-dev/tilt/internal/docker"
 	"github.com/tilt-dev/tilt/internal/k8s"
 	"github.com/tilt-dev/tilt/internal/k8s/testyaml"
+	"github.com/tilt-dev/tilt/internal/localexec"
 	"github.com/tilt-dev/tilt/internal/store"
 	"github.com/tilt-dev/tilt/internal/store/k8sconv"
 	"github.com/tilt-dev/tilt/internal/testutils"
@@ -1018,8 +1019,9 @@ func newIBDFixture(t *testing.T, env k8s.Env) *ibdFixture {
 	clusterEnv := docker.ClusterEnv(docker.Env{})
 	ctrlClient := fake.NewFakeTiltClient()
 	st := store.NewTestingStore()
+	execer := localexec.NewFakeExecer(t)
 	ibd, err := ProvideImageBuildAndDeployer(ctx, dockerClient, kClient, env, kubeContext,
-		clusterEnv, dir, clock, kl, ta, ctrlClient, st)
+		clusterEnv, dir, clock, kl, ta, ctrlClient, st, execer)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/engine/buildcontrol/wire.go
+++ b/internal/engine/buildcontrol/wire.go
@@ -18,6 +18,7 @@ import (
 	"github.com/tilt-dev/tilt/internal/dockercompose"
 	"github.com/tilt-dev/tilt/internal/dockerfile"
 	"github.com/tilt-dev/tilt/internal/k8s"
+	"github.com/tilt-dev/tilt/internal/localexec"
 	"github.com/tilt-dev/tilt/internal/store"
 	"github.com/tilt-dev/tilt/internal/store/liveupdates"
 	"github.com/tilt-dev/tilt/internal/tracer"
@@ -62,7 +63,8 @@ func ProvideImageBuildAndDeployer(
 	kp KINDLoader,
 	analytics *analytics.TiltAnalytics,
 	ctrlclient ctrlclient.Client,
-	st store.RStore) (*ImageBuildAndDeployer, error) {
+	st store.RStore,
+	execer localexec.Execer) (*ImageBuildAndDeployer, error) {
 	wire.Build(
 		BaseWireSet,
 		kubernetesapply.NewReconciler,

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -3990,7 +3990,7 @@ func newTestFixture(t *testing.T, options ...fixtureOptions) *testFixture {
 
 	wsl := server.NewWebsocketList()
 
-	kar := kubernetesapply.NewReconciler(cdc, b.kClient, sch, docker.Env{}, k8s.KubeContext("kind-kind"), st, "default")
+	kar := kubernetesapply.NewReconciler(cdc, b.kClient, sch, docker.Env{}, k8s.KubeContext("kind-kind"), st, "default", execer)
 
 	tfr := ctrltiltfile.NewReconciler(st, tfl, dockerClient, cdc, sch, buildSource, engineMode)
 	tbr := togglebutton.NewReconciler(cdc, sch)

--- a/internal/engine/wire.go
+++ b/internal/engine/wire.go
@@ -59,7 +59,8 @@ func provideFakeBuildAndDeployer(
 	kp buildcontrol.KINDLoader,
 	analytics *analytics.TiltAnalytics,
 	ctrlClient ctrlclient.Client,
-	st store.RStore) (buildcontrol.BuildAndDeployer, error) {
+	st store.RStore,
+	execer localexec.Execer) (buildcontrol.BuildAndDeployer, error) {
 	wire.Build(
 		DeployerWireSetTest,
 		k8s.ProvideContainerRuntime,


### PR DESCRIPTION
Reconciler isn't actually using this still: just pulling it out
into its own commit/PR because the wire changes were fairly
pervasive/noisy on their own.