### PR TITLE
cli: add 'tilt explain', a counterpart to 'kubectl explain'

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -64,6 +64,7 @@ up-to-date in real-time. Think 'docker build && kubectl apply' or 'docker-compos
 	addCommand(rootCmd, &logsCmd{})
 	addCommand(rootCmd, newDescribeCmd())
 	addCommand(rootCmd, newGetCmd())
+	addCommand(rootCmd, newExplainCmd())
 	addCommand(rootCmd, newEditCmd())
 	addCommand(rootCmd, newApiresourcesCmd())
 	addCommand(rootCmd, newDeleteCmd())

--- a/internal/cli/explain.go
+++ b/internal/cli/explain.go
@@ -1,0 +1,112 @@
+/*
+Adapted from
+https://github.com/kubernetes/kubectl/tree/master/pkg/cmd/explain
+*/
+
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cli
+
+import (
+	"context"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/kubectl/pkg/cmd/explain"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+	"k8s.io/kubectl/pkg/util/i18n"
+	"k8s.io/kubectl/pkg/util/templates"
+
+	"github.com/tilt-dev/tilt/internal/analytics"
+	engineanalytics "github.com/tilt-dev/tilt/internal/engine/analytics"
+	"github.com/tilt-dev/tilt/pkg/model"
+)
+
+var (
+	explainLong = templates.LongDesc(i18n.T(`
+		List the fields for supported resources.
+		This command describes the fields associated with each supported API resource.
+		Fields are identified via a simple JSONPath identifier:
+			<type>.<fieldName>[.<fieldName>]
+		Add the --recursive flag to display all of the fields at once without descriptions.
+		Information about each field is retrieved from the server in OpenAPI format.`))
+
+	explainExamples = templates.Examples(i18n.T(`
+		# Get the documentation of the resource and its fields
+		tilt explain cmds
+		# Get the documentation of a specific field of a resource
+		tilt explain cmds.spec.args`))
+)
+
+type explainCmd struct {
+	options *explain.ExplainOptions
+	cmd     *cobra.Command
+}
+
+var _ tiltCmd = &explainCmd{}
+
+func newExplainCmd() *explainCmd {
+	streams := genericclioptions.IOStreams{Out: os.Stdout, ErrOut: os.Stderr, In: os.Stdin}
+	o := explain.NewExplainOptions("tilt", streams)
+	return &explainCmd{
+		options: o,
+	}
+}
+
+func (c *explainCmd) name() model.TiltSubcommand { return "explain" }
+
+func (c *explainCmd) register() *cobra.Command {
+
+	cmd := &cobra.Command{
+		Use:                   "explain RESOURCE",
+		DisableFlagsInUseLine: true,
+		Short:                 i18n.T("Get documentation for a resource"),
+		Long:                  explainLong,
+		Example:               explainExamples,
+	}
+	cmd.Flags().BoolVar(&c.options.Recursive, "recursive", c.options.Recursive, "Print the fields of fields (Currently only 1 level deep)")
+	cmd.Flags().StringVar(&c.options.APIVersion, "api-version", c.options.APIVersion, "Get different explanations for particular API version (API group/version)")
+
+	// TODO(nick): Currently, tilt explain must connect to a running tilt
+	// environment.  But there's not really a fundamental reason why we couldn't
+	// fall back to a headless server, like 'tilt dump openapi' does.
+	addConnectServerFlags(cmd)
+
+	return cmd
+}
+
+func (c *explainCmd) run(ctx context.Context, args []string) error {
+	a := analytics.Get(ctx)
+	cmdTags := engineanalytics.CmdTags(map[string]string{})
+	a.Incr("cmd.explain", cmdTags.AsMap())
+	defer a.Flush(time.Second)
+
+	o := c.options
+	getter, err := wireClientGetter(ctx)
+	if err != nil {
+		return err
+	}
+
+	f := cmdutil.NewFactory(getter)
+	cmd := c.cmd
+	cmdutil.CheckErr(o.Complete(f, cmd))
+	cmdutil.CheckErr(o.Validate(args))
+	cmdutil.CheckErr(o.Run(args))
+	return nil
+}

--- a/internal/cli/explain_test.go
+++ b/internal/cli/explain_test.go
@@ -1,0 +1,35 @@
+package cli
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
+)
+
+func TestExplain(t *testing.T) {
+	f := newServerFixture(t)
+	defer f.TearDown()
+
+	err := f.client.Create(f.ctx, &v1alpha1.Cmd{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-sleep"},
+		Spec: v1alpha1.CmdSpec{
+			Args: []string{"sleep", "1"},
+		},
+	})
+	require.NoError(t, err)
+
+	out := bytes.NewBuffer(nil)
+	explain := newExplainCmd()
+	explain.register()
+	explain.options.IOStreams.Out = out
+
+	err = explain.run(f.ctx, []string{"cmd"})
+	require.NoError(t, err)
+
+	assert.Contains(t, out.String(), `Cmd represents a process on the host machine.`)
+}

--- a/vendor/k8s.io/kubectl/pkg/cmd/explain/explain.go
+++ b/vendor/k8s.io/kubectl/pkg/cmd/explain/explain.go
@@ -1,0 +1,163 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package explain
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+	"k8s.io/kubectl/pkg/explain"
+	"k8s.io/kubectl/pkg/util/i18n"
+	"k8s.io/kubectl/pkg/util/openapi"
+	"k8s.io/kubectl/pkg/util/templates"
+)
+
+var (
+	explainLong = templates.LongDesc(i18n.T(`
+		List the fields for supported resources.
+
+		This command describes the fields associated with each supported API resource.
+		Fields are identified via a simple JSONPath identifier:
+
+			<type>.<fieldName>[.<fieldName>]
+
+		Add the --recursive flag to display all of the fields at once without descriptions.
+		Information about each field is retrieved from the server in OpenAPI format.`))
+
+	explainExamples = templates.Examples(i18n.T(`
+		# Get the documentation of the resource and its fields
+		kubectl explain pods
+
+		# Get the documentation of a specific field of a resource
+		kubectl explain pods.spec.containers`))
+)
+
+type ExplainOptions struct {
+	genericclioptions.IOStreams
+
+	CmdParent  string
+	APIVersion string
+	Recursive  bool
+
+	Mapper meta.RESTMapper
+	Schema openapi.Resources
+}
+
+func NewExplainOptions(parent string, streams genericclioptions.IOStreams) *ExplainOptions {
+	return &ExplainOptions{
+		IOStreams: streams,
+		CmdParent: parent,
+	}
+}
+
+// NewCmdExplain returns a cobra command for swagger docs
+func NewCmdExplain(parent string, f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Command {
+	o := NewExplainOptions(parent, streams)
+
+	cmd := &cobra.Command{
+		Use:                   "explain RESOURCE",
+		DisableFlagsInUseLine: true,
+		Short:                 i18n.T("Get documentation for a resource"),
+		Long:                  explainLong + "\n\n" + cmdutil.SuggestAPIResources(parent),
+		Example:               explainExamples,
+		Run: func(cmd *cobra.Command, args []string) {
+			cmdutil.CheckErr(o.Complete(f, cmd))
+			cmdutil.CheckErr(o.Validate(args))
+			cmdutil.CheckErr(o.Run(args))
+		},
+	}
+	cmd.Flags().BoolVar(&o.Recursive, "recursive", o.Recursive, "Print the fields of fields (Currently only 1 level deep)")
+	cmd.Flags().StringVar(&o.APIVersion, "api-version", o.APIVersion, "Get different explanations for particular API version (API group/version)")
+	return cmd
+}
+
+func (o *ExplainOptions) Complete(f cmdutil.Factory, cmd *cobra.Command) error {
+	var err error
+	o.Mapper, err = f.ToRESTMapper()
+	if err != nil {
+		return err
+	}
+
+	o.Schema, err = f.OpenAPISchema()
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (o *ExplainOptions) Validate(args []string) error {
+	if len(args) == 0 {
+		return fmt.Errorf("You must specify the type of resource to explain. %s\n", cmdutil.SuggestAPIResources(o.CmdParent))
+	}
+	if len(args) > 1 {
+		return fmt.Errorf("We accept only this format: explain RESOURCE\n")
+	}
+
+	return nil
+}
+
+// Run executes the appropriate steps to print a model's documentation
+func (o *ExplainOptions) Run(args []string) error {
+	recursive := o.Recursive
+	apiVersionString := o.APIVersion
+
+	var fullySpecifiedGVR schema.GroupVersionResource
+	var fieldsPath []string
+	var err error
+	if len(apiVersionString) == 0 {
+		fullySpecifiedGVR, fieldsPath, err = explain.SplitAndParseResourceRequestWithMatchingPrefix(args[0], o.Mapper)
+		if err != nil {
+			return err
+		}
+	} else {
+		// TODO: After we figured out the new syntax to separate group and resource, allow
+		// the users to use it in explain (kubectl explain <group><syntax><resource>).
+		// Refer to issue #16039 for why we do this. Refer to PR #15808 that used "/" syntax.
+		fullySpecifiedGVR, fieldsPath, err = explain.SplitAndParseResourceRequest(args[0], o.Mapper)
+		if err != nil {
+			return err
+		}
+	}
+
+	gvk, _ := o.Mapper.KindFor(fullySpecifiedGVR)
+	if gvk.Empty() {
+		gvk, err = o.Mapper.KindFor(fullySpecifiedGVR.GroupResource().WithVersion(""))
+		if err != nil {
+			return err
+		}
+	}
+
+	if len(apiVersionString) != 0 {
+		apiVersion, err := schema.ParseGroupVersion(apiVersionString)
+		if err != nil {
+			return err
+		}
+		gvk = apiVersion.WithKind(gvk.Kind)
+	}
+
+	schema := o.Schema.LookupResource(gvk)
+	if schema == nil {
+		return fmt.Errorf("couldn't find resource for %q", gvk)
+	}
+
+	return explain.PrintModelDescription(fieldsPath, o.Out, schema, gvk, recursive)
+}

--- a/vendor/k8s.io/kubectl/pkg/explain/OWNERS
+++ b/vendor/k8s.io/kubectl/pkg/explain/OWNERS
@@ -1,0 +1,6 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+- apelisse
+reviewers:
+- apelisse

--- a/vendor/k8s.io/kubectl/pkg/explain/explain.go
+++ b/vendor/k8s.io/kubectl/pkg/explain/explain.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package explain
+
+import (
+	"io"
+	"strings"
+
+	"k8s.io/kube-openapi/pkg/util/proto"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+type fieldsPrinter interface {
+	PrintFields(proto.Schema) error
+}
+
+func splitDotNotation(model string) (string, []string) {
+	var fieldsPath []string
+
+	// ignore trailing period
+	model = strings.TrimSuffix(model, ".")
+
+	dotModel := strings.Split(model, ".")
+	if len(dotModel) >= 1 {
+		fieldsPath = dotModel[1:]
+	}
+	return dotModel[0], fieldsPath
+}
+
+// SplitAndParseResourceRequest separates the users input into a model and fields
+func SplitAndParseResourceRequest(inResource string, mapper meta.RESTMapper) (schema.GroupVersionResource, []string, error) {
+	inResource, fieldsPath := splitDotNotation(inResource)
+	gvr, err := mapper.ResourceFor(schema.GroupVersionResource{Resource: inResource})
+	if err != nil {
+		return schema.GroupVersionResource{}, nil, err
+	}
+
+	return gvr, fieldsPath, nil
+}
+
+// SplitAndParseResourceRequestWithMatchingPrefix separates the users input into a model and fields
+// while selecting gvr whose (resource, group) prefix matches the resource
+func SplitAndParseResourceRequestWithMatchingPrefix(inResource string, mapper meta.RESTMapper) (gvr schema.GroupVersionResource, fieldsPath []string, err error) {
+	// ignore trailing period
+	inResource = strings.TrimSuffix(inResource, ".")
+	dotParts := strings.Split(inResource, ".")
+
+	gvrs, err := mapper.ResourcesFor(schema.GroupVersionResource{Resource: dotParts[0]})
+	if err != nil {
+		return schema.GroupVersionResource{}, nil, err
+	}
+
+	for _, gvrItem := range gvrs {
+		// Find first gvr whose gr prefixes requested resource
+		groupResource := gvrItem.GroupResource().String()
+		if strings.HasPrefix(inResource, groupResource) {
+			resourceSuffix := inResource[len(groupResource):]
+			if len(resourceSuffix) > 0 {
+				dotParts := strings.Split(resourceSuffix, ".")
+				if len(dotParts) > 0 {
+					fieldsPath = dotParts[1:]
+				}
+			}
+			return gvrItem, fieldsPath, nil
+		}
+	}
+
+	// If no match, take the first (the highest priority) gvr
+	if len(gvrs) > 0 {
+		gvr = gvrs[0]
+		_, fieldsPath = splitDotNotation(inResource)
+	}
+
+	return gvr, fieldsPath, nil
+}
+
+// PrintModelDescription prints the description of a specific model or dot path.
+// If recursive, all components nested within the fields of the schema will be
+// printed.
+func PrintModelDescription(fieldsPath []string, w io.Writer, schema proto.Schema, gvk schema.GroupVersionKind, recursive bool) error {
+	fieldName := ""
+	if len(fieldsPath) != 0 {
+		fieldName = fieldsPath[len(fieldsPath)-1]
+	}
+
+	// Go down the fieldsPath to find what we're trying to explain
+	schema, err := LookupSchemaForField(schema, fieldsPath)
+	if err != nil {
+		return err
+	}
+	b := fieldsPrinterBuilder{Recursive: recursive}
+	f := &Formatter{Writer: w, Wrap: 80}
+	return PrintModel(fieldName, f, b, schema, gvk)
+}

--- a/vendor/k8s.io/kubectl/pkg/explain/field_lookup.go
+++ b/vendor/k8s.io/kubectl/pkg/explain/field_lookup.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package explain
+
+import (
+	"fmt"
+
+	"k8s.io/kube-openapi/pkg/util/proto"
+)
+
+// fieldLookup walks through a schema by following a path, and returns
+// the final schema.
+type fieldLookup struct {
+	// Path to walk
+	Path []string
+
+	// Return information: Schema found, or error.
+	Schema proto.Schema
+	Error  error
+}
+
+// SaveLeafSchema is used to detect if we are done walking the path, and
+// saves the schema as a match.
+func (f *fieldLookup) SaveLeafSchema(schema proto.Schema) bool {
+	if len(f.Path) != 0 {
+		return false
+	}
+
+	f.Schema = schema
+
+	return true
+}
+
+// VisitArray is mostly a passthrough.
+func (f *fieldLookup) VisitArray(a *proto.Array) {
+	if f.SaveLeafSchema(a) {
+		return
+	}
+
+	// Passthrough arrays.
+	a.SubType.Accept(f)
+}
+
+// VisitMap is mostly a passthrough.
+func (f *fieldLookup) VisitMap(m *proto.Map) {
+	if f.SaveLeafSchema(m) {
+		return
+	}
+
+	// Passthrough maps.
+	m.SubType.Accept(f)
+}
+
+// VisitPrimitive stops the operation and returns itself as the found
+// schema, even if it had more path to walk.
+func (f *fieldLookup) VisitPrimitive(p *proto.Primitive) {
+	// Even if Path is not empty (we're not expecting a leaf),
+	// return that primitive.
+	f.Schema = p
+}
+
+// VisitKind unstacks fields as it finds them.
+func (f *fieldLookup) VisitKind(k *proto.Kind) {
+	if f.SaveLeafSchema(k) {
+		return
+	}
+
+	subSchema, ok := k.Fields[f.Path[0]]
+	if !ok {
+		f.Error = fmt.Errorf("field %q does not exist", f.Path[0])
+		return
+	}
+
+	f.Path = f.Path[1:]
+	subSchema.Accept(f)
+}
+
+func (f *fieldLookup) VisitArbitrary(a *proto.Arbitrary) {
+	f.Schema = a
+}
+
+// VisitReference is mostly a passthrough.
+func (f *fieldLookup) VisitReference(r proto.Reference) {
+	if f.SaveLeafSchema(r) {
+		return
+	}
+
+	// Passthrough references.
+	r.SubSchema().Accept(f)
+}
+
+// LookupSchemaForField looks for the schema of a given path in a base schema.
+func LookupSchemaForField(schema proto.Schema, path []string) (proto.Schema, error) {
+	f := &fieldLookup{Path: path}
+	schema.Accept(f)
+	return f.Schema, f.Error
+}

--- a/vendor/k8s.io/kubectl/pkg/explain/fields_printer.go
+++ b/vendor/k8s.io/kubectl/pkg/explain/fields_printer.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package explain
+
+import "k8s.io/kube-openapi/pkg/util/proto"
+
+// indentDesc is the level of indentation for descriptions.
+const indentDesc = 2
+
+// regularFieldsPrinter prints fields with their type and description.
+type regularFieldsPrinter struct {
+	Writer *Formatter
+	Error  error
+}
+
+var _ proto.SchemaVisitor = &regularFieldsPrinter{}
+var _ fieldsPrinter = &regularFieldsPrinter{}
+
+// VisitArray prints a Array type. It is just a passthrough.
+func (f *regularFieldsPrinter) VisitArray(a *proto.Array) {
+	a.SubType.Accept(f)
+}
+
+// VisitKind prints a Kind type. It prints each key in the kind, with
+// the type, the required flag, and the description.
+func (f *regularFieldsPrinter) VisitKind(k *proto.Kind) {
+	for _, key := range k.Keys() {
+		v := k.Fields[key]
+		required := ""
+		if k.IsRequired(key) {
+			required = " -required-"
+		}
+
+		if err := f.Writer.Write("%s\t<%s>%s", key, GetTypeName(v), required); err != nil {
+			f.Error = err
+			return
+		}
+		if err := f.Writer.Indent(indentDesc).WriteWrapped("%s", v.GetDescription()); err != nil {
+			f.Error = err
+			return
+		}
+		if err := f.Writer.Write(""); err != nil {
+			f.Error = err
+			return
+		}
+	}
+}
+
+// VisitMap prints a Map type. It is just a passthrough.
+func (f *regularFieldsPrinter) VisitMap(m *proto.Map) {
+	m.SubType.Accept(f)
+}
+
+// VisitPrimitive prints a Primitive type. It stops the recursion.
+func (f *regularFieldsPrinter) VisitPrimitive(p *proto.Primitive) {
+	// Nothing to do. Shouldn't really happen.
+}
+
+// VisitReference prints a Reference type. It is just a passthrough.
+func (f *regularFieldsPrinter) VisitReference(r proto.Reference) {
+	r.SubSchema().Accept(f)
+}
+
+// PrintFields will write the types from schema.
+func (f *regularFieldsPrinter) PrintFields(schema proto.Schema) error {
+	schema.Accept(f)
+	return f.Error
+}

--- a/vendor/k8s.io/kubectl/pkg/explain/fields_printer_builder.go
+++ b/vendor/k8s.io/kubectl/pkg/explain/fields_printer_builder.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package explain
+
+// fieldsPrinterBuilder builds either a regularFieldsPrinter or a
+// recursiveFieldsPrinter based on the argument.
+type fieldsPrinterBuilder struct {
+	Recursive bool
+}
+
+// BuildFieldsPrinter builds the appropriate fieldsPrinter.
+func (f fieldsPrinterBuilder) BuildFieldsPrinter(writer *Formatter) fieldsPrinter {
+	if f.Recursive {
+		return &recursiveFieldsPrinter{
+			Writer: writer,
+		}
+	}
+
+	return &regularFieldsPrinter{
+		Writer: writer,
+	}
+}

--- a/vendor/k8s.io/kubectl/pkg/explain/formatter.go
+++ b/vendor/k8s.io/kubectl/pkg/explain/formatter.go
@@ -1,0 +1,178 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package explain
+
+import (
+	"fmt"
+	"io"
+	"regexp"
+	"strings"
+)
+
+// Formatter helps you write with indentation, and can wrap text as needed.
+type Formatter struct {
+	IndentLevel int
+	Wrap        int
+	Writer      io.Writer
+}
+
+// Indent creates a new Formatter that will indent the code by that much more.
+func (f Formatter) Indent(indent int) *Formatter {
+	f.IndentLevel = f.IndentLevel + indent
+	return &f
+}
+
+// Write writes a string with the indentation set for the
+// Formatter. This is not wrapping text.
+func (f *Formatter) Write(str string, a ...interface{}) error {
+	// Don't indent empty lines
+	if str == "" {
+		_, err := io.WriteString(f.Writer, "\n")
+		return err
+	}
+
+	indent := ""
+	for i := 0; i < f.IndentLevel; i++ {
+		indent = indent + " "
+	}
+
+	if len(a) > 0 {
+		str = fmt.Sprintf(str, a...)
+	}
+	_, err := io.WriteString(f.Writer, indent+str+"\n")
+	return err
+}
+
+// WriteWrapped writes a string with the indentation set for the
+// Formatter, and wraps as needed.
+func (f *Formatter) WriteWrapped(str string, a ...interface{}) error {
+	if f.Wrap == 0 {
+		return f.Write(str, a...)
+	}
+	text := fmt.Sprintf(str, a...)
+	strs := wrapString(text, f.Wrap-f.IndentLevel)
+	for _, substr := range strs {
+		if err := f.Write(substr); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+type line struct {
+	wrap  int
+	words []string
+}
+
+func (l *line) String() string {
+	return strings.Join(l.words, " ")
+}
+
+func (l *line) Empty() bool {
+	return len(l.words) == 0
+}
+
+func (l *line) Len() int {
+	return len(l.String())
+}
+
+// Add adds the word to the line, returns true if we could, false if we
+// didn't have enough room. It's always possible to add to an empty line.
+func (l *line) Add(word string) bool {
+	newLine := line{
+		wrap:  l.wrap,
+		words: append(l.words, word),
+	}
+	if newLine.Len() <= l.wrap || len(l.words) == 0 {
+		l.words = newLine.words
+		return true
+	}
+	return false
+}
+
+var bullet = regexp.MustCompile(`^(\d+\.?|-|\*)\s`)
+
+func shouldStartNewLine(lastWord, str string) bool {
+	// preserve line breaks ending in :
+	if strings.HasSuffix(lastWord, ":") {
+		return true
+	}
+
+	// preserve code blocks
+	if strings.HasPrefix(str, "    ") {
+		return true
+	}
+	str = strings.TrimSpace(str)
+	// preserve empty lines
+	if len(str) == 0 {
+		return true
+	}
+	// preserve lines that look like they're starting lists
+	if bullet.MatchString(str) {
+		return true
+	}
+	// otherwise combine
+	return false
+}
+
+func wrapString(str string, wrap int) []string {
+	wrapped := []string{}
+	l := line{wrap: wrap}
+	// track the last word added to the current line
+	lastWord := ""
+	flush := func() {
+		if !l.Empty() {
+			lastWord = ""
+			wrapped = append(wrapped, l.String())
+			l = line{wrap: wrap}
+		}
+	}
+
+	// iterate over the lines in the original description
+	for _, str := range strings.Split(str, "\n") {
+		// preserve code blocks and blockquotes as-is
+		if strings.HasPrefix(str, "    ") {
+			flush()
+			wrapped = append(wrapped, str)
+			continue
+		}
+
+		// preserve empty lines after the first line, since they can separate logical sections
+		if len(wrapped) > 0 && len(strings.TrimSpace(str)) == 0 {
+			flush()
+			wrapped = append(wrapped, "")
+			continue
+		}
+
+		// flush if we should start a new line
+		if shouldStartNewLine(lastWord, str) {
+			flush()
+		}
+		words := strings.Fields(str)
+		for _, word := range words {
+			lastWord = word
+			if !l.Add(word) {
+				flush()
+				if !l.Add(word) {
+					panic("Couldn't add to empty line.")
+				}
+			}
+		}
+	}
+	flush()
+	return wrapped
+}

--- a/vendor/k8s.io/kubectl/pkg/explain/model_printer.go
+++ b/vendor/k8s.io/kubectl/pkg/explain/model_printer.go
@@ -1,0 +1,163 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package explain
+
+import (
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/kube-openapi/pkg/util/proto"
+)
+
+const (
+	// fieldIndentLevel is the level of indentation for fields.
+	fieldIndentLevel = 3
+	// descriptionIndentLevel is the level of indentation for the
+	// description.
+	descriptionIndentLevel = 5
+)
+
+// modelPrinter prints a schema in Writer. Its "Builder" will decide if
+// it's recursive or not.
+type modelPrinter struct {
+	Name         string
+	Type         string
+	Descriptions []string
+	Writer       *Formatter
+	Builder      fieldsPrinterBuilder
+	GVK          schema.GroupVersionKind
+	Error        error
+}
+
+var _ proto.SchemaVisitor = &modelPrinter{}
+
+func (m *modelPrinter) PrintKindAndVersion() error {
+	if err := m.Writer.Write("KIND:     %s", m.GVK.Kind); err != nil {
+		return err
+	}
+	return m.Writer.Write("VERSION:  %s\n", m.GVK.GroupVersion())
+}
+
+// PrintDescription prints the description for a given schema. There
+// might be multiple description, since we collect descriptions when we
+// go through references, arrays and maps.
+func (m *modelPrinter) PrintDescription(schema proto.Schema) error {
+	if err := m.Writer.Write("DESCRIPTION:"); err != nil {
+		return err
+	}
+	empty := true
+	for i, desc := range append(m.Descriptions, schema.GetDescription()) {
+		if desc == "" {
+			continue
+		}
+		empty = false
+		if i != 0 {
+			if err := m.Writer.Write(""); err != nil {
+				return err
+			}
+		}
+		if err := m.Writer.Indent(descriptionIndentLevel).WriteWrapped(desc); err != nil {
+			return err
+		}
+	}
+	if empty {
+		return m.Writer.Indent(descriptionIndentLevel).WriteWrapped("<empty>")
+	}
+	return nil
+}
+
+// VisitArray recurses inside the subtype, while collecting the type if
+// not done yet, and the description.
+func (m *modelPrinter) VisitArray(a *proto.Array) {
+	m.Descriptions = append(m.Descriptions, a.GetDescription())
+	if m.Type == "" {
+		m.Type = GetTypeName(a)
+	}
+	a.SubType.Accept(m)
+}
+
+// VisitKind prints a full resource with its fields.
+func (m *modelPrinter) VisitKind(k *proto.Kind) {
+	if err := m.PrintKindAndVersion(); err != nil {
+		m.Error = err
+		return
+	}
+
+	if m.Type == "" {
+		m.Type = GetTypeName(k)
+	}
+	if m.Name != "" {
+		m.Writer.Write("RESOURCE: %s <%s>\n", m.Name, m.Type)
+	}
+
+	if err := m.PrintDescription(k); err != nil {
+		m.Error = err
+		return
+	}
+	if err := m.Writer.Write("\nFIELDS:"); err != nil {
+		m.Error = err
+		return
+	}
+	m.Error = m.Builder.BuildFieldsPrinter(m.Writer.Indent(fieldIndentLevel)).PrintFields(k)
+}
+
+// VisitMap recurses inside the subtype, while collecting the type if
+// not done yet, and the description.
+func (m *modelPrinter) VisitMap(om *proto.Map) {
+	m.Descriptions = append(m.Descriptions, om.GetDescription())
+	if m.Type == "" {
+		m.Type = GetTypeName(om)
+	}
+	om.SubType.Accept(m)
+}
+
+// VisitPrimitive prints a field type and its description.
+func (m *modelPrinter) VisitPrimitive(p *proto.Primitive) {
+	if err := m.PrintKindAndVersion(); err != nil {
+		m.Error = err
+		return
+	}
+
+	if m.Type == "" {
+		m.Type = GetTypeName(p)
+	}
+	if err := m.Writer.Write("FIELD:    %s <%s>\n", m.Name, m.Type); err != nil {
+		m.Error = err
+		return
+	}
+	m.Error = m.PrintDescription(p)
+}
+
+func (m *modelPrinter) VisitArbitrary(a *proto.Arbitrary) {
+	if err := m.PrintKindAndVersion(); err != nil {
+		m.Error = err
+		return
+	}
+
+	m.Error = m.PrintDescription(a)
+}
+
+// VisitReference recurses inside the subtype, while collecting the description.
+func (m *modelPrinter) VisitReference(r proto.Reference) {
+	m.Descriptions = append(m.Descriptions, r.GetDescription())
+	r.SubSchema().Accept(m)
+}
+
+// PrintModel prints the description of a schema in writer.
+func PrintModel(name string, writer *Formatter, builder fieldsPrinterBuilder, schema proto.Schema, gvk schema.GroupVersionKind) error {
+	m := &modelPrinter{Name: name, Writer: writer, Builder: builder, GVK: gvk}
+	schema.Accept(m)
+	return m.Error
+}

--- a/vendor/k8s.io/kubectl/pkg/explain/recursive_fields_printer.go
+++ b/vendor/k8s.io/kubectl/pkg/explain/recursive_fields_printer.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package explain
+
+import "k8s.io/kube-openapi/pkg/util/proto"
+
+// indentPerLevel is the level of indentation for each field recursion.
+const indentPerLevel = 3
+
+// recursiveFieldsPrinter recursively prints all the fields for a given
+// schema.
+type recursiveFieldsPrinter struct {
+	Writer *Formatter
+	Error  error
+}
+
+var _ proto.SchemaVisitor = &recursiveFieldsPrinter{}
+var _ fieldsPrinter = &recursiveFieldsPrinter{}
+var visitedReferences = map[string]struct{}{}
+
+// VisitArray is just a passthrough.
+func (f *recursiveFieldsPrinter) VisitArray(a *proto.Array) {
+	a.SubType.Accept(f)
+}
+
+// VisitKind prints all its fields with their type, and then recurses
+// inside each of these (pre-order).
+func (f *recursiveFieldsPrinter) VisitKind(k *proto.Kind) {
+	for _, key := range k.Keys() {
+		v := k.Fields[key]
+		f.Writer.Write("%s\t<%s>", key, GetTypeName(v))
+		subFields := &recursiveFieldsPrinter{
+			Writer: f.Writer.Indent(indentPerLevel),
+		}
+		if err := subFields.PrintFields(v); err != nil {
+			f.Error = err
+			return
+		}
+	}
+}
+
+// VisitMap is just a passthrough.
+func (f *recursiveFieldsPrinter) VisitMap(m *proto.Map) {
+	m.SubType.Accept(f)
+}
+
+// VisitPrimitive does nothing, since it doesn't have sub-fields.
+func (f *recursiveFieldsPrinter) VisitPrimitive(p *proto.Primitive) {
+	// Nothing to do.
+}
+
+// VisitReference is just a passthrough.
+func (f *recursiveFieldsPrinter) VisitReference(r proto.Reference) {
+	if _, ok := visitedReferences[r.Reference()]; ok {
+		return
+	}
+	visitedReferences[r.Reference()] = struct{}{}
+	r.SubSchema().Accept(f)
+	delete(visitedReferences, r.Reference())
+}
+
+// PrintFields will recursively print all the fields for the given
+// schema.
+func (f *recursiveFieldsPrinter) PrintFields(schema proto.Schema) error {
+	schema.Accept(f)
+	return f.Error
+}

--- a/vendor/k8s.io/kubectl/pkg/explain/test-recursive-swagger.json
+++ b/vendor/k8s.io/kubectl/pkg/explain/test-recursive-swagger.json
@@ -1,0 +1,63 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Kubernetes",
+    "version": "v1.9.0"
+  },
+  "paths": {},
+  "definitions": {
+    "OneKind": {
+      "description": "OneKind has a short description",
+      "required": [
+        "field1"
+      ],
+      "properties": {
+        "field1": {
+          "description": "This is first reference field",
+          "$ref": "#/definitions/ReferenceKind"
+        },
+        "field2": {
+          "description": "This is other kind field with string and reference",
+          "$ref": "#/definitions/OtherKind"
+        }
+      },
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "",
+          "kind": "OneKind",
+          "version": "v2"
+        }
+      ]
+    },
+    "ReferenceKind": {
+      "description": "This is reference Kind",
+      "properties": {
+        "referencefield": {
+          "description": "This is reference to itself.",
+          "$ref": "#/definitions/ReferenceKind"
+        },
+        "referencesarray": {
+          "description": "This is an array of references",
+          "type": "array",
+          "items": {
+            "description": "This is reference object",
+            "$ref": "#/definitions/ReferenceKind"
+          }
+        }
+      }
+    },
+    "OtherKind": {
+      "description": "This is other kind with string and reference fields",
+      "properties": {
+        "string": {
+          "description": "This string must be a string",
+          "type": "string"
+        },
+        "reference": {
+          "description": "This is reference field.",
+          "$ref": "#/definitions/ReferenceKind"
+        }
+      }
+    }
+  }
+}

--- a/vendor/k8s.io/kubectl/pkg/explain/test-swagger.json
+++ b/vendor/k8s.io/kubectl/pkg/explain/test-swagger.json
@@ -1,0 +1,87 @@
+{
+  "swagger": "2.0",
+  "info": {
+   "title": "Kubernetes",
+   "version": "v1.9.0"
+  },
+  "paths": {},
+  "definitions": {
+    "PrimitiveDef": {
+      "type": "string"
+    },
+    "OneKind": {
+      "description": "OneKind has a short description",
+      "required": [
+        "field1"
+      ],
+      "properties": {
+        "field1": {
+          "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla ut lacus ac enim vulputate imperdiet ac accumsan risus. Integer vel accumsan lectus. Praesent tempus nulla id tortor luctus, quis varius nulla laoreet. Ut orci nisi, suscipit id velit sed, blandit eleifend turpis. Curabitur tempus ante at lectus viverra, a mattis augue euismod. Morbi quam ligula, porttitor sit amet lacus non, interdum pulvinar tortor. Praesent accumsan risus et ipsum dictum, vel ullamcorper lorem egestas.",
+          "$ref": "#/definitions/OtherKind"
+        },
+        "field2": {
+          "description": "This is an array of object of PrimitiveDef",
+          "type": "array",
+          "items": {
+            "description": "This is an object of PrimitiveDef",
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/definitions/PrimitiveDef"
+            }
+          }
+        }
+      },
+      "x-kubernetes-group-version-kind": [
+        {
+          "group": "",
+          "kind": "OneKind",
+          "version": "v1"
+        }
+      ]
+    },
+    "OtherKind": {
+      "description": "This is another kind of Kind",
+      "required": [
+        "string"
+      ],
+      "properties": {
+        "string": {
+          "description": "This string must be a string",
+          "type": "string"
+        },
+        "int": {
+          "description": "This int must be an int",
+          "type": "integer"
+        },
+        "array": {
+          "description": "This array must be an array of int",
+          "type": "array",
+          "items": {
+            "description": "This is an int in an array",
+            "type": "integer"
+          }
+        },
+        "object": {
+          "description": "This is an object of string",
+          "type": "object",
+          "additionalProperties": {
+            "description": "this is a string in an object",
+            "type": "string"
+          }
+        },
+        "primitive": {
+          "$ref": "#/definitions/PrimitiveDef"
+        }
+      }
+    },
+    "CrdKind": {
+      "x-kubernetes-group-version-kind": [
+        {
+         "group": "",
+         "kind": "CrdKind",
+         "version": "v1"
+        }
+       ]
+    }
+  }
+}

--- a/vendor/k8s.io/kubectl/pkg/explain/typename.go
+++ b/vendor/k8s.io/kubectl/pkg/explain/typename.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package explain
+
+import (
+	"fmt"
+
+	"k8s.io/kube-openapi/pkg/util/proto"
+)
+
+// typeName finds the name of a schema
+type typeName struct {
+	Name string
+}
+
+var _ proto.SchemaVisitor = &typeName{}
+
+// VisitArray adds the [] prefix and recurses.
+func (t *typeName) VisitArray(a *proto.Array) {
+	s := &typeName{}
+	a.SubType.Accept(s)
+	t.Name = fmt.Sprintf("[]%s", s.Name)
+}
+
+// VisitKind just returns "Object".
+func (t *typeName) VisitKind(k *proto.Kind) {
+	t.Name = "Object"
+}
+
+// VisitMap adds the map[string] prefix and recurses.
+func (t *typeName) VisitMap(m *proto.Map) {
+	s := &typeName{}
+	m.SubType.Accept(s)
+	t.Name = fmt.Sprintf("map[string]%s", s.Name)
+}
+
+// VisitPrimitive returns the name of the primitive.
+func (t *typeName) VisitPrimitive(p *proto.Primitive) {
+	t.Name = p.Type
+}
+
+// VisitReference is just a passthrough.
+func (t *typeName) VisitReference(r proto.Reference) {
+	r.SubSchema().Accept(t)
+}
+
+// GetTypeName returns the type of a schema.
+func GetTypeName(schema proto.Schema) string {
+	t := &typeName{}
+	schema.Accept(t)
+	return t.Name
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1590,6 +1590,7 @@ k8s.io/kubectl/pkg/cmd/apply
 k8s.io/kubectl/pkg/cmd/create
 k8s.io/kubectl/pkg/cmd/delete
 k8s.io/kubectl/pkg/cmd/describe
+k8s.io/kubectl/pkg/cmd/explain
 k8s.io/kubectl/pkg/cmd/get
 k8s.io/kubectl/pkg/cmd/patch
 k8s.io/kubectl/pkg/cmd/util
@@ -1597,6 +1598,7 @@ k8s.io/kubectl/pkg/cmd/util/editor
 k8s.io/kubectl/pkg/cmd/util/editor/crlf
 k8s.io/kubectl/pkg/cmd/wait
 k8s.io/kubectl/pkg/describe
+k8s.io/kubectl/pkg/explain
 k8s.io/kubectl/pkg/generate
 k8s.io/kubectl/pkg/proxy
 k8s.io/kubectl/pkg/rawhttp


### PR DESCRIPTION
Hello @landism,

Please review the following commits I made in branch nicks/explain:

ca12dd7eade5e27adc48396ce3b0df3b532676bb (2021-11-19 11:19:27 -0500)
cli: add 'tilt explain', a counterpart to 'kubectl explain'

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics