### PR TITLE
build: fix a race condition in constructing tarballs

### DIFF
--- a/internal/controllers/core/liveupdate/reconciler.go
+++ b/internal/controllers/core/liveupdate/reconciler.go
@@ -927,6 +927,9 @@ func (r *Reconciler) applyInternal(
 
 	var lastExecErrorStatus *v1alpha1.LiveUpdateContainerStatus
 	for _, cInfo := range containers {
+		// TODO(nick): We should try to distinguish between cases where the tar writer
+		// fails (which is recoverable) vs when the server-side unpacking
+		// fails (which may not be recoverable).
 		archive := build.TarArchiveForPaths(ctx, toArchive, nil)
 		err = cu.UpdateContainer(ctx, cInfo, archive,
 			build.PathMappingsToContainerPaths(toRemove), boiledSteps, hotReload)


### PR DESCRIPTION
Hello @milas, @landism,

Please review the following commits I made in branch nicks/shortread:

54cb443ec1b190fc43f48ea8bfd00a2248a3c188 (2021-12-14 16:27:51 -0500)
build: fix a race condition in constructing tarballs
i was able to reproduce this with a tilt environment
with a local resource that rapidly writes to a file
and a live-update rule that syncs it.

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics