### PR TITLE
web: reset the confirmation state of `ApiToggleButton`s when navigating between resources

### DIFF
--- a/web/src/ApiButton.testhelpers.tsx
+++ b/web/src/ApiButton.testhelpers.tsx
@@ -37,13 +37,14 @@ export function hiddenField(name: string, value: string): UIInputSpec {
 }
 
 export function makeUIButton(args?: {
+  name?: string
   inputSpecs?: UIInputSpec[]
   inputStatuses?: UIInputStatus[]
   requiresConfirmation?: boolean
 }): UIButton {
   return {
     metadata: {
-      name: "TestButton",
+      name: args?.name ?? "TestButton",
     },
     spec: {
       text: "Click Me!",

--- a/web/src/ApiButton.tsx
+++ b/web/src/ApiButton.tsx
@@ -10,7 +10,13 @@ import ArrowDropDownIcon from "@material-ui/icons/ArrowDropDown"
 import { ClassNameMap } from "@material-ui/styles"
 import moment from "moment"
 import { useSnackbar } from "notistack"
-import React, { PropsWithChildren, useMemo, useRef, useState } from "react"
+import React, {
+  PropsWithChildren,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react"
 import { convertFromNode, convertFromString } from "react-from-dom"
 import { Link } from "react-router-dom"
 import styled from "styled-components"
@@ -521,16 +527,20 @@ function ApiSubmitButton(props: PropsWithChildren<ApiButtonElementProps>) {
 //    options used on submit.
 export function ApiButton(props: PropsWithChildren<ApiButtonProps>) {
   const { className, uiButton, ...buttonProps } = props
+  const buttonName = uiButton.metadata?.name || ""
 
   const [inputValues, setInputValues] = usePersistentState<{
     [name: string]: any
-  }>(`apibutton-${uiButton.metadata?.name}`, {})
+  }>(`apibutton-${buttonName}`, {})
   const { enqueueSnackbar } = useSnackbar()
   const pb = usePathBuilder()
   const { setError } = useHudErrorContext()
 
   const [loading, setLoading] = useState(false)
   const [confirming, setConfirming] = useState(false)
+
+  // Reset the confirmation state when the button's name changes
+  useLayoutEffect(() => setConfirming(false), [buttonName])
 
   const tags = useMemo(() => getButtonTags(uiButton), [uiButton])
   const componentType = uiButton.spec?.location?.componentType as ApiButtonType


### PR DESCRIPTION
This PR fixes a bug in which the `confirming` state of an `ApiToggleButton` persisted across rendering different disable resources buttons. If you clicked "disable resource" on one resource (without confirming or cancelling), then navigated to another resource, that confirmation state would not reset.

The easiest solution I found is to track the button name in the component's formal state and then calculate the actual `confirming` state in the render based on whether or not the current button name matches the tracked state button name.

At first, this was a little bit goofy for me to conceptualize with React. Because, if the props change (i.e., the button name changes), then we want to reset the confirmation state of the component. However, we can't make any `setState` calls within the body of the functional component (which leads to an infinite loop!). I believe the solution I've implemented aligns with React patterns, but if others have suggestions for another approach (or find this one too confusing), I'm open to it.

Closes [ch13124](https://app.shortcut.com/windmill/story/13124/apitogglebutton-s-confirmation-state-does-not-reset-when-navigating-between-resources-in-detail-view)