### PR TITLE
cli: update template for cli docs

### DIFF
--- a/internal/cli/dump.go
+++ b/internal/cli/dump.go
@@ -120,6 +120,7 @@ func (c *dumpCliDocsCmd) filePrepender(path string) string {
 	return `---
 title: Tilt CLI Reference
 layout: docs
+sidebar: reference
 hideEditButton: true
 ---
 `


### PR DESCRIPTION
The CLI docs require a new line in their front matter to render properly.