### PR TITLE
api: report Docker connect events on Tiltfile load

### DIFF
--- a/internal/controllers/core/tiltfile/metrics.go
+++ b/internal/controllers/core/tiltfile/metrics.go
@@ -1,0 +1,44 @@
+package tiltfile
+
+import (
+	"context"
+	"sync"
+
+	dockertypes "github.com/docker/docker/api/types"
+
+	"github.com/tilt-dev/tilt/internal/analytics"
+)
+
+// dockerConnectMetricOnce ensures we only report a single Docker connect status
+// event per `tilt up`. Currently, a client is initialized on start (via wire/DI)
+// and if there's an error, an exploding client is created; we'll never attempt
+// to make a new one after that, so reporting on subsequent Tiltfile loads is
+// not useful, as there's no way its status can change currently (a restart of
+// Tilt is required).
+var dockerConnectMetricOnce sync.Once
+
+// reportDockerConnectionEvent records a metric about Docker connectivity.
+func reportDockerConnectionEvent(ctx context.Context, success bool, serverVersion dockertypes.Version) {
+	dockerConnectMetricOnce.Do(func() {
+		var status string
+		if success {
+			status = "connected"
+		} else {
+			status = "error"
+		}
+
+		tags := map[string]string{
+			"status": status,
+		}
+
+		if serverVersion.Version != "" {
+			tags["server.version"] = serverVersion.Version
+		}
+
+		if serverVersion.Arch != "" {
+			tags["server.arch"] = serverVersion.Arch
+		}
+
+		analytics.Get(ctx).Incr("api.tiltfile.docker.connect", tags)
+	})
+}

--- a/internal/controllers/core/tiltfile/metrics.go
+++ b/internal/controllers/core/tiltfile/metrics.go
@@ -2,24 +2,15 @@ package tiltfile
 
 import (
 	"context"
-	"sync"
 
 	dockertypes "github.com/docker/docker/api/types"
 
 	"github.com/tilt-dev/tilt/internal/analytics"
 )
 
-// dockerConnectMetricOnce ensures we only report a single Docker connect status
-// event per `tilt up`. Currently, a client is initialized on start (via wire/DI)
-// and if there's an error, an exploding client is created; we'll never attempt
-// to make a new one after that, so reporting on subsequent Tiltfile loads is
-// not useful, as there's no way its status can change currently (a restart of
-// Tilt is required).
-var dockerConnectMetricOnce sync.Once
-
 // reportDockerConnectionEvent records a metric about Docker connectivity.
-func reportDockerConnectionEvent(ctx context.Context, success bool, serverVersion dockertypes.Version) {
-	dockerConnectMetricOnce.Do(func() {
+func (r *Reconciler) reportDockerConnectionEvent(ctx context.Context, success bool, serverVersion dockertypes.Version) {
+	r.dockerConnectMetricReporter.Do(func() {
 		var status string
 		if success {
 			status = "connected"

--- a/internal/controllers/core/tiltfile/reconciler.go
+++ b/internal/controllers/core/tiltfile/reconciler.go
@@ -291,6 +291,7 @@ func (r *Reconciler) run(ctx context.Context, nn types.NamespacedName, tf *v1alp
 		if tlr.Error == nil && dockerErr != nil {
 			tlr.Error = errors.Wrap(dockerErr, "Failed to connect to Docker")
 		}
+		reportDockerConnectionEvent(ctx, dockerErr == nil, r.dockerClient.ServerVersion())
 	}
 
 	r.mu.Lock()

--- a/internal/docker/fake_client.go
+++ b/internal/docker/fake_client.go
@@ -160,7 +160,8 @@ func (c *FakeClient) BuilderVersion() types.BuilderVersion {
 }
 func (c *FakeClient) ServerVersion() types.Version {
 	return types.Version{
-		Arch: "amd64",
+		Arch:    "amd64",
+		Version: "20.10.11",
 	}
 }
 


### PR DESCRIPTION
After loading a Tiltfile, report the status of the Docker connection
if the Tiltfile iif it has Docker resources.

Currently, the Docker client is constructed very early in Tilt start
via DI (wire), and if an error is encountered, an exploding client is
used that will error out on any operation. It's not possible to
re-initialize the client at runtime (you need to restart Tilt), so the
status can never change. As a result, a `sync.Once` guards the metric
reporting so that it doesn't happen on every Tiltfile load.

Supersedes #5363.