### PR TITLE
api: simplify/unify RestartOn initialization

### DIFF
--- a/internal/controllers/apis/restarton/restarton_test.go
+++ b/internal/controllers/apis/restarton/restarton_test.go
@@ -13,6 +13,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -69,7 +71,7 @@ func TestExtractKeysForIndexer(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		keys := ExtractKeysForIndexer(ns, tc.restartOn, tc.startOn)
+		keys := extractKeysForIndexer(ns, tc.restartOn, tc.startOn)
 		assert.ElementsMatchf(t, tc.expected, keys,
 			"Indexer keys did not match\nRestartOnSpec: %s\nStartOnSpec: %s",
 			strings.TrimSpace(spew.Sdump(tc.restartOn)),
@@ -116,6 +118,10 @@ func TestFetchObjects_Error(t *testing.T) {
 }
 
 type noopController struct{}
+
+func (n noopController) CreateBuilder(_ ctrl.Manager) (*builder.Builder, error) {
+	return nil, nil
+}
 
 func (n noopController) Reconcile(_ context.Context, _ reconcile.Request) (reconcile.Result, error) {
 	return reconcile.Result{}, nil

--- a/internal/controllers/core/tiltfile/reconciler.go
+++ b/internal/controllers/core/tiltfile/reconciler.go
@@ -55,7 +55,10 @@ func (r *Reconciler) CreateBuilder(mgr ctrl.Manager) (*builder.Builder, error) {
 			handler.EnqueueRequestsFromMapFunc(r.enqueueTriggerQueue)).
 		Watches(r.buildSource, handler.Funcs{})
 
-	restarton.RegisterWatches(b, r.indexer)
+	restarton.SetupController(b, r.indexer, func(obj ctrlclient.Object) (*v1alpha1.RestartOnSpec, *v1alpha1.StartOnSpec) {
+		tf := obj.(*v1alpha1.Tiltfile)
+		return tf.Spec.RestartOn, nil
+	})
 
 	return b, nil
 }
@@ -353,10 +356,7 @@ func (r *Reconciler) deleteExistingRun(nn types.NamespacedName) {
 
 // Find all the objects we need to watch based on the tiltfile model.
 func indexTiltfile(obj client.Object) []indexer.Key {
-	result := []indexer.Key{}
-	tf := obj.(*v1alpha1.Tiltfile)
-	result = append(result, restarton.ExtractKeysForIndexer(tf.Namespace, tf.Spec.RestartOn, nil)...)
-	return result
+	return nil
 }
 
 // Find any objects we need to reconcile based on the trigger queue.


### PR DESCRIPTION
Replace `ExtractKeysForIndexer` + `RegisterWatches` with a unified
`restarton.SetupController` function, which uses these (now unexported)
functions internally.

This is expected to be called as part of a reconciler's `CreateBuilder()`
method and will add watches for all restart on types as well as set up
the indexer. A func must be passed to pull the `RestartOnSpec` and/or
`StartOnSpec` objects off the reconciler object type.

The `ControllerFixture` now invokes `CreateBuilder` to ensure this logic
gets called during tests, which sometimes rely on the indexer being
properly set up. Note that no automatic reconciliation for dependent
objects will happen in a test scenario still.

The `Cmd` reconciler tests were refactored to use `ControllerFixture`
(they pre-dated its existence), so that they continue to pass given
the new functionality describe above which they require.

See also #5093 and #5114 for the evolution of these helpers.