### PR TITLE
features: flip live_update_v2 back on by default

### DIFF
--- a/integration/Tiltfile
+++ b/integration/Tiltfile
@@ -1,7 +1,5 @@
 # -*- mode: Python -*-
 
-enable_feature('live_update_v2')
-
 # HACK: load namespaces on `tilt up` but not on `tilt down`
 load_namespace = not os.environ.get('SKIP_NAMESPACE', '')
 if load_namespace:

--- a/internal/feature/flags.go
+++ b/internal/feature/flags.go
@@ -65,7 +65,7 @@ var MainDefaults = Defaults{
 		Status:  Active,
 	},
 	LiveUpdateV2: Value{
-		Enabled: false,
+		Enabled: true,
 		Status:  Active,
 	},
 	DisableResources: Value{


### PR DESCRIPTION
Hello @milas,

Please review the following commits I made in branch nicks/v2:

984162e5f15a0710fca60649e66eade14a2ad577 (2021-11-09 10:14:28 -0500)
features: flip live_update_v2 back on by default

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics