### PR TITLE
k8s: make OwnerFetcher part of the K8sClient

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,4 @@
 
 *.sh text eol=lf
 
+*_gen.go linguist-generated=true -diff

--- a/internal/cli/wire.go
+++ b/internal/cli/wire.go
@@ -72,7 +72,6 @@ var K8sWireSet = wire.NewSet(
 	k8s.ProvideContainerRuntime,
 	k8s.ProvideServerVersion,
 	k8s.ProvideK8sClient,
-	k8s.ProvideOwnerFetcher,
 	ProvideKubeContextOverride,
 	ProvideNamespaceOverride)
 

--- a/internal/controllers/core/cluster/reconciler_test.go
+++ b/internal/controllers/core/cluster/reconciler_test.go
@@ -111,7 +111,7 @@ func newFixture(t *testing.T) *fixture {
 	cfb := fake.NewControllerFixtureBuilder(t)
 	st := store.NewTestingStore()
 
-	r := NewReconciler(cfb.Client, st, docker.LocalEnv{}, NewConnectionManager())
+	r := NewReconciler(cfb.Context(), cfb.Client, st, docker.LocalEnv{}, NewConnectionManager())
 	return &fixture{
 		ControllerFixture: cfb.Build(r),
 		r:                 r,

--- a/internal/controllers/core/kubernetesdiscovery/reconciler.go
+++ b/internal/controllers/core/kubernetesdiscovery/reconciler.go
@@ -50,11 +50,10 @@ func (w watcherID) String() string {
 }
 
 type Reconciler struct {
-	kCli         k8s.Client
-	ownerFetcher k8s.OwnerFetcher
-	dispatcher   Dispatcher
-	indexer      *indexer.Indexer
-	ctrlClient   ctrlclient.Client
+	kCli       k8s.Client
+	dispatcher Dispatcher
+	indexer    *indexer.Indexer
+	ctrlClient ctrlclient.Client
 
 	// restartDetector compares a previous version of status with the latest and emits log events
 	// for any containers on the pod that restarted.
@@ -101,12 +100,11 @@ func (w *Reconciler) CreateBuilder(mgr ctrl.Manager) (*builder.Builder, error) {
 	return b, nil
 }
 
-func NewReconciler(ctrlClient ctrlclient.Client, scheme *runtime.Scheme, kCli k8s.Client, ownerFetcher k8s.OwnerFetcher, restartDetector *ContainerRestartDetector,
+func NewReconciler(ctrlClient ctrlclient.Client, scheme *runtime.Scheme, kCli k8s.Client, restartDetector *ContainerRestartDetector,
 	st store.RStore) *Reconciler {
 	return &Reconciler{
 		ctrlClient:             ctrlClient,
 		kCli:                   kCli,
-		ownerFetcher:           ownerFetcher,
 		restartDetector:        restartDetector,
 		dispatcher:             st,
 		indexer:                indexer.NewIndexer(scheme, indexKubernetesDiscovery),
@@ -524,7 +522,7 @@ func (w *Reconciler) triagePodTree(pod *v1.Pod, objTree k8s.ObjectRefTree) []tri
 }
 
 func (w *Reconciler) handlePodChange(ctx context.Context, pod *v1.Pod) {
-	objTree, err := w.ownerFetcher.OwnerTreeOf(ctx, k8s.NewK8sEntity(pod))
+	objTree, err := w.kCli.OwnerFetcher().OwnerTreeOf(ctx, k8s.NewK8sEntity(pod))
 	if err != nil {
 		return
 	}

--- a/internal/controllers/core/kubernetesdiscovery/reconciler_test.go
+++ b/internal/controllers/core/kubernetesdiscovery/reconciler_test.go
@@ -421,10 +421,9 @@ func newFixture(t *testing.T) *fixture {
 
 	st := store.NewTestingStore()
 
-	of := k8s.ProvideOwnerFetcher(ctx, kClient)
 	rd := NewContainerRestartDetector()
 	cfb := fake.NewControllerFixtureBuilder(t)
-	pw := NewReconciler(cfb.Client, cfb.Scheme(), kClient, of, rd, st)
+	pw := NewReconciler(cfb.Client, cfb.Scheme(), kClient, rd, st)
 
 	ret := &fixture{
 		ControllerFixture: cfb.Build(pw),

--- a/internal/engine/k8swatch/event_watch_manager_test.go
+++ b/internal/engine/k8swatch/event_watch_manager_test.go
@@ -266,15 +266,13 @@ func newEWMFixture(t *testing.T) *ewmFixture {
 	ctx, _, _ := testutils.CtxAndAnalyticsForTest()
 	ctx, cancel := context.WithCancel(ctx)
 
-	of := k8s.ProvideOwnerFetcher(ctx, kClient)
-
 	clock := clockwork.NewFakeClock()
 	st := store.NewTestingStore()
 
 	ret := &ewmFixture{
 		TempDirFixture: tempdir.NewTempDirFixture(t),
 		kClient:        kClient,
-		ewm:            NewEventWatchManager(kClient, of, k8s.DefaultNamespace),
+		ewm:            NewEventWatchManager(kClient, k8s.DefaultNamespace),
 		ctx:            ctx,
 		cancel:         cancel,
 		t:              t,

--- a/internal/engine/k8swatch/service_watch.go
+++ b/internal/engine/k8swatch/service_watch.go
@@ -15,18 +15,16 @@ import (
 )
 
 type ServiceWatcher struct {
-	kCli         k8s.Client
-	ownerFetcher k8s.OwnerFetcher
+	kCli k8s.Client
 
 	mu                sync.RWMutex
 	watcherKnownState watcherKnownState
 	knownServices     map[types.UID]*v1.Service
 }
 
-func NewServiceWatcher(kCli k8s.Client, ownerFetcher k8s.OwnerFetcher, cfgNS k8s.Namespace) *ServiceWatcher {
+func NewServiceWatcher(kCli k8s.Client, cfgNS k8s.Namespace) *ServiceWatcher {
 	return &ServiceWatcher{
 		kCli:              kCli,
-		ownerFetcher:      ownerFetcher,
 		watcherKnownState: newWatcherKnownState(cfgNS),
 		knownServices:     make(map[types.UID]*v1.Service),
 	}

--- a/internal/engine/k8swatch/service_watch_test.go
+++ b/internal/engine/k8swatch/service_watch_test.go
@@ -144,8 +144,7 @@ func newSWFixture(t *testing.T) *swFixture {
 	ctx, _, _ := testutils.CtxAndAnalyticsForTest()
 	ctx, cancel := context.WithCancel(ctx)
 
-	of := k8s.ProvideOwnerFetcher(ctx, kClient)
-	sw := NewServiceWatcher(kClient, of, k8s.DefaultNamespace)
+	sw := NewServiceWatcher(kClient, k8s.DefaultNamespace)
 	st := store.NewTestingStore()
 
 	return &swFixture{

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -3817,11 +3817,10 @@ func newTestFixture(t *testing.T, options ...fixtureOptions) *testFixture {
 		nil, "tilt-default", webListener, serverOptions,
 		&server.HeadsUpServer{}, assets.NewFakeServer(), model.WebURL{})
 	ns := k8s.Namespace("default")
-	of := k8s.ProvideOwnerFetcher(ctx, kClient)
 	rd := kubernetesdiscovery.NewContainerRestartDetector()
-	kdc := kubernetesdiscovery.NewReconciler(cdc, sch, kClient, of, rd, st)
-	sw := k8swatch.NewServiceWatcher(kClient, of, ns)
-	ewm := k8swatch.NewEventWatchManager(kClient, of, ns)
+	kdc := kubernetesdiscovery.NewReconciler(cdc, sch, kClient, rd, st)
+	sw := k8swatch.NewServiceWatcher(kClient, ns)
+	ewm := k8swatch.NewEventWatchManager(kClient, ns)
 	tcum := cloud.NewStatusManager(httptest.NewFakeClientEmptyJSON(), clock)
 	fe := cmd.NewFakeExecer()
 	fpm := cmd.NewFakeProberManager()
@@ -3861,7 +3860,7 @@ func newTestFixture(t *testing.T, options ...fixtureOptions) *testFixture {
 	cu := &containerupdate.FakeContainerUpdater{}
 	lur := liveupdate.NewFakeReconciler(st, cu, cdc)
 	dir := dockerimage.NewReconciler(cdc)
-	clr := cluster.NewReconciler(cdc, st, docker.LocalEnv{}, cluster.NewConnectionManager())
+	clr := cluster.NewReconciler(ctx, cdc, st, docker.LocalEnv{}, cluster.NewConnectionManager())
 	clr.SetFakeClientsForTesting(kClient, dockerClient)
 
 	cb := controllers.NewControllerBuilder(tscm, controllers.ProvideControllers(

--- a/internal/k8s/exploding_client.go
+++ b/internal/k8s/exploding_client.go
@@ -94,3 +94,7 @@ func (ec *explodingClient) Exec(ctx context.Context, podID PodID, cName containe
 func (ec *explodingClient) CheckConnected(ctx context.Context) (*version.Info, error) {
 	return nil, errors.Wrap(ec.err, "could not set up kubernetes client")
 }
+
+func (ec *explodingClient) OwnerFetcher() OwnerFetcher {
+	return NewOwnerFetcher(context.Background(), ec)
+}

--- a/internal/k8s/owner_fetcher_test.go
+++ b/internal/k8s/owner_fetcher_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestVisitOneParent(t *testing.T) {
 	kCli := NewFakeK8sClient(t)
-	ov := ProvideOwnerFetcher(context.Background(), kCli)
+	ov := NewOwnerFetcher(context.Background(), kCli)
 
 	pod, rs := fakeOneParentChain()
 	kCli.Inject(NewK8sEntity(rs))
@@ -26,7 +26,7 @@ func TestVisitOneParent(t *testing.T) {
 
 func TestVisitTwoParentsEnsureListCaching(t *testing.T) {
 	kCli := NewFakeK8sClient(t)
-	ov := ProvideOwnerFetcher(context.Background(), kCli)
+	ov := NewOwnerFetcher(context.Background(), kCli)
 
 	pod, rs, dep := fakeTwoParentChain()
 	kCli.Inject(NewK8sEntity(rs), NewK8sEntity(dep))
@@ -43,7 +43,7 @@ func TestVisitTwoParentsEnsureListCaching(t *testing.T) {
 func TestVisitTwoParentsNoList(t *testing.T) {
 	kCli := NewFakeK8sClient(t)
 	kCli.listReturnsEmpty = true
-	ov := ProvideOwnerFetcher(context.Background(), kCli)
+	ov := NewOwnerFetcher(context.Background(), kCli)
 
 	pod, rs, dep := fakeTwoParentChain()
 	kCli.Inject(NewK8sEntity(rs), NewK8sEntity(dep))
@@ -60,7 +60,7 @@ func TestVisitTwoParentsNoList(t *testing.T) {
 func TestOwnerFetcherParallelism(t *testing.T) {
 	kCli := NewFakeK8sClient(t)
 	kCli.listReturnsEmpty = true
-	ov := ProvideOwnerFetcher(context.Background(), kCli)
+	ov := NewOwnerFetcher(context.Background(), kCli)
 
 	pod, rs := fakeOneParentChain()
 	kCli.Inject(NewK8sEntity(rs))


### PR DESCRIPTION
Historically, we've injected (via wire) a single Kubernetes client,
so we also injected a single `OwnerFetcher` (which uses the K8s
client).

Now that we're moving to multiple Kubernetes cluster connections
being supported, that means there can be multiple `OwnerFetcher`
instances, BUT we only want 1x `OwnerFetcher` per cluster connection.
(There is a lot of internal caching and clever logic to avoid duplicate
lookups!)

To avoid adding extra book-keeping/logic for consumers to look these
up in addition to the actual Kubernetes client, this moves the
`OwnerFetcher` to be managed by the client, which will ensure there's
a 1:1:1 mapping between cluster connection, Kubernetes cilent, and
`OwnerFetcher`.