### PR TITLE
engine: allow file dependencies for K8sTarget

### DIFF
--- a/internal/engine/buildcontrol/image_build_and_deployer_test.go
+++ b/internal/engine/buildcontrol/image_build_and_deployer_test.go
@@ -45,7 +45,7 @@ func TestDeployTwinImages(t *testing.T) {
 
 	sancho := NewSanchoDockerBuildManifest(f)
 	newK8sTarget := k8s.MustTarget("sancho", yaml.ConcatYAML(SanchoYAML, SanchoTwinYAML)).
-		WithDependencyIDs(sancho.K8sTarget().DependencyIDs(), nil)
+		WithImageDependencies(sancho.K8sTarget().DependencyIDs(), nil)
 	manifest := sancho.WithDeployTarget(newK8sTarget)
 	result, err := f.BuildAndDeploy(BuildTargets(manifest), store.BuildStateSet{})
 	if err != nil {
@@ -129,7 +129,7 @@ func TestDeployPodWithMultipleImages(t *testing.T) {
 	iTarget1 := NewSanchoDockerBuildImageTarget(f)
 	iTarget2 := NewSanchoSidecarDockerBuildImageTarget(f)
 	kTarget := k8s.MustTarget("sancho", testyaml.SanchoSidecarYAML).
-		WithDependencyIDs([]model.TargetID{iTarget1.ID(), iTarget2.ID()}, nil)
+		WithImageDependencies([]model.TargetID{iTarget1.ID(), iTarget2.ID()}, nil)
 	targets := []model.TargetSpec{iTarget1, iTarget2, kTarget}
 
 	result, err := f.BuildAndDeploy(targets, store.BuildStateSet{})
@@ -160,7 +160,7 @@ func TestDeployPodWithMultipleLiveUpdateImages(t *testing.T) {
 	iTarget2 := NewSanchoSidecarLiveUpdateImageTarget(f)
 
 	kTarget := k8s.MustTarget("sancho", testyaml.SanchoSidecarYAML).
-		WithDependencyIDs([]model.TargetID{iTarget1.ID(), iTarget2.ID()}, nil)
+		WithImageDependencies([]model.TargetID{iTarget1.ID(), iTarget2.ID()}, nil)
 	targets := []model.TargetSpec{iTarget1, iTarget2, kTarget}
 
 	result, err := f.BuildAndDeploy(targets, store.BuildStateSet{})
@@ -234,7 +234,7 @@ func TestStatefulSetPodManagementPolicy(t *testing.T) {
 	_, err = f.BuildAndDeploy(
 		[]model.TargetSpec{
 			iTarget,
-			kTarget.WithDependencyIDs([]model.TargetID{iTarget.ID()}, nil),
+			kTarget.WithImageDependencies([]model.TargetID{iTarget.ID()}, nil),
 		},
 		store.BuildStateSet{})
 	if err != nil {
@@ -826,7 +826,7 @@ func TestInjectOverrideCommandsMultipleImages(t *testing.T) {
 	iTarget1 := NewSanchoDockerBuildImageTarget(f).WithOverrideCommand(cmd1)
 	iTarget2 := NewSanchoSidecarDockerBuildImageTarget(f).WithOverrideCommand(cmd2)
 	kTarget := k8s.MustTarget("sancho", testyaml.SanchoSidecarYAML).
-		WithDependencyIDs([]model.TargetID{iTarget1.ID(), iTarget2.ID()}, nil)
+		WithImageDependencies([]model.TargetID{iTarget1.ID(), iTarget2.ID()}, nil)
 	targets := []model.TargetSpec{iTarget1, iTarget2, kTarget}
 
 	_, err := f.BuildAndDeploy(targets, store.BuildStateSet{})

--- a/internal/engine/buildcontrol/testdata_test.go
+++ b/internal/engine/buildcontrol/testdata_test.go
@@ -164,7 +164,7 @@ func NewSanchoLiveUpdateMultiStageManifest(fixture Fixture) model.Manifest {
 		WithDependencyIDs([]model.TargetID{baseImage.ID()})
 
 	kTarget := k8s.MustTarget("sancho", SanchoYAML).
-		WithDependencyIDs([]model.TargetID{srcImage.ID()}, nil)
+		WithImageDependencies([]model.TargetID{srcImage.ID()}, nil)
 
 	return model.Manifest{Name: "sancho"}.
 		WithImageTargets([]model.ImageTarget{baseImage, srcImage}).

--- a/internal/engine/buildcontroller_test.go
+++ b/internal/engine/buildcontroller_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/tilt-dev/tilt/internal/container"
 	"github.com/tilt-dev/tilt/internal/engine/buildcontrol"
 	"github.com/tilt-dev/tilt/internal/hud/server"
+	"github.com/tilt-dev/tilt/internal/k8s"
 	"github.com/tilt-dev/tilt/internal/k8s/testyaml"
 	"github.com/tilt-dev/tilt/internal/store"
 	"github.com/tilt-dev/tilt/internal/store/liveupdates"
@@ -1658,6 +1659,35 @@ func TestDisablingCancelsBuild(t *testing.T) {
 
 	err = f.Stop()
 	require.NoError(t, err)
+}
+
+func TestBuildControllerK8sFileDependencies(t *testing.T) {
+	f := newTestFixture(t)
+	defer f.TearDown()
+
+	kt := k8s.MustTarget("fe", testyaml.SanchoYAML).
+		WithPathDependencies(
+			[]string{f.JoinPath("k8s-dep")},
+			[]model.LocalGitRepo{
+				{LocalPath: "k8s-dep"},
+			})
+	m := model.Manifest{Name: "fe"}.WithDeployTarget(kt)
+
+	f.Start([]model.Manifest{m})
+
+	call := f.nextCall()
+	assert.Empty(t, call.k8sState().FilesChanged())
+
+	// path dependency is on ./k8s-dep/** with a local repo of ./k8s-dep/.git/** (ignored)
+	f.fsWatcher.Events <- watch.NewFileEvent(f.JoinPath("k8s-dep", "file"))
+	f.fsWatcher.Events <- watch.NewFileEvent(f.JoinPath("k8s-dep", ".git", "file"))
+
+	call = f.nextCall()
+	assert.Equal(t, []string{f.JoinPath("k8s-dep", "file")}, call.k8sState().FilesChanged())
+
+	err := f.Stop()
+	assert.NoError(t, err)
+	f.assertAllBuildsConsumed()
 }
 
 func (f *testFixture) waitUntilManifestBuilding(name model.ManifestName) {

--- a/internal/engine/buildcontroller_test.go
+++ b/internal/engine/buildcontroller_test.go
@@ -1669,7 +1669,7 @@ func TestBuildControllerK8sFileDependencies(t *testing.T) {
 		WithPathDependencies(
 			[]string{f.JoinPath("k8s-dep")},
 			[]model.LocalGitRepo{
-				{LocalPath: "k8s-dep"},
+				{LocalPath: f.JoinPath("k8s-dep")},
 			})
 	m := model.Manifest{Name: "fe"}.WithDeployTarget(kt)
 

--- a/internal/engine/testdata_test.go
+++ b/internal/engine/testdata_test.go
@@ -164,7 +164,7 @@ func NewSanchoLiveUpdateMultiStageManifest(fixture Fixture) model.Manifest {
 		WithDependencyIDs([]model.TargetID{baseImage.ID()})
 
 	kTarget := k8s.MustTarget("sancho", SanchoYAML).
-		WithDependencyIDs([]model.TargetID{srcImage.ID()}, nil)
+		WithImageDependencies([]model.TargetID{srcImage.ID()}, nil)
 
 	return model.Manifest{Name: "sancho"}.
 		WithImageTargets([]model.ImageTarget{baseImage, srcImage}).

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -3958,6 +3958,7 @@ type testFixture struct {
 	onchangeCh            chan bool
 	sessionController     *session.Controller
 	localServerController *local.ServerController
+	execer                *localexec.FakeExecer
 }
 
 type fixtureOptions struct {
@@ -4011,7 +4012,7 @@ func newTestFixture(t *testing.T, options ...fixtureOptions) *testFixture {
 	k8sContextExt := k8scontext.NewPlugin("fake-context", env)
 	versionExt := version.NewPlugin(model.TiltBuild{Version: "0.5.0"})
 	configExt := config.NewPlugin("up")
-	execer := localexec.NewProcessExecer(localexec.EmptyEnv())
+	execer := localexec.NewFakeExecer(t)
 	realTFL := tiltfile.ProvideTiltfileLoader(ta, b.kClient, k8sContextExt, versionExt, configExt, fakeDcc, "localhost", execer, feature.MainDefaults, env)
 	tfl := tiltfile.NewFakeTiltfileLoader()
 	buildSource := ctrltiltfile.NewBuildSource()
@@ -4120,6 +4121,7 @@ func newTestFixture(t *testing.T, options ...fixtureOptions) *testFixture {
 		sessionController:     sessionController,
 		localServerController: lsc,
 		engineMode:            engineMode,
+		execer:                execer,
 	}
 
 	ret.disableEnvAnalyticsOpt()

--- a/internal/k8s/target.go
+++ b/internal/k8s/target.go
@@ -90,7 +90,7 @@ func NewTarget(
 		Name:                name,
 		PodReadinessMode:    podReadinessMode,
 		Links:               links,
-	}.WithDependencyIDs(dependencyIDs, model.ToLiveUpdateOnlyMap(imageTargets)).
+	}.WithImageDependencies(dependencyIDs, model.ToLiveUpdateOnlyMap(imageTargets)).
 		WithRefInjectCounts(refInjectCounts), nil
 }
 

--- a/internal/testutils/manifestbuilder/assemble.go
+++ b/internal/testutils/manifestbuilder/assemble.go
@@ -23,7 +23,7 @@ func assembleK8s(m model.Manifest, k model.K8sTarget, iTargets ...model.ImageTar
 		}
 		ids = append(ids, iTarget.ID())
 	}
-	k = k.WithDependencyIDs(ids, model.ToLiveUpdateOnlyMap(iTargets))
+	k = k.WithImageDependencies(ids, model.ToLiveUpdateOnlyMap(iTargets))
 	return m.
 		WithImageTargets(iTargets).
 		WithDeployTarget(k)

--- a/pkg/model/target_test.go
+++ b/pkg/model/target_test.go
@@ -114,5 +114,5 @@ func newK8sTarget(name string, deps ...string) K8sTarget {
 	for i, dep := range deps {
 		depIDs[i] = ImageID(container.MustParseSelector(dep))
 	}
-	return K8sTarget{Name: TargetName(name)}.WithDependencyIDs(depIDs, nil)
+	return K8sTarget{Name: TargetName(name)}.WithImageDependencies(depIDs, nil)
 }


### PR DESCRIPTION
This will be used for `custom_deploy`, where the target has a
command instead of YAML.

(In the `k8s_yaml()` case, the file dependencies actually belong
to the Tiltfile because there's additional K8s entity <> resource
mapping logic that requires the "global" Tiltfile state, so it's
not sufficient to only trigger the target.)