### PR TITLE
tiltfile: infer the registry during reconciliation rather than during tiltfile loading

### DIFF
--- a/internal/container/selector.go
+++ b/internal/container/selector.go
@@ -21,7 +21,7 @@ type RefSelector struct {
 }
 
 func SelectorFromImageMap(spec v1alpha1.ImageMapSpec) (RefSelector, error) {
-	ref, err := reference.ParseNamed(spec.Selector)
+	ref, err := reference.ParseNormalizedNamed(spec.Selector)
 	if err != nil {
 		return RefSelector{}, fmt.Errorf("parsing image map spec (%s): %v", spec.Selector, err)
 	}

--- a/internal/controllers/core/tiltfile/reconciler_test.go
+++ b/internal/controllers/core/tiltfile/reconciler_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/tilt-dev/tilt/internal/container"
 	"github.com/tilt-dev/tilt/internal/controllers/fake"
 	"github.com/tilt-dev/tilt/internal/docker"
+	"github.com/tilt-dev/tilt/internal/k8s"
 	"github.com/tilt-dev/tilt/internal/k8s/testyaml"
 	"github.com/tilt-dev/tilt/internal/store"
 	"github.com/tilt-dev/tilt/internal/testutils/manifestbuilder"
@@ -248,8 +249,9 @@ func newFixture(t *testing.T) *fixture {
 	st := NewTestingStore()
 	tfl := tiltfile.NewFakeTiltfileLoader()
 	d := docker.NewFakeClient()
+	kClient := k8s.NewFakeK8sClient(t)
 	bs := NewBuildSource()
-	r := NewReconciler(st, tfl, d, cfb.Client, v1alpha1.NewScheme(), bs, store.EngineModeUp)
+	r := NewReconciler(st, tfl, kClient, d, cfb.Client, v1alpha1.NewScheme(), bs, store.EngineModeUp)
 	q := workqueue.NewRateLimitingQueue(
 		workqueue.NewItemExponentialFailureRateLimiter(time.Millisecond, time.Millisecond))
 	_ = bs.Start(context.Background(), handler.Funcs{}, q)

--- a/internal/controllers/fake/fake.go
+++ b/internal/controllers/fake/fake.go
@@ -3,11 +3,10 @@ package fake
 import (
 	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
 
-	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
-func NewFakeTiltClient() ctrlclient.Client {
+func NewFakeTiltClient() fakeTiltClient {
 	scheme := v1alpha1.NewScheme()
 	c := fake.NewClientBuilder().
 		WithScheme(scheme).

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -3796,7 +3796,7 @@ func newTestFixture(t *testing.T, options ...fixtureOptions) *testFixture {
 	versionExt := version.NewPlugin(model.TiltBuild{Version: "0.5.0"})
 	configExt := config.NewPlugin("up")
 	execer := localexec.NewFakeExecer(t)
-	realTFL := tiltfile.ProvideTiltfileLoader(ta, kClient, k8sContextExt, versionExt, configExt, fakeDcc, "localhost", execer, feature.MainDefaults, env)
+	realTFL := tiltfile.ProvideTiltfileLoader(ta, k8sContextExt, versionExt, configExt, fakeDcc, "localhost", execer, feature.MainDefaults, env)
 	tfl := tiltfile.NewFakeTiltfileLoader()
 	buildSource := ctrltiltfile.NewBuildSource()
 	cc := configs.NewConfigsController(cdc)
@@ -3846,7 +3846,7 @@ func newTestFixture(t *testing.T, options ...fixtureOptions) *testFixture {
 
 	kar := kubernetesapply.NewReconciler(cdc, kClient, sch, docker.Env{}, k8s.KubeContext("kind-kind"), st, "default", execer)
 
-	tfr := ctrltiltfile.NewReconciler(st, tfl, dockerClient, cdc, sch, buildSource, engineMode)
+	tfr := ctrltiltfile.NewReconciler(st, tfl, kClient, dockerClient, cdc, sch, buildSource, engineMode)
 	tbr := togglebutton.NewReconciler(cdc, sch)
 	extr := extension.NewReconciler(cdc, sch, ta)
 	extrr, err := extensionrepo.NewReconciler(cdc, base)
@@ -4478,6 +4478,10 @@ func (f *testFixture) setupDCFixture() (redis, server model.Manifest) {
 
 	if len(tlr.Manifests) != 2 {
 		f.T().Fatalf("Expected two manifests. Actual: %v", tlr.Manifests)
+	}
+
+	for _, m := range tlr.Manifests {
+		require.NoError(f.t, m.InferImagePropertiesFromCluster(container.Registry{}))
 	}
 
 	return tlr.Manifests[0], tlr.Manifests[1]

--- a/internal/testutils/manifestbuilder/assemble.go
+++ b/internal/testutils/manifestbuilder/assemble.go
@@ -1,7 +1,7 @@
 package manifestbuilder
 
 import (
-	"github.com/tilt-dev/tilt/internal/container"
+	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
 	"github.com/tilt-dev/tilt/pkg/model"
 )
 
@@ -55,9 +55,10 @@ func assembleDC(m model.Manifest, dcTarg model.DockerComposeTarget, iTargets ...
 	}
 
 	if len(ids) == 0 {
-		ref := container.MustParseNamed(dcTarg.Spec.Service)
 		iTarget := model.ImageTarget{
-			Refs: container.MustSimpleRefSet(container.NewRefSelector(ref)),
+			ImageMapSpec: v1alpha1.ImageMapSpec{
+				Selector: dcTarg.Spec.Service,
+			},
 			BuildDetails: model.DockerComposeBuild{
 				Service: dcTarg.Spec.Service,
 			},

--- a/internal/testutils/manifestbuilder/manifestbuilder.go
+++ b/internal/testutils/manifestbuilder/manifestbuilder.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/tilt-dev/tilt/internal/container"
 	"github.com/tilt-dev/tilt/internal/controllers/apis/dockerimage"
 	"github.com/tilt-dev/tilt/internal/controllers/apis/liveupdate"
 	"github.com/tilt-dev/tilt/internal/k8s"
@@ -230,7 +231,11 @@ func (b ManifestBuilder) Build() model.Manifest {
 		return model.Manifest{}
 	}
 	m = m.WithTriggerMode(b.triggerMode)
-	err := m.InferLiveUpdateSelectors()
+
+	err := m.InferImagePropertiesFromCluster(container.Registry{})
+	require.NoError(b.f.T(), err)
+
+	err = m.InferLiveUpdateSelectors()
 	require.NoError(b.f.T(), err)
 	return m
 }

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -258,6 +258,18 @@ func (m Manifest) Validate() error {
 	return nil
 }
 
+// Infer image properties for each image.
+func (m *Manifest) InferImagePropertiesFromCluster(reg container.Registry) error {
+	for i, iTarget := range m.ImageTargets {
+		iTarget, err := iTarget.InferImagePropertiesFromCluster(reg)
+		if err != nil {
+			return fmt.Errorf("manifest %s: %v", m.Name, err)
+		}
+		m.ImageTargets[i] = iTarget
+	}
+	return nil
+}
+
 // Assemble selectors that point to other API objects created by this manifest.
 func (m *Manifest) InferLiveUpdateSelectors() error {
 	dag, err := NewTargetGraph(m.TargetSpecs())


### PR DESCRIPTION
Hello @milas, @nicksieger,

Please review the following commits I made in branch nicks/cluster2:

5e4625c0cb9263a802b37bb08541fd522e8e00b6 (2021-12-10 14:02:44 -0500)
tiltfile: infer the registry during reconciliation rather than during tiltfile loading
We want to support a world where
- k8s connections can be reloaded
- there are multiple k8s connections
- we can change image parameters based on arch

and the reconciler (rather than the tiltfile loader) is in a better position to
do all of that.

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics