### PR TITLE
web: add a load event for expand/collapse

### DIFF
--- a/web/src/ResourceGroupsContext.test.tsx
+++ b/web/src/ResourceGroupsContext.test.tsx
@@ -113,13 +113,23 @@ describe("ResourceGroupsContext", () => {
           <TestConsumer labelName="test" />
         </ResourceGroupsContextProvider>
       )
+      let loadIncr = {
+        name: "ui.web.resourceGroup",
+        tags: { action: AnalyticsAction.Load, expanded: "1", collapsed: "0" },
+      }
+      expectIncrs(loadIncr)
       clickButton()
       // Expect the "collapse" action value because the test label group is expanded
       // when it's clicked on and the "grid" type value because it's hardcoded in the
       // test component
-      expectIncrs({
+      expectIncrs(loadIncr, {
         name: "ui.web.resourceGroup",
-        tags: { action: AnalyticsAction.Collapse, type: AnalyticsType.Grid },
+        tags: {
+          action: AnalyticsAction.Collapse,
+          type: AnalyticsType.Grid,
+          expanded: "1",
+          collapsed: "0",
+        },
       })
     })
   })


### PR DESCRIPTION
Hello @lizzthabet, @landism,

Please review the following commits I made in branch nicks/onload:

9622b3f8f7c97327e976b37b216b5ca8ae4ac66e (2021-11-23 16:28:57 -0500)
web: add a load event for expand/collapse
intended to mirror the similar load event for star/unstar

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics