### PR TITLE
store: remove baselinerestarts from the data model

### DIFF
--- a/internal/engine/k8swatch/reducers.go
+++ b/internal/engine/k8swatch/reducers.go
@@ -51,7 +51,6 @@ func UpdateK8sRuntimeState(ctx context.Context, state *store.EngineState, objMet
 	for podID := range krs.Pods {
 		if !seenPods[podID] {
 			delete(krs.Pods, podID)
-			delete(krs.BaselineRestarts, podID)
 		}
 	}
 
@@ -85,16 +84,10 @@ func maybeUpdateStateForPod(ms *store.ManifestState, pod *v1alpha1.Pod) bool {
 		// Track a new ancestor ID, and delete all existing tracked pods.
 		runtime.Pods = make(map[k8s.PodID]*v1alpha1.Pod)
 		runtime.PodAncestorUID = matchedAncestorUID
-		runtime.BaselineRestarts = make(map[k8s.PodID]int32)
 	}
 
 	existing := runtime.Pods[podID]
-	if existing == nil {
-		// the first time a Pod is seen, the sum of restarts across all containers is used as the baseline
-		// restart count so that everything that happened before Tilt was aware of the Pod can be ignored
-		// (this is also updated after a live update by the build controller)
-		runtime.BaselineRestarts[podID] = store.AllPodContainerRestarts(*pod)
-	} else if equality.Semantic.DeepEqual(existing, pod) {
+	if existing != nil && equality.Semantic.DeepEqual(existing, pod) {
 		return false
 	}
 

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -2294,28 +2294,6 @@ func TestUpperPodLogInCrashLoopPodCurrentlyDown(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestUpperPodRestartsBeforeTiltStart(t *testing.T) {
-	f := newTestFixture(t)
-	defer f.TearDown()
-
-	name := model.ManifestName("fe")
-	manifest := f.newManifest(name.String())
-	pb := f.registerForDeployer(manifest)
-
-	f.Start([]model.Manifest{manifest})
-	f.waitForCompletedBuildCount(1)
-
-	f.startPod(pb.WithRestartCount(1).Build(), manifest.Name)
-
-	f.withManifestState(name, func(ms store.ManifestState) {
-		krs := ms.K8sRuntimeState()
-		assert.Equal(t, int32(1), krs.BaselineRestarts[pb.PodName()])
-	})
-
-	err := f.Stop()
-	assert.NoError(t, err)
-}
-
 func TestUpperRecordPodWithMultipleContainers(t *testing.T) {
 	f := newTestFixture(t)
 	defer f.TearDown()

--- a/internal/store/buildcontrols/reducers.go
+++ b/internal/store/buildcontrols/reducers.go
@@ -220,13 +220,6 @@ func HandleBuildCompleted(ctx context.Context, engineState *store.EngineState, c
 			engineState.FatalError = err
 			return
 		}
-	} else {
-		krs := ms.K8sRuntimeState()
-		for podID, pod := range krs.Pods {
-			// Reset the baseline, so that we don't show restarts
-			// from before any live-updates
-			krs.BaselineRestarts[podID] = store.AllPodContainerRestarts(*pod)
-		}
 	}
 
 	// Track the container ids that have been live-updated whether the

--- a/internal/store/runtime_state.go
+++ b/internal/store/runtime_state.go
@@ -85,10 +85,6 @@ type K8sRuntimeState struct {
 	UpdateStartTime map[k8s.PodID]time.Time
 
 	PodReadinessMode model.PodReadinessMode
-
-	// BaselineRestarts is used as a floor for container restarts to avoid alerting on restarts
-	// that happened either before Tilt started or before a Live Update change.
-	BaselineRestarts map[k8s.PodID]int32
 }
 
 func (K8sRuntimeState) RuntimeState() {}
@@ -111,7 +107,6 @@ func NewK8sRuntimeState(m model.Manifest) K8sRuntimeState {
 		Pods:             PodSet{},
 		LBs:              make(map[k8s.ServiceName]*url.URL),
 		UpdateStartTime:  make(map[k8s.PodID]time.Time),
-		BaselineRestarts: make(map[k8s.PodID]int32),
 	}
 }
 
@@ -257,7 +252,7 @@ func (s K8sRuntimeState) VisiblePodContainerRestarts(podID k8s.PodID) int32 {
 	if p == nil {
 		return 0
 	}
-	return AllPodContainerRestarts(*p) - s.BaselineRestarts[podID]
+	return AllPodContainerRestarts(*p)
 }
 
 func AllPodContainerPorts(p v1alpha1.Pod) []int32 {


### PR DESCRIPTION
Hello @landism,

Please review the following commits I made in branch nicks/pods:

d8ec0b9e63cff9ea01e8cf8a0a9ed1bfa36cf9c1 (2021-11-18 17:37:44 -0500)
store: remove baselinerestarts from the data model
We don't use this anymore for warnings, and it's not modelled in the API.

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics