### PR TITLE
liveupdate: once a container reaches CrashLoopBackOff, stop trying to live-update it

### DIFF
--- a/internal/controllers/core/liveupdate/reconciler_test.go
+++ b/internal/controllers/core/liveupdate/reconciler_test.go
@@ -355,6 +355,74 @@ func TestOneRunningOneTerminatedContainer(t *testing.T) {
 	f.assertSteadyState(&lu)
 }
 
+func TestCrashLoopBackoff(t *testing.T) {
+	f := newFixture(t)
+
+	p, _ := os.Getwd()
+	nowMicro := apis.NowMicro()
+	txtPath := filepath.Join(p, "a.txt")
+	txtChangeTime := metav1.MicroTime{Time: nowMicro.Add(time.Second)}
+
+	f.setupFrontend()
+	f.kdUpdateStatus("frontend-discovery", v1alpha1.KubernetesDiscoveryStatus{
+		Pods: []v1alpha1.Pod{
+			{
+				Name:      "pod-1",
+				Namespace: "default",
+				Containers: []v1alpha1.Container{
+					{
+						Name:  "main",
+						ID:    "main-id",
+						Image: "frontend-image",
+						State: v1alpha1.ContainerState{
+							Waiting: &v1alpha1.ContainerStateWaiting{Reason: "CrashLoopBackOff"},
+						},
+					},
+				},
+			},
+		},
+	})
+
+	f.addFileEvent("frontend-fw", txtPath, txtChangeTime)
+	f.MustReconcile(types.NamespacedName{Name: "frontend-liveupdate"})
+
+	var lu v1alpha1.LiveUpdate
+	f.MustGet(types.NamespacedName{Name: "frontend-liveupdate"}, &lu)
+	if assert.NotNil(t, lu.Status.Failed) {
+		assert.Equal(t, "CrashLoopBackOff", lu.Status.Failed.Reason)
+	}
+	assert.Equal(t, 0, len(f.cu.Calls))
+
+	f.assertSteadyState(&lu)
+
+	f.kdUpdateStatus("frontend-discovery", v1alpha1.KubernetesDiscoveryStatus{
+		Pods: []v1alpha1.Pod{
+			{
+				Name:      "pod-1",
+				Namespace: "default",
+				Containers: []v1alpha1.Container{
+					{
+						Name:  "main",
+						ID:    "main-id",
+						Image: "frontend-image",
+						State: v1alpha1.ContainerState{
+							Running: &v1alpha1.ContainerStateRunning{},
+						},
+					},
+				},
+			},
+		},
+	})
+
+	// CrashLoopBackOff is a permanent state. If the container starts running
+	// again, we don't "revive" the live-update.
+	f.MustReconcile(types.NamespacedName{Name: "frontend-liveupdate"})
+	f.MustGet(types.NamespacedName{Name: "frontend-liveupdate"}, &lu)
+	if assert.NotNil(t, lu.Status.Failed) {
+		assert.Equal(t, "CrashLoopBackOff", lu.Status.Failed.Reason)
+	}
+}
+
 type TestingStore struct {
 	*store.TestingStore
 	ctx                 context.Context


### PR DESCRIPTION
Hello @milas, @landism,

Please review the following commits I made in branch nicks/liveupdate7:

2953b14cd8a658e1874b3c2ae37a017de359740f (2021-11-02 18:31:53 -0400)
liveupdate: once a container reaches CrashLoopBackOff, stop trying to live-update it

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics