### PR TITLE
dockerimage: write image build performance to the apiserver

### DIFF
--- a/internal/build/container_test.go
+++ b/internal/build/container_test.go
@@ -40,7 +40,7 @@ ADD dir/c.txt .
 		DockerfileContents: df.String(),
 		Context:            f.Path(),
 	}
-	refs, err := f.b.BuildImage(f.ctx, f.ps, f.getNameFromTest(), spec,
+	refs, _, err := f.b.BuildImage(f.ctx, f.ps, f.getNameFromTest(), spec,
 		model.EmptyMatcher)
 	if err != nil {
 		t.Fatal(err)
@@ -74,7 +74,7 @@ ADD $some_variable_name /test.txt`)
 		Context:            f.Path(),
 		Args:               []string{"some_variable_name=awesome_variable"},
 	}
-	refs, err := f.b.BuildImage(f.ctx, f.ps, f.getNameFromTest(), spec,
+	refs, _, err := f.b.BuildImage(f.ctx, f.ps, f.getNameFromTest(), spec,
 		model.EmptyMatcher)
 	if err != nil {
 		t.Fatal(err)
@@ -103,7 +103,7 @@ ADD a.txt .`)
 		ExtraTags:          []string{"fe:jenkins-1234"},
 		Args:               []string{"some_variable_name=awesome_variable"},
 	}
-	refs, err := f.b.BuildImage(f.ctx, f.ps, f.getNameFromTest(), spec,
+	refs, _, err := f.b.BuildImage(f.ctx, f.ps, f.getNameFromTest(), spec,
 		model.EmptyMatcher)
 	if err != nil {
 		t.Fatal(err)
@@ -132,7 +132,7 @@ RUN echo 'failed to create LLB definition: failed commit on ref "unknown-sha256:
 `,
 		Context: f.Path(),
 	}
-	_, err := f.b.BuildImage(ctx, ps, f.getNameFromTest(), spec, model.EmptyMatcher)
+	_, _, err := f.b.BuildImage(ctx, ps, f.getNameFromTest(), spec, model.EmptyMatcher)
 	assert.Error(t, err)
 	assert.Contains(t, out.String(), "Detected Buildkit corruption. Rebuilding without Buildkit")
 	assert.Contains(t, out.String(), "[1/2] FROM docker.io/library/alpine") // buildkit-style output

--- a/internal/build/docker_builder_test.go
+++ b/internal/build/docker_builder_test.go
@@ -66,7 +66,7 @@ func TestDigestFromSingleStepOutput(t *testing.T) {
 
 	input := docker.ExampleBuildOutput1
 	expected := digest.Digest("sha256:11cd0b38bc3ceb958ffb2f9bd70be3fb317ce7d255c8a4c3f4af30e298aa1aab")
-	actual, err := f.b.getDigestFromBuildOutput(f.ctx, bytes.NewBuffer([]byte(input)))
+	actual, _, err := f.b.getDigestFromBuildOutput(f.ctx, bytes.NewBuffer([]byte(input)))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -82,7 +82,7 @@ func TestDigestFromOutputV1_23(t *testing.T) {
 	input := docker.ExampleBuildOutputV1_23
 	expected := digest.Digest("sha256:11cd0eb38bc3ceb958ffb2f9bd70be3fb317ce7d255c8a4c3f4af30e298aa1aab")
 	f.fakeDocker.Images["11cd0b38bc3c"] = types.ImageInspect{ID: string(expected)}
-	actual, err := f.b.getDigestFromBuildOutput(f.ctx, bytes.NewBuffer([]byte(input)))
+	actual, _, err := f.b.getDigestFromBuildOutput(f.ctx, bytes.NewBuffer([]byte(input)))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -171,7 +171,7 @@ func TestCleanUpBuildKitErrors(t *testing.T) {
 
 			ctx, _, _ := testutils.CtxAndAnalyticsForTest()
 			s := makeDockerBuildErrorOutput(tc.buildKitError)
-			_, err := f.b.getDigestFromBuildOutput(ctx, strings.NewReader(s))
+			_, _, err := f.b.getDigestFromBuildOutput(ctx, strings.NewReader(s))
 			require.NotNil(t, err)
 			require.Equal(t, fmt.Sprintf("ImageBuild: %s", tc.expectedTiltError), err.Error())
 		})

--- a/internal/controllers/core/dockerimage/status.go
+++ b/internal/controllers/core/dockerimage/status.go
@@ -1,0 +1,66 @@
+package dockerimage
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/tilt-dev/tilt/internal/container"
+	"github.com/tilt-dev/tilt/pkg/apis"
+	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
+	"github.com/tilt-dev/tilt/pkg/model"
+)
+
+// Return a basic Building Status.
+func ToBuildingStatus(iTarget model.ImageTarget, startTime metav1.MicroTime) v1alpha1.DockerImageStatus {
+	return v1alpha1.DockerImageStatus{
+		Building: &v1alpha1.DockerImageStateBuilding{
+			StartedAt: startTime,
+		},
+	}
+}
+
+// Return a completed status when the image build failed.
+func ToCompletedFailStatus(iTarget model.ImageTarget, startTime metav1.MicroTime,
+	stages []v1alpha1.DockerImageStageStatus, err error) v1alpha1.DockerImageStatus {
+	finishTime := apis.NowMicro()
+
+	// Complete all stages.
+	for i, stage := range stages {
+		if stage.StartedAt != nil && stage.FinishedAt == nil {
+			stage.FinishedAt = &finishTime
+			stage.Error = err.Error()
+		}
+		stages[i] = stage
+	}
+
+	return v1alpha1.DockerImageStatus{
+		Completed: &v1alpha1.DockerImageStateCompleted{
+			StartedAt:  startTime,
+			FinishedAt: finishTime,
+			Error:      err.Error(),
+		},
+		StageStatuses: stages,
+	}
+}
+
+// Return a completed status when the image build succeeded.
+func ToCompletedSuccessStatus(iTarget model.ImageTarget, startTime metav1.MicroTime,
+	stages []v1alpha1.DockerImageStageStatus, refs container.TaggedRefs) v1alpha1.DockerImageStatus {
+	finishTime := apis.NowMicro()
+
+	// Complete all stages.
+	for i, stage := range stages {
+		if stage.StartedAt != nil && stage.FinishedAt == nil {
+			stage.FinishedAt = &finishTime
+		}
+		stages[i] = stage
+	}
+
+	return v1alpha1.DockerImageStatus{
+		Ref: container.FamiliarString(refs.LocalRef),
+		Completed: &v1alpha1.DockerImageStateCompleted{
+			StartedAt:  startTime,
+			FinishedAt: finishTime,
+		},
+		StageStatuses: stages,
+	}
+}

--- a/internal/controllers/core/tiltfile/api.go
+++ b/internal/controllers/core/tiltfile/api.go
@@ -15,7 +15,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"github.com/tilt-dev/tilt/internal/controllers/apicmp"
-	"github.com/tilt-dev/tilt/internal/controllers/apis/dockerimage"
 	"github.com/tilt-dev/tilt/internal/controllers/apis/liveupdate"
 	"github.com/tilt-dev/tilt/internal/controllers/apiset"
 	"github.com/tilt-dev/tilt/internal/controllers/indexer"
@@ -400,11 +399,10 @@ func toDockerImageObjects(tlr *tiltfile.TiltfileLoadResult, disableSources disab
 
 	for _, m := range tlr.Manifests {
 		for _, iTarget := range m.ImageTargets {
-			if !iTarget.IsDockerBuild() {
+			name := iTarget.DockerImageName
+			if name == "" {
 				continue
 			}
-
-			name := dockerimage.GetName(m.Name, iTarget.ID())
 
 			// Currently, if a DockerImage is in more than one manifest,
 			// we will create one per manifest.

--- a/internal/engine/buildcontrol/docker_compose_build_and_deployer.go
+++ b/internal/engine/buildcontrol/docker_compose_build_and_deployer.go
@@ -117,7 +117,7 @@ func (bd *DockerComposeBuildAndDeployer) BuildAndDeploy(ctx context.Context, st 
 		// NOTE(maia): we assume that this func takes one DC target and up to one image target
 		// corresponding to that service. If this func ever supports specs for more than one
 		// service at once, we'll have to match up image build results to DC target by ref.
-		refs, err := bd.ib.Build(ctx, iTarget, ps)
+		refs, _, err := bd.ib.Build(ctx, iTarget, ps)
 		if err != nil {
 			return store.ImageBuildResult{}, err
 		}

--- a/internal/testutils/manifestbuilder/manifestbuilder.go
+++ b/internal/testutils/manifestbuilder/manifestbuilder.go
@@ -158,7 +158,7 @@ func (b ManifestBuilder) Build() model.Manifest {
 	// Currently,
 	for index, iTarget := range b.iTargets {
 		if iTarget.IsDockerBuild() {
-			iTarget.DockerImageName = dockerimage.GetName(m.Name, iTarget.ID())
+			iTarget.DockerImageName = dockerimage.GetName(b.name, iTarget.ID())
 		}
 
 		if liveupdate.IsEmptySpec(iTarget.LiveUpdateSpec) {


### PR DESCRIPTION
Hello @milas, @landism,

Please review the following commits I made in branch nicks/dockerimage4:

d918439a8b47cf74a7307b7d8389308c997dd1cc (2021-11-16 17:51:36 -0500)
dockerimage: write image build performance to the apiserver

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics