### PR TITLE
controllers: make the Cmd controller level-triggered rather than edge triggered

### DIFF
--- a/internal/controllers/apis/configmap/disable.go
+++ b/internal/controllers/apis/configmap/disable.go
@@ -6,10 +6,10 @@ import (
 	"strconv"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/tilt-dev/tilt/pkg/apis"
 	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
 )
 
@@ -58,7 +58,7 @@ func MaybeNewDisableStatus(ctx context.Context, client client.Client, disableSou
 	if statusDiffers {
 		return &v1alpha1.DisableStatus{
 			Disabled:       isDisabled,
-			LastUpdateTime: metav1.Now(),
+			LastUpdateTime: apis.Now(),
 			Reason:         reason,
 		}, nil
 	}


### PR DESCRIPTION
Hello @milas, @landism,

Please review the following commits I made in branch nicks/cmd:

4411d4315bd14ed1ffa7e1ac9801be30ae4330e6 (2022-01-03 16:02:28 -0500)
controllers: make the Cmd controller level-triggered rather than edge triggered
Before this PR, the controller would listen for process
changes and update the apiserver on each change.

After this PR, the controller does all bookkeeping about the state of the
process in local memory, then updates the apiserver only during reconciliation.

This should be way more robust and eliminate a lot of race conditions.

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics