### PR TITLE
build: use new CmdImageSpec

### DIFF
--- a/internal/controllers/core/tiltfile/filewatch_test.go
+++ b/internal/controllers/core/tiltfile/filewatch_test.go
@@ -100,8 +100,8 @@ func TestFileWatch_IgnoreOutputsImageRefs(t *testing.T) {
 
 	target := model.MustNewImageTarget(container.MustParseSelector("img")).
 		WithBuildDetails(model.CustomBuild{
-			Deps:              []string{f.Path()},
-			OutputsImageRefTo: f.JoinPath("ref.txt"),
+			CmdImageSpec: v1alpha1.CmdImageSpec{OutputsImageRefTo: f.JoinPath("ref.txt")},
+			Deps:         []string{f.Path()},
 		})
 
 	m := manifestbuilder.New(f, "sancho").

--- a/internal/engine/buildcontrol/image_build_and_deployer_test.go
+++ b/internal/engine/buildcontrol/image_build_and_deployer_test.go
@@ -518,10 +518,12 @@ func TestCustomBuildSkipsLocalDocker(t *testing.T) {
 	f.docker.Images["gcr.io/some-project-162817/sancho:tilt-build"] = types.ImageInspect{ID: string(sha)}
 
 	cb := model.CustomBuild{
-		Command:          model.ToHostCmd("exit 0"),
-		Deps:             []string{f.JoinPath("app")},
-		SkipsLocalDocker: true,
-		Tag:              "tilt-build",
+		CmdImageSpec: v1alpha1.CmdImageSpec{
+			Args:       model.ToHostCmd("exit 0").Argv,
+			OutputTag:  "tilt-build",
+			OutputMode: v1alpha1.CmdImageOutputRemote,
+		},
+		Deps: []string{f.JoinPath("app")},
 	}
 
 	manifest := manifestbuilder.New(f, "sancho").

--- a/internal/engine/buildcontrol/testdata_test.go
+++ b/internal/engine/buildcontrol/testdata_test.go
@@ -54,9 +54,8 @@ func NewSanchoCustomBuildManifest(fixture Fixture) model.Manifest {
 
 func NewSanchoCustomBuildImageTargetWithTag(fixture Fixture, tag string) model.ImageTarget {
 	cb := model.CustomBuild{
-		Command: model.ToHostCmd("exit 0"),
-		Deps:    []string{fixture.JoinPath("app")},
-		Tag:     tag,
+		CmdImageSpec: v1alpha1.CmdImageSpec{Args: model.ToHostCmd("exit 0").Argv, OutputTag: tag},
+		Deps:         []string{fixture.JoinPath("app")},
 	}
 	return model.MustNewImageTarget(SanchoRef).WithBuildDetails(cb)
 }
@@ -70,10 +69,12 @@ func NewSanchoCustomBuildManifestWithTag(fixture Fixture, tag string) model.Mani
 
 func NewSanchoCustomBuildManifestWithPushDisabled(fixture Fixture) model.Manifest {
 	cb := model.CustomBuild{
-		Command:     model.ToHostCmd("exit 0"),
-		Deps:        []string{fixture.JoinPath("app")},
-		DisablePush: true,
-		Tag:         "tilt-build",
+		CmdImageSpec: v1alpha1.CmdImageSpec{
+			Args:       model.ToHostCmd("exit 0").Argv,
+			OutputTag:  "tilt-build",
+			OutputMode: v1alpha1.CmdImageOutputLocalDockerAndRemote,
+		},
+		Deps: []string{fixture.JoinPath("app")},
 	}
 
 	return manifestbuilder.New(fixture, "sancho").

--- a/internal/engine/testdata_test.go
+++ b/internal/engine/testdata_test.go
@@ -69,9 +69,8 @@ func NewSanchoCustomBuildImageTarget(fixture Fixture) model.ImageTarget {
 
 func NewSanchoCustomBuildImageTargetWithTag(fixture Fixture, tag string) model.ImageTarget {
 	cb := model.CustomBuild{
-		Command: model.ToHostCmd("exit 0"),
-		Deps:    []string{fixture.JoinPath("app")},
-		Tag:     tag,
+		CmdImageSpec: v1alpha1.CmdImageSpec{Args: model.ToHostCmd("exit 0").Argv, OutputTag: tag},
+		Deps:         []string{fixture.JoinPath("app")},
 	}
 	return model.MustNewImageTarget(SanchoRef).WithBuildDetails(cb)
 }

--- a/internal/tiltfile/tiltfile_state.go
+++ b/internal/tiltfile/tiltfile_state.go
@@ -1427,14 +1427,22 @@ func (s *tiltfileState) imgTargetsForDependencyIDsHelper(mn model.ManifestName, 
 			}
 			iTarget = iTarget.WithBuildDetails(model.DockerBuild{DockerImageSpec: spec})
 		case CustomBuild:
-			r := model.CustomBuild{
-				WorkDir:           image.workDir,
-				Command:           image.customCommand,
-				Deps:              image.customDeps,
-				Tag:               image.customTag,
-				DisablePush:       image.disablePush,
-				SkipsLocalDocker:  image.skipsLocalDocker,
+			spec := v1alpha1.CmdImageSpec{
+				Args:              image.customCommand.Argv,
+				Dir:               image.workDir,
+				OutputTag:         image.customTag,
 				OutputsImageRefTo: image.outputsImageRefTo,
+			}
+			if image.skipsLocalDocker {
+				spec.OutputMode = v1alpha1.CmdImageOutputRemote
+			} else if image.disablePush {
+				spec.OutputMode = v1alpha1.CmdImageOutputLocalDockerAndRemote
+			} else {
+				spec.OutputMode = v1alpha1.CmdImageOutputLocalDocker
+			}
+			r := model.CustomBuild{
+				CmdImageSpec: spec,
+				Deps:         image.customDeps,
 			}
 			iTarget = iTarget.WithBuildDetails(r)
 		case DockerComposeBuild:

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -2472,7 +2472,7 @@ custom_build(
 			image("gcr.io/foo"),
 		),
 		deployment("foo"))
-	assert.True(t, m.ImageTargets[0].CustomBuildInfo().SkipsLocalDocker)
+	assert.Equal(t, v1alpha1.CmdImageOutputRemote, m.ImageTargets[0].CustomBuildInfo().OutputMode)
 	assert.True(t, m.ImageTargets[0].CustomBuildInfo().SkipsPush())
 }
 
@@ -6222,11 +6222,11 @@ func (f *fixture) assertNextManifest(name model.ManifestName, opts ...interface{
 				case depsHelper:
 					assert.Equal(f.t, matcher.deps, cbInfo.Deps)
 				case cmdHelper:
-					assert.Equal(f.t, matcher.cmd, cbInfo.Command)
+					assert.Equal(f.t, matcher.cmd.Argv, cbInfo.Args)
 				case tagHelper:
-					assert.Equal(f.t, matcher.tag, cbInfo.Tag)
+					assert.Equal(f.t, matcher.tag, cbInfo.OutputTag)
 				case disablePushHelper:
-					assert.Equal(f.t, matcher.disabled, cbInfo.DisablePush)
+					assert.Equal(f.t, matcher.disabled, cbInfo.OutputMode == v1alpha1.CmdImageOutputLocalDockerAndRemote)
 				case entrypointHelper:
 					if !sliceutils.StringSliceEquals(matcher.cmd.Argv, image.OverrideCommand.Command) {
 						f.t.Fatalf("expected OverrideCommand (aka entrypoint) %v, got %v",

--- a/pkg/apis/core/v1alpha1/cmdimage_types.go
+++ b/pkg/apis/core/v1alpha1/cmdimage_types.go
@@ -182,11 +182,11 @@ type CmdImageOutputMode string
 
 const (
 	// Written to the Docker image store only.
-	CmdImageOutputLocalDocker CmdImageOutputMode = "docker-local"
+	CmdImageOutputLocalDocker CmdImageOutputMode = "local-docker"
 
 	// Written to the Docker image store and pushed to the remote
 	// destination.
-	CmdImageOutputLocalDockerAndRemote CmdImageOutputMode = "docker-local-and-remote"
+	CmdImageOutputLocalDockerAndRemote CmdImageOutputMode = "local-docker-and-remote"
 
 	// Written directly to the remote destination.
 	CmdImageOutputRemote CmdImageOutputMode = "remote"

--- a/pkg/model/custom_build_test.go
+++ b/pkg/model/custom_build_test.go
@@ -6,12 +6,13 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/tilt-dev/tilt/internal/container"
+	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
 )
 
 func TestValidate(t *testing.T) {
 	cb := CustomBuild{
-		Command: ToHostCmd("exit 0"),
-		Deps:    []string{"foo", "bar"},
+		CmdImageSpec: v1alpha1.CmdImageSpec{Args: ToHostCmd("exit 0").Argv},
+		Deps:         []string{"foo", "bar"},
 	}
 	it := MustNewImageTarget(container.MustParseSelector("gcr.io/foo/bar")).
 		WithBuildDetails(cb)
@@ -21,8 +22,8 @@ func TestValidate(t *testing.T) {
 
 func TestDoesNotValidate(t *testing.T) {
 	cb := CustomBuild{
-		Command: ToHostCmd(""),
-		Deps:    []string{"foo", "bar"},
+		CmdImageSpec: v1alpha1.CmdImageSpec{},
+		Deps:         []string{"foo", "bar"},
 	}
 	it := MustNewImageTarget(container.MustParseSelector("gcr.io/foo/bar")).
 		WithBuildDetails(cb)

--- a/pkg/model/image_target.go
+++ b/pkg/model/image_target.go
@@ -122,7 +122,7 @@ func (i ImageTarget) Validate() error {
 			return fmt.Errorf("[Validate] Image %q missing build path", i.ImageMapSpec.Selector)
 		}
 	case CustomBuild:
-		if !i.IsLiveUpdateOnly && bd.Command.Empty() {
+		if !i.IsLiveUpdateOnly && len(bd.Args) == 0 {
 			return fmt.Errorf(
 				"[Validate] CustomBuild command must not be empty",
 			)
@@ -189,7 +189,7 @@ func (i ImageTarget) WithBuildDetails(details BuildDetails) ImageTarget {
 
 	cb, ok := details.(CustomBuild)
 	isEmptyLiveUpdateSpec := len(i.LiveUpdateSpec.Syncs) == 0 && len(i.LiveUpdateSpec.Execs) == 0
-	if ok && cmp.Equal(cb.Command.Argv, ToHostCmd(":").Argv) && !isEmptyLiveUpdateSpec {
+	if ok && cmp.Equal(cb.Args, ToHostCmd(":").Argv) && !isEmptyLiveUpdateSpec {
 		// NOTE(nick): This is a hack for the file_sync_only extension
 		// until we come up with a real API for specifying live update
 		// without an image build.
@@ -302,7 +302,7 @@ func (i ImageTarget) InferImagePropertiesFromCluster(reg container.Registry) (Im
 	// CustomBuilder, which already has similar logic for handling these two cases
 	// together.
 	customBuild, ok := i.BuildDetails.(CustomBuild)
-	if ok && customBuild.SkipsLocalDocker && customBuild.Tag != "" {
+	if ok && customBuild.OutputMode == v1alpha1.CmdImageOutputRemote && customBuild.OutputTag != "" {
 		refs = refs.WithoutRegistry()
 	}
 	_, ok = i.BuildDetails.(DockerComposeBuild)
@@ -330,34 +330,25 @@ type DockerBuild struct {
 func (DockerBuild) buildDetails() {}
 
 type CustomBuild struct {
-	WorkDir string
-	Command Cmd
+	v1alpha1.CmdImageSpec
+
 	// Deps is a list of file paths that are dependencies of this command.
+	//
+	// TODO(nick): This creates a FileWatch. We should add a RestartOn field
+	// to CmdImageSpec that points to the FileWatch.
 	Deps []string
-
-	// Optional: tag we expect the image to be built with (we use this to check that
-	// the expected image+tag has been created).
-	// If empty, we create an expected tag at the beginning of CustomBuild (and
-	// export $EXPECTED_REF=name:expected_tag )
-	Tag string
-
-	DisablePush      bool
-	SkipsLocalDocker bool
-
-	// We expect the custom build script to print the image ref to this file,
-	// so that Tilt can read it out when we're done.
-	OutputsImageRefTo string
 }
 
 func (CustomBuild) buildDetails() {}
 
 func (cb CustomBuild) WithTag(t string) CustomBuild {
-	cb.Tag = t
+	cb.CmdImageSpec.OutputTag = t
 	return cb
 }
 
 func (cb CustomBuild) SkipsPush() bool {
-	return cb.SkipsLocalDocker || cb.DisablePush
+	return cb.OutputMode == v1alpha1.CmdImageOutputLocalDockerAndRemote ||
+		cb.OutputMode == v1alpha1.CmdImageOutputRemote
 }
 
 type DockerComposeBuild struct {


### PR DESCRIPTION
Hello @milas,

Please review the following commits I made in branch nicks/cmdimage2:

486ffd37a97d257ad83fc79dc74affa87c94e582 (2021-12-20 19:20:30 -0500)
build: use new CmdImageSpec

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics