### PR TITLE
api: do not log controller-runtime messages after context cancel

### DIFF
--- a/internal/controllers/manager.go
+++ b/internal/controllers/manager.go
@@ -64,6 +64,14 @@ func (m *TiltServerControllerManager) SetUp(ctx context.Context, _ store.RStore)
 	// we don't care about.
 	ctxLog := logger.Get(ctx)
 	logr := genericr.New(func(e genericr.Entry) {
+		if ctx.Err() != nil {
+			// when the root context is canceled, any in-flight reconcile operations
+			// will inevitably return context-cancellation-wrapping errors, which
+			// results in a bunch of unhelpful log messages to that effect, so all
+			// logs after teardown has started are ignored
+			return
+		}
+
 		if e.Error != nil {
 			// Print errors to the global log on all builds.
 			//


### PR DESCRIPTION
This is mostly annoying in tests when trying to reproduce an issue
and running with something like `-count 100`. With the async nature
of the reconcilers, it's pretty inevitable that some things will
still be in-flight when the tests are done (and so cancel the context
to clean up resources), and a bunch of irrelevant errors that are
really just wrapped "context canceled" get logged out.