### PR TITLE
engine: add a ready condition to all uiresources

### DIFF
--- a/internal/cloud/io_test.go
+++ b/internal/cloud/io_test.go
@@ -41,6 +41,14 @@ func TestWriteSnapshotTo(t *testing.T) {
 	snapshot.View.UiResources = resources
 
 	now := time.Unix(1551202573, 0)
+	for _, r := range resources {
+		for i, cond := range r.Status.Conditions {
+			// Clear the transition timestamps so that the test is hermetic.
+			cond.LastTransitionTime = metav1.MicroTime{}
+			r.Status.Conditions[i] = cond
+		}
+	}
+
 	startTime, err := ptypes.TimestampProto(now)
 	require.NoError(t, err)
 	snapshot.View.TiltStartTime = startTime
@@ -70,7 +78,14 @@ func TestWriteSnapshotTo(t *testing.T) {
         "status": {
           "runtimeStatus": "not_applicable",
           "updateStatus": "pending",
-          "order": 1
+          "order": 1,
+          "conditions": [
+            {
+              "type": "Ready",
+              "status": "False",
+              "reason": "UpdatePending"
+            }
+          ]
         }
       }
     ]

--- a/internal/hud/webview/convert_test.go
+++ b/internal/hud/webview/convert_test.go
@@ -256,6 +256,7 @@ func TestReadinessCheckFailing(t *testing.T) {
 	rv, ok := findResource(m.Name, v)
 	require.True(t, ok)
 	require.Equal(t, v1alpha1.RuntimeStatusPending, v1alpha1.RuntimeStatus(rv.RuntimeStatus))
+	require.Equal(t, "False", string(readyCondition(rv).Status))
 }
 
 func TestLocalResource(t *testing.T) {
@@ -278,6 +279,7 @@ func TestLocalResource(t *testing.T) {
 	rs := r.Status
 	assert.Equal(t, "test", r.Name)
 	assert.Equal(t, v1alpha1.RuntimeStatusNotApplicable, rs.RuntimeStatus)
+	require.Equal(t, "False", string(readyCondition(rs).Status))
 	require.Len(t, rs.Specs, 1)
 	spec := rs.Specs[0]
 	require.Equal(t, v1alpha1.UIResourceTargetTypeLocal, spec.Type)
@@ -433,4 +435,13 @@ func lastBuild(r v1alpha1.UIResourceStatus) v1alpha1.UIBuildTerminated {
 	}
 
 	return r.BuildHistory[0]
+}
+
+func readyCondition(rs v1alpha1.UIResourceStatus) *v1alpha1.UIResourceCondition {
+	for _, c := range rs.Conditions {
+		if c.Type == v1alpha1.UIResourceReady {
+			return &c
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
Hello @milas,

Please review the following commits I made in branch nicks/readycond:

06ab713339c5693cad5e15d088cfb62ebf6e36e2 (2021-11-30 12:56:03 -0500)
engine: add a ready condition to all uiresources

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics