### PR TITLE
web: add checkbox column on Table View behind feature flag

### DIFF
--- a/web/src/HUD.tsx
+++ b/web/src/HUD.tsx
@@ -23,6 +23,7 @@ import PathBuilder, { PathBuilderProvider } from "./PathBuilder"
 import { ResourceGroupsContextProvider } from "./ResourceGroupsContext"
 import { ResourceListOptionsProvider } from "./ResourceListOptionsContext"
 import { ResourceNavProvider } from "./ResourceNav"
+import { ResourceSelectionProvider } from "./ResourceSelectionContext"
 import ShareSnapshotModal from "./ShareSnapshotModal"
 import { TiltSnackbarProvider } from "./Snackbar"
 import { SnapshotActionProvider } from "./snapshot"
@@ -259,19 +260,21 @@ export default class HUD extends Component<HudProps, HudState> {
               <LogStoreProvider value={this.state.logStore || new LogStore()}>
                 <ResourceGroupsContextProvider>
                   <ResourceListOptionsProvider>
-                    <Switch>
-                      <Route
-                        path={this.path("/r/:name/overview")}
-                        render={(props: RouteComponentProps<any>) => (
-                          <OverviewResourcePane view={this.state.view} />
-                        )}
-                      />
-                      <Route
-                        render={() => (
-                          <OverviewTablePane view={this.state.view} />
-                        )}
-                      />
-                    </Switch>
+                    <ResourceSelectionProvider>
+                      <Switch>
+                        <Route
+                          path={this.path("/r/:name/overview")}
+                          render={(props: RouteComponentProps<any>) => (
+                            <OverviewResourcePane view={this.state.view} />
+                          )}
+                        />
+                        <Route
+                          render={() => (
+                            <OverviewTablePane view={this.state.view} />
+                          )}
+                        />
+                      </Switch>
+                    </ResourceSelectionProvider>
                   </ResourceListOptionsProvider>
                 </ResourceGroupsContextProvider>
               </LogStoreProvider>

--- a/web/src/OverviewTable.stories.tsx
+++ b/web/src/OverviewTable.stories.tsx
@@ -5,6 +5,7 @@ import LogStore, { LogStoreProvider } from "./LogStore"
 import OverviewTable from "./OverviewTable"
 import { ResourceGroupsContextProvider } from "./ResourceGroupsContext"
 import { ResourceListOptionsProvider } from "./ResourceListOptionsContext"
+import { ResourceSelectionProvider } from "./ResourceSelectionContext"
 import { TiltSnackbarProvider } from "./Snackbar"
 import {
   nButtonView,
@@ -23,6 +24,8 @@ export default {
       const features = new Features({
         [Flag.Labels]: context?.args?.labelsEnabled ?? true,
         [Flag.DisableResources]: context?.args?.disableResourcesEnabled ?? true,
+        [Flag.BulkDisableResources]:
+          context?.args?.bulkDisableResourcesEnabled ?? true,
       })
       return (
         <MemoryRouter initialEntries={["/"]}>
@@ -30,9 +33,11 @@ export default {
             <FeaturesProvider value={features}>
               <ResourceGroupsContextProvider>
                 <ResourceListOptionsProvider>
-                  <div style={{ margin: "-1rem" }}>
-                    <Story />
-                  </div>
+                  <ResourceSelectionProvider>
+                    <div style={{ margin: "-1rem" }}>
+                      <Story />
+                    </div>
+                  </ResourceSelectionProvider>
                 </ResourceListOptionsProvider>
               </ResourceGroupsContextProvider>
             </FeaturesProvider>
@@ -51,6 +56,13 @@ export default {
     },
     disableResourcesEnabled: {
       name: "See disabled resources",
+      control: {
+        type: "boolean",
+      },
+      defaultValue: true,
+    },
+    bulkDisableResourcesEnabled: {
+      name: "See bulk disabling functionality",
       control: {
         type: "boolean",
       },

--- a/web/src/OverviewTable.tsx
+++ b/web/src/OverviewTable.tsx
@@ -28,7 +28,10 @@ import { ReactComponent as StarSvg } from "./assets/svg/star.svg"
 import { linkToTiltDocs, TiltDocsPage } from "./constants"
 import Features, { Flag, useFeatures } from "./feature"
 import { Hold } from "./Hold"
-import { InstrumentedButton } from "./instrumentedComponents"
+import {
+  InstrumentedButton,
+  InstrumentedCheckbox,
+} from "./instrumentedComponents"
 import {
   getResourceLabels,
   GroupByLabelView,
@@ -60,6 +63,7 @@ import {
 } from "./ResourceListOptionsContext"
 import { matchesResourceName, ResourceNameFilter } from "./ResourceNameFilter"
 import { useResourceNav } from "./ResourceNav"
+import { useResourceSelection } from "./ResourceSelectionContext"
 import {
   disabledResourceStyleMixin,
   resourceIsDisabled,
@@ -125,6 +129,7 @@ export type RowValues = {
   triggerMode: TriggerMode
   buttons: UIButton[]
   analyticsTags: Tags
+  selectable: boolean
 }
 
 type OverviewTableTrigger = {
@@ -251,9 +256,18 @@ export const ResourceTableHeaderSortTriangle = styled.div`
   }
 `
 
+export const SelectionCheckbox = styled(InstrumentedCheckbox)`
+  &.MuiCheckbox-root,
+  &.Mui-checked {
+    color: ${Color.gray6};
+  }
+`
+
 const TableHeaderStarIcon = styled(StarSvg)`
   fill: ${Color.gray7};
   height: 13px;
+  margin-left: auto;
+  margin-right: auto;
   width: 13px;
 `
 
@@ -403,6 +417,7 @@ export function TableNoMatchesFound(props: { resources?: UIResource[] }) {
   return null
 }
 
+// Table columns
 function TableStarColumn({ row }: CellProps<RowValues>) {
   let ctx = useStarredResources()
   return (
@@ -421,6 +436,41 @@ function TableUpdateColumn({ row }: CellProps<RowValues>) {
   }
   return (
     <TimeAgo date={row.values.lastDeployTime} formatter={timeAgoFormatter} />
+  )
+}
+
+export function TableSelectionColumn({ row }: CellProps<RowValues>) {
+  // Don't allow a row to be selected if it can't be disabled
+  // This rule can be adjusted when/if there are other bulk actions
+  if (!row.original.selectable) {
+    return null
+  }
+
+  const selections = useResourceSelection()
+  const resourceName = row.original.name
+  const checked = selections.isSelected(resourceName)
+
+  const onChange = (_e: ChangeEvent<HTMLInputElement>) => {
+    if (!checked) {
+      selections.select(resourceName)
+    } else {
+      selections.deselect(resourceName)
+    }
+  }
+
+  const analyticsTags = {
+    ...row.original.analyticsTags,
+    type: AnalyticsType.Grid,
+  }
+
+  return (
+    <SelectionCheckbox
+      analyticsName={"ui.web.checkbox.resourceSelection"}
+      analyticsTags={analyticsTags}
+      checked={checked}
+      onChange={onChange}
+      size="small"
+    />
   )
 }
 
@@ -645,17 +695,23 @@ function statusSortKey(row: RowValues): string {
   return `${order}${row.name}`
 }
 
+const RESOURCE_SELECTION_COLUMN: Column<RowValues> = {
+  Header: "Select",
+  disableSortBy: true,
+  Cell: TableSelectionColumn,
+}
+
 // https://react-table.tanstack.com/docs/api/useTable#column-options
 // The docs on this are not very clear!
 // `accessor` should return a primitive, and that primitive is used for sorting and filtering
 // the Cell function can get whatever it needs to render via row.original
 // best evidence I've (Matt) found: https://github.com/tannerlinsley/react-table/discussions/2429#discussioncomment-25582
 //   (from the author)
-const columnDefs: Column<RowValues>[] = [
+const DEFAULT_COLUMNS: Column<RowValues>[] = [
   {
     Header: () => <TableHeaderStarIcon title="Starred" />,
     id: "starred",
-    accessor: "name", // Note: this accessor is meaningless but required when `Header` returns JSX.The starred column gets its data directly from the StarredResources context and sort on this column is disabled.
+    accessor: "name", // Note: this accessor is meaningless but required when `Header` returns JSX. The starred column gets its data directly from the StarredResources context and sort on this column is disabled.
     disableSortBy: true,
     width: "10px",
     Cell: TableStarColumn,
@@ -716,6 +772,19 @@ const columnDefs: Column<RowValues>[] = [
     Cell: TableTriggerModeColumn,
   },
 ]
+
+function getTableColumns(features?: Features) {
+  if (!features) {
+    return DEFAULT_COLUMNS
+  }
+
+  // If bulk disable is enabled, render the selection column
+  if (features.isEnabled(Flag.BulkDisableResources)) {
+    return [RESOURCE_SELECTION_COLUMN, ...DEFAULT_COLUMNS]
+  }
+
+  return DEFAULT_COLUMNS
+}
 
 const columnNameToInfoTooltip: {
   [key: string]: NonNullable<React.ReactNode>
@@ -845,6 +914,8 @@ function uiResourceToCell(
   let hasBuilt = lastBuild !== null
   let buttons = buttonsForComponent(allButtons, "resource", r.metadata?.name)
   let analyticsTags = { target: resourceTargetType(r) }
+  // Consider a resource `selectable` if it can be disabled
+  const selectable = !!buttons.toggleDisable
 
   return {
     lastDeployTime: res.lastDeployTime ?? "",
@@ -869,6 +940,7 @@ function uiResourceToCell(
     triggerMode: res.triggerMode ?? TriggerMode.TriggerModeAuto,
     buttons: buttons.default,
     analyticsTags: analyticsTags,
+    selectable,
   }
 }
 
@@ -1031,7 +1103,7 @@ export function Table(props: TableProps) {
   const { getTableProps, getTableBodyProps, headerGroups, rows, prepareRow } =
     useTable(
       {
-        columns: columnDefs,
+        columns: props.columns,
         data: props.data,
         autoResetSortBy: false,
         useControlledState: props.useControlledState,
@@ -1112,11 +1184,13 @@ export function TableGroupedByLabels({
   resources,
   buttons,
 }: TableWrapperProps) {
+  const features = useFeatures()
   const logAlertIndex = useLogAlertIndex()
   const data = useMemo(
     () => labeledResourcesToTableCells(resources, buttons, logAlertIndex),
     [resources, buttons]
   )
+  const columns = getTableColumns(features)
 
   // Global table settings are currently used to sort multiple
   // tables by the same column
@@ -1141,7 +1215,7 @@ export function TableGroupedByLabels({
           key={label}
           label={label}
           data={data.labelsToResources[label]}
-          columns={columnDefs}
+          columns={columns}
           useControlledState={useControlledState}
           setGlobalSortBy={setGlobalSortBy}
         />
@@ -1149,14 +1223,14 @@ export function TableGroupedByLabels({
       <TableGroup
         label={UNLABELED_LABEL}
         data={data.unlabeled}
-        columns={columnDefs}
+        columns={columns}
         useControlledState={useControlledState}
         setGlobalSortBy={setGlobalSortBy}
       />
       <TableGroup
         label={TILTFILE_LABEL}
         data={data.tiltfile}
-        columns={columnDefs}
+        columns={columns}
         useControlledState={useControlledState}
         setGlobalSortBy={setGlobalSortBy}
       />
@@ -1165,14 +1239,16 @@ export function TableGroupedByLabels({
 }
 
 export function TableWithoutGroups({ resources, buttons }: TableWrapperProps) {
+  const features = useFeatures()
   const logAlertIndex = useLogAlertIndex()
   const data = useMemo(() => {
     return (
       resources?.map((r) => uiResourceToCell(r, buttons, logAlertIndex)) || []
     )
   }, [resources, buttons])
+  const columns = getTableColumns(features)
 
-  return <Table columns={columnDefs} data={data} />
+  return <Table columns={columns} data={data} />
 }
 
 function OverviewTableContent(props: OverviewTableProps) {

--- a/web/src/OverviewTablePane.stories.tsx
+++ b/web/src/OverviewTablePane.stories.tsx
@@ -4,6 +4,7 @@ import Features, { FeaturesProvider, Flag } from "./feature"
 import OverviewTablePane from "./OverviewTablePane"
 import { ResourceGroupsContextProvider } from "./ResourceGroupsContext"
 import { ResourceListOptionsProvider } from "./ResourceListOptionsContext"
+import { ResourceSelectionProvider } from "./ResourceSelectionContext"
 import { StarredResourceMemoryProvider } from "./StarredResourcesContext"
 import {
   nResourceView,
@@ -19,6 +20,8 @@ export default {
       const features = new Features({
         [Flag.Labels]: context?.args?.labelsEnabled ?? true,
         [Flag.DisableResources]: context?.args?.disableResourcesEnabled ?? true,
+        [Flag.BulkDisableResources]:
+          context?.args?.bulkDisableResourcesEnabled ?? true,
       })
       return (
         <MemoryRouter initialEntries={["/"]}>
@@ -26,9 +29,11 @@ export default {
             <ResourceListOptionsProvider>
               <StarredResourceMemoryProvider>
                 <ResourceGroupsContextProvider>
-                  <div style={{ margin: "-1rem", height: "80vh" }}>
-                    <Story />
-                  </div>
+                  <ResourceSelectionProvider>
+                    <div style={{ margin: "-1rem", height: "80vh" }}>
+                      <Story />
+                    </div>
+                  </ResourceSelectionProvider>
                 </ResourceGroupsContextProvider>
               </StarredResourceMemoryProvider>
             </ResourceListOptionsProvider>
@@ -47,6 +52,13 @@ export default {
     },
     disableResourcesEnabled: {
       name: "See disabled resources",
+      control: {
+        type: "boolean",
+      },
+      defaultValue: true,
+    },
+    bulkDisableResourcesEnabled: {
+      name: "See bulk disabling functionality",
       control: {
         type: "boolean",
       },

--- a/web/src/ResourceSelectionContext.test.tsx
+++ b/web/src/ResourceSelectionContext.test.tsx
@@ -1,0 +1,128 @@
+import { mount, ReactWrapper } from "enzyme"
+import React, { ChangeEvent, useState } from "react"
+import {
+  ResourceSelectionProvider,
+  useResourceSelection,
+} from "./ResourceSelectionContext"
+
+const SELECTED_STATE_ID = "selected-state"
+const SELECTED_TEXT_ID = "selected-text"
+const SELECT_INPUT_ID = "select-input"
+const SELECT_BUTTON_ID = "select-button"
+const DESELECT_BUTTON_ID = "deselect-button"
+const CLEAR_BUTTON_ID = "clear-button"
+
+// This is a very basic test component that prints out the state
+// from the ResourceSelection context and provides buttons to trigger
+// methods returned by the context, so they can be tested
+const TestConsumer = () => {
+  const { selected, isSelected, select, deselect, clearSelections } =
+    useResourceSelection()
+
+  const [value, setValue] = useState("")
+  const onChange = (e: ChangeEvent<HTMLInputElement>) =>
+    setValue(e.target.value)
+  return (
+    <>
+      {/* Print the `selected` state */}
+      <p id={SELECTED_STATE_ID}>{JSON.stringify(selected)}</p>
+      {/* Use an input field to change the resource that can be selected/deselected */}
+      <input id={SELECT_INPUT_ID} type="text" onChange={onChange} />
+      {/* Print the state for whatever resource is currently in the `input` */}
+      <p id={SELECTED_TEXT_ID}>{isSelected(value).toString()}</p>
+      {/* Select the resource that's currently in the `input` */}
+      <button id={SELECT_BUTTON_ID} onClick={() => select(value)}>
+        Select
+      </button>
+      {/* Deselect the resource that's currently in the `input` */}
+      <button id={DESELECT_BUTTON_ID} onClick={() => deselect(value)}>
+        Deselect
+      </button>
+      {/* Clear all selections */}
+      <button id={CLEAR_BUTTON_ID} onClick={() => clearSelections()}>
+        Clear selections
+      </button>
+    </>
+  )
+}
+
+describe("ResourceSelectionContext", () => {
+  let wrapper: ReactWrapper<typeof TestConsumer>
+
+  // Helpers
+  const INITIAL_SELECTIONS = ["vigoda", "magic_beans"]
+  const selectedState = () => wrapper.find(`#${SELECTED_STATE_ID}`).text()
+  const isSelected = () => wrapper.find(`#${SELECTED_TEXT_ID}`).text()
+  const setCurrentResource = (value: string) =>
+    wrapper
+      .find(`#${SELECT_INPUT_ID}`)
+      .simulate("change", { target: { value } })
+  const selectResource = (value: string) => {
+    setCurrentResource(value)
+    wrapper.find(`#${SELECT_BUTTON_ID}`).simulate("click")
+    wrapper.update()
+  }
+  const deselectResource = (value: string) => {
+    setCurrentResource(value)
+    wrapper.find(`#${DESELECT_BUTTON_ID}`).simulate("click")
+    wrapper.update()
+  }
+  const clearResources = () => {
+    wrapper.find(`#${CLEAR_BUTTON_ID}`).simulate("click")
+    wrapper.update()
+  }
+
+  beforeEach(() => {
+    wrapper = mount(
+      <ResourceSelectionProvider initialValuesForTesting={INITIAL_SELECTIONS}>
+        <TestConsumer />
+      </ResourceSelectionProvider>
+    )
+  })
+
+  describe("`selected` property", () => {
+    it("reports an accurate list of selected resources", () => {
+      expect(selectedState()).toBe(JSON.stringify(INITIAL_SELECTIONS))
+
+      clearResources()
+      expect(selectedState()).toBe(JSON.stringify([]))
+    })
+  })
+
+  describe("isSelected", () => {
+    it("returns `true` when a resource is selected", () => {
+      setCurrentResource(INITIAL_SELECTIONS[1])
+      expect(isSelected()).toBe("true")
+    })
+
+    it("returns `false` when a resource is NOT selected", () => {
+      setCurrentResource("sprout")
+      expect(isSelected()).toBe("false")
+    })
+  })
+
+  describe("select", () => {
+    it("adds a resource to the list of selections", () => {
+      selectResource("cool_beans")
+      expect(isSelected()).toBe("true")
+      expect(selectedState()).toBe(
+        JSON.stringify([...INITIAL_SELECTIONS, "cool_beans"])
+      )
+    })
+  })
+
+  describe("deselect", () => {
+    it("removes a resource to the list of selections", () => {
+      deselectResource(INITIAL_SELECTIONS[0])
+      expect(isSelected()).toBe("false")
+      expect(selectedState()).toBe(JSON.stringify([INITIAL_SELECTIONS[1]]))
+    })
+  })
+
+  describe("clearSelections", () => {
+    it("removes all resource selections", () => {
+      clearResources()
+      expect(selectedState()).toBe(JSON.stringify([]))
+    })
+  })
+})

--- a/web/src/ResourceSelectionContext.tsx
+++ b/web/src/ResourceSelectionContext.tsx
@@ -1,0 +1,75 @@
+import { createContext, PropsWithChildren, useContext, useState } from "react"
+
+/**
+ * The ResourceSelection state keeps track of what resources are selected for bulk actions to be performed on them.
+ */
+
+type ResourceSelectionContext = {
+  selected: string[]
+  isSelected: (resourceName: string) => boolean
+  select: (resourceName: string) => void
+  deselect: (resourceName: string) => void
+  clearSelections: () => void
+}
+
+const ResourceSelectionContext = createContext<ResourceSelectionContext>({
+  selected: [],
+  isSelected: (_resourceName: string) => {
+    console.warn("Resource selections context is not set.")
+    return false
+  },
+  select: (_resourceName: string) => {
+    console.warn("Resource selections context is not set.")
+  },
+  deselect: (_resourceName: string) => {
+    console.warn("Resource selections context is not set.")
+  },
+  clearSelections: () => {
+    console.warn("Resource selections context is not set.")
+  },
+})
+
+ResourceSelectionContext.displayName = "ResourceSelectionContext"
+
+export function useResourceSelection(): ResourceSelectionContext {
+  return useContext(ResourceSelectionContext)
+}
+
+export function ResourceSelectionProvider(
+  props: PropsWithChildren<{ initialValuesForTesting?: string[] }>
+) {
+  const selections = props.initialValuesForTesting || []
+  const [selectedResources, setSelectedResources] = useState(selections)
+
+  function isSelected(resourceName: string) {
+    return selectedResources.includes(resourceName)
+  }
+
+  function select(resourceName: string) {
+    return setSelectedResources([...selectedResources, resourceName])
+  }
+
+  function deselect(resourceName: string) {
+    return setSelectedResources(
+      selectedResources.filter((r) => r !== resourceName)
+    )
+  }
+
+  function clearSelections() {
+    setSelectedResources([])
+  }
+
+  const contextValue: ResourceSelectionContext = {
+    selected: selectedResources,
+    isSelected,
+    select,
+    deselect,
+    clearSelections,
+  }
+
+  return (
+    <ResourceSelectionContext.Provider value={contextValue}>
+      {props.children}
+    </ResourceSelectionContext.Provider>
+  )
+}

--- a/web/src/analytics.ts
+++ b/web/src/analytics.ts
@@ -18,7 +18,7 @@ export type Tags = {
 export enum AnalyticsType {
   Account = "account",
   Detail = "resource-detail",
-  Grid = "grid",
+  Grid = "grid", // aka Table View
   Shortcut = "shortcuts",
   Unknown = "unknown",
   Update = "update",

--- a/web/src/instrumentedComponents.tsx
+++ b/web/src/instrumentedComponents.tsx
@@ -90,5 +90,11 @@ export function InstrumentedCheckbox(
     }
   }
 
-  return <Checkbox onChange={instrumentedOnChange} {...checkboxProps} />
+  return (
+    <Checkbox
+      onChange={instrumentedOnChange}
+      disableRipple={true}
+      {...checkboxProps}
+    />
+  )
 }

--- a/web/src/testdata.tsx
+++ b/web/src/testdata.tsx
@@ -330,21 +330,24 @@ export function tenResourceView(): TestDataView {
 }
 
 export function nResourceView(n: number): TestDataView {
-  let resources: UIResource[] = []
+  let uiResources: UIResource[] = []
+  const uiButtons: UIButton[] = []
   for (let i = 0; i < n; i++) {
     if (i === 0) {
       let res = tiltfileResource()
-      resources.push(res)
+      uiResources.push(res)
     } else {
-      let res = oneResource({})
-      res.metadata = { name: "_" + i }
-      res.status!.order = i
-      resources.push(res)
+      const name = `_${i}`
+      let res = oneResource({ name, order: i })
+      uiResources.push(res)
+      // Add a disable button for each non-Tiltfile resource
+      uiButtons.push(disableButton(name, true))
     }
   }
+
   return {
-    uiResources: resources,
-    uiButtons: [],
+    uiResources,
+    uiButtons,
     uiSession: { status: { tiltfileKey: "test", runningTiltBuild } },
   }
 }

--- a/web/storybook.tiltfile
+++ b/web/storybook.tiltfile
@@ -7,8 +7,8 @@ version_settings(constraint='>=0.22.1')
 
 load("ext://uibutton", "cmd_button", "location")
 
-enable_feature("labels")
 enable_feature("disable_resources")
+enable_feature("bulk_disable_resources")
 
 local_resource(
   'storybook',


### PR DESCRIPTION
![Screen Shot 2022-01-12 at 4 38 40 PM](https://user-images.githubusercontent.com/23283986/149225771-4c8f5fd7-2901-44d6-8c1a-2424dc1185b3.png)

* Add a `ResourceSelection` context that tracks what resources are selected by a list of their names
* Add a checkbox column that displays when the bulk feature flag is enabled and only for resources that are disable-able
* Add support for bulk disable resources feature in Storybook stories

(This PR doesn't cover resource group selection or enable/disable menu display yet.)

The easiest way to test is through Storybook (through looking at any of the `OverviewTable` stories and toggling the flag) or spinning up any `Tiltfile` with the `bulk_disable_resources` flag enabled.

Closes [ch12973](https://app.shortcut.com/windmill/story/12973/add-checkbox-selection-to-each-row-in-table-view).