### PR TITLE
engine: use K8s clients from Cluster cache

### DIFF
--- a/internal/cli/wire_gen.go
+++ b/internal/cli/wire_gen.go
@@ -319,7 +319,7 @@ func wireCmdUp(ctx context.Context, analytics3 *analytics.TiltAnalytics, cmdTags
 	terminalStream := hud.NewTerminalStream(incrementalPrinter, storeStore)
 	openInput := _wireOpenInputValue
 	terminalPrompt := prompt.NewTerminalPrompt(analytics3, openInput, openURL, stdout, webHost, webURL)
-	serviceWatcher := k8swatch.NewServiceWatcher(client, namespace)
+	serviceWatcher := k8swatch.NewServiceWatcher(connectionManager, namespace)
 	buildClock := build.ProvideClock()
 	liveUpdateBuildAndDeployer := buildcontrol.NewLiveUpdateBuildAndDeployer(liveupdateReconciler, buildClock)
 	execCustomBuilder := build.NewExecCustomBuilder(switchCli, buildClock)
@@ -340,7 +340,7 @@ func wireCmdUp(ctx context.Context, analytics3 *analytics.TiltAnalytics, cmdTags
 	dockerComposeLogManager := runtimelog.NewDockerComposeLogManager(dockerComposeClient)
 	analyticsReporter := analytics2.ProvideAnalyticsReporter(analytics3, storeStore, client, k8sEnv)
 	analyticsUpdater := analytics2.NewAnalyticsUpdater(analytics3, cmdTags, engineMode)
-	eventWatchManager := k8swatch.NewEventWatchManager(client, namespace)
+	eventWatchManager := k8swatch.NewEventWatchManager(connectionManager, namespace)
 	cloudStatusManager := cloud.NewStatusManager(httpClient, clock)
 	dockerPruner := dockerprune.NewDockerPruner(switchCli)
 	telemetryController := telemetry.NewController(buildClock, spanCollector)
@@ -528,7 +528,7 @@ func wireCmdCI(ctx context.Context, analytics3 *analytics.TiltAnalytics, subcomm
 	terminalStream := hud.NewTerminalStream(incrementalPrinter, storeStore)
 	openInput := _wireOpenInputValue
 	terminalPrompt := prompt.NewTerminalPrompt(analytics3, openInput, openURL, stdout, webHost, webURL)
-	serviceWatcher := k8swatch.NewServiceWatcher(client, namespace)
+	serviceWatcher := k8swatch.NewServiceWatcher(connectionManager, namespace)
 	buildClock := build.ProvideClock()
 	liveUpdateBuildAndDeployer := buildcontrol.NewLiveUpdateBuildAndDeployer(liveupdateReconciler, buildClock)
 	execCustomBuilder := build.NewExecCustomBuilder(switchCli, buildClock)
@@ -550,7 +550,7 @@ func wireCmdCI(ctx context.Context, analytics3 *analytics.TiltAnalytics, subcomm
 	analyticsReporter := analytics2.ProvideAnalyticsReporter(analytics3, storeStore, client, k8sEnv)
 	cmdTags := _wireCmdTagsValue
 	analyticsUpdater := analytics2.NewAnalyticsUpdater(analytics3, cmdTags, engineMode)
-	eventWatchManager := k8swatch.NewEventWatchManager(client, namespace)
+	eventWatchManager := k8swatch.NewEventWatchManager(connectionManager, namespace)
 	cloudStatusManager := cloud.NewStatusManager(httpClient, clock)
 	dockerPruner := dockerprune.NewDockerPruner(switchCli)
 	telemetryController := telemetry.NewController(buildClock, spanCollector)

--- a/internal/controllers/core/cluster/cache_fake.go
+++ b/internal/controllers/core/cluster/cache_fake.go
@@ -1,0 +1,70 @@
+package cluster
+
+import (
+	"sync"
+
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/tilt-dev/tilt/internal/k8s"
+	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
+)
+
+type FakeClientCache struct {
+	mu      sync.Mutex
+	clients map[types.NamespacedName]k8s.Client
+	errors  map[types.NamespacedName]error
+}
+
+var _ ClientCache = &FakeClientCache{}
+
+func NewFakeClientCache(defaultClient k8s.Client) *FakeClientCache {
+	clients := make(map[types.NamespacedName]k8s.Client)
+	if defaultClient != nil {
+		defaultNN := types.NamespacedName{Name: v1alpha1.ClusterNameDefault}
+		clients[defaultNN] = defaultClient
+	}
+
+	return &FakeClientCache{
+		clients: clients,
+		errors:  make(map[types.NamespacedName]error),
+	}
+}
+
+func (f *FakeClientCache) GetK8sClient(key types.NamespacedName) (k8s.Client, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	if err, ok := f.errors[key]; ok {
+		return nil, err
+	}
+
+	cli, ok := f.clients[key]
+	if !ok {
+		return nil, NotFoundError
+	}
+	return cli, nil
+}
+
+func (f *FakeClientCache) SetK8sClient(key types.NamespacedName, client k8s.Client) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.clients[key] = client
+}
+
+func (f *FakeClientCache) SetClusterError(key types.NamespacedName, err error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if err == nil {
+		delete(f.errors, key)
+	} else {
+		f.errors[key] = err
+	}
+}
+
+func (f *FakeClientCache) AddK8sClient(key types.NamespacedName, client k8s.Client) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if _, ok := f.clients[key]; !ok {
+		f.clients[key] = client
+	}
+}

--- a/internal/engine/k8swatch/event_watch_manager_test.go
+++ b/internal/engine/k8swatch/event_watch_manager_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/tilt-dev/tilt/internal/controllers/core/cluster"
 	"github.com/tilt-dev/tilt/pkg/apis"
 
 	"github.com/jonboulle/clockwork"
@@ -272,7 +273,7 @@ func newEWMFixture(t *testing.T) *ewmFixture {
 	ret := &ewmFixture{
 		TempDirFixture: tempdir.NewTempDirFixture(t),
 		kClient:        kClient,
-		ewm:            NewEventWatchManager(kClient, k8s.DefaultNamespace),
+		ewm:            NewEventWatchManager(cluster.NewFakeClientCache(kClient), k8s.DefaultNamespace),
 		ctx:            ctx,
 		cancel:         cancel,
 		t:              t,

--- a/internal/engine/k8swatch/service_watch.go
+++ b/internal/engine/k8swatch/service_watch.go
@@ -8,6 +8,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 
+	"github.com/tilt-dev/tilt/internal/controllers/core/cluster"
 	"github.com/tilt-dev/tilt/internal/k8s"
 	"github.com/tilt-dev/tilt/internal/store"
 	"github.com/tilt-dev/tilt/pkg/logger"
@@ -15,18 +16,18 @@ import (
 )
 
 type ServiceWatcher struct {
-	kCli k8s.Client
+	clients cluster.ClientCache
 
 	mu                sync.RWMutex
 	watcherKnownState watcherKnownState
-	knownServices     map[types.UID]*v1.Service
+	knownServices     map[clusterUID]*v1.Service
 }
 
-func NewServiceWatcher(kCli k8s.Client, cfgNS k8s.Namespace) *ServiceWatcher {
+func NewServiceWatcher(clients cluster.ClientCache, cfgNS k8s.Namespace) *ServiceWatcher {
 	return &ServiceWatcher{
-		kCli:              kCli,
+		clients:           clients,
 		watcherKnownState: newWatcherKnownState(cfgNS),
-		knownServices:     make(map[types.UID]*v1.Service),
+		knownServices:     make(map[clusterUID]*v1.Service),
 	}
 }
 
@@ -65,10 +66,18 @@ func (w *ServiceWatcher) OnChange(ctx context.Context, st store.RStore, _ store.
 	return nil
 }
 
-func (w *ServiceWatcher) setupWatch(ctx context.Context, st store.RStore, ns k8s.Namespace) {
-	ch, err := w.kCli.WatchServices(ctx, ns)
+func (w *ServiceWatcher) setupWatch(ctx context.Context, st store.RStore, ns clusterNamespace) {
+	kCli, err := w.clients.GetK8sClient(ns.cluster)
 	if err != nil {
-		err = errors.Wrapf(err, "Error watching services. Are you connected to kubernetes?\nTry running `kubectl get services -n %q`", ns)
+		// ignore errors, if the cluster status changes, the subscriber
+		// will be re-run and the namespaces will be picked up again as new
+		// since watcherKnownState isn't updated
+		return
+	}
+
+	ch, err := kCli.WatchServices(ctx, ns.namespace)
+	if err != nil {
+		err = errors.Wrapf(err, "Error watching services. Are you connected to kubernetes?\nTry running `kubectl get services -n %q`", ns.namespace)
 		st.Dispatch(store.NewErrorAction(err))
 		return
 	}
@@ -76,15 +85,23 @@ func (w *ServiceWatcher) setupWatch(ctx context.Context, st store.RStore, ns k8s
 	ctx, cancel := context.WithCancel(ctx)
 	w.watcherKnownState.namespaceWatches[ns] = namespaceWatch{cancel: cancel}
 
-	go w.dispatchServiceChangesLoop(ctx, ch, st)
+	go w.dispatchServiceChangesLoop(ctx, kCli, ns.cluster, ch, st)
 }
 
 // When new UIDs are deployed, go through all our known services and dispatch
 // new events. This handles the case where we get the Service change event
 // before the deploy id shows up in the manifest, which is way more common than
 // you would think.
-func (w *ServiceWatcher) setupNewUIDs(ctx context.Context, st store.RStore, newUIDs map[types.UID]model.ManifestName) {
+func (w *ServiceWatcher) setupNewUIDs(ctx context.Context, st store.RStore, newUIDs map[clusterUID]model.ManifestName) {
 	for uid, mn := range newUIDs {
+		kCli, err := w.clients.GetK8sClient(uid.cluster)
+		if err != nil {
+			// ignore errors, if the cluster status changes, the subscriber
+			// will be re-run and the namespaces will be picked up again as new
+			// since watcherKnownState isn't updated
+			continue
+		}
+
 		w.watcherKnownState.knownDeployedUIDs[uid] = mn
 
 		service, ok := w.knownServices[uid]
@@ -92,7 +109,7 @@ func (w *ServiceWatcher) setupNewUIDs(ctx context.Context, st store.RStore, newU
 			continue
 		}
 
-		err := DispatchServiceChange(st, service, mn, w.kCli.NodeIP(ctx))
+		err = DispatchServiceChange(st, service, mn, kCli.NodeIP(ctx))
 		if err != nil {
 			logger.Get(ctx).Infof("error resolving service url %s: %v", service.Name, err)
 		}
@@ -103,11 +120,11 @@ func (w *ServiceWatcher) setupNewUIDs(ctx context.Context, st store.RStore, newU
 //
 // The division between triageServiceUpdate and recordServiceUpdate is a bit artificial,
 // but is designed this way to be consistent with PodWatcher and EventWatchManager.
-func (w *ServiceWatcher) triageServiceUpdate(service *v1.Service) model.ManifestName {
+func (w *ServiceWatcher) triageServiceUpdate(clusterNN types.NamespacedName, service *v1.Service) model.ManifestName {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 
-	uid := service.UID
+	uid := clusterUID{cluster: clusterNN, uid: service.UID}
 	w.knownServices[uid] = service
 
 	manifestName, ok := w.watcherKnownState.knownDeployedUIDs[uid]
@@ -118,7 +135,7 @@ func (w *ServiceWatcher) triageServiceUpdate(service *v1.Service) model.Manifest
 	return manifestName
 }
 
-func (w *ServiceWatcher) dispatchServiceChangesLoop(ctx context.Context, ch <-chan *v1.Service, st store.RStore) {
+func (w *ServiceWatcher) dispatchServiceChangesLoop(ctx context.Context, kCli k8s.Client, clusterNN types.NamespacedName, ch <-chan *v1.Service, st store.RStore) {
 	for {
 		select {
 		case service, ok := <-ch:
@@ -126,12 +143,12 @@ func (w *ServiceWatcher) dispatchServiceChangesLoop(ctx context.Context, ch <-ch
 				return
 			}
 
-			manifestName := w.triageServiceUpdate(service)
+			manifestName := w.triageServiceUpdate(clusterNN, service)
 			if manifestName == "" {
 				continue
 			}
 
-			err := DispatchServiceChange(st, service, manifestName, w.kCli.NodeIP(ctx))
+			err := DispatchServiceChange(st, service, manifestName, kCli.NodeIP(ctx))
 			if err != nil {
 				logger.Get(ctx).Infof("error resolving service url %s: %v", service.Name, err)
 			}

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -3777,6 +3777,7 @@ func newTestFixture(t *testing.T, options ...fixtureOptions) *testFixture {
 
 	watcher := fsevent.NewFakeMultiWatcher()
 	kClient := k8s.NewFakeK8sClient(t)
+	clusterClients := cluster.NewFakeClientCache(kClient)
 
 	timerMaker := fsevent.MakeFakeTimerMaker(t)
 
@@ -3819,8 +3820,8 @@ func newTestFixture(t *testing.T, options ...fixtureOptions) *testFixture {
 	ns := k8s.Namespace("default")
 	rd := kubernetesdiscovery.NewContainerRestartDetector()
 	kdc := kubernetesdiscovery.NewReconciler(cdc, sch, kClient, rd, st)
-	sw := k8swatch.NewServiceWatcher(kClient, ns)
-	ewm := k8swatch.NewEventWatchManager(kClient, ns)
+	sw := k8swatch.NewServiceWatcher(clusterClients, ns)
+	ewm := k8swatch.NewEventWatchManager(clusterClients, ns)
 	tcum := cloud.NewStatusManager(httptest.NewFakeClientEmptyJSON(), clock)
 	fe := cmd.NewFakeExecer()
 	fpm := cmd.NewFakeProberManager()


### PR DESCRIPTION
Do not use an injected client but do a lookup from the
`cluster.ClientCache`.

Most of the changes here are to carry the cluster info
along with the namespace/UID so that it's safe to use
across multiple clusters without collisions.