### PR TITLE
store: add a new RuntimeStatusNone for the case where a build hasn't been triggered yet

### DIFF
--- a/internal/engine/session/conv.go
+++ b/internal/engine/session/conv.go
@@ -160,15 +160,7 @@ func genericRuntimeTarget(mt *store.ManifestTarget, holds buildcontrol.HoldSet) 
 		Type:      session.TargetTypeServer,
 	}
 
-	// HACK: RuntimeState is not populated until engine starts builds in some cases; to avoid weird race conditions,
-	// 	it defaults to pending assuming the resource isn't _actually_ disabled on startup via auto_init=False
-	var runtimeStatus v1alpha1.RuntimeStatus
-	if mt.State.RuntimeState != nil {
-		runtimeStatus = mt.State.RuntimeState.RuntimeStatus()
-	} else if mt.Manifest.TriggerMode.AutoInitial() {
-		runtimeStatus = v1alpha1.RuntimeStatusPending
-	}
-
+	runtimeStatus := mt.RuntimeStatus()
 	switch runtimeStatus {
 	case v1alpha1.RuntimeStatusPending:
 		target.State.Waiting = waitingFromHolds(mt.Manifest.Name, holds)

--- a/internal/store/manifest_target.go
+++ b/internal/store/manifest_target.go
@@ -65,4 +65,13 @@ func (mt *ManifestTarget) UpdateStatus() v1alpha1.UpdateStatus {
 	return us
 }
 
+// Compute the runtime status for the whole Manifest.
+func (mt *ManifestTarget) RuntimeStatus() v1alpha1.RuntimeStatus {
+	m := mt.Manifest
+	if m.IsLocal() && m.LocalTarget().ServeCmd.Empty() {
+		return v1alpha1.RuntimeStatusNotApplicable
+	}
+	return mt.State.RuntimeStatus(m.TriggerMode)
+}
+
 var _ model.Target = &ManifestTarget{}

--- a/internal/store/manifest_target_test.go
+++ b/internal/store/manifest_target_test.go
@@ -15,14 +15,32 @@ func TestLocalTargetUpdateStatus(t *testing.T) {
 		model.NewLocalTarget("serve-cmd", model.Cmd{}, model.ToHostCmd("busybox httpd"), nil))
 	mt := NewManifestTarget(m)
 	assert.Equal(t, v1alpha1.UpdateStatusPending, mt.UpdateStatus())
+	assert.Equal(t, v1alpha1.RuntimeStatusPending, mt.RuntimeStatus())
 
 	mt.State.CurrentBuild = model.BuildRecord{StartTime: time.Now()}
 	assert.Equal(t, v1alpha1.UpdateStatusPending, mt.UpdateStatus())
+	assert.Equal(t, v1alpha1.RuntimeStatusPending, mt.RuntimeStatus())
 
 	mt.State.CurrentBuild = model.BuildRecord{}
 	mt.State.AddCompletedBuild(model.BuildRecord{StartTime: time.Now(), FinishTime: time.Now()})
 	assert.Equal(t, v1alpha1.UpdateStatusNotApplicable, mt.UpdateStatus())
 
+	// We currently have an unknown runtime state when the build completes,
+	// but we haven't received any data from the runtime yet.
+	assert.Equal(t, v1alpha1.RuntimeStatusUnknown, mt.RuntimeStatus())
+
 	mt.State.TriggerReason = model.BuildReasonFlagTriggerWeb
 	assert.Equal(t, v1alpha1.UpdateStatusPending, mt.UpdateStatus())
+	assert.Equal(t, v1alpha1.RuntimeStatusPending, mt.RuntimeStatus())
+}
+
+func TestK8sRuntimeStatus(t *testing.T) {
+	m := model.Manifest{Name: "k8s"}.WithDeployTarget(model.NewK8sTargetForTesting(""))
+	mt := NewManifestTarget(m)
+	assert.Equal(t, v1alpha1.UpdateStatusPending, mt.UpdateStatus())
+	assert.Equal(t, v1alpha1.RuntimeStatusPending, mt.RuntimeStatus())
+
+	mt.Manifest.TriggerMode = model.TriggerModeManual
+	assert.Equal(t, v1alpha1.UpdateStatusNone, mt.UpdateStatus())
+	assert.Equal(t, v1alpha1.RuntimeStatusNone, mt.RuntimeStatus())
 }

--- a/internal/store/runtime_state.go
+++ b/internal/store/runtime_state.go
@@ -52,7 +52,11 @@ var _ RuntimeState = LocalRuntimeState{}
 func (LocalRuntimeState) RuntimeState() {}
 
 func (l LocalRuntimeState) RuntimeStatus() v1alpha1.RuntimeStatus {
-	return l.Status
+	status := l.Status
+	if status == "" {
+		status = v1alpha1.RuntimeStatusUnknown
+	}
+	return status
 }
 
 func (l LocalRuntimeState) RuntimeStatusError() error {

--- a/pkg/apis/core/v1alpha1/runtimestatus_types.go
+++ b/pkg/apis/core/v1alpha1/runtimestatus_types.go
@@ -18,4 +18,8 @@ const (
 
 	// There's no server runtime for this resource and never will be.
 	RuntimeStatusNotApplicable RuntimeStatus = "not_applicable"
+
+	// This server hasn't had any reason to start yet.
+	// This usually indicates that it's a manual trigger with no auto_init.
+	RuntimeStatusNone RuntimeStatus = "none"
 )

--- a/web/src/status.tsx
+++ b/web/src/status.tsx
@@ -67,6 +67,7 @@ function runtimeStatus(
     case RuntimeStatus.Ok:
       return ResourceStatus.Healthy
     case RuntimeStatus.NotApplicable:
+    case RuntimeStatus.None:
       return ResourceStatus.None
   }
   return ResourceStatus.None

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -33,6 +33,7 @@ export enum RuntimeStatus {
   Pending = "pending",
   Error = "error",
   NotApplicable = "not_applicable",
+  None = "none",
 }
 
 // what is the status of the update


### PR DESCRIPTION
Hello @lizzthabet,

Please review the following commits I made in branch nicks/ch13122:

d2dd450538d39edd6502db43a141e6730b6fe1c8 (2021-12-17 12:24:22 -0500)
store: add a new RuntimeStatusNone for the case where a build hasn't been triggered yet
We try to borrow the general pattern from UpdateStatus()

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics