### PR TITLE
Add go_test_changes resource to Tiltfile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ shorttest:
 
 # Run recent changes as seen by Tilt, called from Tiltfile
 uniq = $(if $1,$(firstword $1) $(call uniq,$(filter-out $(firstword $1),$1)))
-seen_files = $(shell tilt get filewatch local:go_test_changed -o json | jq -r '.status.fileEvents[-1].seenFiles[]')
+seen_files = $(shell tilt get filewatch local:go_test_changes -o json | jq -r '.status.fileEvents[-1].seenFiles[]')
 seen_files_rel = $(subst $(PWD),.,$(seen_files))
 go_files = $(filter-out ./vendor/%,$(filter %.go, $(seen_files_rel)))
 go_pkgs = $(call uniq,$(dir $(go_files)))
@@ -60,7 +60,7 @@ testchanges:
 	go test -v -mod vendor -p $(GO_PARALLEL_JOBS) -timeout 60s $(go_pkgs)
 else
 testchanges:
-	@echo No go packages changed
+	@echo No go package changes detected by Tilt
 endif
 
 shorttestsum:

--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,7 @@ test: test-go test-js
 shorttest:
 	go test -mod vendor -p $(GO_PARALLEL_JOBS) -short -tags skipcontainertests,skiplargetiltfiletests -timeout 100s ./...
 
+ifneq ($(TILT_HOST):$(TILT_PORT),:)
 # Run recent changes as seen by Tilt, called from Tiltfile
 uniq = $(if $1,$(firstword $1) $(call uniq,$(filter-out $(firstword $1),$1)))
 seen_files = $(shell tilt get filewatch local:go_test_changes -o json | jq -r '.status.fileEvents[-1].seenFiles[]')
@@ -61,6 +62,7 @@ testchanges:
 else
 testchanges:
 	@echo No go package changes detected by Tilt
+endif
 endif
 
 shorttestsum:

--- a/Tiltfile
+++ b/Tiltfile
@@ -10,10 +10,10 @@ def go(name, entrypoint, all_go_files, srv=""):
   local_resource(name, "go build -o /tmp/%s %s" % (name, entrypoint), serve_cmd=srv, deps=all_go_files)
 
 def go_test_changes(all_go_files):
-  local_resource('go_test_changes', "make testchanges", auto_init=False, deps=all_go_files)
+  test('go_test_changes', "make testchanges", auto_init=False, deps=all_go_files)
 
 def go_lint(all_go_files):
-  local_resource("go_lint", "make lint", deps=all_go_files)
+  test("go_lint", "make lint", deps=all_go_files)
 
 def get_all_ts_files(path):
   res = str(local('cd %s && find . -type f -name "*.ts*" | grep -v node_modules | grep -v __snapshots__' % path)).rstrip().split("\n")
@@ -23,11 +23,11 @@ def yarn_install():
   local_resource("yarn_install", "cd web && yarn", deps=['web/package.json', 'web/yarn.lock'])
 
 def jest(path):
-  local_resource("web_jest", serve_cmd="cd %s && yarn run test --notify " % path, resource_deps=["yarn_install"])
+  test("web_jest", serve_cmd="cd %s && yarn run test --notify " % path, resource_deps=["yarn_install"])
 
 def web_lint():
   ts_deps = get_all_ts_files("web")
-  local_resource("web_lint", "cd web && yarn run check", deps=ts_deps, resource_deps=["yarn_install"])
+  test("web_lint", "cd web && yarn run check", deps=ts_deps, resource_deps=["yarn_install"])
 
 def go_vendor():
   local_resource("go_vendor", "make vendor", deps=['go.sum', 'go.mod'])

--- a/Tiltfile
+++ b/Tiltfile
@@ -9,6 +9,9 @@ def get_all_go_files(path):
 def go(name, entrypoint, all_go_files, srv=""):
   local_resource(name, "go build -o /tmp/%s %s" % (name, entrypoint), serve_cmd=srv, deps=all_go_files)
 
+def go_test_changed(all_go_files):
+  local_resource('go_test_changed', "make testchanges", deps=all_go_files)
+
 def go_lint(all_go_files):
   local_resource("go_lint", "make lint", deps=all_go_files)
 
@@ -32,6 +35,7 @@ def go_vendor():
 all_go_files = get_all_go_files(".")
 
 go("Tilt", "cmd/tilt/main.go", all_go_files, srv="cd /tmp/ && ./tilt up --hud=false --web-mode=prod --port=9765")
+go_test_changed(all_go_files)
 go_lint(all_go_files)
 go_vendor()
 

--- a/Tiltfile
+++ b/Tiltfile
@@ -9,8 +9,8 @@ def get_all_go_files(path):
 def go(name, entrypoint, all_go_files, srv=""):
   local_resource(name, "go build -o /tmp/%s %s" % (name, entrypoint), serve_cmd=srv, deps=all_go_files)
 
-def go_test_changed(all_go_files):
-  local_resource('go_test_changed', "make testchanges", deps=all_go_files)
+def go_test_changes(all_go_files):
+  local_resource('go_test_changes', "make testchanges", deps=all_go_files)
 
 def go_lint(all_go_files):
   local_resource("go_lint", "make lint", deps=all_go_files)
@@ -35,7 +35,7 @@ def go_vendor():
 all_go_files = get_all_go_files(".")
 
 go("Tilt", "cmd/tilt/main.go", all_go_files, srv="cd /tmp/ && ./tilt up --hud=false --web-mode=prod --port=9765")
-go_test_changed(all_go_files)
+go_test_changes(all_go_files)
 go_lint(all_go_files)
 go_vendor()
 

--- a/Tiltfile
+++ b/Tiltfile
@@ -3,30 +3,10 @@ username = str(local('whoami')).rstrip('\n')
 experimental_analytics_report({'user.name': username})
 analytics_settings(enable=True)
 
-def remove_all_empty_and_whitespace(my_list):
-  ret = []
-  for x in my_list:
-    s = x.strip()
-    if s:
-      ret.append(s)
-
-  return ret
-
- #TODO(dmiller): can I memoize this or something?
 def get_all_go_files(path):
   return str(local('cd %s && find . -type f -name "*.go"' % path)).split("\n")
 
-def get_deps_for_pkg(pkg):
-  cmd = """go list -f '{{ join .GoFiles "\\n" }} {{ join .TestGoFiles "\\n" }} {{ join .XTestGoFiles "\\n"}}' '%s'""" % pkg
-  split = str(local(cmd)).split("\n")
-  return remove_all_empty_and_whitespace(split)
-
 def go(name, entrypoint, all_go_files, srv=""):
-  all_packages = remove_all_empty_and_whitespace(str(local('go list ./...')).rstrip().split("\n"))
-  # for pkg in all_packages:
-  #   pkg_deps = get_deps_for_pkg(pkg)
-  #   local_resource("go_test_%s" % pkg, "go test %s" % pkg, deps=pkg_deps)
-
   local_resource(name, "go build -o /tmp/%s %s" % (name, entrypoint), serve_cmd=srv, deps=all_go_files)
 
 def go_lint(all_go_files):

--- a/Tiltfile
+++ b/Tiltfile
@@ -10,7 +10,7 @@ def go(name, entrypoint, all_go_files, srv=""):
   local_resource(name, "go build -o /tmp/%s %s" % (name, entrypoint), serve_cmd=srv, deps=all_go_files)
 
 def go_test_changes(all_go_files):
-  local_resource('go_test_changes', "make testchanges", deps=all_go_files)
+  local_resource('go_test_changes', "make testchanges", auto_init=False, deps=all_go_files)
 
 def go_lint(all_go_files):
   local_resource("go_lint", "make lint", deps=all_go_files)


### PR DESCRIPTION
Adds a local resource to run tests in recently changed go packages. Uses a new makefile target to run `go test` with the most recent set of changes reported by Tilt.

- Makefile: add 'testchanges' which checks Tilt for changed pkgs
- Tiltfile: remove unused code
- Tiltfile: add go_test_changed resource
