### PR TITLE
dockercompose: greenlight dc version 2.2 or later

### DIFF
--- a/internal/dockercompose/client.go
+++ b/internal/dockercompose/client.go
@@ -317,7 +317,7 @@ func dcLoaderOption(opts *loader.Options) {
 }
 
 func dcExecutablePath() string {
-	v1Name := "docker-compose-v1"
+	v1Name := "docker-compose"
 	if runtime.GOOS == "windows" {
 		v1Name += ".exe"
 	}

--- a/internal/dockercompose/client.go
+++ b/internal/dockercompose/client.go
@@ -317,11 +317,11 @@ func dcLoaderOption(opts *loader.Options) {
 }
 
 func dcExecutablePath() string {
-	v1Name := "docker-compose"
+	composeName := "docker-compose"
 	if runtime.GOOS == "windows" {
-		v1Name += ".exe"
+		composeName += ".exe"
 	}
-	composePath, err := exec.LookPath(v1Name)
+	composePath, err := exec.LookPath(composeName)
 	if err != nil {
 		composePath = "docker-compose"
 	}

--- a/internal/dockercompose/client_test.go
+++ b/internal/dockercompose/client_test.go
@@ -2,9 +2,6 @@ package dockercompose
 
 import (
 	"context"
-	"os"
-	"path/filepath"
-	"runtime"
 	"testing"
 
 	"github.com/compose-spec/compose-go/types"
@@ -69,33 +66,6 @@ func TestVariableInterpolation(t *testing.T) {
 			assert.Equal(t, 8081, int(svc.Ports[0].Target))
 		}
 	}
-}
-
-func TestPreferComposeV1(t *testing.T) {
-	t.Run("v1 Symlink Exists", func(t *testing.T) {
-		tmpdir := t.TempDir()
-		v1Name := "docker-compose-v1"
-		if runtime.GOOS == "windows" {
-			v1Name += ".exe"
-		}
-		binPath := filepath.Join(tmpdir, v1Name)
-		require.NoError(t, os.WriteFile(binPath, nil, 0777),
-			"Failed to create fake docker-compose-v1 binary")
-
-		testutils.Setenv(t, "PATH", tmpdir)
-		cli, ok := NewDockerComposeClient(docker.LocalEnv{}).(*cmdDCClient)
-		require.True(t, ok, "Unexpected type for Compose client: %T", cli)
-		assert.Equal(t, binPath, cli.composePath)
-	})
-
-	t.Run("No v1 Symlink Exists", func(t *testing.T) {
-		testutils.Unsetenv(t, "PATH")
-		cli, ok := NewDockerComposeClient(docker.LocalEnv{}).(*cmdDCClient)
-		require.True(t, ok, "Unexpected type for Compose client: %T", cli)
-		// if docker-compose-v1 isn't in path, we just set the path to the unqualified binary name and let it get
-		// resolved at exec time
-		assert.Equal(t, "docker-compose", cli.composePath)
-	})
 }
 
 func TestParseComposeVersionOutput(t *testing.T) {

--- a/internal/tiltfile/tiltfile_docker_compose_test.go
+++ b/internal/tiltfile/tiltfile_docker_compose_test.go
@@ -764,9 +764,10 @@ func TestDockerComposeVersionWarnings(t *testing.T) {
 	}
 	tcs := []tc{
 		{version: "v1.28.0", error: "Tilt requires Docker Compose v1.28.3+ (you have v1.28.0). Please upgrade and re-launch Tilt."},
-		{version: "v2.0.0-rc.3", warning: "Support for Docker Compose v2.x is experimental, and you might encounter errors or broken functionality.\n" +
-			"For best results, we recommend using Docker Compose v1.x with Tilt."},
+		{version: "v2.0.0-rc.3", warning: "Docker Compose v2.0.0-rc.3 (version < 2.2) may result in errors or broken functionality.\n" +
+			"For best results, we recommend upgrading to Docker Compose >= v2.2.0 with Tilt."},
 		{version: "v1.29.2" /* no errors or warnings */},
+		{version: "v2.2.0" /* no errors or warnings */},
 		{version: "v1.99.0-beta.4", warning: "You are running a pre-release version of Docker Compose (v1.99.0-beta.4), which is unsupported.\n" +
 			"You might encounter errors or broken functionality."},
 	}

--- a/internal/tiltfile/tiltfile_docker_compose_test.go
+++ b/internal/tiltfile/tiltfile_docker_compose_test.go
@@ -765,7 +765,7 @@ func TestDockerComposeVersionWarnings(t *testing.T) {
 	tcs := []tc{
 		{version: "v1.28.0", error: "Tilt requires Docker Compose v1.28.3+ (you have v1.28.0). Please upgrade and re-launch Tilt."},
 		{version: "v2.0.0-rc.3", warning: "Using Docker Compose v2.0.0-rc.3 (version < 2.2) may result in errors or broken functionality.\n" +
-			"For best results, we recommend upgrading to Docker Compose >= v2.2.0 with Tilt."},
+			"For best results, we recommend upgrading to Docker Compose >= v2.2.0."},
 		{version: "v1.29.2" /* no errors or warnings */},
 		{version: "v2.2.0" /* no errors or warnings */},
 		{version: "v1.99.0-beta.4", warning: "You are running a pre-release version of Docker Compose (v1.99.0-beta.4), which is unsupported.\n" +

--- a/internal/tiltfile/tiltfile_docker_compose_test.go
+++ b/internal/tiltfile/tiltfile_docker_compose_test.go
@@ -764,7 +764,7 @@ func TestDockerComposeVersionWarnings(t *testing.T) {
 	}
 	tcs := []tc{
 		{version: "v1.28.0", error: "Tilt requires Docker Compose v1.28.3+ (you have v1.28.0). Please upgrade and re-launch Tilt."},
-		{version: "v2.0.0-rc.3", warning: "Docker Compose v2.0.0-rc.3 (version < 2.2) may result in errors or broken functionality.\n" +
+		{version: "v2.0.0-rc.3", warning: "Using Docker Compose v2.0.0-rc.3 (version < 2.2) may result in errors or broken functionality.\n" +
 			"For best results, we recommend upgrading to Docker Compose >= v2.2.0 with Tilt."},
 		{version: "v1.29.2" /* no errors or warnings */},
 		{version: "v2.2.0" /* no errors or warnings */},

--- a/internal/tiltfile/tiltfile_state.go
+++ b/internal/tiltfile/tiltfile_state.go
@@ -1349,7 +1349,7 @@ func (s *tiltfileState) validateDockerComposeVersion() error {
 			minimumDockerComposeVersion,
 			dcVersion)
 	} else if semver.Major(dcVersion) == "v2" && semver.Compare(dcVersion, "v2.2") < 0 {
-		logger.Get(s.ctx).Warnf("Docker Compose %s (version < 2.2) may result in errors or broken functionality.\n"+
+		logger.Get(s.ctx).Warnf("Using Docker Compose %s (version < 2.2) may result in errors or broken functionality.\n"+
 			"For best results, we recommend upgrading to Docker Compose >= v2.2.0 with Tilt.", dcVersion)
 	} else if semver.Prerelease(dcVersion) != "" {
 		logger.Get(s.ctx).Warnf("You are running a pre-release version of Docker Compose (%s), which is unsupported.\n"+

--- a/internal/tiltfile/tiltfile_state.go
+++ b/internal/tiltfile/tiltfile_state.go
@@ -1350,7 +1350,7 @@ func (s *tiltfileState) validateDockerComposeVersion() error {
 			dcVersion)
 	} else if semver.Major(dcVersion) == "v2" && semver.Compare(dcVersion, "v2.2") < 0 {
 		logger.Get(s.ctx).Warnf("Using Docker Compose %s (version < 2.2) may result in errors or broken functionality.\n"+
-			"For best results, we recommend upgrading to Docker Compose >= v2.2.0 with Tilt.", dcVersion)
+			"For best results, we recommend upgrading to Docker Compose >= v2.2.0.", dcVersion)
 	} else if semver.Prerelease(dcVersion) != "" {
 		logger.Get(s.ctx).Warnf("You are running a pre-release version of Docker Compose (%s), which is unsupported.\n"+
 			"You might encounter errors or broken functionality.", dcVersion)

--- a/internal/tiltfile/tiltfile_state.go
+++ b/internal/tiltfile/tiltfile_state.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"time"
 
@@ -1349,20 +1348,9 @@ func (s *tiltfileState) validateDockerComposeVersion() error {
 			"Tilt requires Docker Compose %s+ (you have %s). Please upgrade and re-launch Tilt.",
 			minimumDockerComposeVersion,
 			dcVersion)
-	} else if semver.Major(dcVersion) == "v2" {
-		var downgradeInstructions string
-		if runtime.GOOS == "windows" || runtime.GOOS == "darwin" {
-			// `docker-compose` on Docker Desktop is a shim that conditionally execs either v1 or v2
-			downgradeInstructions = "Run `docker-compose disable-v2` and re-launch Tilt."
-		} else {
-			// Compose v2 on Linux is a Docker plugin, used by running "docker compose" (notice the lack of hyphen -
-			// it's a subcommand found by searching `~/.docker/cli-plugins`), so if `docker-compose` points to v2,
-			// there must be a custom symlink; this will likely become more common over time as users want to
-			// maintain compatibility with existing tooling
-			downgradeInstructions = "Ensure `docker-compose` in your PATH points to Compose v1 and re-launch Tilt.\n"
-		}
-		logger.Get(s.ctx).Warnf("Support for Docker Compose v2.x is experimental, and you might encounter errors or broken functionality.\n"+
-			"For best results, we recommend using Docker Compose v1.x with Tilt.\n%s", downgradeInstructions)
+	} else if semver.Major(dcVersion) == "v2" && semver.Compare(dcVersion, "v2.2") < 0 {
+		logger.Get(s.ctx).Warnf("Docker Compose %s (version < 2.2) may result in errors or broken functionality.\n"+
+			"For best results, we recommend upgrading to Docker Compose >= v2.2.0 with Tilt.", dcVersion)
 	} else if semver.Prerelease(dcVersion) != "" {
 		logger.Get(s.ctx).Warnf("You are running a pre-release version of Docker Compose (%s), which is unsupported.\n"+
 			"You might encounter errors or broken functionality.", dcVersion)


### PR DESCRIPTION
Fixes #4890.

Based on [this comment](https://github.com/tilt-dev/tilt/issues/4993#issuecomment-981637127) on #4993 as well as commentary at the end of docker/compose#8554, version 2.2 or greater appears to be stable.