### PR TITLE
storybook: gce loadbalancers really want the pathType to be ImplementationSpecific

### DIFF
--- a/configs/storybook/templates/ingress.yaml
+++ b/configs/storybook/templates/ingress.yaml
@@ -29,7 +29,7 @@ spec:
         paths:
           {{- range .paths }}
           - path: {{ . }}
-            pathType: Prefix
+            pathType: ImplementationSpecific
             backend:
               service:
                 name: {{ $fullName }}


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/ingress2:

fed4c8a8eff6c86f86260bab115652d49dcd953f (2021-11-16 14:37:01 -0500)
storybook: gce loadbalancers really want the pathType to be ImplementationSpecific
https://cloud.google.com/kubernetes-engine/docs/how-to/load-balance-ingress#creating_an_ingress

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics