### PR TITLE
api: custom apply command support for KubernetesApply

### DIFF
--- a/integration/custom_deploy/Tiltfile
+++ b/integration/custom_deploy/Tiltfile
@@ -1,0 +1,26 @@
+
+v1alpha1.file_watch(
+    name='custom-deploy-fw',
+    watched_paths=['./deploy.yaml']
+)
+
+v1alpha1.kubernetes_apply(
+    name='custom-deploy-int-test',
+    timeout='10s',
+    port_forward_template_spec=v1alpha1.port_forward_template_spec(
+        forwards=[
+            v1alpha1.forward(
+                local_port=54871,
+                container_port=80
+            )
+        ]
+    ),
+    cmd=v1alpha1.kubernetes_apply_cmd(
+        args=['sh', '-c', 'kubectl apply -o yaml -f "${DEPLOY_FILE}"'],
+        dir=config.main_dir,
+        env=['DEPLOY_FILE=deploy.yaml']
+    ),
+    restart_on=v1alpha1.restart_on_spec(
+        file_watches=['custom-deploy-fw']
+    )
+)

--- a/integration/custom_deploy/deploy.yaml
+++ b/integration/custom_deploy/deploy.yaml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: custom-deploy
+  namespace: tilt-integration
+  labels:
+    app: custom-deploy
+spec:
+  selector:
+    matchLabels:
+      app: custom-deploy
+  template:
+    metadata:
+      labels:
+        app: custom-deploy
+        someLabel: someValue1
+    spec:
+      containers:
+        - name: nginx
+          image: nginx
+          ports:
+            - containerPort: 80

--- a/integration/custom_deploy_test.go
+++ b/integration/custom_deploy_test.go
@@ -1,0 +1,57 @@
+//+build integration
+
+package integration
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCustomDeploy(t *testing.T) {
+	kubectlPath, err := exec.LookPath("kubectl")
+	if err != nil || kubectlPath == "" {
+		t.Fatal("`kubectl` not found in PATH")
+	}
+
+	f := newK8sFixture(t, "custom_deploy")
+	defer f.TearDown()
+	f.SetRestrictedCredentials()
+
+	f.TiltUp()
+
+	// ForwardPort will fail if all the pods are not ready.
+	//
+	// We can't use the normal Tilt-managed forwards here because
+	// Tilt doesn't setup forwards when --watch=false.
+	ctx, cancel := context.WithTimeout(f.ctx, time.Minute)
+	defer cancel()
+	f.WaitForAllPodsReady(ctx, "someLabel=someValue1")
+
+	// check that port forward is working
+	ctx, cancel = context.WithTimeout(f.ctx, time.Minute)
+	defer cancel()
+	f.CurlUntil(ctx, "http://localhost:54871", "Welcome to nginx!")
+
+	// check that pod log streaming is working (integration text fixture already streams logs to stdout,
+	// so assert.True is used vs assert.Contains to avoid spewing a duplicate copy on failure)
+	assert.True(t, strings.Contains(f.logs.String(), "start worker processes"),
+		"Container logs not visible on stdout")
+
+	// deploy.yaml is monitored by the FileWatch referenced by restartOn, so it should trigger
+	// reconciliation and the KA Cmd should get re-invoked
+	f.ReplaceContents("deploy.yaml", "someValue1", "someValue2")
+
+	ctx, cancel = context.WithTimeout(f.ctx, time.Minute)
+	defer cancel()
+	f.WaitForAllPodsReady(ctx, "someLabel=someValue2")
+
+	// verify port forward still works
+	ctx, cancel = context.WithTimeout(f.ctx, time.Minute)
+	defer cancel()
+	f.CurlUntil(ctx, "http://localhost:54871", "Welcome to nginx!")
+}

--- a/internal/controllers/core/kubernetesapply/reconciler.go
+++ b/internal/controllers/core/kubernetesapply/reconciler.go
@@ -363,7 +363,7 @@ func (r *Reconciler) runCmdDeploy(ctx context.Context, spec v1alpha1.KubernetesA
 	var stdoutBuf bytes.Buffer
 	runIO := localexec.RunIO{
 		Stdout: &stdoutBuf,
-		Stderr: logger.Get(ctx).Writer(logger.WarnLvl),
+		Stderr: logger.Get(ctx).Writer(logger.InfoLvl),
 	}
 
 	exitCode, err := r.execer.Run(ctx, cmd, runIO)

--- a/internal/controllers/core/kubernetesapply/reconciler.go
+++ b/internal/controllers/core/kubernetesapply/reconciler.go
@@ -348,9 +348,9 @@ func (r *Reconciler) runYAMLDeploy(ctx context.Context, spec v1alpha1.Kubernetes
 
 func (r *Reconciler) runCmdDeploy(ctx context.Context, spec v1alpha1.KubernetesApplySpec) ([]k8s.K8sEntity, error) {
 	cmd := model.Cmd{
-		Argv: append([]string(nil), spec.Cmd.Args...),
+		Argv: spec.Cmd.Args,
 		Dir:  spec.Cmd.Dir,
-		Env:  append([]string(nil), spec.Cmd.Env...),
+		Env:  spec.Cmd.Env,
 	}
 
 	timeout := spec.Timeout.Duration

--- a/internal/controllers/core/kubernetesapply/reconciler_test.go
+++ b/internal/controllers/core/kubernetesapply/reconciler_test.go
@@ -3,9 +3,12 @@ package kubernetesapply
 import (
 	"errors"
 	"fmt"
+	"reflect"
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -97,20 +100,105 @@ func TestBasicApplyYAML(t *testing.T) {
 
 func TestBasicApplyCmd(t *testing.T) {
 	f := newFixture(t)
+
+	entities, err := k8s.ParseYAMLFromString(testyaml.SanchoYAML)
+	require.NoError(t, err, "Could not parse SanchoYAML")
+	for i := range entities {
+		entities[i].SetUID(uuid.New().String())
+	}
+	yamlOut, err := k8s.SerializeSpecYAML(entities)
+	require.NoError(t, err, "Failed to re-serialize SanchoYAML")
+
+	f.execer.RegisterCommand("custom-apply-cmd", 0, yamlOut, "")
+
 	ka := v1alpha1.KubernetesApply{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "a",
 		},
 		Spec: v1alpha1.KubernetesApplySpec{
-			Cmd: &v1alpha1.KubernetesApplyCmd{Args: []string{"false"}},
+			Cmd: &v1alpha1.KubernetesApplyCmd{Args: []string{"custom-apply-cmd"}},
 		},
 	}
 	f.Create(&ka)
 
+	f.MustGet(types.NamespacedName{Name: "a"}, &ka)
+	assert.Empty(t, ka.Status.Error)
+	assert.NotZero(t, ka.Status.LastApplyTime)
+	assert.Equal(t, yamlOut, ka.Status.ResultYAML)
+
+	// verify that a re-reconcile does NOT re-invoke the command
+	f.execer.RegisterCommandError("custom-apply-cmd", errors.New("this should not get invoked"))
 	f.MustReconcile(types.NamespacedName{Name: "a"})
+	lastApplyTime := ka.Status.LastApplyTime
+	f.MustGet(types.NamespacedName{Name: "a"}, &ka)
+	assert.Empty(t, ka.Status.Error)
+	timecmp.AssertTimeEqual(t, lastApplyTime, ka.Status.LastApplyTime)
+}
+
+func TestBasicApplyCmd_ExecError(t *testing.T) {
+	f := newFixture(t)
+
+	f.execer.RegisterCommandError("custom-apply-cmd", errors.New("could not start process"))
+
+	ka := v1alpha1.KubernetesApply{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "a",
+		},
+		Spec: v1alpha1.KubernetesApplySpec{
+			Cmd: &v1alpha1.KubernetesApplyCmd{Args: []string{"custom-apply-cmd"}},
+		},
+	}
+	f.Create(&ka)
+
 	f.MustGet(types.NamespacedName{Name: "a"}, &ka)
 
-	assert.Equal(t, "Cmd apply not supported", ka.Status.Error)
+	assert.Equal(t, "apply command failed: could not start process", ka.Status.Error)
+}
+
+func TestBasicApplyCmd_NonZeroExitCode(t *testing.T) {
+	f := newFixture(t)
+
+	f.execer.RegisterCommand("custom-apply-cmd", 77, "whoops", "oh no")
+
+	ka := v1alpha1.KubernetesApply{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "a",
+			Annotations: map[string]string{v1alpha1.AnnotationManifest: "foo"},
+		},
+		Spec: v1alpha1.KubernetesApplySpec{
+			Cmd: &v1alpha1.KubernetesApplyCmd{Args: []string{"custom-apply-cmd"}},
+		},
+	}
+	f.Create(&ka)
+
+	f.MustGet(types.NamespacedName{Name: "a"}, &ka)
+
+	if assert.Equal(t, "apply command exited with status 77\nstdout:\nwhoops\n", ka.Status.Error) {
+		logAction := f.st.WaitForAction(t, reflect.TypeOf(store.LogAction{}))
+		assert.Equal(t, `manifest: foo, spanID: KubernetesApply-a, msg: "oh no"`, logAction.(store.LogAction).String())
+	}
+}
+
+func TestBasicApplyCmd_MalformedYAML(t *testing.T) {
+	f := newFixture(t)
+
+	f.execer.RegisterCommand("custom-apply-cmd", 0, "this is not yaml", "")
+
+	ka := v1alpha1.KubernetesApply{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "a",
+		},
+		Spec: v1alpha1.KubernetesApplySpec{
+			Cmd: &v1alpha1.KubernetesApplyCmd{Args: []string{"custom-apply-cmd"}},
+		},
+	}
+	f.Create(&ka)
+
+	f.MustGet(types.NamespacedName{Name: "a"}, &ka)
+
+	if assert.Contains(t, ka.Status.Error, "apply command returned malformed YAML") {
+		assert.Contains(t, ka.Status.Error, "stdout:\nthis is not yaml\n")
+	}
 }
 
 func TestGarbageCollectAll(t *testing.T) {
@@ -259,6 +347,7 @@ type fixture struct {
 	r       *Reconciler
 	kClient *k8s.FakeK8sClient
 	execer  *localexec.FakeExecer
+	st      *store.TestingStore
 }
 
 func newFixture(t *testing.T) *fixture {
@@ -282,5 +371,6 @@ func newFixture(t *testing.T) *fixture {
 		r:                 r,
 		kClient:           kClient,
 		execer:            execer,
+		st:                st,
 	}
 }

--- a/internal/localexec/execer.go
+++ b/internal/localexec/execer.go
@@ -144,7 +144,8 @@ var _ Execer = &FakeExecer{}
 
 func NewFakeExecer(t testing.TB) *FakeExecer {
 	return &FakeExecer{
-		t: t,
+		t:    t,
+		cmds: make(map[string]fakeCmdResult),
 	}
 }
 
@@ -163,12 +164,16 @@ func (f *FakeExecer) Run(ctx context.Context, cmd model.Cmd, runIO RunIO) (int, 
 			return -1, r.err
 		}
 
-		if _, err := runIO.Stdout.Write([]byte(r.stdout)); err != nil {
-			return -1, fmt.Errorf("error writing to stdout: %v", err)
+		if runIO.Stdout != nil && r.stdout != "" {
+			if _, err := runIO.Stdout.Write([]byte(r.stdout)); err != nil {
+				return -1, fmt.Errorf("error writing to stdout: %v", err)
+			}
 		}
 
-		if _, err := runIO.Stderr.Write([]byte(r.stderr)); err != nil {
-			return -1, fmt.Errorf("error writing to stderr: %v", err)
+		if runIO.Stderr != nil && r.stderr != "" {
+			if _, err := runIO.Stderr.Write([]byte(r.stderr)); err != nil {
+				return -1, fmt.Errorf("error writing to stderr: %v", err)
+			}
 		}
 
 		return r.exitCode, nil

--- a/internal/store/logger.go
+++ b/internal/store/logger.go
@@ -3,7 +3,6 @@ package store
 import (
 	"context"
 	"fmt"
-	"reflect"
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -43,7 +42,7 @@ func WithObjectLogHandler(ctx context.Context, st RStore, obj runtime.Object) (c
 	mn := meta.GetAnnotations()[v1alpha1.AnnotationManifest]
 	spanID := meta.GetAnnotations()[v1alpha1.AnnotationSpanID]
 	if spanID == "" {
-		spanID = fmt.Sprintf("%s-%s", reflect.TypeOf(obj).Name(), meta.GetName())
+		spanID = fmt.Sprintf("%s-%s", obj.GetObjectKind().GroupVersionKind().Kind, meta.GetName())
 	}
 
 	w := apiLogWriter{


### PR DESCRIPTION
Allow deeper integration with custom deploy tools (e.g. Helm) by
invoking a command to perform the apply instead of having Tilt
call the K8s API directly.

The invoked command MUST return YAML for applied entities on
stdout and return an exit code of 0.