### PR TITLE
buildcontrol: minor tweaks to docker image reporting

### DIFF
--- a/internal/container/selector.go
+++ b/internal/container/selector.go
@@ -102,14 +102,23 @@ func (s RefSelector) Empty() bool {
 }
 
 func (s RefSelector) RefName() string {
+	if s.ref == nil {
+		return ""
+	}
 	return s.ref.Name()
 }
 
 func (s RefSelector) RefFamiliarName() string {
+	if s.ref == nil {
+		return ""
+	}
 	return reference.FamiliarName(s.ref)
 }
 
 func (s RefSelector) RefFamiliarString() string {
+	if s.ref == nil {
+		return ""
+	}
 	return reference.FamiliarString(s.ref)
 }
 

--- a/pkg/model/image_target.go
+++ b/pkg/model/image_target.go
@@ -3,7 +3,6 @@ package model
 import (
 	"fmt"
 
-	"github.com/docker/distribution/reference"
 	"github.com/google/go-cmp/cmp"
 
 	"github.com/tilt-dev/tilt/internal/container"
@@ -162,7 +161,7 @@ func (i ImageTarget) WithDockerImage(spec v1alpha1.DockerImageSpec) ImageTarget 
 func (i ImageTarget) WithBuildDetails(details BuildDetails) ImageTarget {
 	db, ok := details.(DockerBuild)
 	if ok {
-		db.DockerImageSpec.Ref = reference.FamiliarString(i.Refs.ConfigurationRef)
+		db.DockerImageSpec.Ref = i.Refs.ConfigurationRef.RefFamiliarString()
 		details = db
 	}
 


### PR DESCRIPTION
Hello @milas,

Please review the following commits I made in branch nicks/dockerimagetweak:

6aea91397fc267138b791721920ac37769b5442e (2021-11-22 16:52:59 -0500)
buildcontrol: minor tweaks to docker image reporting
1) include the push phase
2) strip docker.io/library prefix correctly

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics