### PR TITLE
features: add flag for bulk disabling resources in Table View

### DIFF
--- a/internal/feature/flags.go
+++ b/internal/feature/flags.go
@@ -26,6 +26,7 @@ const Facets = "facets"
 const Labels = "labels"
 const LiveUpdateV2 = "live_update_v2"
 const DisableResources = "disable_resources"
+const BulkDisableResources = "bulk_disable_resources"
 
 // The Value a flag can have. Status should never be changed.
 type Value struct {
@@ -68,6 +69,10 @@ var MainDefaults = Defaults{
 		Status:  Active,
 	},
 	DisableResources: Value{
+		Enabled: false,
+		Status:  Active,
+	},
+	BulkDisableResources: Value{
 		Enabled: false,
 		Status:  Active,
 	},

--- a/web/src/feature.ts
+++ b/web/src/feature.ts
@@ -16,6 +16,7 @@ export enum Flag {
   Facets = "facets",
   Labels = "labels",
   DisableResources = "disable_resources",
+  BulkDisableResources = "bulk_disable_resources",
 }
 
 export default class Features {


### PR DESCRIPTION
Add a feature flag to develop bulk disabling of resources without interfering with beta testing

(We can remove the `bulk_disable_resources` flag and switch any frontend code to the general `disable_resources` flag when this is ready to be user-facing.)

Closes [ch12972](https://app.shortcut.com/windmill/story/12972/optional-add-bulk-disable-resources-feature-flag).