### PR TITLE
api: make ClientManager resource aware

### DIFF
--- a/internal/controllers/apis/cluster/client.go
+++ b/internal/controllers/apis/cluster/client.go
@@ -26,11 +26,11 @@ var NotFoundError = errors.New("cluster client does not exist")
 // also ensuring that callers handle connection changes uniformly.
 //
 // See the expected usage/flow on ClientManager.
-var StaleClientError = errors.New("cluster hash is stale")
+var StaleClientError = errors.New("cluster revision is stale")
 
-// ClientProvider provides cached clients to the ClientManager.
+// ClientProvider provides client instances to the ClientManager.
 //
-// All clients are goroutine-safe.
+// All clients MUST be goroutine-safe.
 type ClientProvider interface {
 	// GetK8sClient returns the Kubernetes client for the cluster or an error for unknown clusters, connections
 	// in a transient error state, or if the connection is of a different type (i.e. Docker Compose).
@@ -40,7 +40,12 @@ type ClientProvider interface {
 	GetK8sClient(clusterKey types.NamespacedName) (k8s.Client, time.Time, error)
 }
 
-type watermarkedClient struct {
+type clusterRef struct {
+	objKey     types.NamespacedName
+	clusterKey types.NamespacedName
+}
+
+type clientRevision struct {
 	connectedAt time.Time
 	client      k8s.Client
 }
@@ -58,13 +63,13 @@ type ClientManager struct {
 	mu       sync.Mutex
 	provider ClientProvider
 
-	clients map[types.NamespacedName]watermarkedClient
+	revisions map[clusterRef]time.Time
 }
 
-func NewClientManager(cache ClientProvider) *ClientManager {
+func NewClientManager(clientProvider ClientProvider) *ClientManager {
 	return &ClientManager{
-		provider: cache,
-		clients:  make(map[types.NamespacedName]watermarkedClient),
+		provider:  clientProvider,
+		revisions: make(map[clusterRef]time.Time),
 	}
 }
 
@@ -72,64 +77,70 @@ func NewClientManager(cache ClientProvider) *ClientManager {
 //
 // If no client is known for the Cluster object, NotFoundError is returned.
 // If the Cluster object's config hash in the status does not match the known client, StaleClientError is returned.
-func (c *ClientManager) GetK8sClient(cluster *v1alpha1.Cluster) (k8s.Client, error) {
+func (c *ClientManager) GetK8sClient(obj apis.KeyableObject, cluster *v1alpha1.Cluster) (k8s.Client, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	if cluster == nil {
-		return nil, NotFoundError
-	}
-
-	key := apis.Key(cluster)
-	if c, ok := c.clients[key]; ok {
-		if !timecmp.Equal(cluster.Status.ConnectedAt, c.connectedAt) {
-			return nil, StaleClientError
-		}
-
-		return c.client, nil
-	}
-
-	cli, connectedAt, err := c.provider.GetK8sClient(key)
-	if err != nil {
-		return nil, err
-	}
-
-	c.clients[key] = watermarkedClient{client: cli, connectedAt: connectedAt}
-	return cli, nil
+	return c.getK8sClient(obj, cluster)
 }
 
 // Refresh checks to see if there is an updated client for the Cluster object.
 //
 // If it returns true, any state associated with this Cluster should be reset
 // and rebuilt using a new client retrieved via a subsequent call to GetK8sClient.
-func (c *ClientManager) Refresh(cluster *v1alpha1.Cluster) bool {
+func (c *ClientManager) Refresh(obj apis.KeyableObject, cluster *v1alpha1.Cluster) bool {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	key := apis.Key(cluster)
-	existing, hasExisting := c.clients[key]
-	if hasExisting && timecmp.Equal(cluster.Status.ConnectedAt, existing.connectedAt) {
-		// we already have a client with the same watermark as passed in
+	clusterRef := clusterRef{clusterKey: apis.Key(cluster), objKey: apis.Key(obj)}
+	objRevision, knownForObj := c.revisions[clusterRef]
+
+	if knownForObj && timecmp.Equal(cluster.Status.ConnectedAt, objRevision) {
+		// regardless of if there's a new client, state from the perspective
+		// of this caller is in sync because the client its tracking matches
+		// the cluster object it passed in, so having it potentially reset state
+		// (assuming an updated client exists) will be more harmful than helpful
+		// as it won't be able to fetch it
 		return false
 	}
 
-	// get the canonical version from the provider
-	curCli, curConnectedAt, err := c.provider.GetK8sClient(key)
-	if !timecmp.Equal(cluster.Status.ConnectedAt, curConnectedAt) {
-		// the cluster object we passed in doesn't match the canonical connected
-		// at timestamp from the provider, so it must have changed again in the
-		// interim, so don't trigger a refresh until the caller is in sync
-		return false
-	}
-
+	_, err := c.getK8sClient(obj, cluster)
 	if err != nil {
-		// clear the client and return true if it was previously known
-		// (we don't care if it changed from one error to another)
-		delete(c.clients, key)
-		return hasExisting
+		delete(c.revisions, clusterRef)
+		return knownForObj
 	}
 
-	// client either previously unknown or config hash changed, refresh!
-	c.clients[key] = watermarkedClient{client: curCli, connectedAt: curConnectedAt}
-	return true
+	return false
+}
+
+func (c *ClientManager) getK8sClient(obj apis.KeyableObject, cluster *v1alpha1.Cluster) (k8s.Client, error) {
+	if cluster == nil {
+		return nil, NotFoundError
+	}
+
+	clusterNN := apis.Key(cluster)
+	cli, revision, err := c.provider.GetK8sClient(clusterNN)
+	if err != nil {
+		return nil, err
+	}
+
+	if !timecmp.Equal(cluster.Status.ConnectedAt, revision) {
+		// the client does not match the cluster object that was passed in
+		return nil, StaleClientError
+	}
+
+	clusterRef := clusterRef{objKey: apis.Key(obj), clusterKey: clusterNN}
+	if objRevision, ok := c.revisions[clusterRef]; ok {
+		if !timecmp.Equal(revision, objRevision) {
+			// client previously had an old version of client and need to call
+			// refresh to clear out their old state
+			return nil, StaleClientError
+		}
+	} else {
+		// first time this object has fetched this client, so track the version
+		// we gave it so we can detect when it becomes stale
+		c.revisions[clusterRef] = revision
+	}
+
+	return cli, nil
 }

--- a/internal/controllers/apis/cluster/client_test.go
+++ b/internal/controllers/apis/cluster/client_test.go
@@ -1,0 +1,194 @@
+package cluster
+
+import (
+	"errors"
+	"math/rand"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/tilt-dev/tilt/internal/k8s"
+	"github.com/tilt-dev/tilt/internal/timecmp"
+	"github.com/tilt-dev/tilt/pkg/apis"
+	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
+)
+
+func TestClientManager_GetK8sClient_Success(t *testing.T) {
+	f := newCmFixture(t)
+	c := f.setupSuccessCluster()
+
+	obj := newFakeObj()
+	clusterRef := clusterRef{clusterKey: apis.Key(c), objKey: apis.Key(obj)}
+	// ensure we can retrieve the client multiple times
+	for i := 0; i < 5; i++ {
+		cli, err := f.cm.GetK8sClient(obj, c)
+		require.NoError(t, err)
+		require.NotNil(t, cli)
+
+		// manager should be tracking revision and it shouldn't change
+		timecmp.AssertTimeEqual(t, c.Status.ConnectedAt, f.cm.revisions[clusterRef])
+	}
+}
+
+func TestClientManager_GetK8sClient_NotFound(t *testing.T) {
+	f := newCmFixture(t)
+	// create a stub cluster obj that's not known by the ClientProvider
+	c := newCluster()
+
+	obj := newFakeObj()
+	cli, err := f.cm.GetK8sClient(obj, c)
+	require.EqualError(t, err, "cluster client does not exist")
+	require.Nil(t, cli)
+
+	// no revision should have been stored
+	require.Empty(t, f.cm.revisions)
+}
+
+func TestClientManager_GetK8sClient_Stale(t *testing.T) {
+	f := newCmFixture(t)
+	c := f.setupSuccessCluster()
+
+	obj := newFakeObj()
+	old := apis.NewMicroTime(c.Status.ConnectedAt.Add(-time.Second))
+	c.Status.ConnectedAt = &old
+	cli, err := f.cm.GetK8sClient(obj, c)
+	require.EqualError(t, err, "cluster revision is stale")
+	require.Nil(t, cli)
+
+	// no revision should have been stored
+	require.Empty(t, f.cm.revisions)
+}
+
+func TestClientManager_GetK8sClient_Error(t *testing.T) {
+	f := newCmFixture(t)
+	c := f.setupErrorCluster("oh no")
+
+	obj := newFakeObj()
+	cli, err := f.cm.GetK8sClient(obj, c)
+	require.EqualError(t, err, "oh no")
+	require.Nil(t, cli)
+
+	// no revision should have been stored
+	require.Empty(t, f.cm.revisions)
+}
+
+func TestClientManager_GetK8sClient_Refresh(t *testing.T) {
+	f := newCmFixture(t)
+	origCluster := f.setupSuccessCluster()
+
+	objA := newFakeObj()
+	objB := newFakeObj()
+
+	// fetch once for each obj so that it's tracked
+	for _, obj := range []apis.KeyableObject{objA, objB} {
+		cli, err := f.cm.GetK8sClient(obj, origCluster)
+		require.NoError(t, err)
+		require.NotNil(t, cli)
+	}
+
+	// update the client
+	updatedCluster := origCluster.DeepCopy()
+	newRevision := f.cp.SetK8sClient(apis.Key(updatedCluster), k8s.NewFakeK8sClient(t))
+	connectedAt := apis.NewMicroTime(newRevision)
+	updatedCluster.Status.ConnectedAt = &connectedAt
+
+	for _, obj := range []apis.KeyableObject{objA, objB} {
+		clusterRef := clusterRef{clusterKey: apis.Key(origCluster), objKey: apis.Key(obj)}
+
+		cli, err := f.cm.GetK8sClient(obj, origCluster)
+		require.EqualError(t, err, "cluster revision is stale")
+		require.Nil(t, cli)
+
+		// if we pass in the stale cluster object, no refresh should happen
+		require.False(t, f.cm.Refresh(obj, origCluster), "Refresh should return false with original cluster")
+
+		// revision is still the old one
+		timecmp.AssertTimeEqual(t, origCluster.Status.ConnectedAt, f.cm.revisions[clusterRef])
+
+		// once we pass in the updated cluster object, a refresh SHOULD happen
+		// note that this happens for BOTH objA and objB because they might have
+		// independently managed state for the cluster!
+		require.True(t, f.cm.Refresh(obj, updatedCluster), "Refresh should have been triggered")
+
+		// since the refresh occurred, the revision should have been wiped
+		require.Zero(t, f.cm.revisions[clusterRef], "Revision should have been forgotten")
+
+		// we can get the new client now!
+		cli, err = f.cm.GetK8sClient(obj, updatedCluster)
+		require.NoError(t, err)
+		require.NotNil(t, cli)
+
+		// revision is now the new one
+		timecmp.AssertTimeEqual(t, updatedCluster.Status.ConnectedAt, f.cm.revisions[clusterRef])
+	}
+}
+
+type cmFixture struct {
+	t  testing.TB
+	cp *FakeClientProvider
+	cm *ClientManager
+}
+
+func newCmFixture(t testing.TB) *cmFixture {
+	cp := NewFakeClientProvider(nil)
+	return &cmFixture{
+		t:  t,
+		cp: cp,
+		cm: NewClientManager(cp),
+	}
+}
+
+type fakeObj struct {
+	name      string
+	namespace string
+}
+
+var _ apis.KeyableObject = fakeObj{}
+
+func (f fakeObj) GetName() string {
+	return f.name
+}
+
+func (f fakeObj) GetNamespace() string {
+	return f.namespace
+}
+
+func newFakeObj() fakeObj {
+	return fakeObj{
+		namespace: strconv.Itoa(rand.Int()),
+		name:      strconv.Itoa(rand.Int()),
+	}
+}
+
+func (f *cmFixture) setupSuccessCluster() *v1alpha1.Cluster {
+	c := newCluster()
+	c.Status.Arch = "amd64"
+
+	// get the timestamp from the fake client provider and set it
+	ts := f.cp.SetK8sClient(apis.Key(c), k8s.NewFakeK8sClient(f.t))
+	connectedAt := apis.NewMicroTime(ts)
+	c.Status.ConnectedAt = &connectedAt
+
+	return c
+}
+
+func (f *cmFixture) setupErrorCluster(error string) *v1alpha1.Cluster {
+	c := newCluster()
+	c.Status.Error = error
+
+	f.cp.SetClusterError(apis.Key(c), errors.New(error))
+	return c
+}
+
+func newCluster() *v1alpha1.Cluster {
+	c := &v1alpha1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: strconv.Itoa(rand.Int()),
+			Name:      strconv.Itoa(rand.Int()),
+		},
+	}
+	return c
+}

--- a/internal/engine/k8swatch/watcher.go
+++ b/internal/engine/k8swatch/watcher.go
@@ -148,3 +148,24 @@ func (ks *watcherKnownState) resetStateForCluster(clusterKey types.NamespacedNam
 		}
 	}
 }
+
+// watcherClientKey bridges apiserver and engine subscriber semantics.
+//
+// In apiserver reconcilers, each object is evaluated individually, so each
+// one needs to be notified of client changes and reset its own state.
+//
+// The engine subscribers evaluate on global engine state, so this acts as a
+// singleton key for them. The name is purely informative for debugging
+// purposes (collisions aren't an issue - the subscribers do not share a
+// ClientManager instance as there's no real advantage to doing so).
+type watcherClientKey struct {
+	name string
+}
+
+func (w watcherClientKey) GetName() string {
+	return w.name
+}
+
+func (w watcherClientKey) GetNamespace() string {
+	return "tilt-engine"
+}

--- a/pkg/apis/identifiers.go
+++ b/pkg/apis/identifiers.go
@@ -10,8 +10,6 @@ import (
 
 	"k8s.io/apimachinery/pkg/types"
 
-	"github.com/tilt-dev/tilt-apiserver/pkg/server/builder/resource"
-
 	"k8s.io/apimachinery/pkg/api/validation/path"
 	"k8s.io/apimachinery/pkg/util/validation"
 )
@@ -22,8 +20,13 @@ var invalidLabelCharacters = regexp.MustCompile("[^-A-Za-z0-9_.]")
 
 var invalidPathCharacters = regexp.MustCompile(`[` + strings.Join(path.NameMayNotContain, "") + `]`)
 
-func Key(o resource.Object) types.NamespacedName {
-	return KeyFromMeta(*o.GetObjectMeta())
+type KeyableObject interface {
+	GetName() string
+	GetNamespace() string
+}
+
+func Key(o KeyableObject) types.NamespacedName {
+	return types.NamespacedName{Name: o.GetName(), Namespace: o.GetNamespace()}
 }
 
 func KeyFromMeta(objMeta metav1.ObjectMeta) types.NamespacedName {


### PR DESCRIPTION
There's numerous competing concerns with managing K8s clients/their
operations, and a big one is that for efficiency, we only ever want
to set up a namespace-level watch for a specific cluster once and
then triage the incoming data.

In particular, this worked well with the engine subscribers, as
they'd always evaluate global state.

However, for reconcilers, this is trickier, as we operate on
individual objects. Behind the scenes, the reconciler tracks the
consumers for a given watch, so that it can de-duplicate and perform
refcounting to know when it's safe to cancel.

This complicates client refreshes, as if the underlying K8s client
for the `Cluster` object gets changed, we need to reset state for
each referencing object individually when its reconcile happens.

The changes here actually reduce the `ClientManager`'s surface area
by having it act purely as a coordinator on top of the
`ClientProvider` rather than an extra level of caching (i.e. it
no longer stores pointers to the clients themselves but always
delegates reads back to the provider).

As this coordination is now on a per-object basis, there's a slight
hack in the engine subscribers to use a single, virtual object for
keying so that it can continue acting on a global basis.