### PR TITLE
engine: remove "to-be-deployed" ObjectRefs from K8sTarget

### DIFF
--- a/internal/engine/buildcontrol/image_build_and_deployer.go
+++ b/internal/engine/buildcontrol/image_build_and_deployer.go
@@ -225,7 +225,7 @@ func (ibd *ImageBuildAndDeployer) BuildAndDeploy(ctx context.Context, st store.R
 	// (If we pass an empty list of refs here (as we will do if only deploying
 	// yaml), we just don't inject any image refs into the yaml, nbd.
 	k8sResult, err := ibd.deploy(ctx, st, ps, kTarget.ID(), kTarget.KubernetesApplySpec, imageMapSet)
-	reportK8sDeployMetrics(ctx, kTarget, time.Since(startDeployTime), err != nil)
+	reportK8sDeployMetrics(ctx, kTarget.ID(), time.Since(startDeployTime), k8sResult, err != nil)
 	if err != nil {
 		return newResults, WrapDontFallBackError(err)
 	}

--- a/internal/engine/k8swatch/watcher.go
+++ b/internal/engine/k8swatch/watcher.go
@@ -51,21 +51,19 @@ func (ks *watcherKnownState) createTaskList(state store.EngineState) watcherTask
 
 		name := mt.Manifest.Name
 
-		for _, obj := range mt.Manifest.K8sTarget().ObjectRefs {
-			namespace := k8s.Namespace(obj.Namespace)
-			if namespace == "" {
-				namespace = ks.cfgNS
-			}
-			if namespace == "" {
-				namespace = k8s.DefaultNamespace
-			}
-			namespaces[namespace] = true
-		}
-
 		// Collect all the new UIDs
 		applyFilter := mt.State.K8sRuntimeState().ApplyFilter
 		if applyFilter != nil {
 			for _, ref := range applyFilter.DeployedRefs {
+				namespace := k8s.Namespace(ref.Namespace)
+				if namespace == "" {
+					namespace = ks.cfgNS
+				}
+				if namespace == "" {
+					namespace = k8s.DefaultNamespace
+				}
+				namespaces[namespace] = true
+
 				// Our data model allows people to have the same resource defined in
 				// multiple manifests, and so we can have the same deployed UID in
 				// multiple manifests.

--- a/internal/k8s/target.go
+++ b/internal/k8s/target.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"time"
 
-	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 
@@ -53,11 +52,6 @@ func NewTarget(
 		return model.K8sTarget{}, err
 	}
 
-	objectRefs := make([]v1.ObjectReference, 0, len(sorted))
-	for _, e := range sorted {
-		objectRefs = append(objectRefs, e.ToObjectReference())
-	}
-
 	// Use a min component count of 2 for computing names,
 	// so that the resource type appears
 	displayNames := UniqueNames(sorted, 2)
@@ -98,7 +92,6 @@ func NewTarget(
 		KubernetesApplySpec: apply,
 		Name:                name,
 		DisplayNames:        displayNames,
-		ObjectRefs:          objectRefs,
 		PodReadinessMode:    podReadinessMode,
 		Links:               links,
 	}.WithDependencyIDs(dependencyIDs, model.ToLiveUpdateOnlyMap(imageTargets)).

--- a/pkg/model/k8s_target.go
+++ b/pkg/model/k8s_target.go
@@ -3,9 +3,6 @@ package model
 import (
 	"fmt"
 	"reflect"
-	"strings"
-
-	v1 "k8s.io/api/core/v1"
 
 	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
 )
@@ -38,10 +35,6 @@ type K8sTarget struct {
 	// that balances brevity and uniqueness
 	DisplayNames []string
 
-	// Store the name, namespace, and type in a structured form
-	// for easy access. This should duplicate what's specified in the YAML.
-	ObjectRefs []v1.ObjectReference
-
 	PodReadinessMode PodReadinessMode
 
 	// Map configRef -> number of times we (expect to) inject it.
@@ -66,15 +59,6 @@ func NewK8sTargetForTesting(yaml string) K8sTarget {
 }
 
 func (k8s K8sTarget) Empty() bool { return reflect.DeepEqual(k8s, K8sTarget{}) }
-
-func (k8s K8sTarget) HasJob() bool {
-	for _, ref := range k8s.ObjectRefs {
-		if strings.Contains(ref.Kind, "Job") {
-			return true
-		}
-	}
-	return false
-}
 
 func (k8s K8sTarget) DependencyIDs() []TargetID {
 	return append([]TargetID{}, k8s.depIDs...)


### PR DESCRIPTION
We won't always have this anymore since the "to-be-applied" might
be invoking an external deploy command rather than a YAML blob.

There is some impact to this change (unlike the wholly redundant
removal of port forwards here recently):

  1. The `Session` object (used for Tilt CI) will _change_ a target
     type from "server" to "job" since it no longer knows up front
     until it gets deployed. This is a bit odd; longer-term, maybe
     it makes sense to provide explicit user control here and in
     the `k8s_yaml()` case to infer it up front to set a value.

  2. K8s event + service watches won't be started for a given
     namespace until _after_ the first deploy. In practice, this
     should not mean missed events, as the watch will return the
     existing ones when started.