### PR TITLE
buildcontrol: publish CmdImageStatus

### DIFF
--- a/internal/controllers/core/cmdimage/status.go
+++ b/internal/controllers/core/cmdimage/status.go
@@ -1,0 +1,83 @@
+package cmdimage
+
+import (
+	"context"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/tilt-dev/tilt/internal/container"
+	"github.com/tilt-dev/tilt/internal/controllers/apicmp"
+	"github.com/tilt-dev/tilt/pkg/apis"
+	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
+	"github.com/tilt-dev/tilt/pkg/logger"
+	"github.com/tilt-dev/tilt/pkg/model"
+)
+
+// Write the image status to the API server, if necessary.
+// If the image write fails, log it to the debug logs and move on.
+func MaybeUpdateStatus(ctx context.Context, ctrlClient ctrlclient.Client,
+	iTarget model.ImageTarget, status v1alpha1.CmdImageStatus) {
+	if iTarget.CmdImageName == "" {
+		return
+	}
+
+	nn := types.NamespacedName{Name: iTarget.CmdImageName}
+	var di v1alpha1.CmdImage
+	err := ctrlClient.Get(ctx, nn, &di)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return
+		}
+		logger.Get(ctx).Debugf("fetching cmdimage %s: %v", nn.Name, err)
+		return
+	}
+
+	if apicmp.DeepEqual(status, di.Status) {
+		return
+	}
+
+	updated := di.DeepCopy()
+	updated.Status = status
+	err = ctrlClient.Status().Update(ctx, updated)
+	if err != nil {
+		logger.Get(ctx).Debugf("updating cmdimage %s: %v", nn.Name, err)
+	}
+}
+
+// Return a basic Building Status.
+func ToBuildingStatus(iTarget model.ImageTarget, startTime metav1.MicroTime) v1alpha1.CmdImageStatus {
+	return v1alpha1.CmdImageStatus{
+		Building: &v1alpha1.CmdImageStateBuilding{
+			StartedAt: startTime,
+		},
+	}
+}
+
+// Return a completed status when the image build failed.
+func ToCompletedFailStatus(iTarget model.ImageTarget, startTime metav1.MicroTime,
+	err error) v1alpha1.CmdImageStatus {
+	finishTime := apis.NowMicro()
+	return v1alpha1.CmdImageStatus{
+		Completed: &v1alpha1.CmdImageStateCompleted{
+			StartedAt:  startTime,
+			FinishedAt: finishTime,
+			Error:      err.Error(),
+		},
+	}
+}
+
+// Return a completed status when the image build succeeded.
+func ToCompletedSuccessStatus(iTarget model.ImageTarget, startTime metav1.MicroTime,
+	refs container.TaggedRefs) v1alpha1.CmdImageStatus {
+	finishTime := apis.NowMicro()
+	return v1alpha1.CmdImageStatus{
+		Ref: container.FamiliarString(refs.LocalRef),
+		Completed: &v1alpha1.CmdImageStateCompleted{
+			StartedAt:  startTime,
+			FinishedAt: finishTime,
+		},
+	}
+}

--- a/internal/engine/buildcontrol/docker_compose_build_and_deployer.go
+++ b/internal/engine/buildcontrol/docker_compose_build_and_deployer.go
@@ -11,6 +11,7 @@ import (
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/tilt-dev/tilt/internal/analytics"
+	"github.com/tilt-dev/tilt/internal/controllers/core/cmdimage"
 	"github.com/tilt-dev/tilt/internal/controllers/core/dockerimage"
 
 	"github.com/tilt-dev/tilt/internal/build"
@@ -152,6 +153,7 @@ func (bd *DockerComposeBuildAndDeployer) BuildAndDeploy(ctx context.Context, st 
 
 		startTime := apis.NowMicro()
 		dockerimage.MaybeUpdateStatus(ctx, bd.ctrlClient, iTarget, dockerimage.ToBuildingStatus(iTarget, startTime))
+		cmdimage.MaybeUpdateStatus(ctx, bd.ctrlClient, iTarget, cmdimage.ToBuildingStatus(iTarget, startTime))
 
 		expectedRef := iTarget.Refs.ConfigurationRef
 
@@ -161,9 +163,11 @@ func (bd *DockerComposeBuildAndDeployer) BuildAndDeploy(ctx context.Context, st 
 		refs, stages, err := bd.ib.Build(ctx, iTarget, ps)
 		if err != nil {
 			dockerimage.MaybeUpdateStatus(ctx, bd.ctrlClient, iTarget, dockerimage.ToCompletedFailStatus(iTarget, startTime, stages, err))
+			cmdimage.MaybeUpdateStatus(ctx, bd.ctrlClient, iTarget, cmdimage.ToCompletedFailStatus(iTarget, startTime, err))
 			return store.ImageBuildResult{}, err
 		}
 		dockerimage.MaybeUpdateStatus(ctx, bd.ctrlClient, iTarget, dockerimage.ToCompletedSuccessStatus(iTarget, startTime, stages, refs))
+		cmdimage.MaybeUpdateStatus(ctx, bd.ctrlClient, iTarget, cmdimage.ToCompletedSuccessStatus(iTarget, startTime, refs))
 
 		ref, err := bd.tagWithExpected(ctx, refs.LocalRef, expectedRef)
 		if err != nil {

--- a/internal/engine/buildcontrol/image_build_and_deployer.go
+++ b/internal/engine/buildcontrol/image_build_and_deployer.go
@@ -16,6 +16,7 @@ import (
 	"github.com/tilt-dev/tilt/internal/analytics"
 	"github.com/tilt-dev/tilt/internal/build"
 	"github.com/tilt-dev/tilt/internal/container"
+	"github.com/tilt-dev/tilt/internal/controllers/core/cmdimage"
 	"github.com/tilt-dev/tilt/internal/controllers/core/dockerimage"
 	"github.com/tilt-dev/tilt/internal/controllers/core/kubernetesapply"
 	"github.com/tilt-dev/tilt/internal/dockerfile"
@@ -196,10 +197,12 @@ func (ibd *ImageBuildAndDeployer) BuildAndDeploy(ctx context.Context, st store.R
 		// while an image build is going on in parallel.
 		startTime := apis.NowMicro()
 		dockerimage.MaybeUpdateStatus(ctx, ibd.ctrlClient, iTarget, dockerimage.ToBuildingStatus(iTarget, startTime))
+		cmdimage.MaybeUpdateStatus(ctx, ibd.ctrlClient, iTarget, cmdimage.ToBuildingStatus(iTarget, startTime))
 
 		refs, stages, err := ibd.ib.Build(ctx, iTarget, ps)
 		if err != nil {
 			dockerimage.MaybeUpdateStatus(ctx, ibd.ctrlClient, iTarget, dockerimage.ToCompletedFailStatus(iTarget, startTime, stages, err))
+			cmdimage.MaybeUpdateStatus(ctx, ibd.ctrlClient, iTarget, cmdimage.ToCompletedFailStatus(iTarget, startTime, err))
 			return store.ImageBuildResult{}, err
 		}
 
@@ -211,10 +214,12 @@ func (ibd *ImageBuildAndDeployer) BuildAndDeploy(ctx context.Context, st store.R
 		if pushStage != nil && pushStage.Error != "" {
 			err := fmt.Errorf("%s", pushStage.Error)
 			dockerimage.MaybeUpdateStatus(ctx, ibd.ctrlClient, iTarget, dockerimage.ToCompletedFailStatus(iTarget, startTime, stages, err))
+			cmdimage.MaybeUpdateStatus(ctx, ibd.ctrlClient, iTarget, cmdimage.ToCompletedFailStatus(iTarget, startTime, err))
 			return store.ImageBuildResult{}, err
 		}
 
 		dockerimage.MaybeUpdateStatus(ctx, ibd.ctrlClient, iTarget, dockerimage.ToCompletedSuccessStatus(iTarget, startTime, stages, refs))
+		cmdimage.MaybeUpdateStatus(ctx, ibd.ctrlClient, iTarget, cmdimage.ToCompletedSuccessStatus(iTarget, startTime, refs))
 
 		result := store.NewImageBuildResult(iTarget.ID(), refs.LocalRef, refs.ClusterRef)
 		result.ImageMapStatus.BuildStartTime = &startTime

--- a/internal/engine/buildcontrol/image_build_and_deployer_test.go
+++ b/internal/engine/buildcontrol/image_build_and_deployer_test.go
@@ -899,6 +899,67 @@ func TestDockerBuildTargetStage(t *testing.T) {
 	assert.Equal(t, "stage", f.docker.BuildOptions.Target)
 }
 
+func TestDockerBuildStatus(t *testing.T) {
+	f := newIBDFixture(t, k8s.EnvGKE)
+	defer f.TearDown()
+
+	iTarget := NewSanchoDockerBuildImageTarget(f)
+	manifest := manifestbuilder.New(f, "sancho").
+		WithK8sYAML(testyaml.SanchoYAML).
+		WithImageTargets(iTarget).
+		Build()
+
+	iTarget = manifest.ImageTargets[0]
+	nn := ktypes.NamespacedName{Name: iTarget.DockerImageName}
+	err := f.ctrlClient.Create(f.ctx, &v1alpha1.DockerImage{
+		ObjectMeta: metav1.ObjectMeta{Name: nn.Name},
+		Spec:       iTarget.DockerBuildInfo().DockerImageSpec,
+	})
+	require.NoError(t, err)
+
+	_, err = f.BuildAndDeploy(BuildTargets(manifest), store.BuildStateSet{})
+	require.NoError(t, err)
+
+	var di v1alpha1.DockerImage
+	err = f.ctrlClient.Get(f.ctx, nn, &di)
+	require.NoError(t, err)
+	require.NotNil(t, di.Status.Completed)
+}
+
+func TestCustomBuildStatus(t *testing.T) {
+	f := newIBDFixture(t, k8s.EnvGKE)
+	defer f.TearDown()
+
+	sha := digest.Digest("sha256:11cd0eb38bc3ceb958ffb2f9bd70be3fb317ce7d255c8a4c3f4af30e298aa1aab")
+	f.docker.Images["gcr.io/some-project-162817/sancho:tilt-build"] = types.ImageInspect{ID: string(sha)}
+
+	cb := model.CustomBuild{
+		CmdImageSpec: v1alpha1.CmdImageSpec{Args: model.ToHostCmd("exit 0").Argv, OutputTag: "tilt-build"},
+		Deps:         []string{f.JoinPath("app")},
+	}
+	iTarget := model.MustNewImageTarget(SanchoRef).WithBuildDetails(cb)
+	manifest := manifestbuilder.New(f, "sancho").
+		WithK8sYAML(testyaml.SanchoYAML).
+		WithImageTargets(iTarget).
+		Build()
+
+	iTarget = manifest.ImageTargets[0]
+	nn := ktypes.NamespacedName{Name: iTarget.CmdImageName}
+	err := f.ctrlClient.Create(f.ctx, &v1alpha1.CmdImage{
+		ObjectMeta: metav1.ObjectMeta{Name: nn.Name},
+		Spec:       iTarget.CustomBuildInfo().CmdImageSpec,
+	})
+	require.NoError(t, err)
+
+	_, err = f.BuildAndDeploy(BuildTargets(manifest), store.BuildStateSet{})
+	require.NoError(t, err)
+
+	var ci v1alpha1.CmdImage
+	err = f.ctrlClient.Get(f.ctx, nn, &ci)
+	require.NoError(t, err)
+	require.NotNil(t, ci.Status.Completed)
+}
+
 func TestTwoManifestsWithCommonImage(t *testing.T) {
 	f := newIBDFixture(t, k8s.EnvGKE)
 	defer f.TearDown()


### PR DESCRIPTION
Hello @milas,

Please review the following commits I made in branch nicks/cmdimageapi2:

6f85122f225866a7663d1fc077058f37377760a2 (2021-12-21 15:27:37 -0500)
buildcontrol: publish CmdImageStatus

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics