### PR TITLE
tiltfile: include name of crd when image_json_path doesn't match

### DIFF
--- a/internal/tiltfile/k8s.go
+++ b/internal/tiltfile/k8s.go
@@ -129,7 +129,7 @@ func (r *k8sResource) addEntities(entities []k8s.K8sEntity,
 	for _, entity := range entities {
 		images, err := entity.FindImages(locators, envVarImages)
 		if err != nil {
-			return err
+			return errors.Wrapf(err, "finding image in %s/%s", entity.GVK().Kind, entity.Name())
 		}
 		for _, image := range images {
 			r.addImageDep(image, false)

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -2500,6 +2500,25 @@ docker_build('tilt.dev/frontend', '.')
 		m.ImageTargets[0].Refs.LocalRef().String())
 }
 
+func TestImageObjectJSONPathNoMatch(t *testing.T) {
+	f := newFixture(t)
+	defer f.TearDown()
+	f.file("um.yaml", `apiVersion: tilt.dev/v1alpha1
+kind: UselessMachine
+metadata:
+  name: um
+spec:
+  repo: tilt.dev/frontend`)
+	f.dockerfile("Dockerfile")
+	f.file("Tiltfile", `
+k8s_yaml('um.yaml')
+k8s_kind(kind='UselessMachine', image_object={'json_path': '{.spec.image}', 'repo_field': 'repo', 'tag_field': 'tag'})
+docker_build('tilt.dev/frontend', '.')
+`)
+
+	f.loadErrString("finding image", "UselessMachine/um", ".spec.image")
+}
+
 func TestImageObjectJSONPathPodReadinessIgnore(t *testing.T) {
 	f := newFixture(t)
 	defer f.TearDown()


### PR DESCRIPTION
Fixes #5326

Old:
```
Loading Tiltfile at: /Users/matt/go/src/github.com/tilt-dev/tilt/integration/crd/Tiltfile
Matching (json_path="{.spec.image}"): image is not found
```

New:
```
Loading Tiltfile at: /Users/matt/go/src/github.com/tilt-dev/tilt/integration/crd/Tiltfile
Finding image in UselessMachine/bobo2: Matching (json_path="{.spec.image}"): image is not found
```