### PR TITLE
kubernetesapply: print applied objects on failure

### DIFF
--- a/internal/controllers/fake/fixture.go
+++ b/internal/controllers/fake/fixture.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/tilt-dev/tilt-apiserver/pkg/server/builder/resource"
 
+	"github.com/tilt-dev/tilt/internal/store"
 	"github.com/tilt-dev/tilt/internal/testutils"
 	"github.com/tilt-dev/tilt/internal/testutils/bufsync"
 )
@@ -41,6 +42,7 @@ type ControllerFixture struct {
 	ctx        context.Context
 	cancel     context.CancelFunc
 	controller controller
+	Store      store.RStore
 	Scheme     *runtime.Scheme
 	Client     ctrlclient.Client
 }
@@ -52,6 +54,7 @@ type ControllerFixtureBuilder struct {
 	out    *bufsync.ThreadSafeBuffer
 	ma     *analytics.MemoryAnalytics
 	Client ctrlclient.Client
+	Store  store.RStore
 }
 
 func NewControllerFixtureBuilder(t testing.TB) *ControllerFixtureBuilder {
@@ -69,6 +72,7 @@ func NewControllerFixtureBuilder(t testing.TB) *ControllerFixtureBuilder {
 		out:    out,
 		ma:     ma,
 		Client: NewFakeTiltClient(),
+		Store:  NewTestingStore(out),
 	}
 }
 
@@ -98,6 +102,7 @@ func (b ControllerFixtureBuilder) Build(c controller) *ControllerFixture {
 		cancel:     b.cancel,
 		Scheme:     b.Client.Scheme(),
 		Client:     b.Client,
+		Store:      b.Store,
 		controller: c,
 	}
 }

--- a/internal/controllers/fake/store.go
+++ b/internal/controllers/fake/store.go
@@ -1,0 +1,27 @@
+package fake
+
+import (
+	"io"
+
+	"github.com/tilt-dev/tilt/internal/store"
+)
+
+type testStore struct {
+	*store.TestingStore
+	out io.Writer
+}
+
+func NewTestingStore(out io.Writer) *testStore {
+	return &testStore{
+		TestingStore: store.NewTestingStore(),
+		out:          out,
+	}
+}
+
+func (s *testStore) Dispatch(action store.Action) {
+	s.TestingStore.Dispatch(action)
+	switch action := action.(type) {
+	case store.LogAction:
+		_, _ = s.out.Write(action.Message())
+	}
+}


### PR DESCRIPTION
Hello @milas,

Please review the following commits I made in branch nicks/applyprint:

9202477695998e55a157ddcfd9b43c4f6605a6ab (2022-01-12 16:01:38 -0500)
kubernetesapply: print applied objects on failure
also build LogAction handling into the fixture

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics