### PR TITLE
web: refactor single test resource generation into a single, configurable function call

### DIFF
--- a/web/src/HeaderBar.stories.tsx
+++ b/web/src/HeaderBar.stories.tsx
@@ -3,7 +3,7 @@ import { MemoryRouter } from "react-router"
 import HeaderBar from "./HeaderBar"
 import {
   nResourceView,
-  oneResourceTest,
+  oneTestResource,
   tenResourceView,
   twoResourceView,
 } from "./testdata"
@@ -47,6 +47,6 @@ export const UpgradeAvailable = () => {
 
 export const WithTests = () => {
   let view = twoResourceView()
-  view.uiResources.push(oneResourceTest(), oneResourceTest())
+  view.uiResources.push(oneTestResource(), oneTestResource())
   return <HeaderBar view={view} />
 }

--- a/web/src/OverviewActionBar.stories.tsx
+++ b/web/src/OverviewActionBar.stories.tsx
@@ -2,13 +2,7 @@ import { createMemoryHistory } from "history"
 import React from "react"
 import { Router } from "react-router"
 import { ButtonSet } from "./ApiButton"
-import {
-  EMPTY_FILTER_TERM,
-  FilterLevel,
-  FilterSet,
-  FilterSource,
-  useFilterSet,
-} from "./logfilters"
+import { FilterLevel, FilterSource, useFilterSet } from "./logfilters"
 import OverviewActionBar from "./OverviewActionBar"
 import { TiltSnackbarProvider } from "./Snackbar"
 import { StarredResourceMemoryProvider } from "./StarredResourcesContext"
@@ -53,35 +47,19 @@ export default {
   },
 }
 
