### PR TITLE
goreleaser: add autocompletion to our homebrew formula

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -70,6 +70,20 @@ brews:
   url_template: "https://github.com/tilt-dev/tilt/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
   homepage: "https://tilt.dev/"
   description: "A dev environment as code for microservice apps"
+  install: |
+    bin.install "tilt"
+    
+    # Install bash completion
+    output = Utils.safe_popen_read("#{bin}/tilt", "completion", "bash")
+    (bash_completion/"tilt").write output
+
+    # Install zsh completion
+    output = Utils.safe_popen_read("#{bin}/tilt", "completion", "zsh")
+    (zsh_completion/"_tilt").write output
+
+    # Install fish completion
+    output = Utils.safe_popen_read("#{bin}/tilt", "completion", "fish")
+    (fish_completion/"tilt.fish").write output
   test: |
     system "#{bin}/tilt version"
     system "#{bin}/tilt verify-install"


### PR DESCRIPTION
Hello @landism,

Please review the following commits I made in branch nicks/autocomplete:

e16852e6cd253210284fd15be36315340a4991ab (2021-11-23 13:44:15 -0500)
goreleaser: add autocompletion to our homebrew formula
Adapted from: https://github.com/Homebrew/homebrew-core/pull/88977

Thanks to autocompletion support added in https://github.com/tilt-dev/tilt/pull/5029

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics