### PR TITLE
uibutton: add a hash to identify unique buttons

### DIFF
--- a/internal/controllers/core/uibutton/hash.go
+++ b/internal/controllers/core/uibutton/hash.go
@@ -1,0 +1,42 @@
+package uibutton
+
+import (
+	"crypto"
+	"fmt"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/pkg/errors"
+
+	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
+)
+
+const annotationSpecHash = "uibuttonspec-hash"
+
+var defaultJSONIterator = createDefaultJSONIterator()
+
+func createDefaultJSONConfig() jsoniter.Config {
+	return jsoniter.Config{
+		EscapeHTML:             true,
+		SortMapKeys:            true,
+		ValidateJsonRawMessage: true,
+		CaseSensitive:          true,
+	}
+}
+
+func createDefaultJSONIterator() jsoniter.API {
+	return createDefaultJSONConfig().Froze()
+}
+
+func hashUIButtonSpec(spec v1alpha1.UIButtonSpec) (string, error) {
+	data, err := defaultJSONIterator.Marshal(spec)
+	if err != nil {
+		return "", errors.Wrap(err, "serializing spec to json")
+	}
+
+	h := crypto.SHA1.New()
+	_, err = h.Write(data)
+	if err != nil {
+		return "", errors.Wrap(err, "writing to hash")
+	}
+	return fmt.Sprintf("%x", h.Sum(nil)[:10]), nil
+}

--- a/internal/controllers/core/uibutton/reconciler_test.go
+++ b/internal/controllers/core/uibutton/reconciler_test.go
@@ -1,0 +1,54 @@
+package uibutton
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/tilt-dev/tilt/internal/controllers/fake"
+	"github.com/tilt-dev/tilt/internal/hud/server"
+	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
+)
+
+func TestDefault(t *testing.T) {
+	f := newFixture(t)
+
+	b := v1alpha1.UIButton{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "my-button",
+		},
+		Spec: v1alpha1.UIButtonSpec{
+			Text: "Hello world!",
+		},
+	}
+	f.Create(&b)
+
+	f.MustGet(types.NamespacedName{Name: "my-button"}, &b)
+	assert.Equal(t, "dbcfa71870a98e800b0a", b.Annotations[annotationSpecHash])
+	f.assertSteadyState(&b)
+}
+
+type fixture struct {
+	*fake.ControllerFixture
+	r *Reconciler
+}
+
+func newFixture(t *testing.T) *fixture {
+	cfb := fake.NewControllerFixtureBuilder(t)
+	r := NewReconciler(cfb.Client, server.NewWebsocketList())
+	return &fixture{
+		ControllerFixture: cfb.Build(r),
+		r:                 r,
+	}
+}
+
+func (f *fixture) assertSteadyState(b *v1alpha1.UIButton) {
+	f.T().Helper()
+	f.MustReconcile(types.NamespacedName{Name: b.Name})
+	var b2 v1alpha1.UIButton
+	f.MustGet(types.NamespacedName{Name: b.Name}, &b2)
+	assert.Equal(f.T(), b.ResourceVersion, b2.ResourceVersion)
+}

--- a/web/src/ApiButton.tsx
+++ b/web/src/ApiButton.tsx
@@ -12,6 +12,7 @@ import React, { useRef, useState } from "react"
 import { convertFromNode, convertFromString } from "react-from-dom"
 import { Link } from "react-router-dom"
 import styled from "styled-components"
+import { Tags } from "./analytics"
 import FloatDialog from "./FloatDialog"
 import { useHudErrorContext } from "./HudErrorContext"
 import {
@@ -313,7 +314,19 @@ export function ApiButton(props: React.PropsWithChildren<ApiButtonProps>) {
 
   const { setError } = useHudErrorContext()
   let componentType = uiButton.spec?.location?.componentType
-  let tags = { component: componentType }
+  let tags = { component: componentType } as Tags
+  let annotations = (uiButton.metadata?.annotations || {}) as {
+    [key: string]: string
+  }
+  let hash = annotations["uibuttonspec-hash"]
+  if (hash) {
+    tags.specHash = hash
+  }
+
+  let buttonType = annotations["tilt.dev/uibutton-type"]
+  if (buttonType) {
+    tags.buttonType = buttonType
+  }
 
   const onClick = async () => {
     // TODO(milas): currently the loading state just disables the button for the duration of


### PR DESCRIPTION
Hello @lizzthabet,

Please review the following commits I made in branch nicks/metrics7:

d9c5afc9580f7cc0819d0dc5d23841dc7eb66cd5 (2021-11-18 19:52:56 -0500)
uibutton: add a hash to identify unique buttons

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics