### PR TITLE
test: improve pod event synchronization

### DIFF
--- a/internal/controllers/core/kubernetesdiscovery/reconciler.go
+++ b/internal/controllers/core/kubernetesdiscovery/reconciler.go
@@ -363,8 +363,8 @@ func (w *Reconciler) updateStatus(ctx context.Context, watcherID watcherID) erro
 		return fmt.Errorf("failed to update KubernetesDiscovery status for %q: %v", watcherID, err)
 	}
 
-	w.dispatcher.Dispatch(k8swatch.NewKubernetesDiscoveryUpdateStatusAction(kd))
 	w.restartDetector.Detect(w.dispatcher, watcher.lastUpdate, *kd)
+	w.dispatcher.Dispatch(k8swatch.NewKubernetesDiscoveryUpdateStatusAction(kd))
 	watcher.lastUpdate = *status.DeepCopy()
 	w.watchers[watcherID] = watcher
 	return nil

--- a/internal/engine/buildcontroller_test.go
+++ b/internal/engine/buildcontroller_test.go
@@ -567,6 +567,9 @@ func TestRecordLiveUpdatedContainerIDsForFailedLiveUpdate(t *testing.T) {
 		WithContainerIDAtIndex("c1", 0).
 		WithContainerIDAtIndex("c2", 1).
 		Build())
+	f.WaitUntilPod("containers populated", "sancho", basePB.PodName(), func(pod v1alpha1.Pod) bool {
+		return len(pod.Containers) == 2
+	})
 	f.fsWatcher.Events <- watch.NewFileEvent(f.JoinPath("main.go"))
 
 	call = f.nextCall()

--- a/internal/testutils/tempdir/temp_dir_fixture.go
+++ b/internal/testutils/tempdir/temp_dir_fixture.go
@@ -141,7 +141,15 @@ func (f *TempDirFixture) Rm(pathInRepo string) {
 }
 
 func (f *TempDirFixture) NewFile(prefix string) (*os.File, error) {
-	return ioutil.TempFile(f.dir.Path(), prefix)
+	file, err := ioutil.TempFile(f.dir.Path(), prefix)
+	if err == nil {
+		f.t.Cleanup(
+			func() {
+				_ = file.Close()
+			},
+		)
+	}
+	return file, err
 }
 
 func (f *TempDirFixture) TempDir(prefix string) string {


### PR DESCRIPTION
This is a collection of fairly random tweaks to `upper_test.go`
primarily.

The big one is to eliminate usage of `MostRecentPod()` and instead
always explicitly look for the pod by name (via a new helper that
consolidates some oft-duplicated logic and hopefully provides more
helpful failure message with the pod name, particularly for tests
that are interleaving multiple pods).

There's some additional upfront sanity checks as well, e.g. when
dispatching a pod log event, it'll make sure that the pod is known
first or fail early.

A small change was made in the `KubernetesDiscovery` reconciler to
check for pod restarts _before_ dispatching the upsert event; this
won't actually affect anything real world but ensures that things
happen in a deterministic order for the sake of the tests.