### PR TITLE
test: fix race condition in fakeBuildAndDeployer

### DIFF
--- a/internal/engine/buildcontroller_test.go
+++ b/internal/engine/buildcontroller_test.go
@@ -151,14 +151,14 @@ func TestBuildControllerIgnoresImageTags(t *testing.T) {
 	f := newTestFixture(t)
 	defer f.TearDown()
 
-	ref := container.MustParseNamed("image-foo:tagged")
+	ref := container.MustParseNamed("gcr.io/blorg-dev/blorg-backend:devel-nick")
 	refSel := container.NewRefSelector(ref)
 
 	iTarget := NewSanchoLiveUpdateImageTarget(f)
 	iTarget = iTarget.MustWithRef(refSel)
 
 	manifest := manifestbuilder.New(f, "fe").
-		WithK8sYAML(SanchoYAML).
+		WithK8sYAML(testyaml.BlorgJobYAML).
 		WithLiveUpdateBAD().
 		WithImageTarget(iTarget).
 		Build()
@@ -171,7 +171,7 @@ func TestBuildControllerIgnoresImageTags(t *testing.T) {
 
 	pod := basePB.
 		WithPodName("pod-id").
-		WithImage("image-foo:othertag").
+		WithImage("gcr.io/blorg-dev/blorg-backend:othertag").
 		Build()
 	f.podEvent(pod)
 	f.fsWatcher.Events <- watch.NewFileEvent(f.JoinPath("main.go"))
@@ -496,7 +496,7 @@ func TestCrashRebuildTwoContainersTwoImages(t *testing.T) {
 	defer f.TearDown()
 
 	manifest := manifestbuilder.New(f, "sancho").
-		WithK8sYAML(testyaml.SanchoTwoContainersOneImageYAML).
+		WithK8sYAML(testyaml.SanchoSidecarYAML).
 		WithLiveUpdateBAD().
 		WithImageTarget(NewSanchoLiveUpdateImageTarget(f)).
 		WithImageTarget(NewSanchoSidecarLiveUpdateImageTarget(f)).


### PR DESCRIPTION
The real build and deployer invokes the `KubernetesApply`
reconciler via `ForceApply` to trigger reconciliation (i.e.
deployment).

The fake for upper tests was directly updating the `KubernetesApply`
status, i.e. simulating what `ForceApply` would do. However, the
`KubernetesApply` reconciler is still live/running during these
tests. Generally, this would be fine as the reconciler skips doing
deployment for objects annotated to be managed by `buildcontrol`,
opting to allow them to call `ForceApply` when needed to trigger
the logic. This became an issue once the reconciler started doing
more work (even in the managed by `buildcontrol` scenario), as
the reconciler, running asynchronously, might overwrite the test
object with a stale version.

This is possible because the apiserver is not enforcing optimistic
concurrency, so no error is returned if attempting a stale update.

The underlying root cause hasn't been fixed here: the change for
now is to have the `fakeBuildAndDeployer` call `ForceApply` much
like the real implementation does. It preemptively sets the desired
result on the `FakeK8sClient` to get the desired YAML to end upon
the status. Some tests had to be adjusted slightly as they were
violating certain invariants expected by the reconciler.

What's unfortunately very kludgy here is that a lot of the work
from the reconciler is being ignored: the actual input to the K8s
`Upsert()` call is ignored. It'd be nice to let the fake K8s client
do more of the work for common cases to ensure that the test cases
themselves are internally coherent, which would avoid surprises &
failures when other logic is refactored that subsequently expects
the data model to be consistent :)