### PR TITLE
kubernetesdiscovery: make controller level-triggered rather than edge-triggered

### DIFF
--- a/internal/controllers/core/kubernetesdiscovery/container_restart.go
+++ b/internal/controllers/core/kubernetesdiscovery/container_restart.go
@@ -20,7 +20,7 @@ func NewContainerRestartDetector() *ContainerRestartDetector {
 	return &ContainerRestartDetector{}
 }
 
-func (c *ContainerRestartDetector) Detect(dispatcher Dispatcher, prevStatus v1alpha1.KubernetesDiscoveryStatus, current v1alpha1.KubernetesDiscovery) {
+func (c *ContainerRestartDetector) Detect(dispatcher Dispatcher, prevStatus v1alpha1.KubernetesDiscoveryStatus, current *v1alpha1.KubernetesDiscovery) {
 	mn := model.ManifestName(current.Annotations[v1alpha1.AnnotationManifest])
 	if mn == "" {
 		// log actions are dispatched by manifest, so if this spec isn't associated with a manifest,

--- a/internal/controllers/core/kubernetesdiscovery/portforwards_test.go
+++ b/internal/controllers/core/kubernetesdiscovery/portforwards_test.go
@@ -221,7 +221,7 @@ func TestPortForwardNotForPending(t *testing.T) {
 	f.injectK8sObjects(*kd, pod)
 
 	f.requireState(key, func(kd *v1alpha1.KubernetesDiscovery) bool {
-		return kd.Status.Pods[0].Phase == string(v1.PodRunning)
+		return len(kd.Status.Pods) > 0 && kd.Status.Pods[0].Phase == string(v1.PodRunning)
 	}, "pod phase did not change to Running")
 	f.MustReconcile(key)
 

--- a/internal/store/logger.go
+++ b/internal/store/logger.go
@@ -23,7 +23,7 @@ func NewLogActionLogger(ctx context.Context, dispatch func(action Action)) logge
 
 // Read labels and annotations of the given API object to determine where to log,
 // panicking if there's no info available.
-func MustObjectLogHandler(ctx context.Context, st RStore, obj metav1.Object) context.Context {
+func MustObjectLogHandler(ctx context.Context, st Dispatcher, obj metav1.Object) context.Context {
 	ctx, err := WithObjectLogHandler(ctx, st, obj)
 	if err != nil {
 		panic(err)
@@ -32,7 +32,7 @@ func MustObjectLogHandler(ctx context.Context, st RStore, obj metav1.Object) con
 }
 
 // Read labels and annotations of the given API object to determine where to log.
-func WithObjectLogHandler(ctx context.Context, st RStore, obj metav1.Object) (context.Context, error) {
+func WithObjectLogHandler(ctx context.Context, st Dispatcher, obj metav1.Object) (context.Context, error) {
 	// It's ok if the manifest or span id don't exist, they will just
 	// get dumped in the global log.
 	mn := obj.GetAnnotations()[v1alpha1.AnnotationManifest]
@@ -54,7 +54,7 @@ func WithObjectLogHandler(ctx context.Context, st RStore, obj metav1.Object) (co
 }
 
 type apiLogWriter struct {
-	store        RStore
+	store        Dispatcher
 	manifestName model.ManifestName
 	spanID       model.LogSpanID
 }
@@ -62,4 +62,8 @@ type apiLogWriter struct {
 func (w apiLogWriter) Write(level logger.Level, fields logger.Fields, p []byte) error {
 	w.store.Dispatch(NewLogAction(w.manifestName, w.spanID, level, fields, p))
 	return nil
+}
+
+type Dispatcher interface {
+	Dispatch(action Action)
 }


### PR DESCRIPTION
Hello @milas,

Please review the following commits I made in branch nicks/kd:

9ee45731be35c98ded9d5ab05336a3061e0c5c5a (2022-01-06 17:28:07 -0500)
kubernetesdiscovery: make controller level-triggered rather than edge-triggered
also removes all tilt-crashing ErrorActions

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics