### PR TITLE
web: fix multiple analytics calls on instrumented text field input

### DIFF
--- a/web/src/instrumentedComponents.tsx
+++ b/web/src/instrumentedComponents.tsx
@@ -46,7 +46,7 @@ export function InstrumentedButton(props: ButtonProps & InstrumentationProps) {
 // event per this duration. These don't need to be submitted super
 // urgently, and we want to be closer to sending one per user intent than
 // one per keystroke.
-const textFieldEditDebounceMilliseconds = 5000
+export const textFieldEditDebounceMilliseconds = 5000
 
 export function InstrumentedTextField(
   props: TextFieldProps & InstrumentationProps
@@ -57,17 +57,17 @@ export function InstrumentedTextField(
   const debouncedIncr = useMemo(
     () =>
       // debounce so we don't send analytics for every single keypress
-      debounce(() => {
-        incr(analyticsName, {
+      debounce((name: string, tags?: Tags) => {
+        incr(name, {
           action: AnalyticsAction.Edit,
-          ...(analyticsTags ?? {}),
+          ...(tags ?? {}),
         })
       }, textFieldEditDebounceMilliseconds),
-    [analyticsName, analyticsTags]
+    []
   )
 
   const instrumentedOnChange: typeof onChange = (e) => {
-    debouncedIncr()
+    debouncedIncr(analyticsName, analyticsTags)
     if (onChange) {
       onChange(e)
     }


### PR DESCRIPTION
[Originally noted here](https://github.com/tilt-dev/tilt/pull/5212#pullrequestreview-813993395). The analytics events for typing into an `ApiButton`'s text input field are delayed, but they fire multiple times. There's not an event for every keystroke, but it's way more than what I'd expect with a five second debounce delay.

This PR removes `useMemo`'s dependencies to make sure debounce analytics calls fires only once. (The dependencies aren't really needed, since the debounce function has access to the current values for `analyticsName` and `analyticsTags`.)