### PR TITLE
makefile: increase linter timeout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,10 +112,10 @@ benchmark:
 
 golangci-lint:
 ifneq ($(CIRCLECI),true)
-	GOFLAGS="-mod=vendor" golangci-lint run -v --timeout 150s
+	GOFLAGS="-mod=vendor" golangci-lint run -v --timeout 180s
 else
 	mkdir -p test-results
-	GOFLAGS="-mod=vendor" golangci-lint run -v --timeout 150s --out-format junit-xml > test-results/lint.xml
+	GOFLAGS="-mod=vendor" golangci-lint run -v --timeout 180s --out-format junit-xml > test-results/lint.xml
 endif
 
 wire:


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/timeout:

54f61e413f07cb53a089392bd299bc1c50aa67dc (2021-11-03 10:39:11 -0400)
makefile: increase linter timeout

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics