### PR TITLE
(revert the revert) controllers: implement `DisableStatus` for `KubernetesApply`

### DIFF
--- a/internal/controllers/core/filewatch/controller.go
+++ b/internal/controllers/core/filewatch/controller.go
@@ -89,6 +89,9 @@ func (c *Controller) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return ctrl.Result{}, nil
 	}
 
+	// The apiserver is the source of truth, and will ensure the engine state is up to date.
+	c.Store.Dispatch(filewatches.NewFileWatchUpsertAction(&fw))
+
 	// Get configmap's disable status
 	disableStatus, err := configmap.MaybeNewDisableStatus(ctx, c.Client, fw.Spec.DisableSource, fw.Status.DisableStatus)
 	if err != nil {
@@ -109,11 +112,9 @@ func (c *Controller) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 			existing.cleanupWatch(ctx)
 			c.removeWatch(existing)
 		}
+
 		return ctrl.Result{}, nil
 	}
-
-	// The apiserver is the source of truth, and will ensure the engine state is up to date.
-	c.Store.Dispatch(filewatches.NewFileWatchUpsertAction(&fw))
 
 	if !hasExisting || !equality.Semantic.DeepEqual(existing.spec, fw.Spec) {
 		if err := c.addOrReplace(ctx, c.Store, req.NamespacedName, &fw); err != nil {

--- a/internal/controllers/core/kubernetesapply/reconciler.go
+++ b/internal/controllers/core/kubernetesapply/reconciler.go
@@ -10,6 +10,7 @@ import (
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -23,6 +24,7 @@ import (
 	"github.com/tilt-dev/tilt/internal/build"
 	"github.com/tilt-dev/tilt/internal/container"
 	"github.com/tilt-dev/tilt/internal/controllers/apicmp"
+	"github.com/tilt-dev/tilt/internal/controllers/apis/configmap"
 	"github.com/tilt-dev/tilt/internal/controllers/apis/restarton"
 	"github.com/tilt-dev/tilt/internal/controllers/indexer"
 	"github.com/tilt-dev/tilt/internal/k8s"
@@ -57,11 +59,23 @@ type Reconciler struct {
 	results map[types.NamespacedName]*Result
 }
 
+// Partial KubernetesApplyStatus that represents
+// the fields returned by `ForceApply`
+type ForceApplyStatus struct {
+	ResultYAML         string
+	Error              string
+	LastApplyTime      metav1.MicroTime
+	LastApplyStartTime metav1.MicroTime
+	AppliedInputHash   string
+}
+
 func (r *Reconciler) CreateBuilder(mgr ctrl.Manager) (*builder.Builder, error) {
 	b := ctrl.NewControllerManagedBy(mgr).
 		For(&v1alpha1.KubernetesApply{}).
 		Owns(&v1alpha1.KubernetesDiscovery{}).
 		Watches(&source.Kind{Type: &v1alpha1.ImageMap{}},
+			handler.EnqueueRequestsFromMapFunc(r.indexer.Enqueue)).
+		Watches(&source.Kind{Type: &v1alpha1.ConfigMap{}},
 			handler.EnqueueRequestsFromMapFunc(r.indexer.Enqueue))
 
 	restarton.SetupController(b, r.indexer, func(obj ctrlclient.Object) (*v1alpha1.RestartOnSpec, *v1alpha1.StartOnSpec) {
@@ -98,10 +112,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	}
 
 	if apierrors.IsNotFound(err) || !ka.ObjectMeta.DeletionTimestamp.IsZero() {
-		toDelete := r.updateResult(nn, nil)
-		r.bestEffortDelete(ctx, toDelete)
-
-		err := r.manageOwnedKubernetesDiscovery(ctx, nn, nil)
+		err := r.deleteCreatedObjects(ctx, nn)
 		if err != nil {
 			return ctrl.Result{}, err
 		}
@@ -112,6 +123,31 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	// The apiserver is the source of truth, and will ensure the engine state is up to date.
 	r.st.Dispatch(kubernetesapplys.NewKubernetesApplyUpsertAction(&ka))
+
+	// Get configmap's disable status
+	disableStatus, err := configmap.MaybeNewDisableStatus(ctx, r.ctrlClient, ka.Spec.DisableSource, ka.Status.DisableStatus)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// Update kubernetesapply's disable status
+	if disableStatus != ka.Status.DisableStatus {
+		ka.Status.DisableStatus = disableStatus
+		if err := r.ctrlClient.Status().Update(ctx, &ka); err != nil {
+			return ctrl.Result{}, err
+		}
+	}
+
+	// Delete kubernetesapply if it's disabled
+	if disableStatus.Disabled {
+		err := r.deleteCreatedObjects(ctx, nn)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+
+		r.st.Dispatch(kubernetesapplys.NewKubernetesApplyUpsertAction(&ka))
+		return ctrl.Result{}, nil
+	}
 
 	ctx = store.MustObjectLogHandler(ctx, r.st, &ka)
 	err = r.manageOwnedKubernetesDiscovery(ctx, nn, &ka)
@@ -233,12 +269,26 @@ func (r *Reconciler) ForceApply(
 	nn types.NamespacedName,
 	spec v1alpha1.KubernetesApplySpec,
 	imageMaps map[types.NamespacedName]*v1alpha1.ImageMap) (v1alpha1.KubernetesApplyStatus, error) {
+	forceApplyStatus, appliedObjects := r.forceApplyHelper(ctx, spec, imageMaps)
 
-	status, appliedObjects := r.forceApplyHelper(ctx, spec, imageMaps)
-	statusCopy := status.DeepCopy()
+	var ka v1alpha1.KubernetesApply
+	err := r.ctrlClient.Get(ctx, nn, &ka)
+	if err != nil {
+		return v1alpha1.KubernetesApplyStatus{}, err
+	}
+
+	// Copy over status information from `forceApplyHelper`
+	// so other existing status information isn't overwritten
+	updatedStatus := ka.Status.DeepCopy()
+	updatedStatus.ResultYAML = forceApplyStatus.ResultYAML
+	updatedStatus.Error = forceApplyStatus.Error
+	updatedStatus.LastApplyStartTime = forceApplyStatus.LastApplyStartTime
+	updatedStatus.LastApplyTime = forceApplyStatus.LastApplyTime
+	updatedStatus.AppliedInputHash = forceApplyStatus.AppliedInputHash
+
 	result := Result{
 		Spec:           spec,
-		Status:         *statusCopy,
+		Status:         *updatedStatus,
 		AppliedObjects: newObjectRefSet(appliedObjects),
 	}
 
@@ -253,22 +303,16 @@ func (r *Reconciler) ForceApply(
 		result.ImageMapStatuses = append(result.ImageMapStatuses, im.Status)
 	}
 
-	var ka v1alpha1.KubernetesApply
-	err := r.ctrlClient.Get(ctx, nn, &ka)
-	if err != nil {
-		return status, err
-	}
-
-	ka.Status = status
+	ka.Status = *updatedStatus
 	err = r.ctrlClient.Status().Update(ctx, &ka)
 	if err != nil {
-		return status, err
+		return *updatedStatus, err
 	}
 
 	toDelete := r.updateResult(nn, &result)
 	r.bestEffortDelete(ctx, toDelete)
 
-	return status, nil
+	return *updatedStatus, nil
 }
 
 // A helper that applies the given specs to the cluster, but doesn't update the APIServer.
@@ -279,14 +323,15 @@ func (r *Reconciler) ForceApply(
 func (r *Reconciler) forceApplyHelper(
 	ctx context.Context,
 	spec v1alpha1.KubernetesApplySpec,
-	imageMaps map[types.NamespacedName]*v1alpha1.ImageMap) (v1alpha1.KubernetesApplyStatus, []k8s.K8sEntity) {
+	imageMaps map[types.NamespacedName]*v1alpha1.ImageMap,
+) (ForceApplyStatus, []k8s.K8sEntity) {
 
 	startTime := apis.NowMicro()
-	status := v1alpha1.KubernetesApplyStatus{
+	status := ForceApplyStatus{
 		LastApplyStartTime: startTime,
 	}
 
-	errorStatus := func(err error) v1alpha1.KubernetesApplyStatus {
+	errorStatus := func(err error) ForceApplyStatus {
 		status.LastApplyTime = apis.NowMicro()
 		status.Error = err.Error()
 		return status
@@ -554,6 +599,23 @@ func (r *Reconciler) updateResult(nn types.NamespacedName, result *Result) delet
 	return deleteSpec{entities: toDelete}
 }
 
+// A helper that deletes all kubernetesapply objects and the
+// related kubernetesdiscovery objects it owns
+func (r *Reconciler) deleteCreatedObjects(
+	ctx context.Context,
+	nn types.NamespacedName,
+) error {
+	toDelete := r.updateResult(nn, nil)
+	r.bestEffortDelete(ctx, toDelete)
+
+	err := r.manageOwnedKubernetesDiscovery(ctx, nn, nil)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func (r *Reconciler) bestEffortDelete(ctx context.Context, toDelete deleteSpec) {
 	if len(toDelete.entities) == 0 && toDelete.deleteCmd == nil {
 		return
@@ -595,6 +657,17 @@ func indexKubernetesApply(obj client.Object) []indexer.Key {
 			Name: types.NamespacedName{Name: name},
 			GVK:  imGVK,
 		})
+	}
+
+	if ka.Spec.DisableSource != nil {
+		cm := ka.Spec.DisableSource.ConfigMap
+		if cm != nil {
+			cmGVK := v1alpha1.SchemeGroupVersion.WithKind("ConfigMap")
+			result = append(result, indexer.Key{
+				Name: types.NamespacedName{Name: cm.Name},
+				GVK:  cmGVK,
+			})
+		}
 	}
 	return result
 }

--- a/internal/controllers/core/kubernetesapply/reconciler_test.go
+++ b/internal/controllers/core/kubernetesapply/reconciler_test.go
@@ -4,17 +4,18 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"strconv"
 	"testing"
 	"time"
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/google/uuid"
-	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/tilt-dev/tilt/internal/build"
 	"github.com/tilt-dev/tilt/internal/controllers/fake"
@@ -28,6 +29,10 @@ import (
 	"github.com/tilt-dev/tilt/pkg/apis"
 	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
 )
+
+// Test constants
+const timeout = time.Second * 10
+const interval = 5 * time.Millisecond
 
 func TestImageIndexing(t *testing.T) {
 	f := newFixture(t)
@@ -44,7 +49,7 @@ func TestImageIndexing(t *testing.T) {
 	// Verify we can index one image map.
 	reqs := f.r.indexer.Enqueue(&v1alpha1.ImageMap{ObjectMeta: metav1.ObjectMeta{Name: "image-a"}})
 	assert.ElementsMatch(t, []reconcile.Request{
-		reconcile.Request{NamespacedName: types.NamespacedName{Name: "a"}},
+		{NamespacedName: types.NamespacedName{Name: "a"}},
 	}, reqs)
 
 	kb := v1alpha1.KubernetesApply{
@@ -60,17 +65,21 @@ func TestImageIndexing(t *testing.T) {
 	// Verify we can index one image map to two applies.
 	reqs = f.r.indexer.Enqueue(&v1alpha1.ImageMap{ObjectMeta: metav1.ObjectMeta{Name: "image-c"}})
 	assert.ElementsMatch(t, []reconcile.Request{
-		reconcile.Request{NamespacedName: types.NamespacedName{Name: "a"}},
-		reconcile.Request{NamespacedName: types.NamespacedName{Name: "b"}},
+		{NamespacedName: types.NamespacedName{Name: "a"}},
+		{NamespacedName: types.NamespacedName{Name: "b"}},
 	}, reqs)
 
+	// Get the latest ka, since resource version numbers
+	// may have changed since its creation and mismatched
+	// versions will throw an error on update
+	f.MustGet(types.NamespacedName{Name: "a"}, &ka)
 	ka.Spec.ImageMaps = []string{"image-a"}
 	f.Update(&ka)
 
 	// Verify we can remove an image map.
 	reqs = f.r.indexer.Enqueue(&v1alpha1.ImageMap{ObjectMeta: metav1.ObjectMeta{Name: "image-c"}})
 	assert.ElementsMatch(t, []reconcile.Request{
-		reconcile.Request{NamespacedName: types.NamespacedName{Name: "b"}},
+		{NamespacedName: types.NamespacedName{Name: "b"}},
 	}, reqs)
 }
 
@@ -432,6 +441,83 @@ func TestIgnoreManagedObjects(t *testing.T) {
 
 	f.MustGet(nn, &ka)
 	assert.Equal(f.T(), result, ka.Status)
+}
+
+func TestDisableByConfigmap(t *testing.T) {
+	f := newFixture(t)
+	ka := v1alpha1.KubernetesApply{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test",
+		},
+		Spec: v1alpha1.KubernetesApplySpec{
+			YAML: testyaml.SanchoYAML,
+			DisableSource: &v1alpha1.DisableSource{
+				ConfigMap: &v1alpha1.ConfigMapDisableSource{
+					Name: "test-disable",
+					Key:  "isDisabled",
+				},
+			},
+		},
+	}
+	f.Create(&ka)
+
+	f.setDisabled(ka.GetObjectMeta().Name, true)
+
+	f.setDisabled(ka.GetObjectMeta().Name, false)
+
+	f.setDisabled(ka.GetObjectMeta().Name, true)
+}
+
+func (f *fixture) requireKaMatchesInApi(name string, matcher func(ka *v1alpha1.KubernetesApply) bool) *v1alpha1.KubernetesApply {
+	ka := v1alpha1.KubernetesApply{}
+
+	require.Eventually(f.T(), func() bool {
+		f.MustGet(types.NamespacedName{Name: name}, &ka)
+		return matcher(&ka)
+	}, timeout, interval)
+
+	return &ka
+}
+
+func (f *fixture) setDisabled(name string, isDisabled bool) {
+	ka := v1alpha1.KubernetesApply{}
+	f.MustGet(types.NamespacedName{Name: name}, &ka)
+
+	require.NotNil(f.T(), ka.Spec.DisableSource)
+	require.NotNil(f.T(), ka.Spec.DisableSource.ConfigMap)
+
+	cm := v1alpha1.ConfigMap{}
+	cmExists := f.Get(types.NamespacedName{Name: ka.Spec.DisableSource.ConfigMap.Name}, &cm)
+	if !cmExists {
+		cm.ObjectMeta.Name = ka.Spec.DisableSource.ConfigMap.Name
+		cm.Data = map[string]string{ka.Spec.DisableSource.ConfigMap.Key: strconv.FormatBool(isDisabled)}
+		err := f.Client.Create(f.Context(), &cm)
+		require.NoError(f.T(), err)
+	} else {
+		cm.Data[ka.Spec.DisableSource.ConfigMap.Key] = strconv.FormatBool(isDisabled)
+		err := f.Client.Update(f.Context(), &cm)
+		require.NoError(f.T(), err)
+	}
+
+	_, err := f.Reconcile(types.NamespacedName{Name: name})
+	require.NoError(f.T(), err)
+
+	f.requireKaMatchesInApi(name, func(ka *v1alpha1.KubernetesApply) bool {
+		return ka.Status.DisableStatus != nil && ka.Status.DisableStatus.Disabled == isDisabled
+	})
+
+	kd := v1alpha1.KubernetesDiscovery{}
+	kdExists := f.Get(types.NamespacedName{Name: name}, &kd)
+
+	if isDisabled {
+		require.False(f.T(), kdExists)
+
+		require.Contains(f.T(), f.kClient.DeletedYaml, "name: sancho")
+		// Reset the deletedYaml so it doesn't interfere with other tests
+		f.kClient.DeletedYaml = ""
+	} else {
+		require.True(f.T(), kdExists)
+	}
 }
 
 type fixture struct {

--- a/internal/engine/buildcontrol/image_build_and_deployer.go
+++ b/internal/engine/buildcontrol/image_build_and_deployer.go
@@ -306,6 +306,9 @@ func (ibd *ImageBuildAndDeployer) deploy(
 	ps.StartBuildStep(ctx, "Injecting images into Kubernetes YAML")
 
 	kTargetNN := types.NamespacedName{Name: kTargetID.Name.String()}
+	// Note: `KubernetesApply` object may not exist yet when this `ForceApply` is called
+	// and may cause a race-condition-related "Not found" error here.
+	// https://github.com/tilt-dev/tilt/issues/5125
 	status, err := ibd.r.ForceApply(ctx, kTargetNN, spec, imageMaps)
 	if err != nil {
 		return store.K8sBuildResult{}, fmt.Errorf("applying %s: %v", kTargetID, err)


### PR DESCRIPTION
This PR reverts the (original) reverted PR, since @milas posted a fix for the flaky tests seen in `upper_test.go`. (See #5172 for more details.)

Reverts tilt-dev/tilt#5161