### PR TITLE
features: flip live_update_v2 back off by default

### DIFF
--- a/integration/Tiltfile
+++ b/integration/Tiltfile
@@ -1,5 +1,7 @@
 # -*- mode: Python -*-
 
+enable_feature('live_update_v2')
+
 # HACK: load namespaces on `tilt up` but not on `tilt down`
 load_namespace = not os.environ.get('SKIP_NAMESPACE', '')
 if load_namespace:

--- a/integration/live_update_only/Tiltfile
+++ b/integration/live_update_only/Tiltfile
@@ -1,4 +1,6 @@
 
+include('../Tiltfile')
+
 # TODO(milas): this test is failing with live_update_v2 because the LU Reconciler
 #   stops after seeing a path that it can't sync, but a full BaD never happens,
 #   and the resource gets stuck in update Pending

--- a/internal/feature/flags.go
+++ b/internal/feature/flags.go
@@ -64,7 +64,7 @@ var MainDefaults = Defaults{
 		Status:  Active,
 	},
 	LiveUpdateV2: Value{
-		Enabled: true,
+		Enabled: false,
 		Status:  Active,
 	},
 	DisableResources: Value{


### PR DESCRIPTION
Hello @milas,

Please review the following commits I made in branch nicks/lu2:

722764e506f3ba7ba4412b36d7294316eb9f2fa7 (2021-11-05 12:38:46 -0400)
features: flip live_update_v2 back off by default

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics