### PR TITLE
api: fix race during FileWatch cancellation

### DIFF
--- a/internal/controllers/core/cmd/controller.go
+++ b/internal/controllers/core/cmd/controller.go
@@ -473,7 +473,11 @@ func (c *Controller) updateStatus(name types.NamespacedName, update func(status 
 
 	err = c.client.Status().Update(c.globalCtx, &cmd)
 	if err != nil && !apierrors.IsNotFound(err) {
-		c.st.Dispatch(store.NewErrorAction(fmt.Errorf("syncing to apiserver: %v", err)))
+		if c.globalCtx.Err() == nil {
+			// if the global context has been canceled, the controller is being torn down,
+			// so don't propagate a store error
+			c.st.Dispatch(store.NewErrorAction(fmt.Errorf("syncing to apiserver: %v", err)))
+		}
 		return
 	}
 

--- a/internal/controllers/fake/client.go
+++ b/internal/controllers/fake/client.go
@@ -18,6 +18,12 @@ type fakeTiltClient struct {
 //
 // We simulate this behavior to catch this class of bug.
 func (f fakeTiltClient) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		// controller-runtime fake ignores context; check it here to allow controllers to test
+		// handling of cancellation related errors
+		return ctxErr
+	}
+
 	err := f.Client.Update(ctx, obj, opts...)
 	if err != nil {
 		return err
@@ -39,6 +45,12 @@ type fakeStatusWriter struct {
 }
 
 func (f fakeStatusWriter) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		// controller-runtime fake ignores context; check it here to allow controllers to test
+		// handling of cancellation related errors
+		return ctxErr
+	}
+
 	err := f.StatusWriter.Update(ctx, obj, opts...)
 	if err != nil {
 		return err


### PR DESCRIPTION
It's possible for the monitor to get cancelled while in the midst
of reporting an event, which will cause the API operations to fail.

We don't want to treat these as fatal errors: since the monitor
was cancelled, the failed update was stale anyway and we should
just silently ignore it.