### PR TITLE
liveupdate: print pod name and container name instead of container id

### DIFF
--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -2,7 +2,6 @@ package container
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/docker/distribution/reference"
 	"github.com/pkg/errors"
@@ -18,14 +17,6 @@ func (id ID) ShortStr() string {
 		return string(id)[:10]
 	}
 	return string(id)
-}
-
-func ShortStrs(ids []ID) string {
-	shortStrs := make([]string, len(ids))
-	for i, id := range ids {
-		shortStrs[i] = id.ShortStr()
-	}
-	return strings.Join(shortStrs, ", ")
 }
 
 func (n Name) String() string { return string(n) }

--- a/internal/containerupdate/docker_container_updater.go
+++ b/internal/containerupdate/docker_container_updater.go
@@ -62,12 +62,12 @@ func (cu *DockerUpdater) UpdateContainer(ctx context.Context, cInfo liveupdates.
 	}
 
 	if hotReload {
-		l.Debugf("Hot reload on, skipping container restart: %s", cInfo.ContainerID.ShortStr())
+		l.Debugf("Hot reload on, skipping container restart: %s", cInfo.DisplayName())
 		return nil
 	}
 
 	// Restart container so that entrypoint restarts with the updated files etc.
-	l.Debugf("Restarting container: %s", cInfo.ContainerID.ShortStr())
+	l.Debugf("Restarting container: %s", cInfo.DisplayName())
 	err = cu.dCli.ContainerRestartNoWait(ctx, cInfo.ContainerID.String())
 	if err != nil {
 		return errors.Wrap(err, "ContainerRestart")

--- a/internal/controllers/core/liveupdate/reconciler.go
+++ b/internal/controllers/core/liveupdate/reconciler.go
@@ -819,7 +819,7 @@ func (r *Reconciler) applyInternal(
 	cu := r.containerUpdater(input)
 	l := logger.Get(ctx)
 	containers := input.Containers
-	cIDStr := container.ShortStrs(liveupdates.IDsForContainers(containers))
+	names := liveupdates.ContainerDisplayNames(containers)
 	suffix := ""
 	if len(containers) != 1 {
 		suffix = "(s)"
@@ -848,14 +848,14 @@ func (r *Reconciler) applyInternal(
 	}
 
 	if len(toRemove) > 0 {
-		l.Infof("Will delete %d file(s) from container%s: %s", len(toRemove), suffix, cIDStr)
+		l.Infof("Will delete %d file(s) from container%s: %s", len(toRemove), suffix, names)
 		for _, pm := range toRemove {
 			l.Infof("- '%s' (matched local path: '%s')", pm.ContainerPath, pm.LocalPath)
 		}
 	}
 
 	if len(toArchive) > 0 {
-		l.Infof("Will copy %d file(s) to container%s: %s", len(toArchive), suffix, cIDStr)
+		l.Infof("Will copy %d file(s) to container%s: %s", len(toArchive), suffix, names)
 		for _, pm := range toArchive {
 			l.Infof("- %s", pm.PrettyStr())
 		}
@@ -885,7 +885,7 @@ func (r *Reconciler) applyInternal(
 				// Keep running updates -- we want all containers to have the same files on them
 				// even if the Runs don't succeed
 				logger.Get(ctx).Infof("  → Failed to update container %s: run step %q failed with exit code: %d",
-					cInfo.ContainerID.ShortStr(), runFail.Cmd.String(), runFail.ExitCode)
+					cInfo.DisplayName(), runFail.Cmd.String(), runFail.ExitCode)
 				cStatus.LastExecError = err.Error()
 				lastExecErrorStatus = &cStatus
 			} else {
@@ -898,7 +898,7 @@ func (r *Reconciler) applyInternal(
 				return result
 			}
 		} else {
-			logger.Get(ctx).Infof("  → Container %s updated!", cInfo.ContainerID.ShortStr())
+			logger.Get(ctx).Infof("  → Container %s updated!", cInfo.DisplayName())
 			if lastExecErrorStatus != nil {
 				// This build succeeded, but previously at least one failed due to user error.
 				// We may have inconsistent state--bail, and fall back to full build.

--- a/internal/engine/buildcontrol/live_update_build_and_deployer.go
+++ b/internal/engine/buildcontrol/live_update_build_and_deployer.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/tilt-dev/tilt/internal/analytics"
 	"github.com/tilt-dev/tilt/internal/build"
-	"github.com/tilt-dev/tilt/internal/container"
 	"github.com/tilt-dev/tilt/internal/controllers/apis/liveupdate"
 	ctrlliveupdate "github.com/tilt-dev/tilt/internal/controllers/core/liveupdate"
 	"github.com/tilt-dev/tilt/internal/ospath"
@@ -108,12 +107,12 @@ func (lubad *LiveUpdateBuildAndDeployer) buildAndDeploy(ctx context.Context, ps 
 	}()
 
 	containers := info.Containers
-	cIDStr := container.ShortStrs(liveupdates.IDsForContainers(containers))
+	names := liveupdates.ContainerDisplayNames(containers)
 	suffix := ""
 	if len(containers) != 1 {
 		suffix = "(s)"
 	}
-	ps.StartBuildStep(ctx, "Updating container%s: %s", suffix, cIDStr)
+	ps.StartBuildStep(ctx, "Updating container%s: %s", suffix, names)
 
 	status, err := lubad.luReconciler.ForceApply(
 		ctx,

--- a/internal/store/liveupdates/containers.go
+++ b/internal/store/liveupdates/containers.go
@@ -119,6 +119,17 @@ func (c Container) Empty() bool {
 	return c == Container{}
 }
 
+func (c Container) DisplayName() string {
+	if c.PodID == "" {
+		if c.ContainerName == "" {
+			return c.ContainerID.ShortStr()
+		}
+		return c.ContainerName.String()
+	}
+
+	return fmt.Sprintf("%s/%s", c.PodID, c.ContainerName)
+}
+
 func IDsForContainers(infos []Container) []container.ID {
 	ids := make([]container.ID, len(infos))
 	for i, info := range infos {

--- a/internal/store/liveupdates/string.go
+++ b/internal/store/liveupdates/string.go
@@ -1,0 +1,9 @@
+package liveupdates
+
+func ContainerDisplayNames(containers []Container) []string {
+	names := make([]string, 0, len(containers))
+	for _, c := range containers {
+		names = append(names, c.DisplayName())
+	}
+	return names
+}


### PR DESCRIPTION
Hello @milas, @landism,

Please review the following commits I made in branch nicks/lu1:

58c9fa3d8357ea0e65322be71d23b0304a303895 (2021-11-05 11:56:47 -0400)
liveupdate: print pod name and container name instead of container id
container id just isn't that meaningful to people

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics