### PR TITLE
engine: update the tests to use the live update reconciler by default

### DIFF
--- a/internal/engine/build_and_deployer_test.go
+++ b/internal/engine/build_and_deployer_test.go
@@ -138,7 +138,11 @@ func TestLiveUpdateTaskKilled(t *testing.T) {
 
 	changed := f.WriteFile("a.txt", "a")
 
-	manifest := NewSanchoLiveUpdateManifest(f)
+	manifest := manifestbuilder.New(f, "sancho").
+		WithK8sYAML(SanchoYAML).
+		WithLiveUpdateBAD().
+		WithImageTarget(NewSanchoLiveUpdateImageTarget(f)).
+		Build()
 	bs := resultToStateSet(manifest, alreadyBuiltSet, []string{changed}, testContainerInfo)
 	f.docker.SetExecError(docker.ExitError{ExitCode: build.TaskKillExitCode})
 
@@ -189,6 +193,7 @@ func TestLiveUpdateFallbackMessagingRedirect(t *testing.T) {
 	manifest := manifestbuilder.New(f, "foobar").
 		WithImageTarget(NewSanchoDockerBuildImageTarget(f)).
 		WithLiveUpdate(lu).
+		WithLiveUpdateBAD().
 		WithK8sYAML(SanchoYAML).
 		Build()
 
@@ -216,7 +221,11 @@ func TestLiveUpdateFallbackMessagingUnexpectedError(t *testing.T) {
 
 	f.docker.SetExecError(errors.New("some random error"))
 
-	manifest := NewSanchoLiveUpdateManifest(f)
+	manifest := manifestbuilder.New(f, "sancho").
+		WithK8sYAML(SanchoYAML).
+		WithLiveUpdateBAD().
+		WithImageTarget(NewSanchoLiveUpdateImageTarget(f)).
+		Build()
 	changed := f.WriteFile("a.txt", "a")
 	bs := resultToStateSet(manifest, alreadyBuiltSet, []string{changed}, testContainerInfo)
 
@@ -239,7 +248,11 @@ func TestLiveUpdateTwice(t *testing.T) {
 	f := newBDFixture(t, k8s.EnvDockerDesktop, container.RuntimeDocker)
 	defer f.TearDown()
 
-	manifest := NewSanchoLiveUpdateManifest(f)
+	manifest := manifestbuilder.New(f, "sancho").
+		WithK8sYAML(SanchoYAML).
+		WithLiveUpdateBAD().
+		WithImageTarget(NewSanchoLiveUpdateImageTarget(f)).
+		Build()
 	targets := buildcontrol.BuildTargets(manifest)
 	aPath := f.WriteFile("a.txt", "a")
 	bPath := f.WriteFile("b.txt", "b")
@@ -277,7 +290,11 @@ func TestLiveUpdateTwiceDeadPod(t *testing.T) {
 	f := newBDFixture(t, k8s.EnvDockerDesktop, container.RuntimeDocker)
 	defer f.TearDown()
 
-	manifest := NewSanchoLiveUpdateManifest(f)
+	manifest := manifestbuilder.New(f, "sancho").
+		WithK8sYAML(SanchoYAML).
+		WithLiveUpdateBAD().
+		WithImageTarget(NewSanchoLiveUpdateImageTarget(f)).
+		Build()
 	targets := buildcontrol.BuildTargets(manifest)
 	aPath := f.WriteFile("a.txt", "a")
 	bPath := f.WriteFile("b.txt", "b")
@@ -520,7 +537,11 @@ func TestLiveUpdateWithRunFailureReturnsContainerIDs(t *testing.T) {
 	// LiveUpdate will failure with a RunStepFailure
 	f.docker.SetExecError(userFailureErrDocker)
 
-	manifest := NewSanchoLiveUpdateManifest(f)
+	manifest := manifestbuilder.New(f, "sancho").
+		WithK8sYAML(SanchoYAML).
+		WithLiveUpdateBAD().
+		WithImageTarget(NewSanchoLiveUpdateImageTarget(f)).
+		Build()
 	targets := buildcontrol.BuildTargets(manifest)
 	changed := f.WriteFile("a.txt", "a")
 	bs := resultToStateSet(manifest, alreadyBuiltSet, []string{changed}, testContainerInfo)
@@ -727,6 +748,7 @@ func multiImageLiveUpdateManifestAndBuildState(f *bdFixture) (model.Manifest, st
 	manifest := manifestbuilder.New(f, "sancho").
 		WithK8sYAML(testyaml.SanchoSidecarYAML).
 		WithImageTargets(sanchoTarg, sidecarTarg).
+		WithLiveUpdateBAD().
 		Build()
 
 	changed := f.WriteFile("a.txt", "a")

--- a/internal/engine/buildcontrol/build_control.go
+++ b/internal/engine/buildcontrol/build_control.go
@@ -494,7 +494,8 @@ func HoldLiveUpdateTargetsHandledByReconciler(state store.EngineState, mts []*st
 	for _, mt := range mts {
 		iTargets := mt.Manifest.ImageTargets
 		for _, iTarget := range iTargets {
-			isHandledByReconciler := iTarget.LiveUpdateReconciler
+			isHandledByReconciler := !liveupdate.IsEmptySpec(iTarget.LiveUpdateSpec) &&
+				iTarget.LiveUpdateReconciler
 			if !isHandledByReconciler {
 				continue
 			}

--- a/internal/engine/buildcontrol/build_control_test.go
+++ b/internal/engine/buildcontrol/build_control_test.go
@@ -277,6 +277,7 @@ func TestHoldForDeploy(t *testing.T) {
 	sancho := f.upsertManifest(manifestbuilder.New(f, "sancho").
 		WithImageTargets(sanchoImage).
 		WithK8sYAML(testyaml.SanchoYAML).
+		WithLiveUpdateBAD().
 		Build())
 
 	f.assertNextTargetToBuild("sancho")

--- a/internal/engine/buildcontrol/live_update_build_and_deployer_test.go
+++ b/internal/engine/buildcontrol/live_update_build_and_deployer_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/tilt-dev/tilt/internal/store"
 	"github.com/tilt-dev/tilt/internal/store/liveupdates"
 	"github.com/tilt-dev/tilt/internal/testutils"
+	"github.com/tilt-dev/tilt/internal/testutils/manifestbuilder"
 	"github.com/tilt-dev/tilt/internal/testutils/tempdir"
 	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
 	"github.com/tilt-dev/tilt/pkg/model"
@@ -349,7 +350,11 @@ func TestSkipLiveUpdateIfForceUpdate(t *testing.T) {
 	f := newFixture(t)
 	defer f.teardown()
 
-	m := NewSanchoLiveUpdateManifest(f)
+	m := manifestbuilder.New(f, "sancho").
+		WithK8sYAML(SanchoYAML).
+		WithLiveUpdateBAD().
+		WithImageTarget(NewSanchoLiveUpdateImageTarget(f)).
+		Build()
 
 	container := liveupdates.Container{
 		PodID:         "mypod",

--- a/internal/engine/buildcontrol/testdata_test.go
+++ b/internal/engine/buildcontrol/testdata_test.go
@@ -36,13 +36,6 @@ var SanchoRef = container.MustParseSelector(testyaml.SanchoImage)
 var SanchoBaseRef = container.MustParseSelector("sancho-base")
 var SanchoSidecarRef = container.MustParseSelector(testyaml.SanchoSidecarImage)
 
-func NewSanchoLiveUpdateManifest(f Fixture) model.Manifest {
-	return manifestbuilder.New(f, "sancho").
-		WithK8sYAML(SanchoYAML).
-		WithImageTarget(NewSanchoLiveUpdateImageTarget(f)).
-		Build()
-}
-
 func NewSanchoManifestWithImageInEnvVar(f Fixture) model.Manifest {
 	it2 := model.MustNewImageTarget(container.MustParseSelector(SanchoRef.String() + "2")).WithBuildDetails(model.DockerBuild{
 		Dockerfile: SanchoDockerfile,

--- a/internal/engine/testdata_test.go
+++ b/internal/engine/testdata_test.go
@@ -131,7 +131,7 @@ func NewSanchoDockerBuildManifestWithYaml(f Fixture, yaml string) model.Manifest
 		Build()
 }
 
-func NewSanchoDockerBuildMultiStageManifestWithLiveUpdate(fixture Fixture, lu v1alpha1.LiveUpdateSpec) model.Manifest {
+func NewSanchoMultiStageImages(fixture Fixture) []model.ImageTarget {
 	baseImage := model.MustNewImageTarget(SanchoBaseRef).WithBuildDetails(model.DockerBuild{
 		Dockerfile: `FROM golang:1.10`,
 		BuildPath:  fixture.JoinPath("sancho-base"),
@@ -146,12 +146,7 @@ ENTRYPOINT /go/bin/sancho
 `,
 		BuildPath: fixture.JoinPath("sancho"),
 	}).WithDependencyIDs([]model.TargetID{baseImage.ID()})
-
-	return manifestbuilder.New(fixture, "sancho").
-		WithK8sYAML(SanchoYAML).
-		WithImageTargets(baseImage, srcImage).
-		WithLiveUpdateAtIndex(lu, 1).
-		Build()
+	return []model.ImageTarget{baseImage, srcImage}
 }
 
 func NewSanchoLiveUpdateMultiStageManifest(fixture Fixture) model.Manifest {

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -4519,6 +4519,9 @@ func (f *testFixture) newManifest(name string) model.Manifest {
 	iTarget := NewSanchoLiveUpdateImageTarget(f)
 	return manifestbuilder.New(f, model.ManifestName(name)).
 		WithK8sYAML(SanchoYAML).
+		// Right now, most of our tests assume that we're going through
+		// using BuildAndDeployer to do live updates. :\
+		WithLiveUpdateBAD().
 		WithImageTarget(iTarget).
 		Build()
 }

--- a/internal/testutils/manifestbuilder/manifestbuilder.go
+++ b/internal/testutils/manifestbuilder/manifestbuilder.go
@@ -39,6 +39,10 @@ type ManifestBuilder struct {
 	resourceDeps       []string
 	triggerMode        model.TriggerMode
 
+	// When set to true, we'll always use the old build-and-deploy-based liveupdate,
+	// rather than the new apiserver-based liveupdate.
+	useLiveUpdateBAD bool
+
 	iTargets []model.ImageTarget
 }
 
@@ -56,6 +60,11 @@ func New(f Fixture, name model.ManifestName) ManifestBuilder {
 		name:            name,
 		k8sPodReadiness: k8sPodReadiness,
 	}
+}
+
+func (b ManifestBuilder) WithLiveUpdateBAD() ManifestBuilder {
+	b.useLiveUpdateBAD = true
+	return b
 }
 
 func (b ManifestBuilder) WithNamedJSONPathImageLocator(name, path string) ManifestBuilder {
@@ -142,6 +151,22 @@ func (b ManifestBuilder) WithResourceDeps(deps ...string) ManifestBuilder {
 
 func (b ManifestBuilder) Build() model.Manifest {
 	var m model.Manifest
+
+	// Adjust images to use the live update reconciler or the BuildAndDeployer.
+	// Currently,
+	for index, iTarget := range b.iTargets {
+		if liveupdate.IsEmptySpec(iTarget.LiveUpdateSpec) {
+			iTarget.LiveUpdateReconciler = false
+		} else if b.useLiveUpdateBAD {
+			iTarget.LiveUpdateReconciler = false
+		} else if len(b.dcConfigPaths) > 0 {
+			// Docker Compose must use the buildAndDeployer
+			iTarget.LiveUpdateReconciler = false
+		} else {
+			iTarget.LiveUpdateReconciler = true
+		}
+		b.iTargets[index] = iTarget
+	}
 
 	var rds []model.ManifestName
 	for _, dep := range b.resourceDeps {

--- a/internal/tiltfile/tiltfile_state.go
+++ b/internal/tiltfile/tiltfile_state.go
@@ -1078,6 +1078,9 @@ func (s *tiltfileState) translateK8s(resources []*k8sResource, updateSettings mo
 		// and only if the user has flagged it on.
 		if s.features.Get(feature.LiveUpdateV2) {
 			for i, iTarget := range iTargets {
+				if liveupdate.IsEmptySpec(iTarget.LiveUpdateSpec) {
+					continue
+				}
 				iTarget.LiveUpdateReconciler = true
 				iTargets[i] = iTarget
 			}


### PR DESCRIPTION
Hello @milas, @landism,

Please review the following commits I made in branch nicks/liveupdate5:

c9a405eb168f156887283ef4864c8c1bd0ad98e5 (2021-11-02 16:15:00 -0400)
engine: update the tests to use the live update reconciler by default

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics