### PR TITLE
store: log when a resource becomes enabled or disabled

### DIFF
--- a/internal/store/uiresources/reducers.go
+++ b/internal/store/uiresources/reducers.go
@@ -17,14 +17,15 @@ func HandleUIResourceUpsertAction(state *store.EngineState, action UIResourceUps
 		oldCount := old.Status.DisableStatus.DisabledCount
 		newCount := uir.Status.DisableStatus.DisabledCount
 
-		message := ""
+		verb := ""
 		if oldCount == 0 && newCount > 0 {
-			message = fmt.Sprintf("Resource %q disabled.\n", n)
+			verb = "disabled"
 		} else if oldCount > 0 && newCount == 0 {
-			message = fmt.Sprintf("Resource %q enabled.\n", n)
+			verb = "enabled"
 		}
 
-		if message != "" {
+		if verb != "" {
+			message := fmt.Sprintf("Resource %q %s. To enable/disable it, use the Tilt Web UI.\n", n, verb)
 			a := store.NewLogAction(model.ManifestName(n), logstore.SpanID(fmt.Sprintf("disabletoggle-%s", n)), logger.InfoLvl, nil, []byte(message))
 			state.LogStore.Append(a, state.Secrets)
 		}

--- a/internal/store/uiresources/reducers.go
+++ b/internal/store/uiresources/reducers.go
@@ -1,14 +1,38 @@
 package uiresources
 
 import (
+	"fmt"
+
 	"github.com/tilt-dev/tilt/internal/store"
+	"github.com/tilt-dev/tilt/pkg/logger"
 	"github.com/tilt-dev/tilt/pkg/model"
+	"github.com/tilt-dev/tilt/pkg/model/logstore"
 )
 
 func HandleUIResourceUpsertAction(state *store.EngineState, action UIResourceUpsertAction) {
 	n := action.UIResource.Name
-	state.UIResources[n] = action.UIResource
-	if action.UIResource != nil && action.UIResource.Status.DisableStatus.DisabledCount > 0 {
+	old := state.UIResources[n]
+	uir := action.UIResource
+	if old != nil {
+		oldCount := old.Status.DisableStatus.DisabledCount
+		newCount := uir.Status.DisableStatus.DisabledCount
+
+		message := ""
+		if oldCount == 0 && newCount > 0 {
+			message = fmt.Sprintf("Resource %q disabled.\n", n)
+		} else if oldCount > 0 && newCount == 0 {
+			message = fmt.Sprintf("Resource %q enabled.\n", n)
+		}
+
+		if message != "" {
+			a := store.NewLogAction(model.ManifestName(n), logstore.SpanID(fmt.Sprintf("disabletoggle-%s", n)), logger.InfoLvl, nil, []byte(message))
+			state.LogStore.Append(a, state.Secrets)
+		}
+	}
+
+	state.UIResources[n] = uir
+
+	if uir != nil && uir.Status.DisableStatus.DisabledCount > 0 {
 		state.RemoveFromTriggerQueue(model.ManifestName(n))
 	}
 }

--- a/internal/store/uiresources/reducers_test.go
+++ b/internal/store/uiresources/reducers_test.go
@@ -1,6 +1,7 @@
 package uiresources
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -25,8 +26,8 @@ func TestLogging(t *testing.T) {
 		old, new    *v1alpha1.UIResource
 		expectedLog string
 	}{
-		{"enable", resourceWithDisableCount(1), resourceWithDisableCount(0), "Resource \"foo\" enabled.\n"},
-		{"disable", resourceWithDisableCount(0), resourceWithDisableCount(1), "Resource \"foo\" disabled.\n"},
+		{"enable", resourceWithDisableCount(1), resourceWithDisableCount(0), "Resource \"foo\" enabled."},
+		{"disable", resourceWithDisableCount(0), resourceWithDisableCount(1), "Resource \"foo\" disabled."},
 		{"old nil", nil, resourceWithDisableCount(0), ""},
 		{"enabled, no change", resourceWithDisableCount(0), resourceWithDisableCount(0), ""},
 		{"disabled, no change", resourceWithDisableCount(1), resourceWithDisableCount(1), ""},
@@ -39,7 +40,15 @@ func TestLogging(t *testing.T) {
 
 			HandleUIResourceUpsertAction(state, action)
 
-			require.Equal(t, tc.expectedLog, state.LogStore.ManifestLog("foo"))
+			log := state.LogStore.ManifestLog("foo")
+			if tc.expectedLog == "" {
+				require.Equal(t, "", log)
+			} else {
+				lines := strings.Split(log, "\n")
+				require.Equal(t, 2, len(lines))
+				require.Contains(t, lines[0], tc.expectedLog)
+				require.Equal(t, "", lines[1])
+			}
 		})
 	}
 }

--- a/internal/store/uiresources/reducers_test.go
+++ b/internal/store/uiresources/reducers_test.go
@@ -1,0 +1,45 @@
+package uiresources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/tilt-dev/tilt/internal/store"
+	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
+)
+
+func resourceWithDisableCount(count int) *v1alpha1.UIResource {
+	return &v1alpha1.UIResource{
+		ObjectMeta: metav1.ObjectMeta{Name: "foo"},
+		Status: v1alpha1.UIResourceStatus{
+			DisableStatus: v1alpha1.DisableResourceStatus{DisabledCount: int32(count)},
+		},
+	}
+}
+
+func TestLogging(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		old, new    *v1alpha1.UIResource
+		expectedLog string
+	}{
+		{"enable", resourceWithDisableCount(1), resourceWithDisableCount(0), "Resource \"foo\" enabled.\n"},
+		{"disable", resourceWithDisableCount(0), resourceWithDisableCount(1), "Resource \"foo\" disabled.\n"},
+		{"old nil", nil, resourceWithDisableCount(0), ""},
+		{"enabled, no change", resourceWithDisableCount(0), resourceWithDisableCount(0), ""},
+		{"disabled, no change", resourceWithDisableCount(1), resourceWithDisableCount(1), ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			state := store.NewState()
+			state.UIResources["foo"] = tc.old
+
+			action := UIResourceUpsertAction{UIResource: tc.new}
+
+			HandleUIResourceUpsertAction(state, action)
+
+			require.Equal(t, tc.expectedLog, state.LogStore.ManifestLog("foo"))
+		})
+	}
+}


### PR DESCRIPTION
I don't love the actual text being logged, but also couldn't come up with a good alternative.
1. `Resource "foo" is disabled` - why did it become enabled? How do I reenable it?
2. `User disabled resource "foo"` - we don't actually know it was changed by user action, vs some operator writing to the API

Went with the former since if the user clicked, hopefully they'll remember, though maybe it'll still be disabled two days later and they'll have forgotten and not be sure how to reenable. Probably not worth worrying about unless someone is confused by it.