### PR TITLE
scripts: add no-browse to release scripts

### DIFF
--- a/scripts/release-update-homebrew-core.sh
+++ b/scripts/release-update-homebrew-core.sh
@@ -25,4 +25,4 @@ git config --global user.email "it@tilt.dev"
 git config --global user.name "Tilt Dev"
 
 # send the brew team a PR to upgrade homebrew-core
-brew bump-formula-pr --version="$VERSION" tilt
+brew bump-formula-pr --no-browse --version="$VERSION" tilt

--- a/scripts/release.Dockerfile
+++ b/scripts/release.Dockerfile
@@ -45,8 +45,8 @@ RUN curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
     echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
   apt-get update && apt-get install yarn
 
-RUN /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)" && \
-  echo 'eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"' >> /root/.bashrc
+RUN git clone https://github.com/Homebrew/brew /home/linuxbrew/.linuxbrew
+ENV PATH=/home/linuxbrew/.linuxbrew/bin:$PATH
 
 RUN mkdir -p ~/.windmill
 


### PR DESCRIPTION
Hello @nicksieger,

Please review the following commits I made in branch nicks/release2:

7b1772341719a7516bb3b88583630f694484f495 (2022-01-07 18:27:49 -0500)
scripts: add no-browse to release scripts

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics