### PR TITLE
liveupdate: set waiting status correctly when init containers are starting

### DIFF
--- a/internal/controllers/core/liveupdate/reconciler.go
+++ b/internal/controllers/core/liveupdate/reconciler.go
@@ -453,7 +453,7 @@ func (r *Reconciler) visitSelectedContainers(
 		for _, c := range pod.Containers {
 			// Only visit well-formed containers matching our image
 			imageRef, err := container.ParseNamed(c.Image)
-			if err != nil || c.ID == "" || c.Name == "" || imageRef == nil ||
+			if err != nil || c.Name == "" || imageRef == nil ||
 				kSelector.Image != reference.FamiliarName(imageRef) {
 				continue
 			}
@@ -612,7 +612,10 @@ func (r *Reconciler) maybeSync(ctx context.Context, lu *v1alpha1.LiveUpdate, mon
 		}
 
 		var waiting *v1alpha1.LiveUpdateContainerStateWaiting
-		if cInfo.State.Running == nil {
+
+		// We interpret "no container id" as a waiting state
+		// (terminated states should have been caught above).
+		if cInfo.State.Running == nil || cInfo.ID == "" {
 			waiting = &v1alpha1.LiveUpdateContainerStateWaiting{
 				Reason:  "ContainerWaiting",
 				Message: "Waiting for container to start",


### PR DESCRIPTION
Hello @milas, @landism,

Please review the following commits I made in branch nicks/liveupdate4:

55db64896b4842bdd4a20b92203c211f5ea7d951 (2021-11-02 13:11:29 -0400)
liveupdate: set waiting status correctly when init containers are starting

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics