### PR TITLE
feature: enable live_update_v2 by default on kubernetes

### DIFF
--- a/integration/restart_process_different_user_test.go
+++ b/integration/restart_process_different_user_test.go
@@ -43,10 +43,13 @@ func TestRestartProcessDifferentUser(t *testing.T) {
 	_, _ = f.runCommand("kubectl", "exec", secondPods[0], "-c=c2", namespaceFlag,
 		"--", "kill", "1")
 
+	// live update v2 keeps track of all changes since
+	// the container started, and will be able to restore in-place.
 	ctx, cancel = context.WithTimeout(f.ctx, time.Minute)
 	defer cancel()
+	f.CurlUntil(ctx, "http://localhost:8100", "🍄 Two-Up! 🍄")
 	f.CurlUntil(ctx, "http://localhost:8101", "🍄 Two-Up! 🍄")
 
 	replacedPods := f.WaitForAllPodsReady(ctx, "app=rpdu")
-	assert.NotEqual(t, secondPods, replacedPods)
+	assert.Equal(t, secondPods, replacedPods)
 }

--- a/integration/same_img_multi_container_test.go
+++ b/integration/same_img_multi_container_test.go
@@ -43,10 +43,13 @@ func TestSameImgMultiContainer(t *testing.T) {
 	_, _ = f.runCommand("kubectl", "exec", secondPods[0], "-c=c2", namespaceFlag,
 		"--", "kill", "1")
 
+	// live update v2 keeps track of all changes since
+	// the container started, and will be able to restore in-place.
 	ctx, cancel = context.WithTimeout(f.ctx, time.Minute)
 	defer cancel()
+	f.CurlUntil(ctx, "http://localhost:8100", "🍄 Two-Up! 🍄")
 	f.CurlUntil(ctx, "http://localhost:8101", "🍄 Two-Up! 🍄")
 
 	replacedPods := f.WaitForAllPodsReady(ctx, "app=sameimg")
-	assert.NotEqual(t, secondPods, replacedPods)
+	assert.Equal(t, secondPods, replacedPods)
 }

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -822,6 +822,7 @@ func TestConfigFileChangeClearsBuildStateToForceImageBuild(t *testing.T) {
 	f.useRealTiltfileLoader()
 
 	f.WriteFile("Tiltfile", `
+disable_feature('live_update_v2')
 docker_build('gcr.io/windmill-public-containers/servantes/snack', '.', live_update=[sync('.', '/app')])
 k8s_yaml('snack.yaml')
 	`)
@@ -1058,6 +1059,7 @@ func TestConfigChange_TiltfileErrorAndFixWithFileChange(t *testing.T) {
 
 	tiltfileWithCmd := func(cmd string) string {
 		return fmt.Sprintf(`
+disable_feature('live_update_v2')
 docker_build('gcr.io/windmill-public-containers/servantes/snack', './src', dockerfile='Dockerfile',
     live_update=[
         sync('./src', '/src'),

--- a/internal/feature/flags.go
+++ b/internal/feature/flags.go
@@ -64,7 +64,7 @@ var MainDefaults = Defaults{
 		Status:  Active,
 	},
 	LiveUpdateV2: Value{
-		Enabled: false,
+		Enabled: true,
 		Status:  Active,
 	},
 	DisableResources: Value{


### PR DESCRIPTION
Hello @milas, @landism,

Please review the following commits I made in branch nicks/liveupdate6:

96f88eed2e407420d86b15d3409f9e66a3194c06 (2021-11-02 17:03:22 -0400)
feature: enable live_update_v2 by default on kubernetes

1855a5c7b55844cf91f162a6c7cbf12893f31486 (2021-11-02 16:22:58 -0400)
engine: update the tests to use the live update reconciler by default

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics