### PR TITLE
dockercompose: get `docker_compose(Blob)` wired up

### DIFF
--- a/internal/dockercompose/client.go
+++ b/internal/dockercompose/client.go
@@ -223,7 +223,7 @@ func (c *cmdDCClient) Project(ctx context.Context, spec model.DockerComposeProje
 
 	// First, use compose-go to natively load the project.
 	if len(spec.ConfigPaths) > 0 {
-		parsed, err := c.loadProjectNative(spec.ConfigPaths)
+		parsed, err := c.loadProjectNative(spec.ConfigPaths, spec.ProjectPath)
 		if err == nil {
 			proj = parsed
 		}
@@ -265,9 +265,10 @@ func (c *cmdDCClient) Version(ctx context.Context) (string, string, error) {
 	return parseComposeVersionOutput(stdout)
 }
 
-func (c *cmdDCClient) loadProjectNative(configPaths []string) (*types.Project, error) {
+func (c *cmdDCClient) loadProjectNative(configPaths []string, projectPath string) (*types.Project, error) {
 	// NOTE: take care to keep behavior in sync with loadProjectCLI()
-	opts, err := compose.NewProjectOptions(configPaths, dcProjectOptions...)
+	allProjectOptions := append(dcProjectOptions, compose.WithWorkingDirectory(projectPath))
+	opts, err := compose.NewProjectOptions(configPaths, allProjectOptions...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/dockercompose/fake_client.go
+++ b/internal/dockercompose/fake_client.go
@@ -151,7 +151,7 @@ func (c *FakeDCClient) Project(_ context.Context, m model.DockerComposeProject) 
 	workDir := c.WorkDir
 	projectName := m.Name
 	if projectName == "" {
-		projectName = workDir
+		projectName = model.NormalizeName(workDir)
 	}
 	if projectName == "" {
 		projectName = "fakedc"

--- a/internal/dockercompose/fake_client.go
+++ b/internal/dockercompose/fake_client.go
@@ -5,8 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"path/filepath"
-	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -151,18 +149,9 @@ func (c *FakeDCClient) Project(_ context.Context, m model.DockerComposeProject) 
 	}
 
 	workDir := c.WorkDir
-	projectNameOpt := func(opt *loader.Options) {
-		if workDir != "" {
-			name := filepath.Base(workDir)
-			// normalization logic from https://github.com/compose-spec/compose-go/blob/c39f6e771fe5034fe1bec40ba5f0285ec60f5efe/cli/options.go#L366-L371
-			r := regexp.MustCompile("[a-z0-9_-]")
-			name = strings.ToLower(name)
-			name = strings.Join(r.FindAllString(name, -1), "")
-			name = strings.TrimLeft(name, "_-")
-			opt.Name = name
-		} else {
-			opt.Name = "fakedc"
-		}
+	projectName := workDir
+	if projectName == "" {
+		projectName = "fakedc"
 	}
 
 	p, err := loader.Load(types.ConfigDetails{
@@ -173,7 +162,7 @@ func (c *FakeDCClient) Project(_ context.Context, m model.DockerComposeProject) 
 			},
 		},
 		Environment: opts.Environment,
-	}, dcLoaderOption, projectNameOpt)
+	}, dcLoaderOption(projectName))
 	return p, err
 }
 

--- a/internal/dockercompose/fake_client.go
+++ b/internal/dockercompose/fake_client.go
@@ -149,7 +149,10 @@ func (c *FakeDCClient) Project(_ context.Context, m model.DockerComposeProject) 
 	}
 
 	workDir := c.WorkDir
-	projectName := workDir
+	projectName := m.Name
+	if projectName == "" {
+		projectName = workDir
+	}
 	if projectName == "" {
 		projectName = "fakedc"
 	}

--- a/internal/tiltfile/docker_compose.go
+++ b/internal/tiltfile/docker_compose.go
@@ -116,7 +116,7 @@ func (s *tiltfileState) dockerCompose(thread *starlark.Thread, fn *starlark.Buil
 		Project:      project,
 		configPaths:  project.ConfigPaths,
 		services:     services,
-		tiltfilePath: starkit.CurrentExecPath(thread),
+		tiltfilePath: currentTiltfilePath,
 	}
 
 	return starlark.None, nil

--- a/internal/tiltfile/docker_compose.go
+++ b/internal/tiltfile/docker_compose.go
@@ -54,13 +54,18 @@ func (s *tiltfileState) dockerCompose(thread *starlark.Thread, fn *starlark.Buil
 	}
 
 	dc := s.dc
-	project := model.DockerComposeProject{ConfigPaths: dc.configPaths, ProjectPath: dc.Project.ProjectPath}
 
 	currentTiltfilePath := starkit.CurrentExecPath(thread)
 	if dc.tiltfilePath != "" && dc.tiltfilePath != currentTiltfilePath {
 		return starlark.None, fmt.Errorf("Cannot load docker-compose files from two different Tiltfiles.\n"+
 			"docker-compose must have a single working directory:\n"+
 			"(%s, %s)", dc.tiltfilePath, currentTiltfilePath)
+	}
+
+	project := model.DockerComposeProject{
+		ConfigPaths: dc.configPaths,
+		ProjectPath: dc.Project.ProjectPath,
+		Name:        model.NormalizeName(filepath.Base(currentTiltfilePath)),
 	}
 
 	for _, val := range paths {

--- a/internal/tiltfile/docker_compose.go
+++ b/internal/tiltfile/docker_compose.go
@@ -81,6 +81,7 @@ func (s *tiltfileState) dockerCompose(thread *starlark.Thread, fn *starlark.Buil
 			}
 			_, err = tmpfile.WriteString(yaml)
 			if err != nil {
+				tmpfile.Close()
 				return nil, errors.Wrap(err, message)
 			}
 			err = tmpfile.Close()

--- a/internal/tiltfile/docker_compose.go
+++ b/internal/tiltfile/docker_compose.go
@@ -54,7 +54,7 @@ func (s *tiltfileState) dockerCompose(thread *starlark.Thread, fn *starlark.Buil
 	}
 
 	dc := s.dc
-	project := model.DockerComposeProject{ConfigPaths: dc.configPaths, YAML: dc.Project.YAML, ProjectPath: dc.Project.ProjectPath}
+	project := model.DockerComposeProject{ConfigPaths: dc.configPaths, ProjectPath: dc.Project.ProjectPath}
 
 	currentTiltfilePath := starkit.CurrentExecPath(thread)
 	if dc.tiltfilePath != "" && dc.tiltfilePath != currentTiltfilePath {

--- a/internal/tiltfile/docker_compose.go
+++ b/internal/tiltfile/docker_compose.go
@@ -65,7 +65,7 @@ func (s *tiltfileState) dockerCompose(thread *starlark.Thread, fn *starlark.Buil
 	project := model.DockerComposeProject{
 		ConfigPaths: dc.configPaths,
 		ProjectPath: dc.Project.ProjectPath,
-		Name:        model.NormalizeName(filepath.Base(currentTiltfilePath)),
+		Name:        model.NormalizeName(filepath.Base(filepath.Dir(currentTiltfilePath))),
 	}
 
 	for _, val := range paths {

--- a/internal/tiltfile/docker_compose.go
+++ b/internal/tiltfile/docker_compose.go
@@ -2,6 +2,7 @@ package tiltfile
 
 import (
 	"context"
+	"crypto/sha256"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -75,7 +76,11 @@ func (s *tiltfileState) dockerCompose(thread *starlark.Thread, fn *starlark.Buil
 		case io.Blob:
 			yaml := v.String()
 			message := "unable to store yaml blob"
-			tmpfile, err := os.CreateTemp("", fmt.Sprintf("%s-docker-compose-*.yml", filepath.Base(filepath.Dir(currentTiltfilePath))))
+			tmpdir, err := s.tempDir()
+			if err != nil {
+				return nil, errors.Wrap(err, message)
+			}
+			tmpfile, err := os.Create(filepath.Join(tmpdir.Path(), fmt.Sprintf("%x.yml", sha256.Sum256([]byte(yaml)))))
 			if err != nil {
 				return nil, errors.Wrap(err, message)
 			}

--- a/internal/tiltfile/tiltfile_docker_compose_test.go
+++ b/internal/tiltfile/tiltfile_docker_compose_test.go
@@ -150,6 +150,36 @@ func TestDockerComposeYAMLBlob(t *testing.T) {
 	f.assertConfigFiles(expectedConfFiles...)
 }
 
+func TestDockerComposeTwoInlineBlobs(t *testing.T) {
+	f := newFixture(t)
+	defer f.TearDown()
+
+	f.dockerfile(filepath.Join("foo", "Dockerfile"))
+	f.file("Tiltfile", fmt.Sprintf(`docker_compose([blob("""\n%s\n"""), blob("""\n%s\n""")])`, simpleConfig, barServiceConfig))
+
+	f.load()
+
+	assert.Equal(t, 2, len(f.loadResult.Manifests))
+}
+
+func TestDockerComposeBlobAndFileUsesFileDirForProjectPath(t *testing.T) {
+	f := newFixture(t)
+	defer f.TearDown()
+
+	f.dockerfile(filepath.Join("foo", "Dockerfile"))
+	f.file("docker-compose.yml", simpleConfig)
+	f.file("Tiltfile", fmt.Sprintf(`docker_compose([blob("""\n%s\n"""), 'docker-compose.yml'])`, barServiceConfig))
+
+	f.load()
+
+	assert.Equal(t, 2, len(f.loadResult.Manifests))
+	f.assertDcManifest("foo",
+		dcServiceYAML(f.simpleConfigAfterParse()),
+		dockerComposeManagedImage(f.JoinPath("foo", "Dockerfile"), f.JoinPath("foo")),
+		dcPublishedPorts(12312),
+	)
+}
+
 func TestDockerComposeManifestNoDockerfile(t *testing.T) {
 	f := newFixture(t)
 	defer f.TearDown()

--- a/pkg/model/dockercompose.go
+++ b/pkg/model/dockercompose.go
@@ -1,5 +1,10 @@
 package model
 
+import (
+	"regexp"
+	"strings"
+)
+
 // A DockerComposeUpSpec describes how to apply
 // DockerCompose service.
 //
@@ -36,8 +41,20 @@ type DockerComposeProject struct {
 	// If you have multiple docker-compose.yaml files, you can combine them into a
 	// single YAML with `docker-compose -f file1.yaml -f file2.yaml config`.
 	YAML string
+
+	// The docker-compose project name. The default is to use the NormalizedName
+	// of the ProjectPath base name.
+	Name string
 }
 
 func IsEmptyDockerComposeProject(p DockerComposeProject) bool {
 	return len(p.ConfigPaths) == 0 && p.YAML == ""
+}
+
+// normalization logic from https://github.com/compose-spec/compose-go/blob/c39f6e771fe5034fe1bec40ba5f0285ec60f5efe/cli/options.go#L366-L371
+func NormalizeName(s string) string {
+	r := regexp.MustCompile("[a-z0-9_-]")
+	s = strings.ToLower(s)
+	s = strings.Join(r.FindAllString(s, -1), "")
+	return strings.TrimLeft(s, "_-")
 }


### PR DESCRIPTION
Fixes #4999.

Supports any combination of compose file paths and blobs, with the following path resolution:
1. The compose project directory will be set to the parent directory of the first file, if any.
2. Otherwise, the compose project directory will be set to the parent directory of the executing Tiltfile.

Caveats that still exist:
- Multiple `docker_compose` files, blobs, and declarations with any combination of files and blobs are merged into a single compose project with the directory inferred as above.
