### PR TITLE
api: add retry + cleanup to PodSource

### DIFF
--- a/internal/controllers/core/podlogstream/podlogstreamcontroller.go
+++ b/internal/controllers/core/podlogstream/podlogstreamcontroller.go
@@ -137,17 +137,17 @@ func (r *Controller) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	err := r.client.Get(ctx, req.NamespacedName, stream)
 	r.indexer.OnReconcile(req.NamespacedName, stream)
 	if apierrors.IsNotFound(err) {
-		r.podSource.handleReconcileRequest(ctx, req.NamespacedName, stream)
+		r.podSource.handleReconcileRequest(req.NamespacedName, stream)
 		r.deleteStreams(streamName)
 		return reconcile.Result{}, nil
 	} else if err != nil {
 		return reconcile.Result{}, err
 	}
 
-	ctx = store.MustObjectLogHandler(ctx, r.st, stream)
-	r.podSource.handleReconcileRequest(ctx, req.NamespacedName, stream)
+	r.podSource.handleReconcileRequest(req.NamespacedName, stream)
 
 	podNN := types.NamespacedName{Name: stream.Spec.Pod, Namespace: stream.Spec.Namespace}
+	ctx = store.MustObjectLogHandler(ctx, r.st, stream)
 	pod, err := r.kClient.PodFromInformerCache(ctx, podNN)
 	if (err != nil && apierrors.IsNotFound(err)) ||
 		(pod != nil && pod.DeletionTimestamp != nil && !pod.DeletionTimestamp.IsZero()) {

--- a/internal/controllers/core/podlogstream/podlogstreamcontroller_test.go
+++ b/internal/controllers/core/podlogstream/podlogstreamcontroller_test.go
@@ -78,11 +78,8 @@ func TestLogCleanup(t *testing.T) {
 	f.AssertOutputContains("hello world!")
 
 	f.Delete(pls)
-	assert.Len(t, f.plsc.watches, 0)
-
-	// TODO(nick): Currently, namespace watches are never cleanedup,
-	// because the user might restart them again.
-	assert.Len(t, f.plsc.podSource.watchesByNamespace, 1)
+	assert.Empty(t, f.plsc.watches)
+	assert.Empty(t, f.plsc.podSource.watchesByNamespace)
 }
 
 func TestLogActions(t *testing.T) {
@@ -283,7 +280,7 @@ func TestLogReconnection(t *testing.T) {
 	// simulate 15s since we last read a log; this triggers a reconnect
 	f.clock.Advance(15 * time.Second)
 	time.Sleep(20 * time.Millisecond)
-	assert.Error(t, f.kClient.LastPodLogContext.Err())
+	assert.Error(t, f.kClient.LastPodLogContext().Err())
 	require.NoError(t, writer.Close())
 
 	f.AssertOutputContains("goodbye world!")
@@ -509,7 +506,7 @@ func (f *plmFixture) AssertLogStartTime(t time.Time) {
 	f.t.Helper()
 
 	// Truncate the time to match the behavior of metav1.Time
-	timecmp.AssertTimeEqual(f.t, t.Truncate(time.Second), f.kClient.LastPodLogStartTime)
+	timecmp.AssertTimeEqual(f.t, t.Truncate(time.Second), f.kClient.LastPodLogStartTime())
 }
 
 type podBuilder v1.Pod

--- a/internal/controllers/core/podlogstream/podsource.go
+++ b/internal/controllers/core/podlogstream/podsource.go
@@ -3,6 +3,7 @@ package podlogstream
 import (
 	"context"
 	"sync"
+	"time"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -18,6 +19,8 @@ import (
 	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
 	"github.com/tilt-dev/tilt/pkg/logger"
 )
+
+const maxRestartBackoff = 5 * time.Minute
 
 var podGVK = schema.GroupVersionKind{Version: "v1", Kind: "Pod"}
 
@@ -38,6 +41,7 @@ type podWatch struct {
 	ctx       context.Context
 	cancel    func()
 	namespace string
+	watchers  map[types.NamespacedName]bool
 }
 
 var _ source.Source = &PodSource{}
@@ -51,7 +55,11 @@ func NewPodSource(ctx context.Context, kClient k8s.Client, scheme *runtime.Schem
 	}
 }
 
-func (s *PodSource) Start(ctx context.Context, handler handler.EventHandler, q workqueue.RateLimitingInterface, ps ...predicate.Predicate) error {
+// Start initializes the PodSource.
+//
+// NOTE: We ignore the context here because it's managed by controller-runtime and will not have Tilt values (e.g. logger).
+// 	See https://github.com/kubernetes-sigs/controller-runtime/issues/1752.
+func (s *PodSource) Start(_ context.Context, handler handler.EventHandler, q workqueue.RateLimitingInterface, _ ...predicate.Predicate) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.q = q
@@ -72,45 +80,101 @@ func (s *PodSource) TearDown() {
 // Register the pods for this stream.
 //
 // Set up any watches we need.
-func (s *PodSource) handleReconcileRequest(ctx context.Context, name types.NamespacedName, pls *PodLogStream) {
+func (s *PodSource) handleReconcileRequest(plsNN types.NamespacedName, pls *PodLogStream) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	s.indexer.OnReconcile(name, pls)
+	s.indexer.OnReconcile(plsNN, pls)
 
-	ns := pls.Spec.Namespace
+	var ns string
+	if pls != nil {
+		ns = pls.Spec.Namespace
+	}
+
+	// ensure namespace watch registered if PLS object exists + has valid spec
 	if ns != "" {
-		_, ok := s.watchesByNamespace[ns]
+		pw, ok := s.watchesByNamespace[ns]
 		if !ok {
-			ctx, cancel := context.WithCancel(ctx)
-			pw := podWatch{ctx: ctx, cancel: cancel, namespace: ns}
+			pw = newPodWatch(s.ctx, ns)
 			s.watchesByNamespace[ns] = pw
-			go s.doWatch(pw)
+			go s.doWatchWithRetry(pw)
+		}
+		pw.watchers[plsNN] = true
+	}
+
+	// clean up any pre-existing namespace watches
+	// this covers both PLS changing namespace in spec + PLS deletion
+	for nsKey, watch := range s.watchesByNamespace {
+		if watch.watchers[plsNN] && nsKey != ns {
+			delete(watch.watchers, plsNN)
+			s.maybeCleanupWatch(nsKey)
+		}
+	}
+}
+
+// maybeCleanupWatch removes a namespace watch if there are no more active watchers.
+func (s *PodSource) maybeCleanupWatch(nsKey string) {
+	watch, ok := s.watchesByNamespace[nsKey]
+	if !ok {
+		return
+	}
+
+	if len(watch.watchers) != 0 {
+		// there's still active watchers
+		return
+	}
+
+	watch.cancel()
+	delete(s.watchesByNamespace, nsKey)
+}
+
+func (s *PodSource) doWatchWithRetry(pw podWatch) {
+	defer pw.cancel()
+
+	restartBackoff := 500 * time.Millisecond
+	var lastErrMsg string
+	for {
+		err := s.doWatch(pw)
+		if err != nil {
+			if err.Error() != lastErrMsg {
+				logger.Get(pw.ctx).Errorf("watching pods: %v", err)
+			}
+			lastErrMsg = err.Error()
+		} else {
+			lastErrMsg = ""
+		}
+
+		restartBackoff = restartBackoff * 2
+		if restartBackoff > maxRestartBackoff {
+			restartBackoff = maxRestartBackoff
+		}
+
+		select {
+		case <-pw.ctx.Done():
+			return
+		case <-time.After(restartBackoff):
+			// retry
 		}
 	}
 }
 
 // Process pod events and make sure they trigger a reconcile.
-func (s *PodSource) doWatch(pw podWatch) {
-	defer pw.cancel()
-
-	podCh, err := s.kClient.WatchPods(s.ctx, k8s.Namespace(pw.namespace))
+func (s *PodSource) doWatch(pw podWatch) error {
+	podCh, err := s.kClient.WatchPods(pw.ctx, k8s.Namespace(pw.namespace))
 	if err != nil {
-		logger.Get(pw.ctx).Errorf("watching pods: %v", err)
-		return
+		return err
 	}
 
 	for {
 		select {
 		case <-pw.ctx.Done():
-			return
+			return nil
 
 		case pod, ok := <-podCh:
 			if !ok {
-				return
+				return nil
 			}
 			s.handlePod(pod)
-			continue
 		}
 	}
 }
@@ -136,6 +200,16 @@ func (s *PodSource) handlePod(obj k8s.ObjectUpdate) {
 
 	for _, req := range requests {
 		q.Add(req)
+	}
+}
+
+func newPodWatch(ctx context.Context, ns string) podWatch {
+	ctx, cancel := context.WithCancel(ctx)
+	return podWatch{
+		ctx:       ctx,
+		cancel:    cancel,
+		namespace: ns,
+		watchers:  make(map[types.NamespacedName]bool),
 	}
 }
 


### PR DESCRIPTION
Currently, if the `PodSource` fails to watch a namespace, an error
will be logged, but there's no way to get out of that state because
the watch remains, so subsequent attempts to watch will short circuit.

Now, the watch logic uses a retry loop with backoff. Errors are logged
but still not propagated to `PodLogStream` objects currently. In
practice, this should be mostly fine because if the K8s client is
inoperable, the reconciler will also fail when it tries to actually
set up the log streaming. In the future, it'd probably be more robust
to track the error state and propagate it via `handleReconcileRequest`
so that the reconciler can mark the `PodLogStream` status accordingly
and then requeue itself.

Additionally, if there's no more watchers for a namespace, the watch
will be canceled. This will become more important with multi-cluster
work to ensure we dispose of resources for old clients.