### PR TITLE
kubernetesapply: add images to custom commands

### DIFF
--- a/internal/controllers/apis/imagemap/imagemap.go
+++ b/internal/controllers/apis/imagemap/imagemap.go
@@ -1,0 +1,31 @@
+package imagemap
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
+	"github.com/tilt-dev/tilt/pkg/model"
+)
+
+// Inject completed ImageMaps into the environment of a local process that
+// wants to deploy to a cluster..
+//
+// Current env vars:
+// TILT_IMAGE_i - The reference to the image #i from the point of view of the cluster container runtime.
+// TILT_IMAGE_MAP_i - The name of the image map #i with the current status of the image.
+//
+// where an env may depend on arbitrarily many image maps.
+func InjectIntoDeployEnv(cmd *model.Cmd, imageMapNames []string, imageMaps map[types.NamespacedName]*v1alpha1.ImageMap) error {
+	for i, imageMapName := range imageMapNames {
+		imageMap, ok := imageMaps[types.NamespacedName{Name: imageMapName}]
+		if !ok {
+			return fmt.Errorf("internal error: missing imagemap %s", imageMapName)
+		}
+
+		cmd.Env = append(cmd.Env, fmt.Sprintf("TILT_IMAGE_MAP_%d=%s", i, imageMapName))
+		cmd.Env = append(cmd.Env, fmt.Sprintf("TILT_IMAGE_%d=%s", i, imageMap.Status.Image))
+	}
+	return nil
+}

--- a/internal/controllers/core/kubernetesapply/reconciler_test.go
+++ b/internal/controllers/core/kubernetesapply/reconciler_test.go
@@ -148,6 +148,40 @@ func TestBasicApplyCmd(t *testing.T) {
 	assert.Len(t, f.execer.Calls(), 1)
 }
 
+func TestApplyCmdWithImages(t *testing.T) {
+	f := newFixture(t)
+
+	f.Create(&v1alpha1.ImageMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "image-a",
+		},
+		Status: v1alpha1.ImageMapStatus{
+			Image: "image-a:my-tag",
+		},
+	})
+
+	applyCmd, _ := f.createApplyCmd("custom-apply-cmd", testyaml.SanchoYAML)
+	ka := v1alpha1.KubernetesApply{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "a",
+		},
+		Spec: v1alpha1.KubernetesApplySpec{
+			ImageMaps: []string{"image-a"},
+			ApplyCmd:  &applyCmd,
+			DeleteCmd: &v1alpha1.KubernetesApplyCmd{Args: []string{"custom-delete-cmd"}},
+		},
+	}
+	f.Create(&ka)
+
+	if assert.Len(t, f.execer.Calls(), 1) {
+		call := f.execer.Calls()[0]
+		assert.Equal(t, []string{
+			"TILT_IMAGE_MAP_0=image-a",
+			"TILT_IMAGE_0=image-a:my-tag",
+		}, call.Cmd.Env)
+	}
+}
+
 func TestBasicApplyCmd_ExecError(t *testing.T) {
 	f := newFixture(t)
 


### PR DESCRIPTION
Hello @milas,

Please review the following commits I made in branch nicks/kapp-imagemap:

b59556a1259ca7f6f29515ef5453de44b2a52af4 (2021-12-16 15:47:45 -0500)
kubernetesapply: add images to custom commands

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics