### PR TITLE
test: re-enable Live Update v2 for `k8s_custom_deploy` test

### DIFF
--- a/integration/k8s_custom_deploy/Tiltfile
+++ b/integration/k8s_custom_deploy/Tiltfile
@@ -3,9 +3,6 @@ include('../Tiltfile')
 
 enable_feature('k8s_custom_deploy')
 
-# TODO(milas): remove once bug with LU reconciler + LU-only targets after "full" rebuilds is resolved
-disable_feature('live_update_v2')
-
 k8s_custom_deploy(
     'custom-deploy-int-test',
     # forcibly delete and re-create the deployment whenever run

--- a/integration/k8s_custom_deploy_test.go
+++ b/integration/k8s_custom_deploy_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestCustomDeploy(t *testing.T) {
+func TestK8sCustomDeploy(t *testing.T) {
 	kubectlPath, err := exec.LookPath("kubectl")
 	if err != nil || kubectlPath == "" {
 		t.Fatal("`kubectl` not found in PATH")


### PR DESCRIPTION
Underlying issue was fixed by #5145, so this can + should rely on
Live Update v2 (reconciler/API managed).