### PR TITLE
kubernetesapply: improve user-facing logging

### DIFF
--- a/internal/engine/buildcontrol/image_build_and_deployer.go
+++ b/internal/engine/buildcontrol/image_build_and_deployer.go
@@ -310,8 +310,6 @@ func (ibd *ImageBuildAndDeployer) deploy(
 	ps.StartPipelineStep(ctx, "Deploying")
 	defer ps.EndPipelineStep(ctx)
 
-	ps.StartBuildStep(ctx, "Injecting images into Kubernetes YAML")
-
 	kTargetNN := types.NamespacedName{Name: kTargetID.Name.String()}
 	// Note: `KubernetesApply` object may not exist yet when this `ForceApply` is called
 	// and may cause a race-condition-related "Not found" error here.


### PR DESCRIPTION
* Result of apply now consistently logged for both YAML + Cmd deploys
  * This slightly changes things for YAML, which used to show the
    objects it was _going_ to apply
* Image injection message only shown when relevant and moved to debug
  * More detailed, including the entity and the transformation that
    was applied
* Consistent/improved indentation across YAML + Cmd deploys

### `k8s_yaml` example
<img width="1386" alt="YAML deploy" src="https://user-images.githubusercontent.com/841263/142927116-2eed9795-935e-498f-a0bd-9de0aa105419.png">

### `k8s_custom_deploy` example
<img width="470" alt="Custom deploy command" src="https://user-images.githubusercontent.com/841263/142927172-92a7ff28-4074-48d6-b62d-cf75bda03a46.png">

Fixes #5192.