### PR TITLE
controllers: fix a spurious pod log streaming error

### DIFF
--- a/internal/controllers/core/podlogstream/podsource.go
+++ b/internal/controllers/core/podlogstream/podsource.go
@@ -79,12 +79,14 @@ func (s *PodSource) handleReconcileRequest(ctx context.Context, name types.Names
 	s.indexer.OnReconcile(name, pls)
 
 	ns := pls.Spec.Namespace
-	_, ok := s.watchesByNamespace[ns]
-	if !ok {
-		ctx, cancel := context.WithCancel(ctx)
-		pw := podWatch{ctx: ctx, cancel: cancel, namespace: ns}
-		s.watchesByNamespace[ns] = pw
-		go s.doWatch(pw)
+	if ns != "" {
+		_, ok := s.watchesByNamespace[ns]
+		if !ok {
+			ctx, cancel := context.WithCancel(ctx)
+			pw := podWatch{ctx: ctx, cancel: cancel, namespace: ns}
+			s.watchesByNamespace[ns] = pw
+			go s.doWatch(pw)
+		}
 	}
 }
 

--- a/internal/k8s/fake_client.go
+++ b/internal/k8s/fake_client.go
@@ -2,6 +2,7 @@ package k8s
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
@@ -168,6 +169,10 @@ func (c *FakeK8sClient) UpsertEvent(event *v1.Event) {
 }
 
 func (c *FakeK8sClient) PodFromInformerCache(ctx context.Context, nn types.NamespacedName) (*v1.Pod, error) {
+	if nn.Namespace == "" {
+		return nil, fmt.Errorf("missing namespace from pod request")
+	}
+
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	pod, ok := c.pods[nn]
@@ -178,6 +183,10 @@ func (c *FakeK8sClient) PodFromInformerCache(ctx context.Context, nn types.Names
 }
 
 func (c *FakeK8sClient) WatchServices(ctx context.Context, ns Namespace) (<-chan *v1.Service, error) {
+	if ns == "" {
+		return nil, fmt.Errorf("missing namespace from watch request")
+	}
+
 	ctx, cancel := context.WithCancel(ctx)
 
 	c.mu.Lock()
@@ -216,6 +225,10 @@ func (c *FakeK8sClient) WatchServices(ctx context.Context, ns Namespace) (<-chan
 }
 
 func (c *FakeK8sClient) WatchEvents(ctx context.Context, ns Namespace) (<-chan *v1.Event, error) {
+	if ns == "" {
+		return nil, fmt.Errorf("missing namespace from watch request")
+	}
+
 	if c.EventsWatchErr != nil {
 		err := c.EventsWatchErr
 		c.EventsWatchErr = nil
@@ -259,6 +272,10 @@ func (c *FakeK8sClient) WatchEvents(ctx context.Context, ns Namespace) (<-chan *
 }
 
 func (c *FakeK8sClient) WatchMeta(ctx context.Context, gvk schema.GroupVersionKind, ns Namespace) (<-chan metav1.Object, error) {
+	if ns == "" {
+		return nil, fmt.Errorf("missing namespace from watch request")
+	}
+
 	return make(chan metav1.Object), nil
 }
 
@@ -277,6 +294,10 @@ func (c *FakeK8sClient) EmitPodDelete(p *v1.Pod) {
 }
 
 func (c *FakeK8sClient) WatchPods(ctx context.Context, ns Namespace) (<-chan ObjectUpdate, error) {
+	if ns == "" {
+		return nil, fmt.Errorf("missing namespace from watch request")
+	}
+
 	ctx, cancel := context.WithCancel(ctx)
 
 	c.mu.Lock()

--- a/internal/k8s/watch.go
+++ b/internal/k8s/watch.go
@@ -139,6 +139,10 @@ func (s *informerSet) makeInformer(
 	ctx context.Context,
 	ns Namespace,
 	gvr schema.GroupVersionResource) (cache.SharedInformer, error) {
+	if ns == "" {
+		return nil, fmt.Errorf("missing namespace from watch request")
+	}
+
 	key := fmt.Sprintf("%s/%s", ns, gvr)
 	result, err, _ := s.singleflight.Do(key, func() (interface{}, error) {
 		s.mu.Lock()
@@ -169,10 +173,6 @@ func (s *informerSet) makeInformerHelper(
 	ctx context.Context,
 	ns Namespace,
 	gvr schema.GroupVersionResource) (cache.SharedInformer, error) {
-	if ns == "" {
-		return nil, fmt.Errorf("makeInformer no longer supports watching all namespaces")
-	}
-
 	// HACK(dmiller): There's no way to get errors out of an informer. See https://github.com/kubernetes/client-go/issues/155
 	// In the meantime, at least to get authorization and some other errors let's try to set up a watcher and then just
 	// throw it away.


### PR DESCRIPTION
Hello @milas, @landism,

Please review the following commits I made in branch nicks/issue5330:

bfdb3b09c932001bfeab0f3b2ca95bfa15a5968d (2022-01-04 16:12:31 -0500)
controllers: fix a spurious pod log streaming error. Fixes https://github.com/tilt-dev/tilt/issues/5330

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics