### PR TITLE
test: increase the timeout on integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,16 +75,16 @@ endif
 
 integration:
 ifneq ($(CIRCLECI),true)
-		go test -mod vendor -v -count 1 -p $(GO_PARALLEL_JOBS) -tags 'integration' -timeout 700s ./integration
+		go test -mod vendor -v -count 1 -p $(GO_PARALLEL_JOBS) -tags 'integration' -timeout 1000s ./integration
 else
 		mkdir -p test-results
-		gotestsum --format dots --junitfile test-results/unit-tests.xml -- ./integration -mod vendor -count 1 -p $(GO_PARALLEL_JOBS) -tags 'integration' -timeout 700s
+		gotestsum --format dots --junitfile test-results/unit-tests.xml -- ./integration -mod vendor -count 1 -p $(GO_PARALLEL_JOBS) -tags 'integration' -timeout 1000s
 endif
 
 # Run the integration tests on kind
 integration-kind:
 	KIND_CLUSTER_NAME=integration ./integration/kind-with-registry.sh
-	KUBECONFIG="$(kind get kubeconfig-path --name="integration")" go test -mod vendor -p $(GO_PARALLEL_JOBS) -tags 'integration' -timeout 700s ./integration -count 1
+	KUBECONFIG="$(kind get kubeconfig-path --name="integration")" go test -mod vendor -p $(GO_PARALLEL_JOBS) -tags 'integration' -timeout 1000s ./integration -count 1
 	kind delete cluster --name=integration
 
 # Run the extension integration tests against the current kubecontext


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/timeout:

49105c50ceccfbcc88861b6c7a264c862bcff182 (2021-12-17 13:17:05 -0500)
test: increase the timeout on integration tests

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics