### PR TITLE
build: ensure file handles properly closed

### DIFF
--- a/internal/build/buildkit_printer_test.go
+++ b/internal/build/buildkit_printer_test.go
@@ -61,6 +61,9 @@ func TestBuildkitPrinter(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
+			defer func() {
+				_ = f.Close()
+			}()
 
 			responses, err := c.readResponse(f)
 			if err != nil {

--- a/internal/build/tar.go
+++ b/internal/build/tar.go
@@ -294,18 +294,10 @@ func tarContextAndUpdateDf(ctx context.Context, writer io.Writer, df dockerfile.
 
 	err = ab.archiveDf(ctx, df)
 	if err != nil {
+		_ = ab.Close()
 		return errors.Wrap(err, "archiveDf")
 	}
 
-	return ab.Close()
-}
-
-func TarDfOnly(ctx context.Context, writer io.Writer, df dockerfile.Dockerfile) error {
-	ab := NewArchiveBuilder(writer, model.EmptyMatcher)
-	err := ab.archiveDf(ctx, df)
-	if err != nil {
-		return errors.Wrap(err, "tarDfOnly")
-	}
 	return ab.Close()
 }
 
@@ -318,13 +310,14 @@ func TarPath(ctx context.Context, writer io.Writer, path string) error {
 		},
 	})
 	if err != nil {
+		_ = ab.Close()
 		return errors.Wrap(err, "TarPath")
 	}
 
 	return ab.Close()
 }
 
-func TarArchiveForPaths(ctx context.Context, toArchive []PathMapping, filter model.PathMatcher) io.Reader {
+func TarArchiveForPaths(ctx context.Context, toArchive []PathMapping, filter model.PathMatcher) io.ReadCloser {
 	pr, pw := io.Pipe()
 	go tarArchiveForPaths(ctx, pw, toArchive, filter)
 	return pr

--- a/internal/cloud/io.go
+++ b/internal/cloud/io.go
@@ -39,6 +39,9 @@ func (s *Snapshotter) WriteSnapshot(ctx context.Context, path string) {
 		logger.Get(ctx).Errorf("Writing snapshot to file: %v", err)
 		return
 	}
+	defer func() {
+		_ = f.Close()
+	}()
 
 	err = WriteSnapshotTo(ctx, &proto_webview.Snapshot{View: view}, f)
 	if err != nil {

--- a/internal/containerupdate/fake_container_updater.go
+++ b/internal/containerupdate/fake_container_updater.go
@@ -1,7 +1,9 @@
 package containerupdate
 
 import (
+	"bytes"
 	"context"
+	"fmt"
 	"io"
 
 	"github.com/tilt-dev/tilt/internal/store/liveupdates"
@@ -28,9 +30,14 @@ func (cu *FakeContainerUpdater) SetUpdateErr(err error) {
 
 func (cu *FakeContainerUpdater) UpdateContainer(ctx context.Context, cInfo liveupdates.Container,
 	archiveToCopy io.Reader, filesToDelete []string, cmds []model.Cmd, hotReload bool) error {
+
+	var archive bytes.Buffer
+	if _, err := io.Copy(&archive, archiveToCopy); err != nil {
+		return fmt.Errorf("FakeContainerUpdater failed to read archive: %v", err)
+	}
 	cu.Calls = append(cu.Calls, UpdateContainerCall{
 		ContainerInfo: cInfo,
-		Archive:       archiveToCopy,
+		Archive:       &archive,
 		ToDelete:      filesToDelete,
 		Cmds:          cmds,
 		HotReload:     hotReload,

--- a/internal/controllers/core/liveupdate/reconciler.go
+++ b/internal/controllers/core/liveupdate/reconciler.go
@@ -933,6 +933,7 @@ func (r *Reconciler) applyInternal(
 		archive := build.TarArchiveForPaths(ctx, toArchive, nil)
 		err = cu.UpdateContainer(ctx, cInfo, archive,
 			build.PathMappingsToContainerPaths(toRemove), boiledSteps, hotReload)
+		_ = archive.Close()
 
 		lastFileTimeSynced := input.LastFileTimeSynced
 		if lastFileTimeSynced.IsZero() {

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -3578,6 +3578,7 @@ func TestDisablingResourcePreventsBuild(t *testing.T) {
 
 func TestDisableButtonIsCreated(t *testing.T) {
 	f := newTestFixture(t)
+	defer f.TearDown()
 	f.useRealTiltfileLoader()
 
 	f.WriteFile("Tiltfile", `

--- a/internal/watch/notify_test.go
+++ b/internal/watch/notify_test.go
@@ -181,10 +181,11 @@ func TestNewDirectoriesAreRecursivelyWatched(t *testing.T) {
 
 	// change something inside sub directory
 	changeFilePath := filepath.Join(subPath, "change")
-	_, err := os.OpenFile(changeFilePath, os.O_RDONLY|os.O_CREATE, 0666)
+	file, err := os.OpenFile(changeFilePath, os.O_RDONLY|os.O_CREATE, 0666)
 	if err != nil {
 		t.Fatal(err)
 	}
+	_ = file.Close()
 	f.assertEvents(subPath, changeFilePath)
 }
 


### PR DESCRIPTION
I've been running the test suite (`./internal/engine` in particular)
with `-count X` a lot recently to catch timing-related test failures.

After running enough times, the tests start failing due to too many
open files, so I did an audit and found a few places where files or
readers weren't always being closed.