### PR TITLE
cli: make 'up' and server commands choose a free port

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,9 +55,11 @@ else
 	gotestsum --format standard-quiet --junitfile test-results/unit-tests.xml --rerun-fails=2 --rerun-fails-max-failures=10 --packages="./..." -- -mod vendor -count 1 -p $(GO_PARALLEL_JOBS) -short -tags skipcontainertests,skiplargetiltfiletests -timeout 100s
 endif
 
+TEST_RUN_ARG = $(if $(TEST_RUN),-run $(TEST_RUN),)
+
 integration:
 ifneq ($(CIRCLECI),true)
-		go test -mod vendor -v -count 1 -p $(GO_PARALLEL_JOBS) -tags 'integration' -timeout 700s ./integration
+		go test -mod vendor -v -count 1 -p $(GO_PARALLEL_JOBS) $(TEST_RUN_ARG) -tags 'integration' -timeout 700s ./integration
 else
 		mkdir -p test-results
 		gotestsum --format dots --junitfile test-results/unit-tests.xml -- ./integration -mod vendor -count 1 -p $(GO_PARALLEL_JOBS) -tags 'integration' -timeout 700s

--- a/Tiltfile
+++ b/Tiltfile
@@ -51,7 +51,7 @@ def go_vendor():
 
 all_go_files = get_all_go_files(".")
 
-go("Tilt", "cmd/tilt/main.go", all_go_files, srv="cd /tmp/ && ./tilt up --hud=false --web-mode=prod --port=9765")
+go("Tilt", "cmd/tilt/main.go", all_go_files, srv="cd /tmp/ && ./tilt up --hud=false --web-mode=prod")
 go_lint(all_go_files)
 go_vendor()
 

--- a/integration/crash_test.go
+++ b/integration/crash_test.go
@@ -11,18 +11,16 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// Make sure that Tilt crashes if there are two tilts running on the same port.
+// Make sure that Tilt crashes if there are two tilts running on the same requested port.
 func TestCrash(t *testing.T) {
 	f := newK8sFixture(t, "oneup")
 	defer f.TearDown()
 
-	f.TiltUp()
+	f.TiltUp("--port=9975")
 	time.Sleep(500 * time.Millisecond)
 
 	out := bytes.NewBuffer(nil)
-	// fixture assigns a random unused port when created, which is used for all Tilt commands, so this
-	// will collide with the previous invocation
-	res, err := f.tilt.Up(f.ctx, UpCommandUp, out)
+	res, err := f.tilt.Up(f.ctx, UpCommandUp, out, "--port=9975")
 	assert.NoError(t, err)
 	<-res.Done()
 	assert.Contains(t, out.String(), "Tilt cannot start")

--- a/internal/cli/ci.go
+++ b/internal/cli/ci.go
@@ -67,20 +67,19 @@ func (c *ciCmd) run(ctx context.Context, args []string) error {
 
 	log.SetFlags(log.Flags() &^ (log.Ldate | log.Ltime))
 
-	webHost := provideWebHost()
-	webURL, _ := provideWebURL(webHost, provideWebPort())
-	startLine := prompt.StartStatusLine(webURL, webHost)
+	cmdCIDeps, err := wireCmdCI(ctx, a, "ci")
+	if err != nil {
+		deferred.SetOutput(deferred.Original())
+		return err
+	}
+
+	webURL, _ := provideWebURL(cmdCIDeps.Host, cmdCIDeps.Port)
+	startLine := prompt.StartStatusLine(webURL, cmdCIDeps.Host)
 	log.Print(startLine)
 	log.Print(buildStamp())
 
 	if ok, reason := analytics.IsAnalyticsDisabledFromEnv(); ok {
 		log.Printf("Tilt analytics disabled: %s", reason)
-	}
-
-	cmdCIDeps, err := wireCmdCI(ctx, a, "ci")
-	if err != nil {
-		deferred.SetOutput(deferred.Original())
-		return err
 	}
 
 	upper := cmdCIDeps.Upper

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -218,9 +218,16 @@ func provideWebPort() model.WebPort {
 
 func provideServerPort() model.WebPort {
 	host := provideWebHost()
+	port := int(provideWebPort())
+
+	// Return the port as requested if not the default port
+	if port != defaultWebPort {
+		return model.WebPort(port)
+	}
+
 	max_port := ((1 << 16) - 1)
 
-	for port := int(provideWebPort()); port < max_port; port++ {
+	for ; port < max_port; port++ {
 		listener, err := net.Listen("tcp", fmt.Sprintf("%s:%d", string(host), port))
 		if err == nil {
 			listener.Close()

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -218,16 +218,18 @@ func provideWebPort() model.WebPort {
 
 func provideServerPort() model.WebPort {
 	host := provideWebHost()
-	port := int(provideWebPort())
-	for {
+	max_port := ((1 << 16) - 1)
+
+	for port := int(provideWebPort()); port < max_port; port++ {
 		listener, err := net.Listen("tcp", fmt.Sprintf("%s:%d", string(host), port))
 		if err == nil {
 			listener.Close()
 			webPortFlag = port
 			return model.WebPort(port)
 		}
-		port++
 	}
+
+	panic("Error: unable to find a free web port to serve")
 }
 
 func provideWebURL(webHost model.WebHost, webPort model.WebPort) (model.WebURL, error) {

--- a/internal/hud/server/apiserver.go
+++ b/internal/hud/server/apiserver.go
@@ -93,8 +93,7 @@ func ProvideWebListener(host model.WebHost, port model.WebPort) (WebListener, er
 	webListener, err := net.Listen("tcp", fmt.Sprintf("%s:%d", string(host), int(port)))
 	if err != nil {
 		return nil, fmt.Errorf("Tilt cannot start because you already have another process on port %d\n"+
-			"If you want to run multiple Tilt instances simultaneously,\n"+
-			"use the --port flag or TILT_PORT env variable to set a custom port\nOriginal error: %v",
+			"Choose another port, or run Tilt without the --port flag to find an open port\nOriginal error: %v",
 			port, err)
 	}
 	return WebListener(webListener), nil


### PR DESCRIPTION
For those Tilt users that run multiple Tilt processes on their machines (and leave them running), this PR obviates the need to manage the `--port` on which to run. `tilt up` will find and advertise the first available free port starting with 10350. 