### PR TITLE
down: support specifying services w/ DC

### DIFF
--- a/internal/dockercompose/client.go
+++ b/internal/dockercompose/client.go
@@ -45,7 +45,8 @@ var dcProjectOptions = []compose.ProjectOptionsFn{
 
 type DockerComposeClient interface {
 	Up(ctx context.Context, spec model.DockerComposeUpSpec, shouldBuild bool, stdout, stderr io.Writer) error
-	Down(ctx context.Context, spec model.DockerComposeProject, stdout, stderr io.Writer) error
+	Down(ctx context.Context, p model.DockerComposeProject, stdout, stderr io.Writer) error
+	Rm(ctx context.Context, specs []model.DockerComposeUpSpec, stdout, stderr io.Writer) error
 	StreamLogs(ctx context.Context, spec model.DockerComposeUpSpec) io.ReadCloser
 	StreamEvents(ctx context.Context, spec model.DockerComposeProject) (<-chan string, error)
 	Project(ctx context.Context, spec model.DockerComposeProject) (*types.Project, error)
@@ -138,6 +139,42 @@ func (c *cmdDCClient) Down(ctx context.Context, p model.DockerComposeProject, st
 	}
 
 	args = append(args, "down")
+	cmd := c.dcCommand(ctx, args)
+	cmd.Stdin = strings.NewReader(p.YAML)
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+
+	err := cmd.Run()
+	if err != nil {
+		return FormatError(cmd, nil, err)
+	}
+
+	return nil
+}
+
+func (c *cmdDCClient) Rm(ctx context.Context, specs []model.DockerComposeUpSpec, stdout, stderr io.Writer) error {
+	if len(specs) == 0 {
+		return nil
+	}
+
+	// To be safe, we try not to run two docker-compose downs in parallel,
+	// because we know docker-compose up is not thread-safe.
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	p := specs[0].Project
+	args := c.projectArgs(p)
+	if logger.Get(ctx).Level().ShouldDisplay(logger.VerboseLvl) {
+		args = append(args, "--verbose")
+	}
+
+	var serviceNames []string
+	for _, s := range specs {
+		serviceNames = append(serviceNames, s.Service)
+	}
+
+	args = append(args, []string{"rm", "--stop", "--force"}...)
+	args = append(args, serviceNames...)
 	cmd := c.dcCommand(ctx, args)
 	cmd.Stdin = strings.NewReader(p.YAML)
 	cmd.Stdout = stdout

--- a/internal/dockercompose/fake_client.go
+++ b/internal/dockercompose/fake_client.go
@@ -34,7 +34,10 @@ type FakeDCClient struct {
 	VersionOutput     string
 
 	UpCalls   []UpCall
+	DownCalls []DownCall
+	RmCalls   []RmCall
 	DownError error
+	RmError   error
 	WorkDir   string
 }
 
@@ -44,6 +47,15 @@ var _ DockerComposeClient = &FakeDCClient{}
 type UpCall struct {
 	Spec        model.DockerComposeUpSpec
 	ShouldBuild bool
+}
+
+// Represents a single call to Down
+type DownCall struct {
+	Proj model.DockerComposeProject
+}
+
+type RmCall struct {
+	Specs []model.DockerComposeUpSpec
 }
 
 func NewFakeDockerComposeClient(t *testing.T, ctx context.Context) *FakeDCClient {
@@ -61,10 +73,21 @@ func (c *FakeDCClient) Up(ctx context.Context, spec model.DockerComposeUpSpec,
 	return nil
 }
 
-func (c *FakeDCClient) Down(ctx context.Context, p model.DockerComposeProject, stdout, stderr io.Writer) error {
+func (c *FakeDCClient) Down(ctx context.Context, proj model.DockerComposeProject, stdout, stderr io.Writer) error {
+	c.DownCalls = append(c.DownCalls, DownCall{proj})
 	if c.DownError != nil {
 		err := c.DownError
 		c.DownError = err
+		return err
+	}
+	return nil
+}
+
+func (c *FakeDCClient) Rm(ctx context.Context, specs []model.DockerComposeUpSpec, stdout, stderr io.Writer) error {
+	c.RmCalls = append(c.RmCalls, RmCall{specs})
+	if c.RmError != nil {
+		err := c.RmError
+		c.RmError = err
 		return err
 	}
 	return nil

--- a/internal/sliceutils/sliceutils.go
+++ b/internal/sliceutils/sliceutils.go
@@ -52,6 +52,31 @@ func StringSliceEquals(a, b []string) bool {
 	return true
 }
 
+// return true iff `a` has the same elements as `b`, ignoring order
+func StringSliceSameElements(a, b []string) bool {
+	aElems := make(map[string]int)
+	bElems := make(map[string]int)
+	for _, s := range a {
+		aElems[s] += 1
+	}
+
+	for _, s := range b {
+		bElems[s] += 1
+	}
+
+	if len(aElems) != len(bElems) {
+		return false
+	}
+
+	for s, c1 := range aElems {
+		if c1 != bElems[s] {
+			return false
+		}
+	}
+
+	return true
+}
+
 // StringSliceStartsWith returns true if slice A starts with the given elem.
 func StringSliceStartsWith(a []string, elem string) bool {
 	if len(a) == 0 {


### PR DESCRIPTION
### Repro
w/ a DC config:
`tilt up foo bar baz`
`tilt down foo`

### Expected
tilt stops "foo"

### observed
tilt stops all services specified in the DC config

### Solution
AFAICT the only option to stop individual DC services is `docker-compose rm`, so use that if only a subset of the DC services are specified.