### PR TITLE
tiltfile: by default, local servers can start in parallel

### DIFF
--- a/internal/tiltfile/tiltfile_state.go
+++ b/internal/tiltfile/tiltfile_state.go
@@ -1619,7 +1619,7 @@ func (s *tiltfileState) translateLocal() ([]model.Manifest, error) {
 		lt := model.NewLocalTarget(model.TargetName(r.name), r.updateCmd, r.serveCmd, r.deps).
 			WithRepos(reposForPaths(paths)).
 			WithIgnores(ignores).
-			WithAllowParallel(r.allowParallel).
+			WithAllowParallel(r.allowParallel || r.updateCmd.Empty()).
 			WithLinks(r.links).
 			WithTags(r.tags).
 			WithIsTest(r.isTest).

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -4932,6 +4932,7 @@ func TestLocalResourceAllowParallel(t *testing.T) {
 	f.file("Tiltfile", `
 local_resource("a", ["echo", "hi"], allow_parallel=True)
 local_resource("b", ["echo", "hi"])
+local_resource("c", serve_cmd=["echo", "hi"])
 `)
 
 	f.load()
@@ -4939,6 +4940,12 @@ local_resource("b", ["echo", "hi"])
 	assert.True(t, a.LocalTarget().AllowParallel)
 	b := f.assertNextManifest("b")
 	assert.False(t, b.LocalTarget().AllowParallel)
+
+	// local_resource serve_cmd is currently modeled as a no-op local cmd that
+	// triggers a server restart. It's always OK for those no-op local cmds to
+	// run in parallel.
+	c := f.assertNextManifest("c")
+	assert.True(t, c.LocalTarget().AllowParallel)
 }
 
 func TestLocalResourceInvalidName(t *testing.T) {


### PR DESCRIPTION
Hello @landism,

Please review the following commits I made in branch nicks/allowparallel:

af2afc1678b44f376cc0fa4108987edf6b3ab26a (2021-12-06 18:07:44 -0500)
tiltfile: by default, local servers can start in parallel

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics