### PR TITLE
docker: track connect events as a metric

### DIFF
--- a/internal/docker/client_integration_test.go
+++ b/internal/docker/client_integration_test.go
@@ -21,7 +21,9 @@ func TestCli_Run(t *testing.T) {
 	cli := NewDockerClient(ctx, Env(dEnv))
 	defer func() {
 		// release any idle connections to avoid out of file errors if running test many times
-		_ = cli.(*Cli).Close()
+		if dockerCli, ok := cli.(*Cli); ok {
+			_ = dockerCli.Close()
+		}
 	}()
 
 	ref, err := reference.ParseNamed("docker.io/library/hello-world")

--- a/internal/docker/client_test.go
+++ b/internal/docker/client_test.go
@@ -109,7 +109,14 @@ func TestProvideEnv(t *testing.T) {
 	}
 
 	cases := []provideEnvTestCase{
-		{},
+		{
+			expectedCluster: Env{
+				Type: "cluster",
+			},
+			expectedLocal: Env{
+				Type: "local",
+			},
+		},
 		{
 			env: k8s.EnvUnknown,
 			osEnv: map[string]string{
@@ -123,12 +130,14 @@ func TestProvideEnv(t *testing.T) {
 				Host:       "tcp://192.168.99.100:2376",
 				CertPath:   "/home/nick/.minikube/certs",
 				APIVersion: "1.35",
+				Type:       "cluster",
 			},
 			expectedLocal: Env{
 				TLSVerify:  "1",
 				Host:       "tcp://192.168.99.100:2376",
 				CertPath:   "/home/nick/.minikube/certs",
 				APIVersion: "1.35",
+				Type:       "local",
 			},
 		},
 		{
@@ -137,12 +146,21 @@ func TestProvideEnv(t *testing.T) {
 			expectedCluster: Env{
 				Host:                microK8sDockerHost,
 				BuildToKubeContexts: []string{"microk8s-me"},
+				Type:                "cluster",
 			},
-			expectedLocal: Env{},
+			expectedLocal: Env{
+				Type: "local",
+			},
 		},
 		{
 			env:     k8s.EnvMicroK8s,
 			runtime: container.RuntimeCrio,
+			expectedCluster: Env{
+				Type: "cluster",
+			},
+			expectedLocal: Env{
+				Type: "local",
+			},
 		},
 		{
 			env:     k8s.EnvMinikube,
@@ -153,6 +171,9 @@ func TestProvideEnv(t *testing.T) {
 				"DOCKER_CERT_PATH":   "/home/nick/.minikube/certs",
 				"DOCKER_API_VERSION": "1.35",
 			},
+			expectedLocal: Env{
+				Type: "local",
+			},
 			expectedCluster: Env{
 				TLSVerify:           "1",
 				Host:                "tcp://192.168.99.100:2376",
@@ -160,6 +181,7 @@ func TestProvideEnv(t *testing.T) {
 				APIVersion:          "1.35",
 				IsOldMinikube:       true,
 				BuildToKubeContexts: []string{"minikube-me"},
+				Type:                "cluster",
 			},
 		},
 		{
@@ -172,12 +194,16 @@ func TestProvideEnv(t *testing.T) {
 				"DOCKER_CERT_PATH":   "/home/nick/.minikube/certs",
 				"DOCKER_API_VERSION": "1.35",
 			},
+			expectedLocal: Env{
+				Type: "local",
+			},
 			expectedCluster: Env{
 				TLSVerify:           "1",
 				Host:                "tcp://192.168.99.100:2376",
 				CertPath:            "/home/nick/.minikube/certs",
 				APIVersion:          "1.35",
 				BuildToKubeContexts: []string{"minikube-me"},
+				Type:                "cluster",
 			},
 		},
 		{
@@ -194,9 +220,11 @@ func TestProvideEnv(t *testing.T) {
 			},
 			expectedCluster: Env{
 				Host: "tcp://registry.local:80",
+				Type: "cluster",
 			},
 			expectedLocal: Env{
 				Host: "tcp://registry.local:80",
+				Type: "local",
 			},
 		},
 		{
@@ -220,6 +248,7 @@ func TestProvideEnv(t *testing.T) {
 				CertPath:            "/home/nick/.minikube/certs",
 				IsOldMinikube:       true,
 				BuildToKubeContexts: []string{"minikube-me"},
+				Type:                "cluster",
 			},
 			expectedLocal: Env{
 				TLSVerify:           "1",
@@ -227,6 +256,7 @@ func TestProvideEnv(t *testing.T) {
 				CertPath:            "/home/nick/.minikube/certs",
 				IsOldMinikube:       true,
 				BuildToKubeContexts: []string{"minikube-me"},
+				Type:                "local",
 			},
 		},
 		{
@@ -237,6 +267,12 @@ func TestProvideEnv(t *testing.T) {
 				"DOCKER_HOST":        "tcp://192.168.99.100:2376",
 				"DOCKER_CERT_PATH":   "/home/nick/.minikube/certs",
 				"DOCKER_API_VERSION": "1.35",
+			},
+			expectedCluster: Env{
+				Type: "cluster",
+			},
+			expectedLocal: Env{
+				Type: "local",
 			},
 		},
 		{
@@ -252,12 +288,14 @@ func TestProvideEnv(t *testing.T) {
 				Host:       "tcp://localhost:2376",
 				CertPath:   "/home/nick/.minikube/certs",
 				APIVersion: "1.35",
+				Type:       "cluster",
 			},
 			expectedLocal: Env{
 				TLSVerify:  "1",
 				Host:       "tcp://localhost:2376",
 				CertPath:   "/home/nick/.minikube/certs",
 				APIVersion: "1.35",
+				Type:       "local",
 			},
 		},
 	}

--- a/internal/docker/clients.go
+++ b/internal/docker/clients.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 )
 
 type LocalClient Client
@@ -18,7 +19,7 @@ func ProvideClusterCli(ctx context.Context, lEnv LocalEnv, cEnv ClusterEnv, lCli
 	// If the Cluster Env and the LocalEnv are the same, we can re-use the cluster
 	// client as a local client.
 	var cClient ClusterClient
-	if cmp.Equal(Env(lEnv), Env(cEnv)) {
+	if cmp.Equal(Env(lEnv), Env(cEnv), cmpopts.IgnoreFields(Env{}, "Type")) {
 		cClient = ClusterClient(lClient)
 	} else {
 		cClient = NewDockerClient(ctx, Env(cEnv))

--- a/internal/docker/env.go
+++ b/internal/docker/env.go
@@ -86,7 +86,7 @@ type ClusterEnv Env
 type LocalEnv Env
 
 func ProvideLocalEnv(ctx context.Context, kubeContext k8s.KubeContext, env k8s.Env, cEnv ClusterEnv) LocalEnv {
-	result := overlayOSEnvVars(Env{Type: "local"})
+	result := overlayOSEnvVars(Env{})
 
 	// The user may have already configured their local docker client
 	// to use Minikube's docker server. We check for that by comparing
@@ -100,18 +100,19 @@ func ProvideLocalEnv(ctx context.Context, kubeContext k8s.KubeContext, env k8s.E
 		result.BuildToKubeContexts = append(result.BuildToKubeContexts, string(kubeContext))
 	}
 
+	result.Type = "local"
 	return LocalEnv(result)
 }
 
 func ProvideClusterEnv(ctx context.Context, kubeContext k8s.KubeContext, env k8s.Env, runtime container.Runtime, minikubeClient k8s.MinikubeClient) ClusterEnv {
-	result := Env{Type: "cluster"}
+	result := Env{}
 
 	if runtime == container.RuntimeDocker {
 		if env == k8s.EnvMinikube {
 			// If we're running Minikube with a docker runtime, talk to Minikube's docker socket.
 			envMap, ok, err := minikubeClient.DockerEnv(ctx)
 			if err != nil {
-				return ClusterEnv{Error: err}
+				return ClusterEnv{Type: "cluster", Error: err}
 			}
 
 			if ok {
@@ -150,6 +151,7 @@ func ProvideClusterEnv(ctx context.Context, kubeContext k8s.KubeContext, env k8s
 		result.BuildToKubeContexts = append(result.BuildToKubeContexts, string(kubeContext))
 	}
 
+	result.Type = "cluster"
 	return ClusterEnv(result)
 }
 

--- a/internal/docker/env.go
+++ b/internal/docker/env.go
@@ -48,6 +48,9 @@ type Env struct {
 	// If the env failed to load for some reason, propagate that error
 	// so that we can report it when the user tries to do a docker_build.
 	Error error
+
+	// Type of the env (local or cluster). This field is purely informative.
+	Type string
 }
 
 // Determines if this docker client can build images directly to the given cluster.
@@ -83,7 +86,7 @@ type ClusterEnv Env
 type LocalEnv Env
 
 func ProvideLocalEnv(ctx context.Context, kubeContext k8s.KubeContext, env k8s.Env, cEnv ClusterEnv) LocalEnv {
-	result := overlayOSEnvVars(Env{})
+	result := overlayOSEnvVars(Env{Type: "local"})
 
 	// The user may have already configured their local docker client
 	// to use Minikube's docker server. We check for that by comparing
@@ -101,7 +104,7 @@ func ProvideLocalEnv(ctx context.Context, kubeContext k8s.KubeContext, env k8s.E
 }
 
 func ProvideClusterEnv(ctx context.Context, kubeContext k8s.KubeContext, env k8s.Env, runtime container.Runtime, minikubeClient k8s.MinikubeClient) ClusterEnv {
-	result := Env{}
+	result := Env{Type: "cluster"}
 
 	if runtime == container.RuntimeDocker {
 		if env == k8s.EnvMinikube {


### PR DESCRIPTION
Similar to K8s cluster connections from #5362, report Docker client
connections via analytics.

The goal here is to determine how frequently users are running into
Docker issues at startup.