-let defaultFilter: FilterSet = {
-  source: FilterSource.all,
-  level: FilterLevel.all,
-  term: EMPTY_FILTER_TERM,
-}
-
 export const OverflowTextBar = () => {
   let filterSet = useFilterSet()
-  let res = oneResource()
-  res.status = res.status || {}
-  res.status.endpointLinks = [
-    { url: "http://my-pod-grafana-long-service-name-deadbeef:4001" },
-    { url: "http://my-pod-grafana-long-service-name-deadbeef:4002" },
-  ]
-  res.status.k8sResourceInfo = {
-    podName: "my-pod-grafana-long-service-name-deadbeef",
-  }
+  let res = oneResource({
+    isBuilding: true,
+    name: "my-grafana-long-service-name-deadbeef",
+    endpoints: 2,
+  })
   return <OverviewActionBar resource={res} filterSet={filterSet} />
 }
 
 export const FullBar = () => {
   let filterSet = useFilterSet()
-  let res = oneResource()
-  res.status = res.status || {}
-  res.status.endpointLinks = [
-    { url: "http://localhost:4001" },
-    { url: "http://localhost:4002" },
-  ]
-  res.status.k8sResourceInfo = { podName: "my-pod-deadbeef" }
+  let res = oneResource({ isBuilding: true, name: "my-deadbeef", endpoints: 2 })
   let buttons: ButtonSet = {
     default: [oneButton(1, "vigoda")],
     toggleDisable: disableButton("vigoda", true),
@@ -93,7 +71,7 @@ export const FullBar = () => {
 
 export const EmptyBar = () => {
   let filterSet = useFilterSet()
-  let res = oneResource()
+  let res = oneResource({ isBuilding: true })
   res.status = res.status || {}
   res.status.endpointLinks = []
   res.status.k8sResourceInfo = {}

--- a/web/src/OverviewActionBar.test.tsx
+++ b/web/src/OverviewActionBar.test.tsx
@@ -27,7 +27,7 @@ import OverviewActionBar, {
   FILTER_INPUT_DEBOUNCE,
 } from "./OverviewActionBar"
 import { EmptyBar, FullBar } from "./OverviewActionBar.stories"
-import { disableButton, oneButton, oneResourceNoAlerts } from "./testdata"
+import { disableButton, oneButton, oneResource } from "./testdata"
 
 let history: MemoryHistory
 beforeEach(() => {
@@ -63,7 +63,7 @@ it("shows pod ID", () => {
   const podId = root.find(ActionBarTopRow).find(CopyButton)
 
   expect(podId).toHaveLength(1)
-  expect(podId.text()).toContain("my-pod-deadbeef Pod ID") // Hardcoded from test data
+  expect(podId.text()).toContain("my-deadbeef-pod Pod ID") // Hardcoded from test data
 })
 
 it("skips the top bar when empty", () => {
@@ -107,7 +107,7 @@ describe("disabled resource view", () => {
   let root: ReactWrapper<any, any>
 
   beforeEach(() => {
-    const resource = oneResourceNoAlerts({
+    const resource = oneResource({
       name: "i-am-not-enabled",
       disabled: true,
     })

--- a/web/src/OverviewResourceBar.stories.tsx
+++ b/web/src/OverviewResourceBar.stories.tsx
@@ -3,7 +3,7 @@ import { MemoryRouter } from "react-router"
 import OverviewResourceBar from "./OverviewResourceBar"
 import {
   nResourceView,
-  oneResourceTest,
+  oneTestResource,
   tenResourceView,
   twoResourceView,
 } from "./testdata"
@@ -53,6 +53,6 @@ export const UpgradeAvailable = () => {
 
 export const WithTests = () => {
   let view = twoResourceView()
-  view.uiResources.push(oneResourceTest(), oneResourceTest())
+  view.uiResources.push(oneTestResource(), oneTestResource())
   return <OverviewResourceBar view={view} />
 }

--- a/web/src/OverviewResourcePane.test.tsx
+++ b/web/src/OverviewResourcePane.test.tsx
@@ -122,7 +122,7 @@ describe("alert filtering", () => {
 
   it("categorizes buttons", () => {
     const view = {
-      uiResources: [oneResource()],
+      uiResources: [oneResource({ isBuilding: true })],
       uiButtons: [oneButton(0, "vigoda"), disableButton("vigoda", true)],
     }
     const root = mount(

--- a/web/src/OverviewResourceSidebar.stories.tsx
+++ b/web/src/OverviewResourceSidebar.stories.tsx
@@ -11,8 +11,7 @@ import {
   nResourceView,
   nResourceWithLabelsView,
   oneResource,
-  oneResourceNoAlerts,
-  oneResourceTest,
+  oneTestResource,
   tenResourceView,
   tiltfileResource,
   twoResourceView,
@@ -86,12 +85,11 @@ export const OneHundredResources = () => (
 export function TwoResourcesTwoTests() {
   let all: UIResource[] = [
     tiltfileResource(),
-    oneResource(),
-    oneResourceNoAlerts({}),
-    oneResourceTest(),
-    oneResourceTest(),
+    oneResource({ isBuilding: true }),
+    oneResource({ name: "snack" }),
+    oneTestResource(),
+    oneTestResource(),
   ]
-  all[2].metadata = { name: "snack" }
   all[3].metadata = { name: "beep" }
   let view = { uiResources: all, tiltfileKey: "test" }
   return <OverviewResourceSidebar name={""} view={view} />
@@ -103,7 +101,7 @@ export function TestsWithErrors() {
   let spans = {} as any
   let all: UIResource[] = [tiltfileResource()]
   for (let i = 0; i < 8; i++) {
-    let test = oneResourceTest()
+    let test = oneTestResource()
     let name = "test_" + i
     test.metadata = { name: name }
 

--- a/web/src/OverviewTable.stories.tsx
+++ b/web/src/OverviewTable.stories.tsx
@@ -10,7 +10,7 @@ import {
   nButtonView,
   nResourceView,
   nResourceWithLabelsView,
-  oneResourceNoAlerts,
+  oneResource,
   tiltfileResource,
   twoResourceView,
 } from "./testdata"
@@ -91,8 +91,8 @@ export const TenResources = () => {
   const view = nResourceView(8)
 
   // Add a couple disabled resources
-  const disableResource9 = oneResourceNoAlerts({ disabled: true, name: "_8" })
-  const disableResource10 = oneResourceNoAlerts({ disabled: true, name: "_9" })
+  const disableResource9 = oneResource({ disabled: true, name: "_8" })
+  const disableResource10 = oneResource({ disabled: true, name: "_9" })
   view.uiResources.push(disableResource9)
   view.uiResources.push(disableResource10)
 
@@ -103,12 +103,12 @@ export const TenResourceWithLabels = () => {
   const view = nResourceWithLabelsView(8)
 
   // Add a couple disabled resources
-  const disableResource9 = oneResourceNoAlerts({
+  const disableResource9 = oneResource({
     disabled: true,
     name: "_8",
     labels: 2,
   })
-  const disableResource10 = oneResourceNoAlerts({ disabled: true, name: "_9" })
+  const disableResource10 = oneResource({ disabled: true, name: "_9" })
   view.uiResources.push(disableResource9)
   view.uiResources.push(disableResource10)
 

--- a/web/src/OverviewTable.test.tsx
+++ b/web/src/OverviewTable.test.tsx
@@ -53,7 +53,7 @@ import {
   nResourceView,
   nResourceWithLabelsView,
   oneButton,
-  oneResourceNoAlerts,
+  oneResource,
   TestDataView,
 } from "./testdata"
 import { RuntimeStatus, UpdateStatus } from "./types"
@@ -148,7 +148,7 @@ it("sorts by status", () => {
   view.uiResources[3].status!.updateStatus = UpdateStatus.Error
   view.uiResources[7].status!.runtimeStatus = RuntimeStatus.Error
   view.uiResources.unshift(
-    oneResourceNoAlerts({ disabled: true, name: "disabled_resource" })
+    oneResource({ disabled: true, name: "disabled_resource" })
   )
   const root = mount(
     tableViewWithSettings({ view, disableResourcesEnabled: true })
@@ -617,11 +617,11 @@ describe("when disable resources feature is enabled", () => {
   beforeEach(() => {
     view = nResourceView(4)
     // Add two disabled resources to view and place them throughout list
-    const firstDisabledResource = oneResourceNoAlerts({
+    const firstDisabledResource = oneResource({
       name: "zee_disabled_resource",
       disabled: true,
     })
-    const secondDisabledResource = oneResourceNoAlerts({
+    const secondDisabledResource = oneResource({
       name: "_0_disabled_resource",
       disabled: true,
     })
@@ -707,7 +707,7 @@ describe("when disable resources feature is NOT enabled", () => {
   beforeEach(() => {
     view = nResourceView(8)
     // Add a disabled resource to view
-    const disabledResource = oneResourceNoAlerts({
+    const disabledResource = oneResource({
       name: "disabled_resource",
       disabled: true,
     })

--- a/web/src/SidebarItemView.stories.tsx
+++ b/web/src/SidebarItemView.stories.tsx
@@ -6,7 +6,7 @@ import { ResourceNavContextProvider } from "./ResourceNav"
 import SidebarItem from "./SidebarItem"
 import SidebarItemView, { SidebarItemViewProps } from "./SidebarItemView"
 import { Width } from "./style-helpers"
-import { oneResourceNoAlerts } from "./testdata"
+import { oneResource } from "./testdata"
 import {
   ResourceName,
   ResourceStatus,
@@ -105,7 +105,7 @@ function withArgs(args: Args): optionFn {
 
 function itemView(...options: optionFn[]) {
   let ls = new LogStore()
-  let item = new SidebarItem(oneResourceNoAlerts({}), ls)
+  let item = new SidebarItem(oneResource({}), ls)
   let props = {
     item: item,
     selected: false,

--- a/web/src/SidebarItemView.test.tsx
+++ b/web/src/SidebarItemView.test.tsx
@@ -8,7 +8,7 @@ import SidebarItemView, {
   DisabledSidebarItemView,
   EnabledSidebarItemView,
 } from "./SidebarItemView"
-import { oneResourceNoAlerts, TestResourceOptions } from "./testdata"
+import { oneResource, TestResourceOptions } from "./testdata"
 import { ResourceView } from "./types"
 
 const PATH_BUILDER = PathBuilder.forTesting("localhost", "/")
@@ -40,7 +40,7 @@ const SidebarItemViewTestWrapper = ({
 }
 
 const oneSidebarItem = (options: TestResourceOptions) => {
-  return new SidebarItem(oneResourceNoAlerts(options), LOG_ALERT_INDEX)
+  return new SidebarItem(oneResource(options), LOG_ALERT_INDEX)
 }
 
 describe("SidebarItemView", () => {

--- a/web/src/SidebarResources.test.tsx
+++ b/web/src/SidebarResources.test.tsx
@@ -35,7 +35,7 @@ import {
   nResourceView,
   nResourceWithLabelsView,
   oneResource,
-  oneResourceTestWithName,
+  oneTestResource,
   twoResourceView,
 } from "./testdata"
 import { ResourceStatus, ResourceView } from "./types"
@@ -213,9 +213,9 @@ describe("SidebarResources", () => {
 
       let ls = new LogStore()
       const items = [
-        oneResource(),
-        oneResourceTestWithName("a"),
-        oneResourceTestWithName("b"),
+        oneResource({ isBuilding: true }),
+        oneTestResource("a"),
+        oneTestResource("b"),
       ].map((res) => new SidebarItem(res, ls))
 
       const root = mount(
@@ -252,9 +252,9 @@ describe("SidebarResources", () => {
     (name, expectedOptions) => {
       let ls = new LogStore()
       const items = [
-        oneResource(),
-        oneResourceTestWithName("a"),
-        oneResourceTestWithName("b"),
+        oneResource({ isBuilding: true }),
+        oneTestResource("a"),
+        oneTestResource("b"),
       ].map((res) => new SidebarItem(res, ls))
 
       const root = mount(

--- a/web/src/SidebarTriggerModeToggle.test.tsx
+++ b/web/src/SidebarTriggerModeToggle.test.tsx
@@ -19,11 +19,7 @@ import {
   StyledSidebarTriggerModeToggle,
   ToggleTriggerModeTooltip,
 } from "./SidebarTriggerModeToggle"
-import {
-  oneResourceTest,
-  oneResourceTestWithName,
-  twoResourceView,
-} from "./testdata"
+import { oneTestResource, twoResourceView } from "./testdata"
 import { ResourceView, TriggerMode } from "./types"
 
 let pathBuilder = PathBuilder.forTesting("localhost", "/")
@@ -48,7 +44,7 @@ describe("SidebarTriggerButton", () => {
   it("shows toggle button only for test cards", () => {
     let ls = new LogStore()
     let view = twoResourceView()
-    view.uiResources.push(oneResourceTest())
+    view.uiResources.push(oneTestResource())
     let items = view.uiResources.map((r) => new SidebarItem(r, ls))
 
     const root = mount(
@@ -69,10 +65,10 @@ describe("SidebarTriggerButton", () => {
 
   it("shows different icon depending on current trigger mode", () => {
     let resources = [
-      oneResourceTestWithName("auto_auto-init"),
-      oneResourceTestWithName("auto_no-init"),
-      oneResourceTestWithName("manual_auto-init"),
-      oneResourceTestWithName("manual_no-init"),
+      oneTestResource("auto_auto-init"),
+      oneTestResource("auto_no-init"),
+      oneTestResource("manual_auto-init"),
+      oneTestResource("manual_no-init"),
     ]
     resources[0].status!.triggerMode = TriggerMode.TriggerModeAuto
     resources[1].status!.triggerMode = TriggerMode.TriggerModeAutoWithManualInit

--- a/web/src/analytics_test_helpers.ts
+++ b/web/src/analytics_test_helpers.ts
@@ -8,23 +8,6 @@ export function cleanupMockAnalyticsCalls() {
   fetchMock.reset()
 }
 
-// TODO(matt) migrate uses of this to `expectIncrs`
-export function expectIncr(fetchMockIndex: number, name: string, tags: Tags) {
-  expect(fetchMock.calls().length).toBeGreaterThan(fetchMockIndex)
-  expect(fetchMock.calls()[fetchMockIndex][0]).toEqual(
-    "//localhost/api/analytics"
-  )
-  expect(fetchMock.calls()[fetchMockIndex][1]?.body).toEqual(
-    JSON.stringify([
-      {
-        verb: "incr",
-        name: name,
-        tags: tags,
-      },
-    ])
-  )
-}
-
 export function expectIncrs(...incrs: { name: string; tags: Tags }[]) {
   const expectedRequestBodies = incrs.map((i) => [
     {

--- a/web/src/status.test.tsx
+++ b/web/src/status.test.tsx
@@ -19,7 +19,7 @@ class FakeAlertIndex implements LogAlertIndex {
 }
 
 function emptyResource() {
-  let res = oneResource()
+  let res = oneResource({})
   res.status!.currentBuild = { startTime: zeroTime }
   res.status!.buildHistory = []
   res.status!.pendingBuildSince = zeroTime
@@ -50,7 +50,6 @@ describe("combinedStatus", () => {
 
   it("healthy when runtime ok", () => {
     let ls = new LogStore()
-    const ts = Date.now().toLocaleString()
     let res = emptyResource()
     res.status!.updateStatus = UpdateStatus.Ok
     res.status!.runtimeStatus = RuntimeStatus.Ok
@@ -61,7 +60,6 @@ describe("combinedStatus", () => {
 
   it("unhealthy when runtime error", () => {
     let ls = new LogStore()
-    const ts = Date.now().toLocaleString()
     let res = emptyResource()
     res.status!.updateStatus = UpdateStatus.Ok
     res.status!.runtimeStatus = RuntimeStatus.Error
@@ -72,7 +70,6 @@ describe("combinedStatus", () => {
 
   it("unhealthy when last build error", () => {
     let ls = new LogStore()
-    const ts = Date.now().toLocaleString()
     let res = emptyResource()
     res.status!.updateStatus = UpdateStatus.Error
     res.status!.runtimeStatus = RuntimeStatus.Ok
@@ -83,7 +80,6 @@ describe("combinedStatus", () => {
 
   it("building when runtime status error, but also building", () => {
     let ls = new LogStore()
-    const ts = Date.now().toLocaleString()
     let res = emptyResource()
     res.status!.updateStatus = UpdateStatus.InProgress
     res.status!.runtimeStatus = RuntimeStatus.Error
@@ -130,7 +126,6 @@ describe("combinedStatus", () => {
 
   it("healthy when n/a runtime status and last build succeeded", () => {
     let ls = new LogStore()
-    const ts = Date.now().toLocaleString()
     let res = emptyResource()
     res.status!.runtimeStatus = RuntimeStatus.NotApplicable
     res.status!.updateStatus = UpdateStatus.Ok
@@ -141,7 +136,6 @@ describe("combinedStatus", () => {
 
   it("unhealthy when n/a runtime status and last build failed", () => {
     let ls = new LogStore()
-    const ts = Date.now().toLocaleString()
     let res = emptyResource()
     res.status!.runtimeStatus = RuntimeStatus.NotApplicable
     res.status!.updateStatus = UpdateStatus.Error


### PR DESCRIPTION
I find myself doing a bunch of manual manipulation of generated resources in tests or copy-pasta'ing another test data function and changing things slightly for what I need. Rather than have multiple `<some-description>Resource()` with slight variability, this PR refactors the `oneResourceNoAlerts()` into a parametrized function that returns a configured resource. 

So something like this:
```js
// multiple generators with similar code
oneResourceNoAlerts() {...}
oneResourceNoAlertsWithLabels() {...}

// or manually manipulating the test resource
const myResource = oneResourceNoAlerts()
myResource.name = "bleep"
myResource.metadata.labels = ["bloop", "beep"]
```
becomes this with this PR:
```js
oneResource({ name: "bleep", labels: 2 })
```

I expect that tests will still need to manipulate the returned resource to some extent, since it'll be difficult to cover every scenario, but this should be a move in the right direction! I opted to keep this PR just to single resource generation and get some feedback, before tackling `nResourceView` functions as well.

(This PR does a little bit of miscellaneous cleanup of test files, too.)

Most of the diff is related to find + replace, and the meaningful changes are in `testdata.tsx`.