### PR TITLE
api: set Cluster client config hash on status

### DIFF
--- a/internal/controllers/apis/cluster/client.go
+++ b/internal/controllers/apis/cluster/client.go
@@ -1,0 +1,4 @@
+package cluster
+
+// ClientConfigHash is used to determine if two clients are the same.
+type ClientConfigHash string

--- a/internal/controllers/core/cluster/cache.go
+++ b/internal/controllers/core/cluster/cache.go
@@ -8,6 +8,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/types"
 
+	"github.com/tilt-dev/tilt/internal/controllers/apis/cluster"
 	"github.com/tilt-dev/tilt/internal/docker"
 	"github.com/tilt-dev/tilt/internal/k8s"
 	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
@@ -50,6 +51,7 @@ type connection struct {
 	error        string
 	createdAt    time.Time
 	arch         string
+	clientHash   cluster.ClientConfigHash
 }
 
 func (k *ConnectionManager) GetK8sClient(key types.NamespacedName) (k8s.Client, error) {

--- a/internal/controllers/core/cluster/hash.go
+++ b/internal/controllers/core/cluster/hash.go
@@ -1,0 +1,60 @@
+package cluster
+
+import (
+	"encoding/binary"
+	"hash/fnv"
+	"strconv"
+
+	"k8s.io/client-go/rest"
+
+	"github.com/tilt-dev/tilt/internal/controllers/apis/cluster"
+
+	"github.com/tilt-dev/tilt/internal/k8s"
+)
+
+// hashClientConfig produces a hash from relevant cluster connection fields.
+func hashClientConfig(config *rest.Config, ns k8s.Namespace) cluster.ClientConfigHash {
+	h := fnv.New64a()
+
+	// in practice, what we _really_ care about is the host/namespace changing
+	// since that means we actually changed from one cluster to another (or
+	// "logical" cluster in the case of namespace)
+	//
+	// changing the auth portion of a cluster config (much less other settings)
+	// isn't really a goal to support, but we include many of those fields to
+	// at least make an attempt; this isn't comprehensive/sufficient (e.g. the
+	// path to a cert file might not change but its contents could have!)
+	fields := []interface{}{
+		ns.String(),
+		config.Host,
+		config.APIPath,
+		config.BearerToken,
+		config.BearerTokenFile,
+		config.Username,
+		config.Password,
+		config.TLSClientConfig.CertFile,
+		config.TLSClientConfig.CertData,
+		config.TLSClientConfig.CAFile,
+		config.TLSClientConfig.CAData,
+		config.TLSClientConfig.KeyFile,
+		config.TLSClientConfig.KeyData,
+		config.TLSClientConfig.Insecure,
+		config.TLSClientConfig.ServerName,
+	}
+
+	for _, f := range fields {
+		if fStr, ok := f.(string); ok {
+			f = []byte(fStr)
+		}
+
+		if err := binary.Write(h, binary.LittleEndian, f); err != nil {
+			// actual write to fnv hash cannot fail
+			// the binary::Write call can only fail if given an invalid type,
+			// but we are passing valid types above, so panic if this invariant
+			// ever changes
+			panic(err)
+		}
+	}
+
+	return cluster.ClientConfigHash(strconv.FormatUint(h.Sum64(), 10))
+}

--- a/internal/controllers/core/cluster/hash_test.go
+++ b/internal/controllers/core/cluster/hash_test.go
@@ -1,0 +1,23 @@
+package cluster
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/rest"
+)
+
+func TestHashRESTConfig(t *testing.T) {
+	a := hashClientConfig(&rest.Config{Host: "example.com"}, "foo")
+	require.NotZero(t, a, "Config hash should not be empty")
+	b := hashClientConfig(&rest.Config{Host: "example.com", QPS: 1.0}, "foo")
+	require.Equal(t, a, b, "Config hashes were not equal")
+
+	b = hashClientConfig(&rest.Config{Host: "other.example.com"}, "foo")
+	require.NotZero(t, b, "Config hash should not be empty")
+	require.NotEqualf(t, a, b, "Client hashes should not be equal")
+
+	b = hashClientConfig(&rest.Config{Host: "example.com"}, "bar")
+	require.NotZero(t, b, "Config hash should not be empty")
+	require.NotEqualf(t, a, b, "Client hashes should not be equal")
+}


### PR DESCRIPTION
Set a hash for the Cluster connection based on the client config
so that consumers have a single value to determine whether their
client is current based on the Cluster status.