### PR TITLE
Revert "web: add a load event for expand/collapse (#5219)"

### DIFF
--- a/web/src/ResourceGroupsContext.test.tsx
+++ b/web/src/ResourceGroupsContext.test.tsx
@@ -113,23 +113,13 @@ describe("ResourceGroupsContext", () => {
           <TestConsumer labelName="test" />
         </ResourceGroupsContextProvider>
       )
-      let loadIncr = {
-        name: "ui.web.resourceGroup",
-        tags: { action: AnalyticsAction.Load, expanded: "1", collapsed: "0" },
-      }
-      expectIncrs(loadIncr)
       clickButton()
       // Expect the "collapse" action value because the test label group is expanded
       // when it's clicked on and the "grid" type value because it's hardcoded in the
       // test component
-      expectIncrs(loadIncr, {
+      expectIncrs({
         name: "ui.web.resourceGroup",
-        tags: {
-          action: AnalyticsAction.Collapse,
-          type: AnalyticsType.Grid,
-          expanded: "1",
-          collapsed: "0",
-        },
+        tags: { action: AnalyticsAction.Collapse, type: AnalyticsType.Grid },
       })
     })
   })

--- a/web/src/ResourceGroupsContext.tsx
+++ b/web/src/ResourceGroupsContext.tsx
@@ -1,5 +1,5 @@
-import { createContext, PropsWithChildren, useContext, useEffect } from "react"
-import { AnalyticsAction, AnalyticsType, incr, Tags } from "./analytics"
+import { createContext, PropsWithChildren, useContext } from "react"
+import { AnalyticsAction, AnalyticsType, incr } from "./analytics"
 import { usePersistentState } from "./LocalStorage"
 
 export type GroupState = { expanded: boolean }
@@ -34,22 +34,6 @@ export function useResourceGroups(): ResourceGroupsContext {
   return useContext(resourceGroupsContext)
 }
 
-function getTags(groups: GroupsState): Tags {
-  let expandCount = 0
-  let collapseCount = 0
-  Object.values(groups).forEach((group) => {
-    if (group.expanded) {
-      expandCount++
-    } else {
-      collapseCount++
-    }
-  })
-  return {
-    expanded: String(expandCount),
-    collapsed: String(collapseCount),
-  }
-}
-
 export function ResourceGroupsContextProvider(
   props: PropsWithChildren<{ initialValuesForTesting?: GroupsState }>
 ) {
@@ -58,16 +42,6 @@ export function ResourceGroupsContextProvider(
     "resource-groups",
     defaultPersistentValue
   )
-  let analyticsTags = getTags(groups)
-
-  useEffect(() => {
-    incr("ui.web.resourceGroup", {
-      action: AnalyticsAction.Load,
-      ...analyticsTags,
-    })
-    // empty deps because we only want to report nce per app load
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
 
   function toggleGroupExpanded(groupLabel: string, page: AnalyticsType) {
     const currentGroupState = groups[groupLabel] ?? { ...DEFAULT_GROUP_STATE }
@@ -79,11 +53,7 @@ export function ResourceGroupsContextProvider(
     const action = nextGroupState.expanded
       ? AnalyticsAction.Expand
       : AnalyticsAction.Collapse
-    incr("ui.web.resourceGroup", {
-      action,
-      type: page,
-      ...analyticsTags,
-    })
+    incr("ui.web.resourceGroup", { action, type: page })
 
     setGroups((prevState) => {
       return {


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/revert:

665aa44b1d4cb05045ce60f68c0ec52b9dec2b79 (2021-11-24 15:06:19 -0500)
Revert "web: add a load event for expand/collapse (#5219)"
This reverts commit ac711d0ea03bdd4d9a80f2386db20f41012e3994.

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics