### PR TITLE
cli: add 'tilt wait' to wait on resources to become ready

### DIFF
--- a/internal/cli/wait.go
+++ b/internal/cli/wait.go
@@ -52,8 +52,9 @@ var (
 		# Wait for the tiltfile to load.
 		tilt wait --for=condition=Ready "uiresource/(Tiltfile)"
 
-		# Wait for a deployment to become ready.
-		tilt wait --for=condition=Ready "uiresource/my-deployment"`))
+		# When used with a Kubernetes resource, waits for the pod
+    # to deploy, start running, and pass all readiness probes.
+		tilt wait --for=condition=Ready "uiresource/my-kubernetes-deployment"`))
 )
 
 type waitCmd struct {

--- a/internal/cli/wait.go
+++ b/internal/cli/wait.go
@@ -1,0 +1,109 @@
+/*
+Adapted from
+https://github.com/kubernetes/kubectl/tree/master/pkg/cmd/wait
+*/
+
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cli
+
+import (
+	"context"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+	"k8s.io/kubectl/pkg/cmd/wait"
+	"k8s.io/kubectl/pkg/util/i18n"
+	"k8s.io/kubectl/pkg/util/templates"
+
+	"github.com/tilt-dev/tilt/internal/analytics"
+	engineanalytics "github.com/tilt-dev/tilt/internal/engine/analytics"
+	"github.com/tilt-dev/tilt/pkg/model"
+)
+
+var (
+	waitLong = templates.LongDesc(i18n.T(`
+		Experimental: Wait for a specific condition on one or many resources.
+
+		The command takes multiple resources and waits until the specified condition
+		is seen in the Status field of every given resource.
+
+		A successful message will be printed to stdout indicating when the specified
+    condition has been met. You can use -o option to change to output destination.`))
+
+	waitExample = templates.Examples(i18n.T(`
+		# Wait for the tiltfile to load.
+		tilt wait --for=condition=Ready "uiresource/(Tiltfile)"
+
+		# Wait for a deployment to become ready.
+		tilt wait --for=condition=Ready "uiresource/my-deployment"`))
+)
+
+type waitCmd struct {
+	flags *wait.WaitFlags
+}
+
+var _ tiltCmd = &waitCmd{}
+
+func newWaitCmd() *waitCmd {
+	streams := genericclioptions.IOStreams{Out: os.Stdout, ErrOut: os.Stderr, In: os.Stdin}
+	flags := wait.NewWaitFlags(nil, streams)
+	return &waitCmd{
+		flags: flags,
+	}
+}
+
+func (c *waitCmd) name() model.TiltSubcommand { return "wait" }
+
+func (c *waitCmd) register() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "wait ([-f FILENAME] | resource.group/resource.name | resource.group [(-l label | --all)]) [--for=delete|--for condition=available]",
+		Short:   "Experimental: Wait for a specific condition on one or many resources",
+		Long:    waitLong,
+		Example: waitExample,
+
+		DisableFlagsInUseLine: true,
+	}
+
+	c.flags.AddFlags(cmd)
+	addConnectServerFlags(cmd)
+
+	return cmd
+}
+
+func (c *waitCmd) run(ctx context.Context, args []string) error {
+	a := analytics.Get(ctx)
+	cmdTags := engineanalytics.CmdTags(map[string]string{})
+	a.Incr("cmd.wait", cmdTags.AsMap())
+	defer a.Flush(time.Second)
+
+	getter, err := wireClientGetter(ctx)
+	if err != nil {
+		return err
+	}
+
+	c.flags.RESTClientGetter = getter
+
+	o, err := c.flags.ToOptions(args)
+	cmdutil.CheckErr(err)
+	cmdutil.CheckErr(o.RunWait())
+
+	return nil
+}

--- a/internal/cli/wait_test.go
+++ b/internal/cli/wait_test.go
@@ -1,0 +1,45 @@
+package cli
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/tilt-dev/tilt/pkg/apis"
+	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
+)
+
+func TestWait(t *testing.T) {
+	f := newServerFixture(t)
+	defer f.TearDown()
+
+	err := f.client.Create(f.ctx, &v1alpha1.UIResource{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-sleep"},
+		Status: v1alpha1.UIResourceStatus{
+			Conditions: []v1alpha1.UIResourceCondition{
+				{
+					Type:               v1alpha1.UIResourceReady,
+					Status:             metav1.ConditionTrue,
+					LastTransitionTime: apis.NowMicro(),
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	out := bytes.NewBuffer(nil)
+	wait := newWaitCmd()
+	cmd := wait.register()
+	wait.flags.IOStreams.Out = out
+
+	err = cmd.Flags().Parse([]string{"--for=condition=Ready"})
+	require.NoError(t, err)
+
+	err = wait.run(f.ctx, []string{"uiresource/my-sleep"})
+	require.NoError(t, err)
+
+	assert.Contains(t, out.String(), `uiresource.tilt.dev/my-sleep condition met`)
+}


### PR DESCRIPTION
Hello @milas,

Please review the following commits I made in branch nicks/wait:

3393803952243553ffcd4544c0350ea38bf2978b (2021-11-30 16:04:29 -0500)
cli: add 'tilt wait' to wait on resources to become ready

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics