### PR TITLE
fix: lookup hosts before passing to NewOnAddresses

### DIFF
--- a/internal/hud/server/apiserver.go
+++ b/internal/hud/server/apiserver.go
@@ -92,10 +92,13 @@ func ProvideConfigAccess(dir *dirs.TiltDevDir) clientcmd.ConfigAccess {
 func ProvideWebListener(host model.WebHost, port model.WebPort) (WebListener, error) {
 	webListener, err := net.Listen("tcp", fmt.Sprintf("%s:%d", string(host), int(port)))
 	if err != nil {
-		return nil, fmt.Errorf("Tilt cannot start because you already have another process on port %d\n"+
-			"If you want to run multiple Tilt instances simultaneously,\n"+
-			"use the --port flag or TILT_PORT env variable to set a custom port\nOriginal error: %v",
-			port, err)
+		if strings.HasSuffix(err.Error(), "address already in use") {
+			return nil, fmt.Errorf("Tilt cannot start because you already have another process on port %d\n"+
+				"If you want to run multiple Tilt instances simultaneously,\n"+
+				"use the --port flag or TILT_PORT env variable to set a custom port\nOriginal error: %v",
+				port, err)
+		}
+		return nil, err
 	}
 	return WebListener(webListener), nil
 }

--- a/internal/k8s/portforward.go
+++ b/internal/k8s/portforward.go
@@ -130,7 +130,10 @@ func (c portForwardClient) CreatePortForwarder(ctx context.Context, namespace Na
 			ports,
 			readyChan)
 	} else {
-		addresses := []string{host}
+		addresses, lookupErr := net.LookupHost(host)
+		if lookupErr != nil {
+			return nil, errors.Wrap(err, fmt.Sprintf("failed to look up address for %s", host))
+		}
 		pf, err = portforward.NewOnAddresses(
 			ctx,
 			dialer,

--- a/internal/k8s/portforward.go
+++ b/internal/k8s/portforward.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"net/url"
 	"strconv"
 
 	v1 "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -130,9 +131,14 @@ func (c portForwardClient) CreatePortForwarder(ctx context.Context, namespace Na
 			ports,
 			readyChan)
 	} else {
-		addresses, lookupErr := net.LookupHost(host)
-		if lookupErr != nil {
-			return nil, errors.Wrap(lookupErr, fmt.Sprintf("failed to look up address for %s", host))
+		// handle IPv6 literals like `[::1]`
+		url, hostErr := url.Parse(fmt.Sprintf("http://%s/", host))
+		if hostErr != nil {
+			return nil, errors.Wrap(hostErr, fmt.Sprintf("invalid host %s", host))
+		}
+		addresses, hostErr := net.LookupHost(url.Hostname())
+		if hostErr != nil {
+			return nil, errors.Wrap(hostErr, fmt.Sprintf("failed to look up address for %s", host))
 		}
 		pf, err = portforward.NewOnAddresses(
 			ctx,

--- a/internal/k8s/portforward.go
+++ b/internal/k8s/portforward.go
@@ -156,18 +156,17 @@ func (c portForwardClient) CreatePortForwarder(ctx context.Context, namespace Na
 
 func getListenableAddresses(host string) ([]string, error) {
 	// handle IPv6 literals like `[::1]`
-	url, hostErr := url.Parse(fmt.Sprintf("http://%s/", host))
-	if hostErr != nil {
-		return nil, errors.Wrap(hostErr, fmt.Sprintf("invalid host %s", host))
+	url, err := url.Parse(fmt.Sprintf("http://%s/", host))
+	if err != nil {
+		return nil, errors.Wrap(err, fmt.Sprintf("invalid host %s", host))
 	}
-	addresses, hostErr := net.LookupHost(url.Hostname())
-	if hostErr != nil {
-		return nil, errors.Wrap(hostErr, fmt.Sprintf("failed to look up address for %s", host))
+	addresses, err := net.LookupHost(url.Hostname())
+	if err != nil {
+		return nil, errors.Wrap(err, fmt.Sprintf("failed to look up address for %s", host))
 	}
 	listenable := make([]string, 0)
 	for _, addr := range addresses {
 		var l net.Listener
-		var err error
 		if ipv6 := strings.Contains(addr, ":"); ipv6 {
 			l, err = net.Listen("tcp6", fmt.Sprintf("[%s]:0", addr))
 		} else {
@@ -179,7 +178,7 @@ func getListenableAddresses(host string) ([]string, error) {
 		}
 	}
 	if len(listenable) == 0 {
-		return nil, errors.New(fmt.Sprintf("host %s: cannot listen on any resolved addresses: %v", host, addresses))
+		return nil, errors.Errorf("host %s: cannot listen on any resolved addresses: %v", host, addresses)
 	}
 	return listenable, nil
 }

--- a/internal/k8s/portforward.go
+++ b/internal/k8s/portforward.go
@@ -132,7 +132,7 @@ func (c portForwardClient) CreatePortForwarder(ctx context.Context, namespace Na
 	} else {
 		addresses, lookupErr := net.LookupHost(host)
 		if lookupErr != nil {
-			return nil, errors.Wrap(err, fmt.Sprintf("failed to look up address for %s", host))
+			return nil, errors.Wrap(lookupErr, fmt.Sprintf("failed to look up address for %s", host))
 		}
 		pf, err = portforward.NewOnAddresses(
 			ctx,


### PR DESCRIPTION
After trying multiple ways of looking up and caching the provided value for `--host`/`providedWebHost`, this turned out to be the simplest option to just look up the host before creating the portforward, so it will handle both the defaulted web host and specified hosts. It has the added benefit of creating portforwards on IPV6 addresses if any are resolved for the given host.

- Fixes #5043.
- Also fixes port-forwarding when passing an IPv6 literal like `tilt up --host='[::1]'`
- Only sets up port-forwards on addresses that can be listened, and returns an error if none of the resolved addresses can.
- Clarify error message between port collision and other errors
```
$ tilt up --port 10350
Tilt started on http://localhost:10350/
v0.23.1-dev, built 2021-12-02
Error: Tilt cannot start because you already have another process on port 10350
If you want to run multiple Tilt instances simultaneously,
use the --port flag or TILT_PORT env variable to set a custom port
Original error: listen tcp 127.0.0.1:10350: bind: address already in use

$ tilt up --host '[::1' --port 10351
Tilt started (without browser UI)
v0.23.1-dev, built 2021-12-02
Error: listen tcp: address [::1:10351: missing ']' in address
```