### PR TITLE
liveupdate: clear stop_path failures on new build/apply

### DIFF
--- a/integration/live_update_only_test.go
+++ b/integration/live_update_only_test.go
@@ -58,4 +58,10 @@ func TestLiveUpdateOnly(t *testing.T) {
 		afterFileChangeLogs := logStr[fileChangeIdx:]
 		return strings.Contains(afterFileChangeLogs, `STEP 1/1 — Deploying`)
 	}, 15*time.Second, 500*time.Millisecond, "Full rebuild never triggered")
+
+	// attempt another Live Update
+	f.ReplaceContents(filepath.Join("web", "index.html"), "Greetings", "Salutations")
+	ctx, cancel = context.WithTimeout(f.ctx, 10*time.Second)
+	defer cancel()
+	f.CurlUntil(ctx, "http://localhost:28195", "Salutations from Live Update!")
 }

--- a/internal/controllers/core/liveupdate/monitor.go
+++ b/internal/controllers/core/liveupdate/monitor.go
@@ -45,8 +45,12 @@ type monitorContainerKey struct {
 type monitorContainerStatus struct {
 	lastFileTimeSynced metav1.MicroTime
 
-	// Once a container is marked unrecoverable,
-	// we never send updates to it again.
-	failedReason  string
-	failedMessage string
+	// The low water mark is the oldest file timestamp
+	// triggered a build failure.
+	//
+	// If we get a new ImageBuild or new KubernetesApply
+	// after this mark, we should try again.
+	failedLowWaterMark metav1.MicroTime
+	failedReason       string
+	failedMessage      string
 }


### PR DESCRIPTION
Hello @milas,

Please review the following commits I made in branch nicks/lu4:

5e117358113871b9996a9b590ff3f27b3bc667dc (2021-11-05 18:31:04 -0400)
liveupdate: clear stop_path failures on new build/apply

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics