### PR TITLE
web: add additional analytics to toggle `ApiButton` interactions

### DIFF
--- a/web/src/ApiButton.tsx
+++ b/web/src/ApiButton.tsx
@@ -334,16 +334,27 @@ async function updateButtonStatus(
 }
 
 function getButtonTags(button: UIButton): Tags {
+  const tags: Tags = {}
+
   // The location of the button in the UI
   const component = button.spec?.location?.componentType as ApiButtonType
+  if (component !== undefined) {
+    tags.component = component
+  }
 
   const buttonAnnotations = annotations(button)
 
   // A unique hash of the button text to help identify which button was clicked
   const specHash = buttonAnnotations[UIBUTTON_SPEC_HASH]
+  if (specHash !== undefined) {
+    tags.specHash = specHash
+  }
 
   // Tilt-specific button annotation, currently only used to differentiate disable toggles
   const buttonType = buttonAnnotations[UIBUTTON_ANNOTATION_TYPE]
+  if (buttonType !== undefined) {
+    tags.buttonType = buttonType
+  }
 
   // A toggle button will have a hidden input field with the current value of the toggle
   // e.g., when a disable button is clicked, the hidden input will be "on" because that's
@@ -355,25 +366,19 @@ function getButtonTags(button: UIButton): Tags {
     )
   }
 
-  let toggleValue: ApiButtonToggleState | undefined
   if (toggleInput !== undefined) {
-    const definedValue = toggleInput.hidden?.value
+    const toggleValue = toggleInput.hidden?.value
     // Only use values defined in `ApiButtonToggleState`, so no user-specific information is saved.
     // When toggle buttons are exposed in the button extension, this mini allowlist can be revisited.
     if (
-      definedValue === ApiButtonToggleState.On ||
-      definedValue === ApiButtonToggleState.Off
+      toggleValue === ApiButtonToggleState.On ||
+      toggleValue === ApiButtonToggleState.Off
     ) {
-      toggleValue = definedValue
+      tags.toggleValue = toggleValue
     }
   }
 
-  return {
-    buttonType,
-    component,
-    specHash,
-    toggleValue,
-  }
+  return tags
 }
 
 // Renders a UIButton.

--- a/web/src/CustomNav.tsx
+++ b/web/src/CustomNav.tsx
@@ -52,9 +52,8 @@ export function CustomNav(props: CustomNavProps) {
   return (
     <React.Fragment>
       {buttons.map((b) => (
-        <MenuButtonLabeled label={b.spec?.text}>
+        <MenuButtonLabeled label={b.spec?.text} key={b.metadata?.name}>
           <CustomNavButton
-            key={b.metadata?.name}
             uiButton={b}
             variant="contained"
             aria-label={b.spec?.text}

--- a/web/src/SidebarItem.tsx
+++ b/web/src/SidebarItem.tsx
@@ -7,10 +7,10 @@ import { resourceTargetType } from "./ResourceStatus"
 import { buildStatus, runtimeStatus } from "./status"
 import { timeDiff } from "./time"
 import {
-  Build,
   ResourceName,
   ResourceStatus,
   TriggerMode,
+  UIBuild,
   UIResource,
   UIResourceStatus,
 } from "./types"
@@ -32,7 +32,7 @@ class SidebarItem {
   triggerMode: TriggerMode
   hasPendingChanges: boolean
   queued: boolean
-  lastBuild: Build | null = null
+  lastBuild: UIBuild | null = null
   hold: Hold | null = null
   targetType: string
 

--- a/web/src/testdata.tsx
+++ b/web/src/testdata.tsx
@@ -1,6 +1,10 @@
 import { Href, UnregisterCallback } from "history"
 import { RouteComponentProps } from "react-router-dom"
-import { AnnotationButtonType, ToggleDisableButtonType } from "./ApiButton"
+import {
+  ApiButtonType,
+  UIBUTTON_ANNOTATION_TYPE,
+  UIBUTTON_TOGGLE_DISABLE_TYPE,
+} from "./ApiButton"
 import {
   ResourceName,
   TriggerMode,
@@ -410,14 +414,14 @@ export function disableButton(
     metadata: {
       name: `toggle-${resourceName}-disable`,
       annotations: {
-        [AnnotationButtonType]: ToggleDisableButtonType,
+        [UIBUTTON_ANNOTATION_TYPE]: UIBUTTON_TOGGLE_DISABLE_TYPE,
       },
     },
     spec: {
       text: enabled ? "Disable Resource" : "Enable Resource",
       location: {
         componentID: resourceName,
-        componentType: "resource",
+        componentType: ApiButtonType.Resource,
       },
     },
   }

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -53,7 +53,7 @@ export enum ResourceStatus {
   Healthy, // e.g., build succeeded and pod is running and healthy
   Unhealthy, // e.g., last build failed, or CrashLoopBackOff
   Warning, // e.g., an undismissed restart
-  Disabled, // e.g., a resource is disabled by the user through the API
+  Disabled, // e.g., a resource is disabled by the user through the API / UI
   None, // e.g., a manual build that has never executed
 }
 
@@ -146,6 +146,8 @@ export enum ResourceName {
 export type UISession = Proto.v1alpha1UISession
 export type UIResource = Proto.v1alpha1UIResource
 export type UIResourceStatus = Proto.v1alpha1UIResourceStatus
-export type Build = Proto.v1alpha1UIBuildTerminated
+export type UIBuild = Proto.v1alpha1UIBuildTerminated
 export type UILink = Proto.v1alpha1UIResourceLink
 export type UIButton = Proto.v1alpha1UIButton
+export type UIInputSpec = Proto.v1alpha1UIInputSpec
+export type UIInputStatus = Proto.v1alpha1UIInputStatus


### PR DESCRIPTION
To prep for the disable resources launch:
* Add `toggleValue` property to toggle button analytics to indicate what the value for toggle is when the user clicks on it
* Add toggle button analytics tags to the confirm/cancel buttons
* Reorganize and add more types and constants for `ApiButton`

The `toggleValue` property will help us know if a user is clicking `disable` or `enable` on a resource. I could see this value being potentially confusing because it doesn't represent the value that will result from the user interaction. But because a user could confirm or cancel their toggle, I think it's fine to record the value "pre" toggle. 

Here's what a disable resource button click looks like:
```json
{
  "action": "click",
  "buttonType": "DisableToggle",
  "component": "Resource",
  "specHash": "9ac7c2a31917ba7ca7ca",
  "toggleValue": "on"
}
```
and a confirmation button click:
```json
{
  "action": "click",
  "confirm": "true",
  "buttonType": "DisableToggle",
  "component": "Resource",
  "specHash": "9ac7c2a31917ba7ca7ca",
  "toggleValue": "on"
}
```
A cancel button click will have `confirm: "false"`, but otherwise look the same as above.

Will link a related pr for the schema documentation shortly!

Closes [CH13015](https://app.shortcut.com/windmill/story/13015/non-launch-blocker-analytics-test).