### PR TITLE
build: refactor so that the builders read image dependencies from the API

### DIFF
--- a/internal/build/container_test.go
+++ b/internal/build/container_test.go
@@ -42,6 +42,8 @@ ADD dir/c.txt .
 		Context:            f.Path(),
 	}
 	refs, _, err := f.b.BuildImage(f.ctx, f.ps, f.getNameFromTest(), spec,
+		defaultCluster,
+		nil,
 		model.EmptyMatcher)
 	if err != nil {
 		t.Fatal(err)
@@ -76,6 +78,8 @@ ADD $some_variable_name /test.txt`)
 		Args:               []string{"some_variable_name=awesome_variable"},
 	}
 	refs, _, err := f.b.BuildImage(f.ctx, f.ps, f.getNameFromTest(), spec,
+		defaultCluster,
+		nil,
 		model.EmptyMatcher)
 	if err != nil {
 		t.Fatal(err)
@@ -105,6 +109,8 @@ ADD a.txt .`)
 		Args:               []string{"some_variable_name=awesome_variable"},
 	}
 	refs, _, err := f.b.BuildImage(f.ctx, f.ps, f.getNameFromTest(), spec,
+		defaultCluster,
+		nil,
 		model.EmptyMatcher)
 	if err != nil {
 		t.Fatal(err)
@@ -133,7 +139,10 @@ RUN echo 'failed to create LLB definition: failed commit on ref "unknown-sha256:
 `,
 		Context: f.Path(),
 	}
-	_, _, err := f.b.BuildImage(ctx, ps, f.getNameFromTest(), spec, model.EmptyMatcher)
+	_, _, err := f.b.BuildImage(ctx, ps, f.getNameFromTest(), spec,
+		defaultCluster,
+		nil,
+		model.EmptyMatcher)
 	assert.Error(t, err)
 	assert.Contains(t, out.String(), "Detected Buildkit corruption. Rebuilding without Buildkit")
 	assert.Contains(t, out.String(), "[1/2] FROM docker.io/library/alpine") // buildkit-style output

--- a/internal/build/inject.go
+++ b/internal/build/inject.go
@@ -1,0 +1,101 @@
+package build
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/tilt-dev/tilt/internal/container"
+	"github.com/tilt-dev/tilt/internal/dockerfile"
+	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
+)
+
+// Derived from
+// https://github.com/moby/buildkit/blob/175e8415e38228dbb75e6b54efd2c8e9fc5b1cbf/util/archutil/detect.go#L15
+var validBuildkitArchSet = map[string]bool{
+	"amd64":    true,
+	"arm64":    true,
+	"riscv64":  true,
+	"ppc64le":  true,
+	"s390x":    true,
+	"386":      true,
+	"mips64le": true,
+	"mips64":   true,
+	"arm":      true,
+}
+
+// Create a new ImageTarget with the platform OS/Arch from the target cluster.
+func InjectClusterPlatform(spec v1alpha1.DockerImageSpec, cluster *v1alpha1.Cluster) v1alpha1.DockerImageSpec {
+	if spec.Platform != "" || cluster == nil {
+		return spec
+	}
+
+	// Eventually, it might make sense to read the supported platforms
+	// off the buildkit server and negotiate the right one, but for
+	// now we hard-code a whitelist.
+	targetArch := cluster.Status.Arch
+	if !validBuildkitArchSet[targetArch] {
+		return spec
+	}
+
+	if targetArch == "arm" {
+		// This is typically communicated with GOARM.
+		// For now, just assume arm/v7
+		targetArch = "arm/v7"
+	}
+
+	// Currently Tilt only supports linux containers.
+	// We don't even build windows-compatible docker contexts.
+	spec.Platform = fmt.Sprintf("linux/%s", targetArch)
+	return spec
+}
+
+// Create a new ImageTarget with the Dockerfiles rewritten with the injected images.
+func InjectImageDependencies(spec v1alpha1.DockerImageSpec, imageMaps map[types.NamespacedName]*v1alpha1.ImageMap) (v1alpha1.DockerImageSpec, error) {
+	if len(spec.ImageMaps) == 0 {
+		return spec, nil
+	}
+
+	df := dockerfile.Dockerfile(spec.DockerfileContents)
+	buildArgs := spec.Args
+
+	ast, err := dockerfile.ParseAST(df)
+	if err != nil {
+		return spec, errors.Wrap(err, "injectImageDependencies")
+	}
+
+	for _, dep := range spec.ImageMaps {
+		im, ok := imageMaps[types.NamespacedName{Name: dep}]
+		if !ok || im.Status.ImageFromLocal == "" {
+			return spec, fmt.Errorf("missing image dependency: %s", dep)
+		}
+
+		image := im.Status.ImageFromLocal
+		imageRef, err := container.ParseNamedTagged(image)
+		if err != nil {
+			return spec, errors.Wrap(err, "injectImageDependencies parse")
+		}
+
+		selector, err := container.SelectorFromImageMap(im.Spec)
+		if err != nil {
+			return spec, errors.Wrap(err, "injectImageDependencies selector")
+		}
+
+		modified, err := ast.InjectImageDigest(selector, imageRef, buildArgs)
+		if err != nil {
+			return spec, errors.Wrap(err, "injectImageDependencies inject")
+		} else if !modified {
+			return spec, fmt.Errorf("Could not inject image %q into Dockerfile of image %q", image, selector)
+		}
+	}
+
+	newDf, err := ast.Print()
+	if err != nil {
+		return spec, errors.Wrap(err, "injectImageDependencies")
+	}
+
+	spec.DockerfileContents = newDf.String()
+
+	return spec, nil
+}

--- a/internal/engine/buildcontrol/docker_compose_build_and_deployer.go
+++ b/internal/engine/buildcontrol/docker_compose_build_and_deployer.go
@@ -8,6 +8,7 @@ import (
 	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/go-connections/nat"
+	ktypes "k8s.io/apimachinery/pkg/types"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/tilt-dev/tilt/internal/analytics"
@@ -20,6 +21,7 @@ import (
 	"github.com/tilt-dev/tilt/internal/dockercompose"
 	"github.com/tilt-dev/tilt/internal/store"
 	"github.com/tilt-dev/tilt/pkg/apis"
+	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
 	"github.com/tilt-dev/tilt/pkg/logger"
 	"github.com/tilt-dev/tilt/pkg/model"
 )
@@ -112,6 +114,7 @@ func (bd *DockerComposeBuildAndDeployer) BuildAndDeploy(ctx context.Context, st 
 		})
 	}()
 
+	iTargets := plan.tiltManagedImageTargets
 	q, err := NewImageTargetQueue(ctx, plan.tiltManagedImageTargets, currentState, bd.ib.CanReuseRef)
 	if err != nil {
 		return store.BuildResultSet{}, err
@@ -138,16 +141,25 @@ func (bd *DockerComposeBuildAndDeployer) BuildAndDeploy(ctx context.Context, st 
 		ps.EndPipelineStep(ctx)
 	}
 
-	iTargetMap := model.ImageTargetsByID(plan.tiltManagedImageTargets)
+	imageMapSet := make(map[ktypes.NamespacedName]*v1alpha1.ImageMap, len(plan.dockerComposeTarget.Spec.ImageMaps))
+	for _, iTarget := range iTargets {
+		if iTarget.IsLiveUpdateOnly {
+			continue
+		}
+
+		var im v1alpha1.ImageMap
+		nn := ktypes.NamespacedName{Name: iTarget.ImageMapName()}
+		err := bd.ctrlClient.Get(ctx, nn, &im)
+		if err != nil {
+			return nil, err
+		}
+		imageMapSet[nn] = im.DeepCopy()
+	}
+
 	err = q.RunBuilds(func(target model.TargetSpec, depResults []store.ImageBuildResult) (store.ImageBuildResult, error) {
 		iTarget, ok := target.(model.ImageTarget)
 		if !ok {
 			return store.ImageBuildResult{}, fmt.Errorf("Not an image target: %T", target)
-		}
-
-		iTarget, err := InjectImageDependencies(iTarget, iTargetMap, depResults)
-		if err != nil {
-			return store.ImageBuildResult{}, err
 		}
 
 		startTime := apis.NowMicro()
@@ -159,7 +171,7 @@ func (bd *DockerComposeBuildAndDeployer) BuildAndDeploy(ctx context.Context, st 
 		// NOTE(maia): we assume that this func takes one DC target and up to one image target
 		// corresponding to that service. If this func ever supports specs for more than one
 		// service at once, we'll have to match up image build results to DC target by ref.
-		refs, stages, err := bd.ib.Build(ctx, iTarget, ps)
+		refs, stages, err := bd.ib.Build(ctx, iTarget, nil, imageMapSet, ps)
 		if err != nil {
 			dockerimage.MaybeUpdateStatus(ctx, bd.ctrlClient, iTarget, dockerimage.ToCompletedFailStatus(iTarget, startTime, stages, err))
 			cmdimage.MaybeUpdateStatus(ctx, bd.ctrlClient, iTarget, cmdimage.ToCompletedFailStatus(iTarget, startTime, err))
@@ -173,7 +185,20 @@ func (bd *DockerComposeBuildAndDeployer) BuildAndDeploy(ctx context.Context, st 
 			return store.ImageBuildResult{}, err
 		}
 
-		return store.NewImageBuildResultSingleRef(iTarget.ID(), ref), nil
+		result := store.NewImageBuildResultSingleRef(iTarget.ID(), ref)
+		result.ImageMapStatus.BuildStartTime = &startTime
+		nn := ktypes.NamespacedName{Name: iTarget.ImageMapName()}
+		im, ok := imageMapSet[nn]
+		if !ok {
+			return store.ImageBuildResult{}, fmt.Errorf("apiserver missing ImageMap: %s", iTarget.ID().Name)
+		}
+		im.Status = result.ImageMapStatus
+		err = bd.ctrlClient.Status().Update(ctx, im)
+		if err != nil {
+			return store.ImageBuildResult{}, fmt.Errorf("updating ImageMap: %v", err)
+		}
+
+		return result, nil
 	})
 
 	newResults := q.NewResults().ToBuildResultSet()

--- a/internal/engine/buildcontrol/docker_compose_build_and_deployer_test.go
+++ b/internal/engine/buildcontrol/docker_compose_build_and_deployer_test.go
@@ -7,6 +7,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ktypes "k8s.io/apimachinery/pkg/types"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/tilt-dev/wmclient/pkg/dirs"
 
@@ -18,6 +21,7 @@ import (
 	"github.com/tilt-dev/tilt/internal/testutils"
 	"github.com/tilt-dev/tilt/internal/testutils/manifestbuilder"
 	"github.com/tilt-dev/tilt/internal/testutils/tempdir"
+	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
 	"github.com/tilt-dev/tilt/pkg/model"
 )
 
@@ -31,7 +35,7 @@ func TestDockerComposeTargetBuilt(t *testing.T) {
 	manifest := manifestbuilder.New(f, "fe").WithDockerCompose().Build()
 	dcTarg := manifest.DockerComposeTarget()
 
-	res, err := f.dcbad.BuildAndDeploy(f.ctx, f.st, BuildTargets(manifest), store.BuildStateSet{})
+	res, err := f.BuildAndDeploy(BuildTargets(manifest), store.BuildStateSet{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -57,7 +61,7 @@ func TestTiltBuildsImage(t *testing.T) {
 		Build()
 	dcTarg := manifest.DockerComposeTarget()
 
-	res, err := f.dcbad.BuildAndDeploy(f.ctx, f.st, BuildTargets(manifest), store.BuildStateSet{})
+	res, err := f.BuildAndDeploy(BuildTargets(manifest), store.BuildStateSet{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -89,7 +93,7 @@ func TestTiltBuildsImageWithTag(t *testing.T) {
 		WithImageTarget(iTarget).
 		Build()
 
-	_, err := f.dcbad.BuildAndDeploy(f.ctx, f.st, BuildTargets(manifest), store.BuildStateSet{})
+	_, err := f.BuildAndDeploy(BuildTargets(manifest), store.BuildStateSet{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -116,7 +120,7 @@ func TestMultiStageDockerCompose(t *testing.T) {
 		WithDeployTarget(defaultDockerComposeTarget(f, "sancho"))
 
 	stateSet := store.BuildStateSet{}
-	_, err := f.dcbad.BuildAndDeploy(f.ctx, f.st, BuildTargets(manifest), stateSet)
+	_, err := f.BuildAndDeploy(BuildTargets(manifest), stateSet)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -147,7 +151,7 @@ func TestMultiStageDockerComposeWithOnlyOneDirtyImage(t *testing.T) {
 	result := store.NewImageBuildResultSingleRef(iTargetID, container.MustParseNamedTagged("sancho-base:tilt-prebuilt"))
 	state := store.NewBuildState(result, nil, nil)
 	stateSet := store.BuildStateSet{iTargetID: state}
-	_, err := f.dcbad.BuildAndDeploy(f.ctx, f.st, BuildTargets(manifest), stateSet)
+	_, err := f.BuildAndDeploy(BuildTargets(manifest), stateSet)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -169,11 +173,12 @@ ENTRYPOINT /go/bin/sancho
 
 type dcbdFixture struct {
 	*tempdir.TempDirFixture
-	ctx   context.Context
-	dcCli *dockercompose.FakeDCClient
-	dCli  *docker.FakeClient
-	dcbad *DockerComposeBuildAndDeployer
-	st    *store.TestingStore
+	ctx        context.Context
+	dcCli      *dockercompose.FakeDCClient
+	dCli       *docker.FakeClient
+	dcbad      *DockerComposeBuildAndDeployer
+	st         *store.TestingStore
+	ctrlClient ctrlclient.Client
 }
 
 func newDCBDFixture(t *testing.T) *dcbdFixture {
@@ -202,7 +207,45 @@ func newDCBDFixture(t *testing.T) *dcbdFixture {
 		dCli:           dCli,
 		dcbad:          dcbad,
 		st:             st,
+		ctrlClient:     cdc,
 	}
+}
+
+func (f *dcbdFixture) upsert(obj ctrlclient.Object) {
+	err := f.ctrlClient.Create(f.ctx, obj)
+	if err == nil {
+		return
+	}
+
+	copy := obj.DeepCopyObject().(ctrlclient.Object)
+	err = f.ctrlClient.Get(f.ctx, ktypes.NamespacedName{Name: obj.GetName()}, copy)
+	assert.NoError(f.T(), err)
+
+	obj.SetResourceVersion(copy.GetResourceVersion())
+
+	err = f.ctrlClient.Update(f.ctx, obj)
+	assert.NoError(f.T(), err)
+}
+
+func (f *dcbdFixture) BuildAndDeploy(specs []model.TargetSpec, stateSet store.BuildStateSet) (store.BuildResultSet, error) {
+	for _, spec := range specs {
+		iTarget, ok := spec.(model.ImageTarget)
+		if !ok || iTarget.IsLiveUpdateOnly {
+			continue
+		}
+
+		im := v1alpha1.ImageMap{
+			ObjectMeta: metav1.ObjectMeta{Name: iTarget.ID().Name.String()},
+			Spec:       iTarget.ImageMapSpec,
+		}
+		state := stateSet[iTarget.ID()]
+		imageBuildResult, ok := state.LastResult.(store.ImageBuildResult)
+		if ok {
+			im.Status = imageBuildResult.ImageMapStatus
+		}
+		f.upsert(&im)
+	}
+	return f.dcbad.BuildAndDeploy(f.ctx, f.st, specs, stateSet)
 }
 
 func defaultDockerComposeTarget(f Fixture, name string) model.DockerComposeTarget {

--- a/internal/engine/buildcontrol/image_build_and_deployer.go
+++ b/internal/engine/buildcontrol/image_build_and_deployer.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/docker/distribution/reference"
-	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -19,7 +18,6 @@ import (
 	"github.com/tilt-dev/tilt/internal/controllers/core/cmdimage"
 	"github.com/tilt-dev/tilt/internal/controllers/core/dockerimage"
 	"github.com/tilt-dev/tilt/internal/controllers/core/kubernetesapply"
-	"github.com/tilt-dev/tilt/internal/dockerfile"
 	"github.com/tilt-dev/tilt/internal/k8s"
 	"github.com/tilt-dev/tilt/internal/store"
 	"github.com/tilt-dev/tilt/internal/store/k8sconv"
@@ -160,7 +158,6 @@ func (ibd *ImageBuildAndDeployer) BuildAndDeploy(ctx context.Context, st store.R
 	// If the cluster fetch fails, that's OK.
 	_ = ibd.ctrlClient.Get(ctx, types.NamespacedName{Name: "default"}, &cluster)
 
-	iTargetMap := model.ImageTargetsByID(iTargets)
 	imageMapSet := make(map[types.NamespacedName]*v1alpha1.ImageMap, len(kTarget.ImageMaps))
 	for _, iTarget := range iTargets {
 		if iTarget.IsLiveUpdateOnly {
@@ -182,13 +179,6 @@ func (ibd *ImageBuildAndDeployer) BuildAndDeploy(ctx context.Context, st store.R
 			return store.ImageBuildResult{}, fmt.Errorf("Not an image target: %T", target)
 		}
 
-		iTarget, err := InjectImageDependencies(iTarget, iTargetMap, depResults)
-		if err != nil {
-			return store.ImageBuildResult{}, err
-		}
-
-		iTarget = InjectClusterPlatform(iTarget, &cluster)
-
 		// TODO(nick): It might make sense to reset the ImageMapStatus here
 		// to an empty image while the image is building. maybe?
 		// I guess it depends on how image reconciliation works, and
@@ -198,7 +188,7 @@ func (ibd *ImageBuildAndDeployer) BuildAndDeploy(ctx context.Context, st store.R
 		dockerimage.MaybeUpdateStatus(ctx, ibd.ctrlClient, iTarget, dockerimage.ToBuildingStatus(iTarget, startTime))
 		cmdimage.MaybeUpdateStatus(ctx, ibd.ctrlClient, iTarget, cmdimage.ToBuildingStatus(iTarget, startTime))
 
-		refs, stages, err := ibd.ib.Build(ctx, iTarget, ps)
+		refs, stages, err := ibd.ib.Build(ctx, iTarget, &cluster, imageMapSet, ps)
 		if err != nil {
 			dockerimage.MaybeUpdateStatus(ctx, ibd.ctrlClient, iTarget, dockerimage.ToCompletedFailStatus(iTarget, startTime, stages, err))
 			cmdimage.MaybeUpdateStatus(ctx, ibd.ctrlClient, iTarget, cmdimage.ToCompletedFailStatus(iTarget, startTime, err))
@@ -379,99 +369,4 @@ func (ibd *ImageBuildAndDeployer) delete(ctx context.Context, k8sTarget model.K8
 
 	// wait for entities to be fully deleted from the server so that it's safe to re-create them
 	return ibd.k8sClient.Delete(ctx, entities, true)
-}
-
-// Derived from
-// https://github.com/moby/buildkit/blob/175e8415e38228dbb75e6b54efd2c8e9fc5b1cbf/util/archutil/detect.go#L15
-var validBuildkitArchSet = map[string]bool{
-	"amd64":    true,
-	"arm64":    true,
-	"riscv64":  true,
-	"ppc64le":  true,
-	"s390x":    true,
-	"386":      true,
-	"mips64le": true,
-	"mips64":   true,
-	"arm":      true,
-}
-
-// Create a new ImageTarget with the platform OS/Arch from the target cluster.
-func InjectClusterPlatform(iTarget model.ImageTarget, cluster *v1alpha1.Cluster) model.ImageTarget {
-	bd, ok := iTarget.BuildDetails.(model.DockerBuild)
-	if !ok {
-		return iTarget
-	}
-
-	// If the platform is specified explicitly, we should skip this.
-	if bd.DockerImageSpec.Platform != "" {
-		return iTarget
-	}
-
-	// Eventually, it might make sense to read the supported platforms
-	// off the buildkit server and negotiate the right one, but for
-	// now we hard-code a whitelist.
-	targetArch := cluster.Status.Arch
-	if !validBuildkitArchSet[targetArch] {
-		return iTarget
-	}
-
-	if targetArch == "arm" {
-		// This is typically communicated with GOARM.
-		// For now, just assume arm/v7
-		targetArch = "arm/v7"
-	}
-
-	// Currently Tilt only supports linux containers.
-	// We don't even build windows-compatible docker contexts.
-	bd.DockerImageSpec.Platform = fmt.Sprintf("linux/%s", targetArch)
-	return iTarget.WithBuildDetails(bd)
-}
-
-// Create a new ImageTarget with the Dockerfiles rewritten with the injected images.
-func InjectImageDependencies(iTarget model.ImageTarget, iTargetMap map[model.TargetID]model.ImageTarget, deps []store.ImageBuildResult) (model.ImageTarget, error) {
-	if len(deps) == 0 {
-		return iTarget, nil
-	}
-
-	df := dockerfile.Dockerfile("")
-	var buildArgs []string
-	switch bd := iTarget.BuildDetails.(type) {
-	case model.DockerBuild:
-		df = dockerfile.Dockerfile(bd.DockerfileContents)
-		buildArgs = bd.Args
-	default:
-		return model.ImageTarget{}, fmt.Errorf("image %q has no valid buildDetails", iTarget.Refs.ConfigurationRef)
-	}
-
-	ast, err := dockerfile.ParseAST(df)
-	if err != nil {
-		return model.ImageTarget{}, errors.Wrap(err, "injectImageDependencies")
-	}
-
-	for _, dep := range deps {
-		image := dep.ImageMapStatus.ImageFromLocal
-		imageRef, err := container.ParseNamedTagged(image)
-		if err != nil {
-			return model.ImageTarget{}, errors.Wrap(err, "injectImageDependencies")
-		}
-
-		id := dep.TargetID()
-		modified, err := ast.InjectImageDigest(iTargetMap[id].Refs.ConfigurationRef, imageRef, buildArgs)
-		if err != nil {
-			return model.ImageTarget{}, errors.Wrap(err, "injectImageDependencies")
-		} else if !modified {
-			return model.ImageTarget{}, fmt.Errorf("Could not inject image %q into Dockerfile of image %q", image, iTarget.Refs.ConfigurationRef)
-		}
-	}
-
-	newDf, err := ast.Print()
-	if err != nil {
-		return model.ImageTarget{}, errors.Wrap(err, "injectImageDependencies")
-	}
-
-	bd := iTarget.DockerBuildInfo()
-	bd.DockerImageSpec.DockerfileContents = newDf.String()
-	iTarget = iTarget.WithBuildDetails(bd)
-
-	return iTarget, nil
 }


### PR DESCRIPTION
Hello @landism,

Please review the following commits I made in branch nicks/imagemap7:

bd576bab9a0a18275c37f5e001a332f58e560759 (2021-12-23 16:16:24 -0500)
build: refactor so that the builders read image dependencies from the API
There should be no functional changes in this PR.
This is preparation for custom_build to handle image dependencies
the same way DockerImage handles image dependencies.

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics