### PR TITLE
api: fix Live Update selector inference for LU-only targets

### DIFF
--- a/integration/live_update_only/Tiltfile
+++ b/integration/live_update_only/Tiltfile
@@ -1,0 +1,21 @@
+
+# TODO(milas): this test is failing with live_update_v2 because the LU Reconciler
+#   stops after seeing a path that it can't sync, but a full BaD never happens,
+#   and the resource gets stuck in update Pending
+# disable_feature('live_update_v2')
+
+custom_build(
+    ref='nginx',
+    # this is a hack that puts the builder into "live update only" mode
+    command=':',
+    deps=['./web', 'special.txt'],
+    disable_push=True,
+    skips_local_docker=True,
+    live_update=[
+        sync('./web/', '/usr/share/nginx/html/')
+    ]
+)
+
+k8s_yaml('nginx.yaml')
+
+k8s_resource('lu-only', port_forwards=['28195:80'])

--- a/integration/live_update_only/nginx.yaml
+++ b/integration/live_update_only/nginx.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: lu-only
+  namespace: tilt-integration
+  labels:
+    app: lu-only
+spec:
+  selector:
+    matchLabels:
+      app: lu-only
+  template:
+    metadata:
+      labels:
+        app: lu-only
+    spec:
+      containers:
+        - name: nginx
+          image: nginx
+          ports:
+            - containerPort: 80

--- a/integration/live_update_only/special.txt
+++ b/integration/live_update_only/special.txt
@@ -1,0 +1,1 @@
+this file triggers a full rebuild

--- a/integration/live_update_only/web/index.html
+++ b/integration/live_update_only/web/index.html
@@ -1,0 +1,1 @@
+Hello from Live Update!

--- a/integration/live_update_only_test.go
+++ b/integration/live_update_only_test.go
@@ -1,0 +1,62 @@
+//+build integration
+
+package integration
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLiveUpdateOnly(t *testing.T) {
+	f := newK8sFixture(t, "live_update_only")
+	defer f.TearDown()
+	f.SetRestrictedCredentials()
+
+	f.TiltUp()
+
+	// ForwardPort will fail if all the pods are not ready.
+	//
+	// We can't use the normal Tilt-managed forwards here because
+	// Tilt doesn't setup forwards when --watch=false.
+	ctx, cancel := context.WithTimeout(f.ctx, time.Minute)
+	defer cancel()
+	f.WaitForAllPodsReady(ctx, "app=lu-only")
+
+	ctx, cancel = context.WithTimeout(f.ctx, time.Minute)
+	defer cancel()
+	// since we're using a public image, until we modify a file, the original contents are there
+	f.CurlUntil(ctx, "http://localhost:28195", "Welcome to nginx!")
+
+	f.ReplaceContents(filepath.Join("web", "index.html"), "Hello", "Greetings")
+
+	// verify file was changed (we know it's the same pod because this file can ONLY exist via Live Update sync)
+	ctx, cancel = context.WithTimeout(f.ctx, time.Minute)
+	defer cancel()
+	f.CurlUntil(ctx, "http://localhost:28195", "Greetings from Live Update!")
+
+	f.ReplaceContents("special.txt",
+		"this file triggers a full rebuild",
+		"time to rebuild!")
+
+	// TODO(milas): this is ridiculously hacky - we should use `tilt wait` once that exists
+	// 	or otherwise poll the API manually instead of playing with log strings
+	var logs strings.Builder
+	assert.Eventually(t, func() bool {
+		logs.WriteString(f.logs.String())
+
+		logStr := logs.String()
+		fileChangeIdx := strings.Index(logStr, `1 File Changed: [special.txt]`)
+		if fileChangeIdx == -1 {
+			return false
+		}
+
+		afterFileChangeLogs := logStr[fileChangeIdx:]
+		return strings.Contains(afterFileChangeLogs, `Falling back to a full image build + deploy`) &&
+			strings.Contains(afterFileChangeLogs, `STEP 1/1 — Deploying`)
+	}, 15*time.Second, 500*time.Millisecond, "Full rebuild never triggered")
+}

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -295,7 +295,12 @@ func (m *Manifest) InferLiveUpdateSelectors() error {
 			// FileWatches and ImageMaps related to the ImageTarget ID.
 			id := dep.ID()
 			fw := id.String()
-			imageMap := id.Name.String()
+
+			// LiveUpdateOnly targets do NOT have an associated image map
+			var imageMap string
+			if depImg, ok := dep.(ImageTarget); ok && !depImg.IsLiveUpdateOnly {
+				imageMap = id.Name.String()
+			}
 
 			luSpec.Sources = append(luSpec.Sources, v1alpha1.LiveUpdateSource{
 				FileWatch: fw,


### PR DESCRIPTION
There is no corresponding `ImageMap` for Live Update-only targets,
so it can be skipped.