### PR TITLE
web: display disabled resources in detail view based on feature flag

### DIFF
--- a/web/src/ResourceStatus.ts
+++ b/web/src/ResourceStatus.ts
@@ -1,4 +1,4 @@
-import { ResourceStatus } from "./types"
+import { ResourceStatus, UIResource } from "./types"
 
 export function ClassNameFromResourceStatus(rs: ResourceStatus): string {
   switch (rs) {
@@ -15,4 +15,13 @@ export function ClassNameFromResourceStatus(rs: ResourceStatus): string {
     case ResourceStatus.None:
       return "isNone"
   }
+}
+
+export function resourceIsDisabled(resource: UIResource): boolean {
+  const disableCount = resource.status?.disableStatus?.disabledCount ?? 0
+  if (disableCount > 0) {
+    return true
+  }
+
+  return false
 }

--- a/web/src/SidebarItem.tsx
+++ b/web/src/SidebarItem.tsx
@@ -3,13 +3,17 @@ import { buildAlerts, runtimeAlerts } from "./alerts"
 import { Hold } from "./Hold"
 import { getResourceLabels } from "./labels"
 import { LogAlertIndex } from "./LogStore"
+import { resourceIsDisabled } from "./ResourceStatus"
 import { buildStatus, runtimeStatus } from "./status"
 import { timeDiff } from "./time"
-import { ResourceName, ResourceStatus, TriggerMode } from "./types"
-
-type UIResource = Proto.v1alpha1UIResource
-type UIResourceStatus = Proto.v1alpha1UIResourceStatus
-type Build = Proto.v1alpha1UIBuildTerminated
+import {
+  Build,
+  ResourceName,
+  ResourceStatus,
+  TriggerMode,
+  UIResource,
+  UIResourceStatus,
+} from "./types"
 
 class SidebarItem {
   name: string
@@ -30,6 +34,7 @@ class SidebarItem {
   queued: boolean
   lastBuild: Build | null = null
   hold: Hold | null = null
+  disabled: boolean
 
   /**
    * Create a pared down SidebarItem from a ResourceView
@@ -59,6 +64,7 @@ class SidebarItem {
     this.queued = !!status.queued
     this.lastBuild = lastBuild
     this.hold = status.waiting ? new Hold(status.waiting) : null
+    this.disabled = resourceIsDisabled(res)
   }
 }
 

--- a/web/src/SidebarItemView.test.tsx
+++ b/web/src/SidebarItemView.test.tsx
@@ -1,0 +1,96 @@
+import { mount } from "enzyme"
+import React from "react"
+import Features, { FeaturesProvider, Flag } from "./feature"
+import { LogAlertIndex } from "./LogStore"
+import PathBuilder from "./PathBuilder"
+import SidebarItem from "./SidebarItem"
+import SidebarItemView, {
+  DisabledSidebarItemView,
+  EnabledSidebarItemView,
+} from "./SidebarItemView"
+import { nResourceView } from "./testdata"
+import { ResourceView } from "./types"
+
+const PATH_BUILDER = PathBuilder.forTesting("localhost", "/")
+const LOG_ALERT_INDEX: LogAlertIndex = { alertsForSpanId: () => [] }
+
+// Note: this test wrapper can be refactored to take
+// more parameters as more tests are added to this suite
+const SidebarItemViewTestWrapper = ({
+  item,
+  disableResourcesEnabled,
+}: {
+  item: SidebarItem
+  disableResourcesEnabled?: boolean
+}) => {
+  const features = new Features({
+    [Flag.DisableResources]: disableResourcesEnabled ?? true,
+  })
+  return (
+    <FeaturesProvider value={features}>
+      <SidebarItemView
+        item={item}
+        selected={false}
+        resourceView={ResourceView.Log}
+        pathBuilder={PATH_BUILDER}
+        groupView={false}
+      />
+    </FeaturesProvider>
+  )
+}
+
+const oneSidebarItem = () => {
+  return new SidebarItem(nResourceView(1).uiResources[0], LOG_ALERT_INDEX)
+}
+
+describe("SidebarItemView", () => {
+  describe("when `disable_resources` flag is NOT enabled", () => {
+    it("does NOT display a disabled resource", () => {
+      const item = oneSidebarItem()
+      item.disabled = true
+      const wrapper = mount(
+        <SidebarItemViewTestWrapper
+          item={item}
+          disableResourcesEnabled={false}
+        />
+      )
+      expect(wrapper.find(DisabledSidebarItemView).length).toBe(0)
+    })
+
+    it("does render an enabled resource with enabled view", () => {
+      const item = oneSidebarItem()
+      const wrapper = mount(
+        <SidebarItemViewTestWrapper
+          item={item}
+          disableResourcesEnabled={false}
+        />
+      )
+      expect(wrapper.find(EnabledSidebarItemView).length).toBe(1)
+    })
+  })
+
+  describe("when `disable_resources` flag is enabled", () => {
+    it("does display a disabled resource with disabled view", () => {
+      const item = oneSidebarItem()
+      item.disabled = true
+      const wrapper = mount(
+        <SidebarItemViewTestWrapper
+          item={item}
+          disableResourcesEnabled={true}
+        />
+      )
+      expect(wrapper.find(DisabledSidebarItemView).length).toBe(1)
+    })
+
+    it("does render an enabled resource with enabled view", () => {
+      const item = oneSidebarItem()
+      const wrapper = mount(
+        <SidebarItemViewTestWrapper
+          item={item}
+          disableResourcesEnabled={true}
+        />
+      )
+      expect(wrapper.find(EnabledSidebarItemView).length).toBe(1)
+    })
+  })
+})

--- a/web/storybook.tiltfile
+++ b/web/storybook.tiltfile
@@ -6,6 +6,7 @@ version_settings(constraint='>=0.22.1')
 #v1alpha1.extension(name='cancel', repo_name='default', repo_path='cancel')
 
 enable_feature("labels")
+enable_feature("disable_resources")
 
 local_resource(
   'storybook',


### PR DESCRIPTION
This PR displays disabled resources in the Resource Detail View based on the `disable_resources` feature flag.
* Consider a resource disabled when its `disableStatus.disableCount` > 0
* If flag is off, don't display disabled resources or groups with only disabled resources
* If flag is on, display disabled resources in their own list at the bottom of the enabled resource list
* Add tests for `SidebarResources` and `SidebarItemView`

I ran out of time to add Storybook examples, but happy to do that! For now, you can test locally by disabling resources through the Tilt API and enabling the feature flag.

Disabled resources with groups with one disabled resource selected and another disabled resource on hover:
![Screen Shot 2021-11-04 at 4 07 11 PM](https://user-images.githubusercontent.com/23283986/140412247-83e625d7-92a1-43b1-8687-d9825f9f7c5e.png)

Here's that same list when the feature flag is off (and disabled resources + groups are hidden):
![Screen Shot 2021-11-04 at 4 07 20 PM](https://user-images.githubusercontent.com/23283986/140412470-95624ce5-e0d1-4572-83b9-2aef9f254ac7.png)

Closes [CH12684](https://app.shortcut.com/windmill/story/12684/resource-detail-view-displays-disabled-resources)