### PR TITLE
cli: `tilt args` allows editing args in $EDITOR

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0
 	github.com/jonboulle/clockwork v0.2.2
 	github.com/json-iterator/go v1.1.11
+	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/looplab/tarjan v0.0.0-20161115091335-9cc6d6cebfb5
 	github.com/mattn/go-colorable v0.1.7
 	github.com/mattn/go-isatty v0.0.12

--- a/go.sum
+++ b/go.sum
@@ -732,6 +732,8 @@ github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7V
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0 h1:iQTw/8FWTuc7uiaSepXwyf3o52HaUYcV+Tu66S3F5GA=
 github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0/go.mod h1:1NbS8ALrpOvjt0rHPNLyCIeMtbizbir8U//inJ+zuB8=
+github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 h1:Z9n2FFNUXsshfwJMBgNA0RU6/i7WVaAegv3PtuIHPMs=
+github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=

--- a/internal/cli/args_test.go
+++ b/internal/cli/args_test.go
@@ -76,6 +76,9 @@ func TestArgsEdit(t *testing.T) {
 		{"multiple lines", "foo\nbar\n", nil, "cannot have multiple non-comment lines"},
 		{"empty lines ignored", "1 2\n\n\n", []string{"1", "2"}, ""},
 		{"dashes", "--foo --bar", []string{"--foo", "--bar"}, ""},
+		{"quoted hash", "1 '2 # not a comment'", []string{"1", "2 # not a comment"}, ""},
+		// TODO - fix comment parsing so the below passes
+		// {"mid-line comment", "1 2 # comment", []string{"1", "2"}, ""},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			f := newServerFixture(t)

--- a/internal/cli/args_test.go
+++ b/internal/cli/args_test.go
@@ -84,6 +84,7 @@ func TestArgsEdit(t *testing.T) {
 			f, err := os.CreateTemp(t.TempDir(), "writeargs*.bat")
 			require.NoError(t, err)
 			_, err = f.WriteString(fmt.Sprintf(`type %s > %%1`, argFile.Name()))
+			require.NoError(t, err)
 			err = f.Close()
 			require.NoError(t, err)
 			return f.Name()

--- a/internal/cli/args_test.go
+++ b/internal/cli/args_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"fmt"
 	"os"
+	"runtime"
 	"testing"
 
 	"github.com/alessio/shellescape"
@@ -62,6 +63,9 @@ func TestArgsClearAndNewValue(t *testing.T) {
 }
 
 func TestArgsEdit(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("haven't figured out an appropriate $EDITOR for windows")
+	}
 	for _, tc := range []struct {
 		name          string
 		contents      string

--- a/vendor/github.com/kballard/go-shellquote/LICENSE
+++ b/vendor/github.com/kballard/go-shellquote/LICENSE
@@ -1,0 +1,19 @@
+Copyright (C) 2014 Kevin Ballard
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
+OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/vendor/github.com/kballard/go-shellquote/README
+++ b/vendor/github.com/kballard/go-shellquote/README
@@ -1,0 +1,33 @@
+PACKAGE
+
+package shellquote
+import "github.com/kballard/go-shellquote"
+
+    Shellquote provides utilities for joining/splitting strings using sh's
+    word-splitting rules.
+
+VARIABLES
+
+var (
+UnterminatedSingleQuoteError = errors.New("Unterminated single-quoted string")
+UnterminatedDoubleQuoteError = errors.New("Unterminated double-quoted string")
+UnterminatedEscapeError = errors.New("Unterminated backslash-escape")
+)
+
+FUNCTIONS
+
+func Join(args ...string) string
+Join quotes each argument and joins them with a space. If passed to
+/bin/sh, the resulting string will be split back into the original
+arguments.
+
+func Split(input string) (words []string, err error)
+Split splits a string according to /bin/sh's word-splitting rules. It
+supports backslash-escapes, single-quotes, and double-quotes. Notably it
+does not support the $'' style of quoting. It also doesn't attempt to
+perform any other sort of expansion, including brace expansion, shell
+expansion, or pathname expansion.
+
+    If the given input has an unterminated quoted string or ends in a
+    backslash-escape, one of UnterminatedSingleQuoteError,
+    UnterminatedDoubleQuoteError, or UnterminatedEscapeError is returned.

--- a/vendor/github.com/kballard/go-shellquote/doc.go
+++ b/vendor/github.com/kballard/go-shellquote/doc.go
@@ -1,0 +1,3 @@
+// Shellquote provides utilities for joining/splitting strings using sh's
+// word-splitting rules.
+package shellquote

--- a/vendor/github.com/kballard/go-shellquote/quote.go
+++ b/vendor/github.com/kballard/go-shellquote/quote.go
@@ -1,0 +1,102 @@
+package shellquote
+
+import (
+	"bytes"
+	"strings"
+	"unicode/utf8"
+)
+
+// Join quotes each argument and joins them with a space.
+// If passed to /bin/sh, the resulting string will be split back into the
+// original arguments.
+func Join(args ...string) string {
+	var buf bytes.Buffer
+	for i, arg := range args {
+		if i != 0 {
+			buf.WriteByte(' ')
+		}
+		quote(arg, &buf)
+	}
+	return buf.String()
+}
+
+const (
+	specialChars      = "\\'\"`${[|&;<>()*?!"
+	extraSpecialChars = " \t\n"
+	prefixChars       = "~"
+)
+
+func quote(word string, buf *bytes.Buffer) {
+	// We want to try to produce a "nice" output. As such, we will
+	// backslash-escape most characters, but if we encounter a space, or if we
+	// encounter an extra-special char (which doesn't work with
+	// backslash-escaping) we switch over to quoting the whole word. We do this
+	// with a space because it's typically easier for people to read multi-word
+	// arguments when quoted with a space rather than with ugly backslashes
+	// everywhere.
+	origLen := buf.Len()
+
+	if len(word) == 0 {
+		// oops, no content
+		buf.WriteString("''")
+		return
+	}
+
+	cur, prev := word, word
+	atStart := true
+	for len(cur) > 0 {
+		c, l := utf8.DecodeRuneInString(cur)
+		cur = cur[l:]
+		if strings.ContainsRune(specialChars, c) || (atStart && strings.ContainsRune(prefixChars, c)) {
+			// copy the non-special chars up to this point
+			if len(cur) < len(prev) {
+				buf.WriteString(prev[0 : len(prev)-len(cur)-l])
+			}
+			buf.WriteByte('\\')
+			buf.WriteRune(c)
+			prev = cur
+		} else if strings.ContainsRune(extraSpecialChars, c) {
+			// start over in quote mode
+			buf.Truncate(origLen)
+			goto quote
+		}
+		atStart = false
+	}
+	if len(prev) > 0 {
+		buf.WriteString(prev)
+	}
+	return
+
+quote:
+	// quote mode
+	// Use single-quotes, but if we find a single-quote in the word, we need
+	// to terminate the string, emit an escaped quote, and start the string up
+	// again
+	inQuote := false
+	for len(word) > 0 {
+		i := strings.IndexRune(word, '\'')
+		if i == -1 {
+			break
+		}
+		if i > 0 {
+			if !inQuote {
+				buf.WriteByte('\'')
+				inQuote = true
+			}
+			buf.WriteString(word[0:i])
+		}
+		word = word[i+1:]
+		if inQuote {
+			buf.WriteByte('\'')
+			inQuote = false
+		}
+		buf.WriteString("\\'")
+	}
+	if len(word) > 0 {
+		if !inQuote {
+			buf.WriteByte('\'')
+		}
+		buf.WriteString(word)
+		buf.WriteByte('\'')
+	}
+}

--- a/vendor/github.com/kballard/go-shellquote/unquote.go
+++ b/vendor/github.com/kballard/go-shellquote/unquote.go
@@ -1,0 +1,156 @@
+package shellquote
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"unicode/utf8"
+)
+
+var (
+	UnterminatedSingleQuoteError = errors.New("Unterminated single-quoted string")
+	UnterminatedDoubleQuoteError = errors.New("Unterminated double-quoted string")
+	UnterminatedEscapeError      = errors.New("Unterminated backslash-escape")
+)
+
+var (
+	splitChars        = " \n\t"
+	singleChar        = '\''
+	doubleChar        = '"'
+	escapeChar        = '\\'
+	doubleEscapeChars = "$`\"\n\\"
+)
+
+// Split splits a string according to /bin/sh's word-splitting rules. It
+// supports backslash-escapes, single-quotes, and double-quotes. Notably it does
+// not support the $'' style of quoting. It also doesn't attempt to perform any
+// other sort of expansion, including brace expansion, shell expansion, or
+// pathname expansion.
+//
+// If the given input has an unterminated quoted string or ends in a
+// backslash-escape, one of UnterminatedSingleQuoteError,
+// UnterminatedDoubleQuoteError, or UnterminatedEscapeError is returned.
+func Split(input string) (words []string, err error) {
+	var buf bytes.Buffer
+	words = make([]string, 0)
+
+	for len(input) > 0 {
+		// skip any splitChars at the start
+		c, l := utf8.DecodeRuneInString(input)
+		if strings.ContainsRune(splitChars, c) {
+			input = input[l:]
+			continue
+		} else if c == escapeChar {
+			// Look ahead for escaped newline so we can skip over it
+			next := input[l:]
+			if len(next) == 0 {
+				err = UnterminatedEscapeError
+				return
+			}
+			c2, l2 := utf8.DecodeRuneInString(next)
+			if c2 == '\n' {
+				input = next[l2:]
+				continue
+			}
+		}
+
+		var word string
+		word, input, err = splitWord(input, &buf)
+		if err != nil {
+			return
+		}
+		words = append(words, word)
+	}
+	return
+}
+
+func splitWord(input string, buf *bytes.Buffer) (word string, remainder string, err error) {
+	buf.Reset()
+
+raw:
+	{
+		cur := input
+		for len(cur) > 0 {
+			c, l := utf8.DecodeRuneInString(cur)
+			cur = cur[l:]
+			if c == singleChar {
+				buf.WriteString(input[0 : len(input)-len(cur)-l])
+				input = cur
+				goto single
+			} else if c == doubleChar {
+				buf.WriteString(input[0 : len(input)-len(cur)-l])
+				input = cur
+				goto double
+			} else if c == escapeChar {
+				buf.WriteString(input[0 : len(input)-len(cur)-l])
+				input = cur
+				goto escape
+			} else if strings.ContainsRune(splitChars, c) {
+				buf.WriteString(input[0 : len(input)-len(cur)-l])
+				return buf.String(), cur, nil
+			}
+		}
+		if len(input) > 0 {
+			buf.WriteString(input)
+			input = ""
+		}
+		goto done
+	}
+
+escape:
+	{
+		if len(input) == 0 {
+			return "", "", UnterminatedEscapeError
+		}
+		c, l := utf8.DecodeRuneInString(input)
+		if c == '\n' {
+			// a backslash-escaped newline is elided from the output entirely
+		} else {
+			buf.WriteString(input[:l])
+		}
+		input = input[l:]
+	}
+	goto raw
+
+single:
+	{
+		i := strings.IndexRune(input, singleChar)
+		if i == -1 {
+			return "", "", UnterminatedSingleQuoteError
+		}
+		buf.WriteString(input[0:i])
+		input = input[i+1:]
+		goto raw
+	}
+
+double:
+	{
+		cur := input
+		for len(cur) > 0 {
+			c, l := utf8.DecodeRuneInString(cur)
+			cur = cur[l:]
+			if c == doubleChar {
+				buf.WriteString(input[0 : len(input)-len(cur)-l])
+				input = cur
+				goto raw
+			} else if c == escapeChar {
+				// bash only supports certain escapes in double-quoted strings
+				c2, l2 := utf8.DecodeRuneInString(cur)
+				cur = cur[l2:]
+				if strings.ContainsRune(doubleEscapeChars, c2) {
+					buf.WriteString(input[0 : len(input)-len(cur)-l-l2])
+					if c2 == '\n' {
+						// newline is special, skip the backslash entirely
+					} else {
+						buf.WriteRune(c2)
+					}
+					input = cur
+				}
+			}
+		}
+		return "", "", UnterminatedDoubleQuoteError
+	}
+
+done:
+	return buf.String(), input, nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -384,6 +384,9 @@ github.com/json-iterator/go
 github.com/json-iterator/go/extra
 # github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0
 ## explicit
+# github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
+## explicit
+github.com/kballard/go-shellquote
 # github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de
 ## explicit
 github.com/liggitt/tabwriter


### PR DESCRIPTION
Previously:
* `tilt args` w/ no args would just generate an error telling the user to use `--clear` if they wanted to clear the args
* `tilt args` operated via a gorilla-routed api

Now:
* `tilt args` w/ no args opens the current args in $EDITOR and applies the result to the Tiltfile (using a chunk of the code that powers `kubectl edit`)
* `tilt args` operates via the Tilt API server

Notes:
* I haven't implemented the "on error, re-open the file and iterate" behavior that `kubectl edit` has - that seemed like more of a nice-to-have and better as a separate PR.
* Suggestions on wording (the initial comment/instructions placed in the editor, error messages, help) welcome!