### PR TITLE
api: add helper for registering RestartOn watches

### DIFF
--- a/internal/controllers/core/kubernetesapply/reconciler.go
+++ b/internal/controllers/core/kubernetesapply/reconciler.go
@@ -59,6 +59,8 @@ func (r *Reconciler) CreateBuilder(mgr ctrl.Manager) (*builder.Builder, error) {
 		Watches(&source.Kind{Type: &v1alpha1.ImageMap{}},
 			handler.EnqueueRequestsFromMapFunc(r.indexer.Enqueue))
 
+	restarton.RegisterWatches(b, r.indexer)
+
 	return b, nil
 }
 
@@ -66,7 +68,7 @@ func NewReconciler(ctrlClient ctrlclient.Client, k8sClient k8s.Client, scheme *r
 	return &Reconciler{
 		ctrlClient:  ctrlClient,
 		k8sClient:   k8sClient,
-		indexer:     indexer.NewIndexer(scheme, indexImageMap),
+		indexer:     indexer.NewIndexer(scheme, indexKubernetesApply),
 		execer:      execer,
 		dkc:         dkc,
 		kubeContext: kubeContext,
@@ -530,8 +532,8 @@ func (r *Reconciler) bestEffortDelete(ctx context.Context, entities []k8s.K8sEnt
 
 var imGVK = v1alpha1.SchemeGroupVersion.WithKind("ImageMap")
 
-// Find all the objects we need to watch based on the Cmd model.
-func indexImageMap(obj client.Object) []indexer.Key {
+// indexKubernetesApply returns keys for all the objects we need to watch based on the spec.
+func indexKubernetesApply(obj client.Object) []indexer.Key {
 	ka := obj.(*v1alpha1.KubernetesApply)
 	result := []indexer.Key{}
 

--- a/internal/controllers/core/tiltfile/reconciler.go
+++ b/internal/controllers/core/tiltfile/reconciler.go
@@ -51,11 +51,11 @@ type Reconciler struct {
 func (r *Reconciler) CreateBuilder(mgr ctrl.Manager) (*builder.Builder, error) {
 	b := ctrl.NewControllerManagedBy(mgr).
 		For(&v1alpha1.Tiltfile{}).
-		Watches(&source.Kind{Type: &v1alpha1.FileWatch{}},
-			handler.EnqueueRequestsFromMapFunc(r.indexer.Enqueue)).
 		Watches(&source.Kind{Type: &v1alpha1.ConfigMap{}},
 			handler.EnqueueRequestsFromMapFunc(r.enqueueTriggerQueue)).
 		Watches(r.buildSource, handler.Funcs{})
+
+	restarton.RegisterWatches(b, r.indexer)
 
 	return b, nil
 }


### PR DESCRIPTION
I did not actually add a watch when adding `RestartOn` to the
`KubernetesApply` spec, so it wouldn't actually work.

I realized that the Tiltfile reconciler was also only watching
`FileWatch` and not `UIButton` so thought a helper was probably
warranted to ensure these all stay in sync.