### PR TITLE
tiltfile: add cmd() built-in

### DIFF
--- a/integration/local_resource/Tiltfile
+++ b/integration/local_resource/Tiltfile
@@ -8,6 +8,7 @@ p = probe(initial_delay_secs=0,
 local_resource('foo', serve_cmd=['./hello.sh', 'foo'], deps=['greeting'], readiness_probe=p)
 
 # readiness probe explicitly set to None
-local_resource('bar', serve_cmd=['./hello.sh', 'bar'],
+local_resource('bar',
+               serve_cmd=cmd('./hello.sh $NAME', env={'NAME': 'bar'}),
                readiness_probe=None,
                resource_deps=['foo'])

--- a/integration/local_resource_test.go
+++ b/integration/local_resource_test.go
@@ -30,7 +30,7 @@ func TestLocalResource(t *testing.T) {
 
 	f.TiltUp()
 
-	const barServeLogMessage = "Running cmd: ./hello.sh bar"
+	const barServeLogMessage = "Running cmd: ./hello.sh $NAME"
 	const readinessProbeSuccessMessage = `[readiness probe: success] fake probe success message`
 
 	require.NoError(t, f.logs.WaitUntilContains("hello! foo #1", 5*time.Second))

--- a/internal/tiltfile/tiltfile_state.go
+++ b/internal/tiltfile/tiltfile_state.go
@@ -22,6 +22,7 @@ import (
 	"github.com/tilt-dev/tilt/internal/tiltfile/probe"
 	"github.com/tilt-dev/tilt/internal/tiltfile/sys"
 	"github.com/tilt-dev/tilt/internal/tiltfile/tiltextension"
+	"github.com/tilt-dev/tilt/internal/tiltfile/value"
 
 	"github.com/tilt-dev/tilt/internal/container"
 	"github.com/tilt-dev/tilt/internal/dockercompose"
@@ -222,6 +223,7 @@ func (s *tiltfileState) loadManifests(tf *v1alpha1.Tiltfile) ([]model.Manifest, 
 		print.NewPlugin(),
 		probe.NewPlugin(),
 		tfv1alpha1.NewPlugin(),
+		value.NewCmdPlugin(),
 	)
 	if err != nil {
 		return nil, result, starkit.UnpackBacktrace(err)

--- a/internal/tiltfile/value/cmd.go
+++ b/internal/tiltfile/value/cmd.go
@@ -1,0 +1,72 @@
+package value
+
+import (
+	"fmt"
+
+	"go.starlark.net/starlark"
+	"go.starlark.net/starlarkstruct"
+
+	"github.com/tilt-dev/tilt/internal/tiltfile/starkit"
+	"github.com/tilt-dev/tilt/pkg/model"
+)
+
+const typeCmd = "cmd"
+
+type CmdPlugin struct{}
+
+func NewCmdPlugin() CmdPlugin {
+	return CmdPlugin{}
+}
+
+var _ starkit.Plugin = CmdPlugin{}
+
+func (p CmdPlugin) OnStart(env *starkit.Environment) error {
+	if err := env.AddBuiltin("cmd", p.cmd); err != nil {
+		return fmt.Errorf("could not add cmd builtin: %v", err)
+	}
+	return nil
+}
+
+func (p CmdPlugin) cmd(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple,
+	kwargs []starlark.Tuple) (starlark.Value, error) {
+	var argsVal, argsBatVal starlark.Value
+	// TODO(milas): should we also except ['FOO=bar'] style list?
+	var env StringStringMap
+	var dir starlark.Value
+
+	err := starkit.UnpackArgs(
+		thread, fn.Name(), args, kwargs,
+		"args", &argsVal,
+		"env?", &env,
+		"dir?", &dir,
+		"args_bat?", &argsBatVal,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	cmd, err := ValueGroupToCmdHelper(thread, argsVal, argsBatVal, dir, env)
+	if err != nil {
+		return nil, err
+	}
+
+	return Cmd{
+		Struct: starlarkstruct.FromKeywords(
+			starlark.String(typeCmd), []starlark.Tuple{
+				{starlark.String("args"), StringSliceToList(cmd.Argv)},
+				{starlark.String("env"), StringSliceToList(cmd.Env)},
+				{starlark.String("dir"), starlark.String(cmd.Dir)},
+			},
+		),
+		cmd: cmd,
+	}, nil
+}
+
+type Cmd struct {
+	*starlarkstruct.Struct
+	cmd model.Cmd
+}
+
+func (c Cmd) ToModelCmd() model.Cmd {
+	return c.cmd
+}

--- a/internal/tiltfile/value/cmd_test.go
+++ b/internal/tiltfile/value/cmd_test.go
@@ -1,0 +1,107 @@
+package value
+
+import (
+	"encoding/json"
+	"fmt"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tilt-dev/tilt/internal/tiltfile/starkit"
+)
+
+func TestCmdPlugin(t *testing.T) {
+	type tc struct {
+		input string
+		args  interface{}
+		dir   string
+		env   []string
+	}
+
+	tcs := []tc{
+		{input: `cmd('echo hi')`, args: "echo hi"},
+		{input: `cmd(['echo', 'hi'])`, args: []string{"echo", "hi"}},
+		{
+			input: `cmd(args='cat foo.txt', env={'FOO': 'bar', 'bar': 'FOO'})`,
+			args:  "cat foo.txt",
+			env:   []string{"FOO=bar", "bar=FOO"},
+		},
+		{
+			input: `cmd(args=["abc"], dir='/foo/bar')`,
+			args:  []string{"abc"},
+			// N.B. there's no OS validation of this path, so it's fine that this isn't portable for Windows
+			dir: "/foo/bar",
+		},
+		{
+			input: `cmd(args=["abc"], env={"A": "1"}, dir='/foo/bar')`,
+			args:  []string{"abc"},
+			// N.B. there's no OS validation of this path, so it's fine that this isn't portable for Windows
+			dir: "/foo/bar",
+			env: []string{"A=1"},
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.input, func(t *testing.T) {
+			f := starkit.NewFixture(t, NewCmdPlugin())
+			defer f.TearDown()
+
+			f.File(
+				"Tiltfile", fmt.Sprintf(`
+c = %s
+
+print(c.args)
+print(c.dir)
+print(c.env)
+`, tc.input))
+
+			_, err := f.ExecFile("Tiltfile")
+			require.NoError(t, err)
+
+			output := strings.Split(strings.ReplaceAll(strings.TrimSpace(f.PrintOutput()), "\r\n", "\n"), "\n")
+			require.Len(t, output, 3, "Output should have been 3 lines long (args, dir, env)")
+
+			var expectedArgs []string
+			if argv, ok := tc.args.([]string); ok {
+				// arguments were passed as an argv array, keep them as-is
+				expectedArgs = argv
+			} else if script, ok := tc.args.(string); ok {
+				if runtime.GOOS == "windows" {
+					expectedArgs = []string{"cmd", "/S", "/C", script}
+				} else {
+					expectedArgs = []string{"sh", "-c", script}
+				}
+			} else {
+				require.Fail(t, "Bad args type %T: %v", tc.args, tc.args)
+			}
+
+			// Starlark's stringified output of a string list is JSON-compatible,
+			// so we use that for args + env to get better assertion output in the
+			// tests vs just string comparisons
+			var actualArgs []string
+			require.NoError(t, json.Unmarshal([]byte(output[0]), &actualArgs),
+				"Could not read args from output: %s", output[0])
+			assert.Equal(t, expectedArgs, actualArgs, "Cmd args did not match")
+
+			expectedDir := tc.dir
+			if expectedDir == "" {
+				expectedDir = f.Path()
+			}
+			assert.Equal(t, expectedDir, output[1], "Dir did not match")
+
+			expectedEnv := tc.env
+			if expectedEnv == nil {
+				// the helpers will always give us an empty list instead of nil
+				// but the distinction is irrelevant in usage
+				expectedEnv = make([]string, 0)
+			}
+			var actualEnv []string
+			require.NoError(t, json.Unmarshal([]byte(output[2]), &actualEnv),
+				"Could not read env from output: %s", output[2])
+			assert.Equal(t, expectedEnv, actualEnv, "Env did not match")
+		})
+	}
+}


### PR DESCRIPTION
Tiltfile functions that accept commands currently require 4 arguments
per command (cmd, env, dir, cmd_bat). In some cases, like
`local_resource` where there are multiple commands, that gets unwieldy
fast.

The `cmd` built-in lets us group these into a single object, which
maps to the `model.Cmd`. Anywhere that currently accepts a `cmd`
can now optionally accept this instead. However, to avoid breaking
Tiltfile compatibility, the separate arguments are still available,
but CANNOT be used in conjunction with the `cmd()` built-in for a
given command assembly.

There's a side benefit here when working with API types in a Tiltfile,
which is that this can be used as a bridge/helper to get things into
the expected format. For example, the APIs all take `Args` as an
argv-style string array, and don't support the auto-magical
string -> shell wrapper, so callers can now make a `cmd` object and
then use `cmd.args` for the field value. Ditto for env, where it's
nicer in Starlark to make a `dict`, but that then needs to be mapped
to a `KEY=value` string list, which can be accessed via `cmd.env`.