### PR TITLE
extensions: write fetch errors to log

### DIFF
--- a/internal/tiltfile/tiltextension/github_fetcher.go
+++ b/internal/tiltfile/tiltextension/github_fetcher.go
@@ -9,11 +9,13 @@ import (
 	"time"
 
 	"github.com/tilt-dev/go-get"
+
+	"github.com/tilt-dev/tilt/pkg/logger"
 )
 
 type Downloader interface {
 	RootDir() string
-	Download(pkg string) (string, error)
+	Download(ctx context.Context, pkg string) (string, error)
 }
 
 type TempDirDownloader struct {
@@ -32,8 +34,10 @@ func (d *TempDirDownloader) RootDir() string {
 	return d.rootDir
 }
 
-func (d *TempDirDownloader) Download(pkg string) (string, error) {
+func (d *TempDirDownloader) Download(ctx context.Context, pkg string) (string, error) {
 	dlr := get.NewDownloader(d.rootDir)
+	dlr.Stderr = logger.Get(ctx).Writer(logger.InfoLvl)
+
 	return dlr.Download(pkg)
 }
 
@@ -50,7 +54,7 @@ func (f *GithubFetcher) CleanUp() error {
 }
 
 func (f *GithubFetcher) Fetch(ctx context.Context, moduleName string) (ModuleContents, error) {
-	dir, err := f.dlr.Download(path.Join("github.com/tilt-dev/tilt-extensions", moduleName))
+	dir, err := f.dlr.Download(ctx, path.Join("github.com/tilt-dev/tilt-extensions", moduleName))
 	if err != nil {
 		return ModuleContents{}, fmt.Errorf("Fetching tilt-extensions: %v", err)
 	}


### PR DESCRIPTION
extension git fetch errors were writing directly to [os.Stderr](https://github.com/tilt-dev/tilt/blob/2d0ddc5cb13e7779fde1b8bdb6b56b423b499aa4/vendor/github.com/tilt-dev/go-get/get.go#L56), leaving the log looking pretty useless:
```
Loading Tiltfile at: /Users/matt/tmp/tilt_tests/Tiltfile
Traceback (most recent call last):
  /Users/matt/tmp/tilt_tests/Tiltfile:2:8: in <toplevel>
  <builtin>: in include
Error: Fetching tilt-extensions: exit status 1
```

This fix takes the same approach we use in [the reconciler](https://github.com/tilt-dev/tilt/blob/a959e0ac25da2c55a7fa78b77042c77e237f6548/internal/controllers/core/extensionrepo/reconciler.go#L158).

The unit testing approaches I could think of for this seemed ugly enough to not be worth it, but I could be convinced.