### PR TITLE
localexec: improve flaky test

### DIFF
--- a/internal/localexec/execer_test.go
+++ b/internal/localexec/execer_test.go
@@ -2,6 +2,7 @@ package localexec
 
 import (
 	"context"
+	"errors"
 	"os"
 	"runtime"
 	"strconv"
@@ -14,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/tilt-dev/tilt/internal/testutils"
+	"github.com/tilt-dev/tilt/internal/testutils/bufsync"
 	"github.com/tilt-dev/tilt/pkg/model"
 )
 
@@ -50,20 +52,42 @@ func TestProcessExecer_Run_ProcessGroup(t *testing.T) {
 
 	script := `sleep 60 & echo $!`
 
+	// to speed up test execution, as soon as we see the PID written to stdout, cancel the context
+	// to trigger process termination
+	var childPid int
+	stdoutBuf := bufsync.NewThreadSafeBuffer()
+	go func() {
+		for {
+			if ctx.Err() != nil {
+				return
+			}
+			output := strings.TrimSpace(stdoutBuf.String())
+			if output != "" {
+				var err error
+				childPid, err = strconv.Atoi(output)
+				if err == nil {
+					cancel()
+					return
+				}
+			}
+			time.Sleep(5 * time.Millisecond)
+		}
+	}()
+
 	execer := NewProcessExecer(EmptyEnv())
-	r, err := OneShot(ctx, execer, model.ToUnixCmd(script))
+	exitCode, err := execer.Run(ctx, model.ToUnixCmd(script), RunIO{Stdout: stdoutBuf})
 
 	require.NoError(t, err)
-	assert.Equal(t, 137, r.ExitCode)
+	assert.Equal(t, 137, exitCode)
 
-	output := strings.TrimSpace(string(r.Stdout))
-	if assert.NotEmpty(t, output) {
-		childPid, err := strconv.Atoi(output)
-		require.NoError(t, err, "Couldn't get child PID from stdout/stderr: %s", output)
+	if assert.NotZero(t, childPid, "Process did not write child PID to stdout") {
 		// os.FindProcess is a no-op on Unix-like systems and always succeeds; need to send signal 0 to probe it
 		proc, _ := os.FindProcess(childPid)
-		err = proc.Signal(syscall.Signal(0))
-		if !assert.Equal(t, os.ErrProcessDone, err, "Child process was still running") {
+		childProcStopped := assert.Eventually(t, func() bool {
+			err = proc.Signal(syscall.Signal(0))
+			return errors.Is(err, os.ErrProcessDone)
+		}, time.Second, 50*time.Millisecond, "Child process was still running")
+		if !childProcStopped {
 			_ = proc.Kill()
 		}
 	}


### PR DESCRIPTION
This failed a couple times in CI - I can't reproduce the failure
on my macOS laptop, but I'm guessing it's a timing issue due to
the CI runners being slower.

Changes are two-fold:
 * Aggressively cancel context (i.e. trigger SIGKILL to process
   group) as soon as PID is seen - this makes it possible to run
   this test hundreds of times much quicker, which was useful to
   try and reproduce the issue
 * Allow grace period for child PID to get terminated - hopefully
   this prevents flakiness on CI runners

It's _possible_ the CI flakiness is actually due to the child PID
getting recycled, but that seems very unlikely given the timings
here combined with standard OS behavior for Linux. If these changes
don't eliminate the flakiness, we might just need to reduce the
strictness of this test and not attempt to assert on the child PID
at all (see `cmd/excer_test.go`, which has a similar test and does
not attempt to assert on the child process state).