### PR TITLE
engine: infer image architecture off the cluster

### DIFF
--- a/internal/build/docker_builder.go
+++ b/internal/build/docker_builder.go
@@ -160,7 +160,11 @@ func (d *dockerImageBuilder) ImageExists(ctx context.Context, ref reference.Name
 }
 
 func (d *dockerImageBuilder) BuildImage(ctx context.Context, ps *PipelineState, refs container.RefSet, spec v1alpha1.DockerImageSpec, filter model.PathMatcher) (container.TaggedRefs, []v1alpha1.DockerImageStageStatus, error) {
-	logger.Get(ctx).Infof("Building Dockerfile:\n%s\n", indent(spec.DockerfileContents, "  "))
+	platformSuffix := ""
+	if spec.Platform != "" {
+		platformSuffix = fmt.Sprintf(" for platform %s", spec.Platform)
+	}
+	logger.Get(ctx).Infof("Building Dockerfile%s:\n%s\n", platformSuffix, indent(spec.DockerfileContents, "  "))
 
 	ps.StartBuildStep(ctx, "Building image")
 	allowBuildkit := true

--- a/internal/k8s/watch.go
+++ b/internal/k8s/watch.go
@@ -340,10 +340,11 @@ func supportsPartialMetadata(v *version.Info) bool {
 }
 
 func (kCli *K8sClient) WatchMeta(ctx context.Context, gvk schema.GroupVersionKind, ns Namespace) (<-chan metav1.Object, error) {
-	gvr, err := kCli.forceDiscovery(ctx, gvk)
+	mapping, err := kCli.forceDiscovery(ctx, gvk)
 	if err != nil {
 		return nil, errors.Wrap(err, "WatchMeta")
 	}
+	gvr := mapping.Resource
 
 	version, err := kCli.discovery.ServerVersion()
 	if err != nil {


### PR DESCRIPTION
Hello @milas, @nicksieger,

Please review the following commits I made in branch nicks/platform:

3fd9959370431a01e1502741d4fa82e769e945d1 (2021-12-14 15:04:19 -0500)
engine: infer image architecture off the cluster
Fixes https://github.com/tilt-dev/tilt/issues/4274

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics