### PR TITLE
api: only ignore buildcontrol managed KubernetesApply objs

### DIFF
--- a/internal/controllers/core/kubernetesapply/reconciler.go
+++ b/internal/controllers/core/kubernetesapply/reconciler.go
@@ -9,7 +9,6 @@ import (
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -156,11 +155,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 //    or one of the inputs has changed since the last deploy.
 func (r *Reconciler) shouldDeployOnReconcile(nn types.NamespacedName, ka *v1alpha1.KubernetesApply,
 	imageMaps map[types.NamespacedName]*v1alpha1.ImageMap, restartObjs restarton.Objects) bool {
-	owner := metav1.GetControllerOf(ka)
-	if owner != nil && owner.Kind == v1alpha1.OwnerKindTiltfile {
+	if ka.Annotations[v1alpha1.AnnotationManagedBy] != "" {
 		// Until resource dependencies are expressed in the API,
 		// we can't use reconciliation to deploy KubernetesApply objects
-		// owned by the Tiltfile.
+		// managed by the buildcontrol engine.
 		return false
 	}
 

--- a/internal/controllers/core/tiltfile/api.go
+++ b/internal/controllers/core/tiltfile/api.go
@@ -287,8 +287,9 @@ func toKubernetesApplyObjects(tlr *tiltfile.TiltfileLoadResult, disableSources d
 			ObjectMeta: metav1.ObjectMeta{
 				Name: name,
 				Annotations: map[string]string{
-					v1alpha1.AnnotationManifest: name,
-					v1alpha1.AnnotationSpanID:   fmt.Sprintf("kubernetesapply:%s", name),
+					v1alpha1.AnnotationManifest:  name,
+					v1alpha1.AnnotationSpanID:    fmt.Sprintf("kubernetesapply:%s", name),
+					v1alpha1.AnnotationManagedBy: "buildcontrol",
 				},
 			},
 			Spec: kTarget.KubernetesApplySpec,


### PR DESCRIPTION
Instead of ignoring any `KubernetesApply` resource owned by
the Tiltfile, only ignore those that have a "managed by" annotation.

This will mean that _implicitly_ created `KubernetesApply` objs
(i.e. those that come from manifests) will continue to not be
reconciled, instead relying on `ForceApply` from the engine.

However, objects explicitly created via `v1alpha1.kubernetes_apply()`
_will_ be reconciled and exclusively managed via API.