### PR TITLE
engine: remove DisplayNames from K8sTarget

### DIFF
--- a/internal/hud/webview/convert.go
+++ b/internal/hud/webview/convert.go
@@ -361,7 +361,7 @@ func populateResourceInfoView(mt *store.ManifestTarget, r *v1alpha1.UIResource) 
 			PodStatusMessage:   strings.Join(pod.Errors, "\n"),
 			AllContainersReady: store.AllPodContainersReady(pod),
 			PodRestarts:        kState.VisiblePodContainerRestarts(podID),
-			DisplayNames:       mt.Manifest.K8sTarget().DisplayNames,
+			DisplayNames:       kState.EntityDisplayNames(),
 		}
 		if podID != "" {
 			rK8s.SpanID = string(k8sconv.SpanIDForPod(mt.Manifest.Name, podID))

--- a/internal/k8s/target.go
+++ b/internal/k8s/target.go
@@ -52,9 +52,6 @@ func NewTarget(
 		return model.K8sTarget{}, err
 	}
 
-	// Use a min component count of 2 for computing names,
-	// so that the resource type appears
-	displayNames := UniqueNames(sorted, 2)
 	myLocators := []v1alpha1.KubernetesImageLocator{}
 	for _, locator := range allLocators {
 		if LocatorMatchesOne(locator, entities) {
@@ -91,7 +88,6 @@ func NewTarget(
 	return model.K8sTarget{
 		KubernetesApplySpec: apply,
 		Name:                name,
-		DisplayNames:        displayNames,
 		PodReadinessMode:    podReadinessMode,
 		Links:               links,
 	}.WithDependencyIDs(dependencyIDs, model.ToLiveUpdateOnlyMap(imageTargets)).

--- a/internal/k8s/target_test.go
+++ b/internal/k8s/target_test.go
@@ -3,7 +3,6 @@ package k8s
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/tilt-dev/tilt/internal/k8s/testyaml"
@@ -23,15 +22,4 @@ func TestNewTargetSortsK8sEntities(t *testing.T) {
 	require.NoError(t, err)
 
 	assertKindOrder(t, expectedKindOrder, actual, "result of `NewTarget` should contain sorted YAML")
-
-	expectedDisplayNames := []string{
-		"postgres-pv-volume:persistentvolume",
-		"postgres-pv-claim:persistentvolumeclaim",
-		"postgres-config:configmap",
-		"postgres:service",
-		"postgres:statefulset",
-		"blorg-job:job",
-		"sleep:pod",
-	}
-	assert.Equal(t, expectedDisplayNames, targ.DisplayNames)
 }

--- a/internal/store/k8sconv/resource.go
+++ b/internal/store/k8sconv/resource.go
@@ -79,6 +79,7 @@ func NewKubernetesApplyFilter(status *v1alpha1.KubernetesApplyStatus) (*Kubernet
 	if err != nil {
 		return nil, err
 	}
+	deployed = k8s.SortedEntities(deployed)
 
 	podTemplateSpecHashes := []k8s.PodTemplateSpecHash{}
 	for _, entity := range deployed {

--- a/pkg/model/k8s_target.go
+++ b/pkg/model/k8s_target.go
@@ -31,10 +31,6 @@ type K8sTarget struct {
 
 	Name TargetName
 
-	// Each K8s entity should have a display name for user interfaces
-	// that balances brevity and uniqueness
-	DisplayNames []string
-
 	PodReadinessMode PodReadinessMode
 
 	// Map configRef -> number of times we (expect to) inject it.


### PR DESCRIPTION
This is now a computed property on `K8sRuntimeState` that uses
the deployed references.

These are included in `UIResource`, but not shown in the web
UI. The TUI does use them, so there's a slight behavior change
here that they won't show up until after applied. (Note that
they are also only used in the case when you've set pod readiness
mode to `ignore`.)