### PR TITLE
api: concurrent update fixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -51,7 +51,7 @@ require (
 	github.com/tilt-dev/go-get v0.2.1
 	github.com/tilt-dev/localregistry-go v0.0.0-20200615231835-07e386f4ebd7
 	github.com/tilt-dev/probe v0.3.1
-	github.com/tilt-dev/tilt-apiserver v0.5.2
+	github.com/tilt-dev/tilt-apiserver v0.5.4
 	github.com/tilt-dev/wmclient v0.0.0-20201109174454-1839d0355fbc
 	github.com/tonistiigi/fsutil v0.0.0-20200724193237-c3ed55f3b481
 	github.com/tonistiigi/units v0.0.0-20180711220420-6950e57a87ea

--- a/go.sum
+++ b/go.sum
@@ -1135,8 +1135,8 @@ github.com/tilt-dev/localregistry-go v0.0.0-20200615231835-07e386f4ebd7 h1:ysHGL
 github.com/tilt-dev/localregistry-go v0.0.0-20200615231835-07e386f4ebd7/go.mod h1:bZecZHy8tHzZWeF+MEQMugKbGhi9cF1A7tuaZNIxoDs=
 github.com/tilt-dev/probe v0.3.1 h1:PQhXSBkgcGBUU/eKt4vgAUKsAWWjBr2F53xNAc0E7zs=
 github.com/tilt-dev/probe v0.3.1/go.mod h1:F53NFbqblwu5oyIk2t+BPkswiboxuF8e5D3wbPnY4JA=
-github.com/tilt-dev/tilt-apiserver v0.5.2 h1:QRLB8bt4v76MURLNCUs4bqNhsZLfbP9/gIJuCQ9GR6U=
-github.com/tilt-dev/tilt-apiserver v0.5.2/go.mod h1:WfOq4XyMpYqXpMaIXZZodR9GX6clNkueNQCV2u1q5os=
+github.com/tilt-dev/tilt-apiserver v0.5.4 h1:IXWPPZFUrOh4+QAXkUQNyZsSsvBJ5QZpXjTbgAQ/HFY=
+github.com/tilt-dev/tilt-apiserver v0.5.4/go.mod h1:WfOq4XyMpYqXpMaIXZZodR9GX6clNkueNQCV2u1q5os=
 github.com/tilt-dev/wmclient v0.0.0-20201109174454-1839d0355fbc h1:wGkAoZhrvnmq93B4W2v+agiPl7xzqUaxXkxmKrwJ6bc=
 github.com/tilt-dev/wmclient v0.0.0-20201109174454-1839d0355fbc/go.mod h1:n01fG3LbImzxBP3GGCTHkgXuPeJusWg6xv0QYGm9HtE=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=

--- a/internal/controllers/core/cmd/controller.go
+++ b/internal/controllers/core/cmd/controller.go
@@ -413,14 +413,14 @@ func (c *Controller) handleProbeResultFunc(ctx context.Context, name types.Names
 		}
 
 		ready := result == prober.Success || result == prober.Warning
-		if statusChanged {
-			c.updateStatus(name, func(status *CmdStatus) {
-				//
-				if status.Running != nil {
-					status.Ready = ready
-				}
-			}, stillHasSameProcNum)
-		}
+		c.updateStatus(name, func(status *CmdStatus) {
+			// TODO(milas): this isn't quite right - we might end up setting
+			// 	a terminated process to ready, for example; in practice, we
+			// 	should update internal state on any goroutine/async trackers
+			// 	and trigger a reconciliation, which can then evaluate the full
+			// 	state + current spec
+			status.Ready = ready
+		}, stillHasSameProcNum)
 	}
 }
 

--- a/internal/controllers/core/filewatch/watcher.go
+++ b/internal/controllers/core/filewatch/watcher.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/tilt-dev/tilt/internal/controllers/apicmp"
 	"github.com/tilt-dev/tilt/internal/store"
 	"github.com/tilt-dev/tilt/internal/watch"
 	filewatches "github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
@@ -60,20 +61,41 @@ func (w *watcher) recordEvent(ctx context.Context, client ctrlclient.Client, st 
 			w.status.FileEvents = w.status.FileEvents[len(w.status.FileEvents)-MaxFileEventHistory:]
 		}
 
+		// TODO(milas): we should only update the internal status and then trigger
+		// 	reconciliation and let that handle updating status
+		//
+		// historically, this method did a PUT/replace, which meant file events
+		// could be indefinitely delayed on optimistic concurrency failures due
+		// to lack of retry
+		//
+		// now, we PATCH assuming the spec matches at the time of fetch, but this
+		// means there is technically still a race if the spec changes between
+		// our fetch and server processing the update, where we'll post "stale"
+		// events, but this is less harmful than effectively missing files events
 		var fw filewatches.FileWatch
 		err := client.Get(ctx, w.name, &fw)
 		if err != nil {
-			// status is updated internally so will become eventually consistent, but if there's no file
-			// changes for a while after this, the updates aren't going to appear; retry logic is probably
-			// warranted here
+			// status is updated internally so will become eventually consistent,
+			// but the file event won't be seen until the _next_ event!
+			//
+			// see the note above on how we should really resolve this
+			return nil
+		}
+		if !apicmp.DeepEqual(w.spec, fw.Spec) {
+			// spec changed - these events are outdated, so don't write them to the status
 			return nil
 		}
 
-		w.status.DeepCopyInto(&fw.Status)
-		err = client.Status().Update(ctx, &fw)
+		// only modify the specific fields on status that we care about so we can do a PATCH
+		patchBase := ctrlclient.MergeFrom(fw.DeepCopy())
+		updateStatus := w.status.DeepCopy()
+		fw.Status.LastEventTime = updateStatus.LastEventTime
+		fw.Status.FileEvents = updateStatus.FileEvents
+
+		err = client.Status().Patch(ctx, &fw, patchBase)
 		if err == nil {
 			st.Dispatch(NewFileWatchUpdateStatusAction(&fw))
-		} else if !apierrors.IsNotFound(err) && !apierrors.IsConflict(err) {
+		} else if !apierrors.IsNotFound(err) {
 			// can safely ignore not found/conflict errors - because this work loop is the only updater of
 			// status, any conflict errors means the spec was changed since fetching it, and as a result,
 			// these events are no longer useful anyway

--- a/internal/controllers/core/kubernetesapply/reconciler.go
+++ b/internal/controllers/core/kubernetesapply/reconciler.go
@@ -132,8 +132,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	// Update kubernetesapply's disable status
 	if disableStatus != ka.Status.DisableStatus {
+		patchBase := client.MergeFrom(ka.DeepCopy())
 		ka.Status.DisableStatus = disableStatus
-		if err := r.ctrlClient.Status().Update(ctx, &ka); err != nil {
+		if err := r.ctrlClient.Status().Patch(ctx, &ka, patchBase); err != nil {
 			return ctrl.Result{}, err
 		}
 	}
@@ -276,6 +277,7 @@ func (r *Reconciler) ForceApply(
 	if err != nil {
 		return v1alpha1.KubernetesApplyStatus{}, err
 	}
+	patchBase := client.MergeFrom(ka.DeepCopy())
 
 	// Copy over status information from `forceApplyHelper`
 	// so other existing status information isn't overwritten
@@ -304,7 +306,7 @@ func (r *Reconciler) ForceApply(
 	}
 
 	ka.Status = *updatedStatus
-	err = r.ctrlClient.Status().Update(ctx, &ka)
+	err = r.ctrlClient.Status().Patch(ctx, &ka, patchBase)
 	if err != nil {
 		return *updatedStatus, err
 	}

--- a/internal/controllers/core/kubernetesdiscovery/reconciler.go
+++ b/internal/controllers/core/kubernetesdiscovery/reconciler.go
@@ -348,6 +348,7 @@ func (w *Reconciler) updateStatus(ctx context.Context, watcherID watcherID) erro
 		// if the spec got deleted, there's nothing to update
 		return nil
 	}
+	patchBase := ctrlclient.MergeFrom(kd.DeepCopy())
 
 	if !equality.Semantic.DeepEqual(watcher.spec, kd.Spec) {
 		// the spec has changed and we haven't reconciled that change yet; this state update is
@@ -356,7 +357,7 @@ func (w *Reconciler) updateStatus(ctx context.Context, watcherID watcherID) erro
 	}
 
 	kd.Status = status
-	if err := w.ctrlClient.Status().Update(ctx, kd); err != nil {
+	if err := w.ctrlClient.Status().Patch(ctx, kd, patchBase); err != nil {
 		if apierrors.IsNotFound(err) {
 			// similar to above but for the event that it gets deleted between get + update
 			return nil

--- a/internal/controllers/fake/client.go
+++ b/internal/controllers/fake/client.go
@@ -62,3 +62,22 @@ func (f fakeStatusWriter) Update(ctx context.Context, obj client.Object, opts ..
 	}
 	return json.Unmarshal(content, obj)
 }
+
+func (f fakeStatusWriter) Patch(ctx context.Context, obj ctrlclient.Object, patch ctrlclient.Patch, opts ...ctrlclient.PatchOption) error {
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		// controller-runtime fake ignores context; check it here to allow controllers to test
+		// handling of cancellation related errors
+		return ctxErr
+	}
+
+	err := f.StatusWriter.Patch(ctx, obj, patch, opts...)
+	if err != nil {
+		return err
+	}
+
+	content, err := json.Marshal(obj)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(content, obj)
+}

--- a/vendor/github.com/kballard/go-shellquote/README
+++ b/vendor/github.com/kballard/go-shellquote/README
@@ -1,7 +1,7 @@
 PACKAGE
 
 package shellquote
-import "github.com/kballard/go-shellquote"
+    import "github.com/kballard/go-shellquote"
 
     Shellquote provides utilities for joining/splitting strings using sh's
     word-splitting rules.
@@ -9,25 +9,28 @@ import "github.com/kballard/go-shellquote"
 VARIABLES
 
 var (
-UnterminatedSingleQuoteError = errors.New("Unterminated single-quoted string")
-UnterminatedDoubleQuoteError = errors.New("Unterminated double-quoted string")
-UnterminatedEscapeError = errors.New("Unterminated backslash-escape")
+    UnterminatedSingleQuoteError = errors.New("Unterminated single-quoted string")
+    UnterminatedDoubleQuoteError = errors.New("Unterminated double-quoted string")
+    UnterminatedEscapeError      = errors.New("Unterminated backslash-escape")
 )
+
 
 FUNCTIONS
 
 func Join(args ...string) string
-Join quotes each argument and joins them with a space. If passed to
-/bin/sh, the resulting string will be split back into the original
-arguments.
+    Join quotes each argument and joins them with a space. If passed to
+    /bin/sh, the resulting string will be split back into the original
+    arguments.
 
 func Split(input string) (words []string, err error)
-Split splits a string according to /bin/sh's word-splitting rules. It
-supports backslash-escapes, single-quotes, and double-quotes. Notably it
-does not support the $'' style of quoting. It also doesn't attempt to
-perform any other sort of expansion, including brace expansion, shell
-expansion, or pathname expansion.
+    Split splits a string according to /bin/sh's word-splitting rules. It
+    supports backslash-escapes, single-quotes, and double-quotes. Notably it
+    does not support the $'' style of quoting. It also doesn't attempt to
+    perform any other sort of expansion, including brace expansion, shell
+    expansion, or pathname expansion.
 
     If the given input has an unterminated quoted string or ends in a
     backslash-escape, one of UnterminatedSingleQuoteError,
     UnterminatedDoubleQuoteError, or UnterminatedEscapeError is returned.
+
+

--- a/vendor/github.com/tilt-dev/tilt-apiserver/pkg/storage/filepath/jsonfile_rest.go
+++ b/vendor/github.com/tilt-dev/tilt-apiserver/pkg/storage/filepath/jsonfile_rest.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
-	"sync/atomic"
 	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -21,6 +20,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/watch"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/apiserver/pkg/registry/generic/registry"
 	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/apiserver/pkg/storage"
 )
@@ -75,11 +75,10 @@ type filepathREST struct {
 	newFunc     func() runtime.Object
 	newListFunc func() runtime.Object
 
-	strategy       Strategy
-	groupResource  schema.GroupResource
-	fs             FS
-	watchSet       *WatchSet
-	currentVersion int64
+	strategy      Strategy
+	groupResource schema.GroupResource
+	fs            FS
+	watchSet      *WatchSet
 }
 
 func (f *filepathREST) notifyWatchers(ev watch.Event) {
@@ -173,13 +172,15 @@ func (f *filepathREST) Create(
 		return nil, err
 	}
 	filename := f.objectFileName(ctx, accessor.GetName())
-	accessor.SetResourceVersion(fmt.Sprintf("%d", atomic.AddInt64(&f.currentVersion, 1)))
 
 	if f.fs.Exists(filename) {
 		return nil, apierrors.NewAlreadyExists(f.groupResource, accessor.GetName())
 	}
 
-	if err := f.fs.Write(f.codec, filename, obj); err != nil {
+	if err := f.fs.Write(f.codec, filename, obj, 0); err != nil {
+		if errors.Is(err, VersionError) {
+			err = f.conflictErr(accessor.GetName())
+		}
 		return nil, err
 	}
 
@@ -200,108 +201,129 @@ func (f *filepathREST) Update(
 	forceAllowCreate bool,
 	options *metav1.UpdateOptions,
 ) (runtime.Object, bool, error) {
-	isCreate := false
-	oldObj, err := f.Get(ctx, name, nil)
-	if err != nil {
-		if !forceAllowCreate {
-			return nil, false, err
+	var isCreate bool
+	var isDelete bool
+	// attempt to update the object, automatically retrying on storage-level conflicts
+	// (see guaranteedUpdate docs for details)
+	obj, err := f.guaranteedUpdate(ctx, name, func(input runtime.Object) (output runtime.Object, err error) {
+		isCreate = false
+		isDelete = false
+
+		if input == nil {
+			if !forceAllowCreate {
+				return nil, apierrors.NewNotFound(f.groupResource, name)
+			}
+			isCreate = true
 		}
-		isCreate = true
-	}
-
-	// TODO: should not be necessary, verify Get works before creating filepath
-	if f.NamespaceScoped() {
-		// ensures namespace dir
-		ns, ok := genericapirequest.NamespaceFrom(ctx)
-		if !ok {
-			return nil, false, ErrNamespaceNotExists
+		inputVersion, err := getResourceVersion(input)
+		if err != nil {
+			return nil, err
 		}
-		if err := f.fs.EnsureDir(filepath.Join(f.objRootPath, ns)); err != nil {
-			return nil, false, err
-		}
-	}
 
-	updatedObj, err := objInfo.UpdatedObject(ctx, oldObj)
-	if err != nil {
-		return nil, false, err
-	}
-
-	if err := rest.BeforeUpdate(f.strategy, ctx, updatedObj, oldObj); err != nil {
-		return nil, false, err
-	}
-
-	filename := f.objectFileName(ctx, name)
-
-	if isCreate {
-		if createValidation != nil {
-			if err := createValidation(ctx, updatedObj); err != nil {
-				return nil, false, err
+		// TODO: should not be necessary, verify Get works before creating filepath
+		if f.NamespaceScoped() {
+			// ensures namespace dir
+			ns, ok := genericapirequest.NamespaceFrom(ctx)
+			if !ok {
+				return nil, ErrNamespaceNotExists
+			}
+			if err := f.fs.EnsureDir(filepath.Join(f.objRootPath, ns)); err != nil {
+				return nil, err
 			}
 		}
-		if err := f.fs.Write(f.codec, filename, updatedObj); err != nil {
-			return nil, false, err
+
+		output, err = objInfo.UpdatedObject(ctx, input)
+		if err != nil {
+			return nil, err
 		}
+
+		// this check MUST happen before rest.BeforeUpdate is called - for subresource updates, it'll
+		// use the input (storage version) to copy the subresource to (to avoid changing the spec),
+		// so the version from the request object will be lost, breaking optimistic concurrency
+		updatedVersion, err := getResourceVersion(output)
+		if err != nil {
+			return nil, err
+		}
+		if inputVersion != updatedVersion {
+			return nil, f.conflictErr(name)
+		}
+
+		if err := rest.BeforeUpdate(f.strategy, ctx, output, input); err != nil {
+			return nil, err
+		}
+
+		if isCreate {
+			if createValidation != nil {
+				if err := createValidation(ctx, input); err != nil {
+					return nil, err
+				}
+			}
+			return output, nil
+		}
+
+		if updateValidation != nil {
+			if err := updateValidation(ctx, output, input); err != nil {
+				return nil, err
+			}
+		}
+
+		outputMeta, err := meta.Accessor(output)
+		if err != nil {
+			return nil, err
+		}
+
+		// handle 2-phase deletes -> for entities with finalizers, DeletionTimestamp is set and reconcilers execute +
+		// remove them (triggering more updates); once drained, it can be deleted from the final update operation
+		// loosely based off https://github.com/kubernetes/apiserver/blob/947ebe755ed8aed2e0f0f5d6420caad07fc04cc2/pkg/registry/generic/registry/store.go#L624
+		if len(outputMeta.GetFinalizers()) == 0 && !outputMeta.GetDeletionTimestamp().IsZero() {
+			// to simplify semantics here, we allow this update to go through and then
+			// delete it - if this becomes a bottleneck (seems unlikely), we can delete
+			// here and return a special sentinel error
+			isDelete = true
+			return output, nil
+		}
+
+		return output, nil
+	})
+	if err != nil {
+		// TODO(milas): we need a better way of handling standard errors and
+		// 	wrapping any others in generic apierrors - returning plain Go errors
+		// 	(which still happens in some code paths) makes apiserver log out
+		// 	warnings, though it doesn't actually break things so is not critical
+		if os.IsNotExist(err) {
+			return nil, false, apierrors.NewNotFound(f.groupResource, name)
+		}
+		return nil, false, err
+	}
+
+	if isCreate {
 		f.notifyWatchers(watch.Event{
 			Type:   watch.Added,
-			Object: updatedObj,
+			Object: obj,
 		})
-		return updatedObj, true, nil
+		return obj, true, nil
 	}
 
-	if updateValidation != nil {
-		if err := updateValidation(ctx, updatedObj, oldObj); err != nil {
-			return nil, false, err
-		}
-	}
-
-	oldMeta, err := meta.Accessor(oldObj)
-	if err != nil {
-		return nil, false, err
-	}
-	updatedMeta, err := meta.Accessor(updatedObj)
-	if err != nil {
-		return nil, false, err
-	}
-
-	// TODO(milas): when we read the old object, we should take a lock on it so that no other
-	// 	write actions can occur until our "transaction" is done; currently, there's still the
-	// 	possibility for two concurrent updates to read in the same old object, resulting in a
-	// 	race; similarly, it's possible for a delete to happen mid-update, with both operations
-	// 	succeeding, resulting in a deleted object being re-created by the update
-	// 	(alternatively, the FS layer could track versions and provide these guarantees)
-	if oldMeta.GetResourceVersion() != updatedMeta.GetResourceVersion() {
-		kinds, _, _ := f.strategy.ObjectKinds(updatedObj)
-		conflictErr := apierrors.NewConflict(
-			schema.GroupResource{Group: kinds[0].Group, Resource: kinds[0].Kind},
-			name,
-			errors.New("object was modified"))
-		return nil, false, conflictErr
-	}
-
-	updatedMeta.SetResourceVersion(fmt.Sprintf("%d", atomic.AddInt64(&f.currentVersion, 1)))
-
-	// handle 2-phase deletes -> for entities with finalizers, DeletionTimestamp is set and reconcilers execute +
-	// remove them (triggering more updates); once drained, it can be deleted from the final update operation
-	// loosely based off https://github.com/kubernetes/apiserver/blob/947ebe755ed8aed2e0f0f5d6420caad07fc04cc2/pkg/registry/generic/registry/store.go#L624
-	if len(updatedMeta.GetFinalizers()) == 0 && !updatedMeta.GetDeletionTimestamp().IsZero() {
+	if isDelete {
+		filename := f.objectFileName(ctx, name)
 		if err := f.fs.Remove(filename); err != nil {
+			if os.IsNotExist(err) {
+				return nil, false, apierrors.NewNotFound(f.groupResource, name)
+			}
 			return nil, false, err
 		}
 		f.notifyWatchers(watch.Event{
 			Type:   watch.Deleted,
-			Object: updatedObj,
+			Object: obj,
 		})
-		return updatedObj, false, nil
+		return obj, false, nil
 	}
 
-	if err := f.fs.Write(f.codec, filename, updatedObj); err != nil {
-		return nil, false, err
-	}
 	f.notifyWatchers(watch.Event{
 		Type:   watch.Modified,
-		Object: updatedObj,
+		Object: obj,
 	})
-	return updatedObj, false, nil
+	return obj, false, nil
 }
 
 func (f *filepathREST) Delete(
@@ -326,7 +348,6 @@ func (f *filepathREST) Delete(
 	}
 	// loosely adapted from https://github.com/kubernetes/apiserver/blob/947ebe755ed8aed2e0f0f5d6420caad07fc04cc2/pkg/registry/generic/registry/store.go#L854-L877
 	if len(objMeta.GetFinalizers()) != 0 {
-
 		now := metav1.NewTime(time.Now())
 		// per-contract, deletion timestamps can not be unset and can only be moved _earlier_
 		if objMeta.GetDeletionTimestamp() == nil || now.Before(objMeta.GetDeletionTimestamp()) {
@@ -335,7 +356,15 @@ func (f *filepathREST) Delete(
 		zero := int64(0)
 		objMeta.SetDeletionGracePeriodSeconds(&zero)
 
-		if err := f.fs.Write(f.codec, filename, oldObj); err != nil {
+		version, err := getResourceVersion(oldObj)
+		if err != nil {
+			return nil, false, err
+		}
+
+		if err := f.fs.Write(f.codec, filename, oldObj, version); err != nil {
+			if errors.Is(err, VersionError) {
+				err = f.conflictErr(name)
+			}
 			return nil, false, err
 		}
 
@@ -408,6 +437,73 @@ func (f *filepathREST) objectDirName(ctx context.Context) string {
 	return filepath.Join(f.objRootPath)
 }
 
+// updateFunc should return the updated object to persist to storage.
+//
+// This function might be called more than once, so must be idempotent. If an
+// error is returned from it, the error will be propagated and the update halted.
+type updateFunc func(input runtime.Object) (output runtime.Object, err error)
+
+// guaranteedUpdate keeps calling tryUpdate to update an object retrying the update
+// until success if there is a storage-level conflict.
+//
+// The input object passed to tryUpdate may change across invocations of tryUpdate
+// if other writers are simultaneously updating it, so tryUpdate needs to take into
+// account the current contents of the object when deciding how the update object
+// should look.
+//
+// The "guaranteed" in the name comes from a method of the same name in the
+// Kubernetes apiserver/etcd code. Most of this method comment is copied from
+// its godoc.
+//
+// See https://github.com/kubernetes/apiserver/blob/544b6014f353b0f5e7c6fd2d3e04a7810d0ba5fc/pkg/storage/interfaces.go#L205-L238
+func (f *filepathREST) guaranteedUpdate(ctx context.Context, name string, tryUpdate updateFunc) (runtime.Object, error) {
+	// technically, this loop should be safe to run indefinitely, but a cap is
+	// applied to avoid bugs resulting in an infinite* loop
+	//
+	// if the cap is hit, an internal server error will be returned
+	//
+	// * really until the context is canceled, but busy looping here for ~30 secs
+	//   until it times out is not great either
+	const maxAttempts = 100
+	for i := 0; i < maxAttempts; i++ {
+		if err := ctx.Err(); err != nil {
+			// the FS layer doesn't use context, so we explicitly check it on
+			// each loop iteration so that we'll stop retrying if the context
+			// gets canceled (e.g. request timeout)
+			return nil, err
+		}
+
+		storageObj, err := f.Get(ctx, name, nil)
+		if err != nil && !apierrors.IsNotFound(err) {
+			// some objects allow create-on-update semantics, so NotFound is not terminal
+			return nil, err
+		}
+		storageVersion, err := getResourceVersion(storageObj)
+		if err != nil {
+			return nil, err
+		}
+
+		out, err := tryUpdate(storageObj)
+		if err != nil {
+			// TODO(milas): check error type and wrap if necessary
+			return nil, err
+		}
+
+		filename := f.objectFileName(ctx, name)
+		if err := f.fs.Write(f.codec, filename, out, storageVersion); err != nil {
+			if errors.Is(err, VersionError) {
+				// storage conflict, retry
+				continue
+			}
+			return nil, err
+		}
+		return out, nil
+	}
+
+	// a non-early return means the loop exhausted all attempts
+	return nil, apierrors.NewInternalError(errors.New("failed to persist to storage"))
+}
+
 func appendItem(v reflect.Value, obj runtime.Object) {
 	v.Set(reflect.Append(v, reflect.ValueOf(obj).Elem()))
 }
@@ -455,6 +551,13 @@ func (f *filepathREST) Watch(ctx context.Context, options *metainternalversion.L
 	jw.Start(p, initEvents)
 
 	return jw, nil
+}
+
+func (f *filepathREST) conflictErr(name string) error {
+	return apierrors.NewConflict(
+		f.groupResource,
+		name,
+		errors.New(registry.OptimisticLockErrorMsg))
 }
 
 func newSelectionPredicate(options *metainternalversion.ListOptions) storage.SelectionPredicate {

--- a/vendor/github.com/tilt-dev/tilt-apiserver/pkg/storage/filepath/version.go
+++ b/vendor/github.com/tilt-dev/tilt-apiserver/pkg/storage/filepath/version.go
@@ -1,0 +1,57 @@
+package filepath
+
+import (
+	"fmt"
+	"strconv"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func getResourceVersion(obj runtime.Object) (uint64, error) {
+	if obj == nil {
+		return 0, nil
+	}
+	objMeta, err := meta.Accessor(obj)
+	if err != nil {
+		return 0, err
+	}
+	return parseResourceVersion(objMeta.GetResourceVersion())
+}
+
+func setResourceVersion(obj runtime.Object, v uint64) error {
+	if v <= 0 {
+		return fmt.Errorf("resourceVersion must be positive: %d", v)
+	}
+
+	objMeta, err := meta.Accessor(obj)
+	if err != nil {
+		return err
+	}
+	objMeta.SetResourceVersion(formatResourceVersion(v))
+	return nil
+}
+
+func clearResourceVersion(obj runtime.Object) error {
+	objMeta, err := meta.Accessor(obj)
+	if err != nil {
+		return err
+	}
+	objMeta.SetResourceVersion("")
+	return nil
+}
+
+func parseResourceVersion(v string) (uint64, error) {
+	if v == "" {
+		return 0, nil
+	}
+	version, err := strconv.ParseUint(v, 10, 64)
+	if err != nil {
+		return 0, err
+	}
+	return version, nil
+}
+
+func formatResourceVersion(v uint64) string {
+	return strconv.FormatUint(v, 10)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -611,7 +611,7 @@ github.com/tilt-dev/localregistry-go
 github.com/tilt-dev/probe/internal/procutil
 github.com/tilt-dev/probe/pkg/probe
 github.com/tilt-dev/probe/pkg/prober
-# github.com/tilt-dev/tilt-apiserver v0.5.2
+# github.com/tilt-dev/tilt-apiserver v0.5.4
 ## explicit; go 1.16
 github.com/tilt-dev/tilt-apiserver/pkg/server/apiserver
 github.com/tilt-dev/tilt-apiserver/pkg/server/builder


### PR DESCRIPTION
Most of the heavy-lifting is from the `tilt-apiserver` update here,
which fixes three important issues:
 * Fix race condition at storage-level that would result in two
   conflicting updates both being accepted
 * Fix optimistic concurrency check for subresources (i.e. status)
 * Fix `PATCH` semantics so it can't fail due to resource versioning

On the actual Tilt side, the only change currently is to start using
`PATCH` for status updates in the `KuberenetesApply` reconciler,
which has multiple concurrent writers between the standard
reconcilation process and the `ForceApply` calls from the
`BuildAndDeployer`. The latter doesn't support elegant retry, so
any optimistic concurrency failures result in a failed build. By
using `PATCH`, we prevent these failures, which prevents a host of
race conditions, particularly at Tilt startup.

As with the prior round of optimistic concurrency fixes, there's the
possibility that more "object was modified" errors will be seen than
before - these were previously silent and probably resulting in some
odd bugs/inconsistent state behind the scenes.