### PR TITLE
api: support nil for time comparisons

### DIFF
--- a/internal/timecmp/assert.go
+++ b/internal/timecmp/assert.go
@@ -2,7 +2,6 @@ package timecmp
 
 import (
 	"fmt"
-	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -20,24 +19,10 @@ type stringableTimeValue interface {
 func AssertTimeEqual(t testing.TB, expected stringableTimeValue, actual stringableTimeValue) (equal bool) {
 	t.Helper()
 
-	defer func() {
-		if !equal {
-			assert.Fail(t, fmt.Sprintf("Not equal: \n"+
-				"expected: %s\n"+
-				"actual  : %s", expected, actual))
-		}
-	}()
-
-	expectedNil := isNilValue(expected)
-	actualNil := isNilValue(actual)
-	if expectedNil && actualNil {
-		return true
-	} else if expectedNil || actualNil {
-		return false
-	}
-
 	if !Equal(expected, actual) {
-		return false
+		return assert.Fail(t, fmt.Sprintf("Not equal: \n"+
+			"expected: %v\n"+
+			"actual  : %v", expected, actual))
 	}
 	return true
 }
@@ -51,17 +36,4 @@ func RequireTimeEqual(t testing.TB, expected stringableTimeValue, actual stringa
 	if !AssertTimeEqual(t, expected, actual) {
 		t.FailNow()
 	}
-}
-
-// K8s types will come back with typed nils, so normal comparisons won't
-// work; since this is purely for tests, reflection is easiest option
-func isNilValue(t stringableTimeValue) bool {
-	if t == nil {
-		return true
-	}
-	v := reflect.ValueOf(t)
-	if v.Kind() == reflect.Ptr {
-		return v.IsNil()
-	}
-	return false
 }


### PR DESCRIPTION
We've been using more pointer types for time fields in the API
recently, which makes doing comparisons with them a nuisance.

The time comparison helpers now normalize any `nil` time value
to the zero time internally. This should still result in sane
behavior across the comparison operations.