### PR TITLE
test: only surface production dependencies, not dev dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/**"
+    schedule:
+      interval: "daily"
+    allow:
+      - dependency-type: "production"
+  - package-ecosystem: "gomod"
+    directory: "/**"
+    schedule:
+      interval: "daily"
+    allow:
+      - dependency-type: "production"


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/dependabot:

cd8a42aa7ae18e47beeec86c3d4270d83e5ec4e5 (2021-12-17 14:13:35 -0500)
test: only surface production dependencies, not dev dependencies
I have no idea why this isn't the default, here are some threads on the issues:
https://github.com/dependabot/dependabot-core/issues/4146
https://github.com/dependabot/dependabot-core/issues/2521
https://github.com/facebook/create-react-app/issues/11174

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics