### PR TITLE
test: remove helm2 CI job

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -26,10 +26,6 @@ RUN curl --silent --show-error --location --fail --retry 3 --output /tmp/kustomi
   && tar -xz -C /tmp -f /tmp/kustomize.tar.gz \
   && mv /tmp/kustomize /usr/bin/kustomize
 
-RUN curl --silent --show-error --location --fail --retry 3 --output /tmp/helm.tar.gz https://get.helm.sh/helm-v2.16.1-linux-amd64.tar.gz \
-  && tar -xz -C /tmp -f /tmp/helm.tar.gz \
-  && mv /tmp/linux-amd64/helm /usr/bin/helm2
-
 RUN curl --silent --show-error --location --fail --retry 3 --output /tmp/helm.tar.gz  https://get.helm.sh/helm-v3.5.0-linux-amd64.tar.gz \
   && tar -xz -C /tmp -f /tmp/helm.tar.gz \
   && mv /tmp/linux-amd64/helm /usr/bin/helm3

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,17 +30,6 @@ jobs:
           path: test-results
       - slack/notify-on-failure:
           only_for_branches: master
-  helm2:
-    docker:
-      - image: gcr.io/windmill-public-containers/tilt-ci@sha256:1185c8fe8c863dc09552c5a52bb1b66c1e60e5eb6ef9a84c1408d6eed0473f5c
-    steps:
-      - checkout
-      - run: sudo mv /usr/bin/helm2 /usr/bin/helm
-      - run: make test-go-helm-only
-      - store_test_results:
-          path: test-results
-      - slack/notify-on-failure:
-          only_for_branches: master
 
   build-js:
     docker:
@@ -188,7 +177,6 @@ workflows:
     # The linux job is cheaper than the others, so run that first.
     jobs:
       - build-linux
-      - helm2
       - build-js:
           requires:
             - build-linux

--- a/Makefile
+++ b/Makefile
@@ -36,14 +36,6 @@ else
 		gotestsum --format standard-quiet --junitfile test-results/unit-tests.xml -- ./... -mod vendor -p $(GO_PARALLEL_JOBS) -timeout 100s
 endif
 
-test-go-helm-only:
-ifneq ($(CIRCLECI),true)
-		go test -mod vendor -p $(GO_PARALLEL_JOBS) -timeout 100s ./internal/tiltfile -run "(?i)(.*)Helm(.*)"
-else
-		mkdir -p test-results
-		gotestsum --format standard-quiet --junitfile test-results/unit-tests.xml -- ./internal/tiltfile -mod vendor -p $(GO_PARALLEL_JOBS) -timeout 100s -run "(?i)(.*)Helm(.*)"
-endif
-
 test: test-go test-js
 
 # skip some tests that are slow and not always relevant


### PR DESCRIPTION
Hello @landism,

Please review the following commits I made in branch nicks/helm2:

3bf761ced58406209ab4e35da951292ac6258da7 (2021-11-15 17:45:55 -0500)
test: remove helm2 CI job
Helm2 was end-of-life'd 1 year ago:
https://helm.sh/blog/helm-v2-deprecation-timeline/
That doesn't mean we're removing support for Helm2.
Just that it's not worth maintaining a separate CI job.

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics