### PR TITLE
tiltfile: add custom_build(image_deps)

### DIFF
--- a/internal/controllers/apis/imagemap/imagemap.go
+++ b/internal/controllers/apis/imagemap/imagemap.go
@@ -2,6 +2,7 @@ package imagemap
 
 import (
 	"fmt"
+	"os/exec"
 
 	"k8s.io/apimachinery/pkg/types"
 
@@ -10,7 +11,7 @@ import (
 )
 
 // Inject completed ImageMaps into the environment of a local process that
-// wants to deploy to a cluster..
+// wants to deploy to a cluster.
 //
 // Current env vars:
 // TILT_IMAGE_i - The reference to the image #i from the point of view of the cluster container runtime.
@@ -25,7 +26,28 @@ func InjectIntoDeployEnv(cmd *model.Cmd, imageMapNames []string, imageMaps map[t
 		}
 
 		cmd.Env = append(cmd.Env, fmt.Sprintf("TILT_IMAGE_MAP_%d=%s", i, imageMapName))
-		cmd.Env = append(cmd.Env, fmt.Sprintf("TILT_IMAGE_%d=%s", i, imageMap.Status.Image))
+		cmd.Env = append(cmd.Env, fmt.Sprintf("TILT_IMAGE_%d=%s", i, imageMap.Status.ImageFromCluster))
+	}
+	return nil
+}
+
+// Inject completed ImageMaps into the environment of a local process that
+// wants to build images locally.
+//
+// Current env vars:
+// TILT_IMAGE_i - The reference to the image #i from the point of view of the local host.
+// TILT_IMAGE_MAP_i - The name of the image map #i with the current status of the image.
+//
+// where an env may depend on arbitrarily many image maps.
+func InjectIntoLocalEnv(cmd *exec.Cmd, imageMapNames []string, imageMaps map[types.NamespacedName]*v1alpha1.ImageMap) error {
+	for i, imageMapName := range imageMapNames {
+		imageMap, ok := imageMaps[types.NamespacedName{Name: imageMapName}]
+		if !ok {
+			return fmt.Errorf("internal error: missing imagemap %s", imageMapName)
+		}
+
+		cmd.Env = append(cmd.Env, fmt.Sprintf("TILT_IMAGE_MAP_%d=%s", i, imageMapName))
+		cmd.Env = append(cmd.Env, fmt.Sprintf("TILT_IMAGE_%d=%s", i, imageMap.Status.ImageFromLocal))
 	}
 	return nil
 }

--- a/internal/testutils/tempdir/temp_dir_fixture.go
+++ b/internal/testutils/tempdir/temp_dir_fixture.go
@@ -106,6 +106,16 @@ func (f *TempDirFixture) CopyFile(originalPath, newPath string) {
 	f.WriteFile(newPath, string(contents))
 }
 
+// Read the file.
+func (f *TempDirFixture) ReadFile(path string) string {
+	fullPath := f.JoinPath(path)
+	contents, err := ioutil.ReadFile(fullPath)
+	if err != nil {
+		f.t.Fatal(err)
+	}
+	return string(contents)
+}
+
 func (f *TempDirFixture) WriteSymlink(linkContents, destPath string) {
 	fullDestPath := f.JoinPath(destPath)
 	err := os.MkdirAll(filepath.Dir(fullDestPath), os.FileMode(0777))

--- a/internal/tiltfile/custom_build_test.go
+++ b/internal/tiltfile/custom_build_test.go
@@ -1,0 +1,55 @@
+package tiltfile
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCustomBuildImageDeps(t *testing.T) {
+	f := newFixture(t)
+	defer f.TearDown()
+
+	f.file("Tiltfile", `
+custom_build(
+  'base',
+  'build.sh',
+  ['.']
+)
+custom_build(
+  'fe',
+  'build.sh',
+  ['.'],
+  image_deps=['base'],
+)
+k8s_yaml('fe.yaml')
+`)
+	f.file("Dockerfile", "FROM alpine")
+	f.yaml("fe.yaml", deployment("fe", image("fe")))
+
+	f.load()
+
+	m := f.assertNextManifest("fe")
+	if assert.Equal(t, 2, len(m.ImageTargets)) {
+		assert.Equal(t, []string{"base"}, m.ImageTargets[1].CustomBuildInfo().ImageMaps)
+	}
+}
+
+func TestCustomBuildMissingImageDeps(t *testing.T) {
+	f := newFixture(t)
+	defer f.TearDown()
+
+	f.file("Tiltfile", `
+custom_build(
+  'fe',
+  'build.sh',
+  ['.'],
+  image_deps=['base'],
+)
+k8s_yaml('fe.yaml')
+`)
+	f.file("Dockerfile", "FROM alpine")
+	f.yaml("fe.yaml", deployment("fe", image("fe")))
+
+	f.loadErrString(`image "fe": image dep "base" not found`)
+}


### PR DESCRIPTION
Hello @milas, @landism,

Please review the following commits I made in branch nicks/imagemap8:

25c40350a13f53383996c00fc25b1216631faa95 (2022-01-03 11:45:49 -0500)
tiltfile: add custom_build(image_deps)
Fixes https://github.com/tilt-dev/tilt/issues/2856

51b9477de4b39be44f9ec0e31b43ea17d5a1c22f (2022-01-03 10:24:44 -0500)
build: refactor so that the builders read image dependencies from the API
There should be no functional changes in this PR.
This is preparation for custom_build to handle image dependencies
the same way DockerImage handles image dependencies.

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics