### PR TITLE
buildcontrol: now that LiveUpdate fires BuildStarted events, we can't synchronize based on number of BuildStarted events

### DIFF
--- a/integration/live_update_only/Tiltfile
+++ b/integration/live_update_only/Tiltfile
@@ -1,0 +1,21 @@
+
+# TODO(milas): this test is failing with live_update_v2 because the LU Reconciler
+#   stops after seeing a path that it can't sync, but a full BaD never happens,
+#   and the resource gets stuck in update Pending
+# disable_feature('live_update_v2')
+
+custom_build(
+    ref='nginx',
+    # this is a hack that puts the builder into "live update only" mode
+    command=':',
+    deps=['./web', 'special.txt'],
+    disable_push=True,
+    skips_local_docker=True,
+    live_update=[
+        sync('./web/', '/usr/share/nginx/html/')
+    ]
+)
+
+k8s_yaml('nginx.yaml')
+
+k8s_resource('lu-only', port_forwards=['28195:80'])

--- a/integration/live_update_only/nginx.yaml
+++ b/integration/live_update_only/nginx.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: lu-only
+  namespace: tilt-integration
+  labels:
+    app: lu-only
+spec:
+  selector:
+    matchLabels:
+      app: lu-only
+  template:
+    metadata:
+      labels:
+        app: lu-only
+    spec:
+      containers:
+        - name: nginx
+          image: nginx
+          ports:
+            - containerPort: 80

--- a/integration/live_update_only/special.txt
+++ b/integration/live_update_only/special.txt
@@ -1,0 +1,1 @@
+this file triggers a full rebuild

--- a/integration/live_update_only/web/index.html
+++ b/integration/live_update_only/web/index.html
@@ -1,0 +1,1 @@
+Hello from Live Update!

--- a/integration/live_update_only_test.go
+++ b/integration/live_update_only_test.go
@@ -56,7 +56,6 @@ func TestLiveUpdateOnly(t *testing.T) {
 		}
 
 		afterFileChangeLogs := logStr[fileChangeIdx:]
-		return strings.Contains(afterFileChangeLogs, `Falling back to a full image build + deploy`) &&
-			strings.Contains(afterFileChangeLogs, `STEP 1/1 — Deploying`)
+		return strings.Contains(afterFileChangeLogs, `STEP 1/1 — Deploying`)
 	}, 15*time.Second, 500*time.Millisecond, "Full rebuild never triggered")
 }

--- a/integration/live_update_only_test.go
+++ b/integration/live_update_only_test.go
@@ -1,0 +1,62 @@
+//+build integration
+
+package integration
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLiveUpdateOnly(t *testing.T) {
+	f := newK8sFixture(t, "live_update_only")
+	defer f.TearDown()
+	f.SetRestrictedCredentials()
+
+	f.TiltUp()
+
+	// ForwardPort will fail if all the pods are not ready.
+	//
+	// We can't use the normal Tilt-managed forwards here because
+	// Tilt doesn't setup forwards when --watch=false.
+	ctx, cancel := context.WithTimeout(f.ctx, time.Minute)
+	defer cancel()
+	f.WaitForAllPodsReady(ctx, "app=lu-only")
+
+	ctx, cancel = context.WithTimeout(f.ctx, time.Minute)
+	defer cancel()
+	// since we're using a public image, until we modify a file, the original contents are there
+	f.CurlUntil(ctx, "http://localhost:28195", "Welcome to nginx!")
+
+	f.ReplaceContents(filepath.Join("web", "index.html"), "Hello", "Greetings")
+
+	// verify file was changed (we know it's the same pod because this file can ONLY exist via Live Update sync)
+	ctx, cancel = context.WithTimeout(f.ctx, time.Minute)
+	defer cancel()
+	f.CurlUntil(ctx, "http://localhost:28195", "Greetings from Live Update!")
+
+	f.ReplaceContents("special.txt",
+		"this file triggers a full rebuild",
+		"time to rebuild!")
+
+	// TODO(milas): this is ridiculously hacky - we should use `tilt wait` once that exists
+	// 	or otherwise poll the API manually instead of playing with log strings
+	var logs strings.Builder
+	assert.Eventually(t, func() bool {
+		logs.WriteString(f.logs.String())
+
+		logStr := logs.String()
+		fileChangeIdx := strings.Index(logStr, `1 File Changed: [special.txt]`)
+		if fileChangeIdx == -1 {
+			return false
+		}
+
+		afterFileChangeLogs := logStr[fileChangeIdx:]
+		return strings.Contains(afterFileChangeLogs, `Falling back to a full image build + deploy`) &&
+			strings.Contains(afterFileChangeLogs, `STEP 1/1 — Deploying`)
+	}, 15*time.Second, 500*time.Millisecond, "Full rebuild never triggered")
+}

--- a/internal/engine/buildcontroller.go
+++ b/internal/engine/buildcontroller.go
@@ -53,7 +53,7 @@ func (c *BuildController) needsBuild(ctx context.Context, st store.RStore) (buil
 
 	// Don't start the next build until the previous action has been recorded,
 	// so that we don't accidentally repeat the same build.
-	if c.buildsStartedCount != state.StartedBuildCount {
+	if c.buildsStartedCount > state.BuildControllerStartCount {
 		return buildEntry{}, false
 	}
 
@@ -112,6 +112,7 @@ func (c *BuildController) OnChange(ctx context.Context, st store.RStore, summary
 		Reason:             entry.buildReason,
 		SpanID:             entry.spanID,
 		FullBuildTriggered: entry.buildStateSet.FullBuildTriggered(),
+		IsBuildController:  true,
 	})
 
 	go func() {

--- a/internal/engine/buildcontroller_test.go
+++ b/internal/engine/buildcontroller_test.go
@@ -1396,7 +1396,7 @@ func TestDontStartBuildIfControllerAndEngineUnsynced(t *testing.T) {
 
 	// deliberately de-sync engine state and build controller
 	st := f.store.LockMutableStateForTesting()
-	st.StartedBuildCount--
+	st.BuildControllerStartCount--
 	f.store.UnlockMutableState()
 
 	// this build won't start while state and build controller are out of sync
@@ -1404,7 +1404,7 @@ func TestDontStartBuildIfControllerAndEngineUnsynced(t *testing.T) {
 
 	// resync the two counts...
 	st = f.store.LockMutableStateForTesting()
-	st.StartedBuildCount++
+	st.BuildControllerStartCount++
 	f.store.UnlockMutableState()
 
 	// ...and manB build will start as expected

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -4308,7 +4308,7 @@ func (f *testFixture) SetNextBuildError(err error) {
 	f.WaitUntil("any in-flight builds have hit the buildAndDeployer", func(state store.EngineState) bool {
 		f.b.mu.Lock()
 		defer f.b.mu.Unlock()
-		return f.b.buildCount == state.StartedBuildCount
+		return f.b.buildCount == state.BuildControllerStartCount
 	})
 
 	_ = f.store.RLockState()
@@ -4322,7 +4322,7 @@ func (f *testFixture) SetNextLiveUpdateCompileError(err error, containerIDs []co
 	f.WaitUntil("any in-flight builds have hit the buildAndDeployer", func(state store.EngineState) bool {
 		f.b.mu.Lock()
 		defer f.b.mu.Unlock()
-		return f.b.buildCount == state.StartedBuildCount
+		return f.b.buildCount == state.BuildControllerStartCount
 	})
 
 	_ = f.store.RLockState()

--- a/internal/store/buildcontrols/actions.go
+++ b/internal/store/buildcontrols/actions.go
@@ -15,6 +15,7 @@ type BuildStartedAction struct {
 	Reason             model.BuildReason
 	SpanID             logstore.SpanID
 	FullBuildTriggered bool
+	IsBuildController  bool
 }
 
 func (BuildStartedAction) Action() {}

--- a/internal/store/buildcontrols/reducers.go
+++ b/internal/store/buildcontrols/reducers.go
@@ -19,7 +19,9 @@ import (
 )
 
 func HandleBuildStarted(ctx context.Context, state *store.EngineState, action BuildStartedAction) {
-	state.StartedBuildCount++
+	if action.IsBuildController {
+		state.BuildControllerStartCount++
+	}
 
 	mn := action.ManifestName
 	manifest, ok := state.Manifest(mn)

--- a/internal/store/engine_state.go
+++ b/internal/store/engine_state.go
@@ -40,7 +40,7 @@ type EngineState struct {
 
 	// For synchronizing BuildController -- wait until engine records all builds started
 	// so far before starting another build
-	StartedBuildCount int
+	BuildControllerStartCount int
 
 	// How many builds have been completed (pass or fail) since starting tilt
 	CompletedBuildCount int

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -295,7 +295,12 @@ func (m *Manifest) InferLiveUpdateSelectors() error {
 			// FileWatches and ImageMaps related to the ImageTarget ID.
 			id := dep.ID()
 			fw := id.String()
-			imageMap := id.Name.String()
+
+			// LiveUpdateOnly targets do NOT have an associated image map
+			var imageMap string
+			if depImg, ok := dep.(ImageTarget); ok && !depImg.IsLiveUpdateOnly {
+				imageMap = id.Name.String()
+			}
 
 			luSpec.Sources = append(luSpec.Sources, v1alpha1.LiveUpdateSource{
 				FileWatch: fw,


### PR DESCRIPTION
Hello @milas,

Please review the following commits I made in branch nicks/lu-only-fix:

2f74377a9200e1d6e21d3344b76cde58c0973e8c (2021-11-04 19:57:35 -0400)
buildcontrol: now that LiveUpdate fires BuildStarted events, we can't synchronize based on number of BuildStarted events

12fa319d6c0e61b9ca317aa40aa0743e993a5dcb (2021-11-04 17:39:47 -0400)
api: fix Live Update selector inference for LU-only targets
There is no corresponding `ImageMap` for Live Update-only targets,
so it can be skipped.

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics