### PR TITLE
cli: starter Tiltfile formatting + language adjustments

### DIFF
--- a/Tiltfile.starter
+++ b/Tiltfile.starter
@@ -1,56 +1,128 @@
 # Welcome to Tilt!
-# To get you started as quickly as possible, we have created this generic Tiltfile.
-# Modify and comment out any commands to make them work for you.
-print("""
-✨ Hello Tilt! This appears in the (Tiltfile) pane whenever Tilt evaluates this file.
-
-Open {tiltfile_path} in your favorite editor to get started.
-""".format(tiltfile_path=config.main_path))
-
-# Build docker image for a resource
-# More info on https://docs.tilt.dev/api.html#api.docker_build
+#   To get you started as quickly as possible, we have created a
+#   starter Tiltfile for you.
 #
-# docker_build('my-resource-image-name', '.', dockerfile='deploy/docs.dockerfile',
-#              # Define the only files that are relevant for the docker build
-#              only=['./src', './healthcheck.sh', './docs'],
-#              # Define steps for updating a running container, more info on https://docs.tilt.dev/live_update_reference.html
+#   Uncomment, modify, and delete any commands as needed for your
+#   project's configuration.
+
+
+# Output diagnostic messages
+#   You can print log messages, warnings, and fatal errors, which will
+#   appear in the (Tiltfile) resource in the web UI. Tiltfiles support
+#   multiline strings and common string operations such as formatting.
+#
+#   More info: https://docs.tilt.dev/api.html#api.warn
+print("""
+-----------------------------------------------------------------
+✨ Hello Tilt! This appears in the (Tiltfile) pane whenever Tilt
+   evaluates this file.
+-----------------------------------------------------------------
+""".strip())
+warn('ℹ️ Open {tiltfile_path} in your favorite editor to get started.'.format(
+    tiltfile_path=config.main_path))
+
+# Build Docker image
+#   Tilt will automatically associate image builds with the resource(s)
+#   that reference them (e.g. via Kubernetes or Docker Compose YAML).
+#
+#   More info: https://docs.tilt.dev/api.html#api.docker_build
+#
+# docker_build('registry.example.com/my-image',
+#              context='.',
+#              # (Optional) Use a custom Dockerfile path
+#              dockerfile='./deploy/app.dockerfile',
+#              # (Optional) Filter the paths used in the build
+#              only=['./app'],
+#              # (Recommended) Updating a running container in-place
+#              # https://docs.tilt.dev/live_update_reference.html
 #              live_update=[
-#                 # Specify where files should be synced to from host to container system
-#                 sync('./src', '/src/'),
-#                 # Specify the command to be executed when updating a container, run only when files defined in "trigger" list changed
-#                 run('sync.sh', trigger=['watched-file'])
+#                 # Sync files from host to container
+#                 sync('./app', '/src/'),
+#                 # Execute commands inside the container when certain
+#                 # paths change
+#                 run('/src/codegen.sh', trigger=['./app/api'])
 #              ]
 # )
 
-# Apply k8s manifests
-# More info: https://docs.tilt.dev/api.html#api.k8s_yaml
+
+# Apply Kubernetes manifests
+#   Tilt will build & push any necessary images, re-deploying your
+#   resources as they change.
+#
+#   More info: https://docs.tilt.dev/api.html#api.k8s_yaml
 #
 # k8s_yaml(['k8s/deployment.yaml', 'k8s/service.yaml'])
 
-# Configure a k8s resource for port forwarding
-# 'my-resource' can be anything you wish, but often will align with a name
-# of a deployment in the deployment manifest (k8s/deployment.yaml above).
-# More info: https://docs.tilt.dev/api.html#api.k8s_resource
-#
-# k8s_resource('my-resource', port_forwards=[5000])
 
-# Run a one-time command e.g. to install prerequisites
-# `cmd_bat`, when present, is used instead of `cmd` on Windows.
-# More info: https://docs.tilt.dev/local_resource.html
+# Customize a Kubernetes resource
+#   By default, Kubernetes resource names are automatically assigned
+#   based on objects in the YAML manifests, e.g. Deployment name.
 #
-# local_resource('install-commands',
+#   Tilt strives for sane defaults, so calling k8s_resource is
+#   optional, and you only need to pass the arguments you want to
+#   override.
+#
+#   More info: https://docs.tilt.dev/api.html#api.k8s_resource
+#
+# k8s_resource('my-deployment',
+#              # map one or more local ports to ports on your Pod
+#              port_forwards=['5000:8080'],
+#              # change whether the resource is started by default
+#              auto_init=False,
+#              # control whether the resource automatically updates
+#              trigger_mode=TRIGGER_MODE_MANUAL
+# )
+
+
+# Run a local commands
+#   Local commands can be helpful for one-time tasks like installing
+#   project prerequisites. They can also manage long-lived processes
+#   for non-containerized services or dependencies.
+#
+#   More info: https://docs.tilt.dev/local_resource.html
+#
+# local_resource('install-helm',
 #                cmd='which helm > /dev/null || brew install helm',
-#                cmd_bat=['powershell.exe', '-Noninteractive', '-Command', '& {if (!(Get-Command helm -ErrorAction SilentlyContinue)) {scoop install helm}}'])
+#                # `cmd_bat`, when present, is used instead of `cmd` on Windows.
+#                cmd_bat=[
+#                    'powershell.exe',
+#                    '-Noninteractive',
+#                    '-Command',
+#                    '& {if (!(Get-Command helm -ErrorAction SilentlyContinue)) {scoop install helm}}'
+#                ]
+# )
 
-# You can package related resources and statements in a function. Here we
-# checkout and load the tilt-avatars demo app from Github using `git_checkout`
-# from the `git_resource` extension.
+
+# Extensions are open-source, pre-packaged functions that extend Tilt
+#
+#   More info: https://github.com/tilt-dev/tilt-extensions
+#
 load('ext://git_resource', 'git_checkout')
+
+
+# Organize logic into functions
+#   Tiltfiles are written in Starlark, a Python-inspired language, so
+#   you can use functions, conditionals, loops, and more.
+#
+#   More info: https://docs.tilt.dev/tiltfile_concepts.html
+#
 def tilt_demo():
+    # Tilt provides many useful portable built-ins
+    # https://docs.tilt.dev/api.html#modules.os.path.exists
     if os.path.exists('tilt-avatars/Tiltfile'):
+        # It's possible to load other Tiltfiles to further organize
+        # your logic in large projects
+        # https://docs.tilt.dev/multiple_repos.html
         load_dynamic('tilt-avatars/Tiltfile')
     watch_file('tilt-avatars/Tiltfile')
-    git_checkout('https://github.com/tilt-dev/tilt-avatars.git', checkout_dir='tilt-avatars')
+    git_checkout('https://github.com/tilt-dev/tilt-avatars.git',
+                 checkout_dir='tilt-avatars')
 
-# Uncomment the tilt_demo() invocation to see it in action.
-#tilt_demo()
+
+# Edit your Tiltfile without restarting Tilt
+#   While running `tilt up`, Tilt watches the Tiltfile on disk and
+#   automatically re-evaluates it on change.
+#
+#   To see it in action, try uncommenting the following line with
+#   Tilt running.
+# tilt_demo()

--- a/Tiltfile.starter
+++ b/Tiltfile.starter
@@ -21,6 +21,7 @@ print("""
 warn('ℹ️ Open {tiltfile_path} in your favorite editor to get started.'.format(
     tiltfile_path=config.main_path))
 
+
 # Build Docker image
 #   Tilt will automatically associate image builds with the resource(s)
 #   that reference them (e.g. via Kubernetes or Docker Compose YAML).

--- a/Tiltfile.starter
+++ b/Tiltfile.starter
@@ -1,7 +1,11 @@
 # Welcome to Tilt!
 # To get you started as quickly as possible, we have created this generic Tiltfile. 
 # Modify and comment out any commands to make them work for you.
-print("✨ Hello Tilt! This appears in the (Tiltfile) pane whenever Tilt evaluates this file.")
+print("""
+✨ Hello Tilt! This appears in the (Tiltfile) pane whenever Tilt evaluates this file.
+
+Open {tiltfile_path} in your favorite editor to get started.
+""".format(tiltfile_path=config.main_path))
 
 # Run a one-time command e.g. to install prerequisites
 # `cmd_bat`, when present, is used instead of `cmd` on Windows.

--- a/Tiltfile.starter
+++ b/Tiltfile.starter
@@ -1,5 +1,5 @@
 # Welcome to Tilt!
-# To get you started as quickly as possible, we have created this generic Tiltfile. 
+# To get you started as quickly as possible, we have created this generic Tiltfile.
 # Modify and comment out any commands to make them work for you.
 print("""
 ✨ Hello Tilt! This appears in the (Tiltfile) pane whenever Tilt evaluates this file.
@@ -11,15 +11,15 @@ Open {tiltfile_path} in your favorite editor to get started.
 # More info on https://docs.tilt.dev/api.html#api.docker_build
 #
 # docker_build('my-resource-image-name', '.', dockerfile='deploy/docs.dockerfile',
-              # Define the only files that are relevant for the docker build
-              # only=['./src', './healthcheck.sh', './docs'],
-              # Define steps for updating a running container, more info on https://docs.tilt.dev/live_update_reference.html
-              # live_update=[
-                # Specify where files should be synced to from host to container system
-                # sync('./src', '/src/'),
-                # Specify the command to be executed when updating a container, run only when files defined in "trigger" list changed
-                # run('sync.sh', trigger=['watched-file'])
-              # ]
+#              # Define the only files that are relevant for the docker build
+#              only=['./src', './healthcheck.sh', './docs'],
+#              # Define steps for updating a running container, more info on https://docs.tilt.dev/live_update_reference.html
+#              live_update=[
+#                 # Specify where files should be synced to from host to container system
+#                 sync('./src', '/src/'),
+#                 # Specify the command to be executed when updating a container, run only when files defined in "trigger" list changed
+#                 run('sync.sh', trigger=['watched-file'])
+#              ]
 # )
 
 # Apply k8s manifests

--- a/Tiltfile.starter
+++ b/Tiltfile.starter
@@ -46,11 +46,11 @@ Open {tiltfile_path} in your favorite editor to get started.
 # You can package related resources and statements in a function. Here we
 # checkout and load the tilt-avatars demo app from Github using `git_checkout`
 # from the `git_resource` extension.
+load('ext://git_resource', 'git_checkout')
 def tilt_demo():
     if os.path.exists('tilt-avatars/Tiltfile'):
         load_dynamic('tilt-avatars/Tiltfile')
     watch_file('tilt-avatars/Tiltfile')
-    load('ext://git_resource', 'git_checkout')
     git_checkout('https://github.com/tilt-dev/tilt-avatars.git', checkout_dir='tilt-avatars')
 
 # Uncomment the tilt_demo() invocation to see it in action.

--- a/Tiltfile.starter
+++ b/Tiltfile.starter
@@ -7,15 +7,6 @@ print("""
 Open {tiltfile_path} in your favorite editor to get started.
 """.format(tiltfile_path=config.main_path))
 
-# Run a one-time command e.g. to install prerequisites
-# `cmd_bat`, when present, is used instead of `cmd` on Windows.
-# More info: https://docs.tilt.dev/local_resource.html
-#
-# local_resource('install-commands',
-#                cmd='which helm > /dev/null || brew install helm',
-#                cmd_bat=['powershell.exe', '-Noninteractive', '-Command', '& {if (!(Get-Command helm -ErrorAction SilentlyContinue)) {scoop install helm}}'])
-
-
 # Build docker image for a resource
 # More info on https://docs.tilt.dev/api.html#api.docker_build
 #
@@ -42,6 +33,14 @@ Open {tiltfile_path} in your favorite editor to get started.
 # More info: https://docs.tilt.dev/api.html#api.k8s_resource
 #
 # k8s_resource('my-resource', port_forwards=[5000])
+
+# Run a one-time command e.g. to install prerequisites
+# `cmd_bat`, when present, is used instead of `cmd` on Windows.
+# More info: https://docs.tilt.dev/local_resource.html
+#
+# local_resource('install-commands',
+#                cmd='which helm > /dev/null || brew install helm',
+#                cmd_bat=['powershell.exe', '-Noninteractive', '-Command', '& {if (!(Get-Command helm -ErrorAction SilentlyContinue)) {scoop install helm}}'])
 
 # You can package related resources and statements in a function. Here we
 # checkout and load the tilt-avatars demo app from Github using `git_checkout`

--- a/Tiltfile.starter
+++ b/Tiltfile.starter
@@ -75,7 +75,7 @@ warn('ℹ️ Open {tiltfile_path} in your favorite editor to get started.'.forma
 # )
 
 
-# Run a local commands
+# Run local commands
 #   Local commands can be helpful for one-time tasks like installing
 #   project prerequisites. They can also manage long-lived processes
 #   for non-containerized services or dependencies.


### PR DESCRIPTION
I might have gone a bit overboard here so making this a PR to Lian's branch instead of pushing straight to #5366  😅 

* Improved formatting on "hello world" so it's more noticeable
* Provide path to generated Tiltfile in logs
* Move `local_resource` example below Docker/K8s
* Ensure file is (99%) 72-col friendly
* Make examples IDE friendly to uncomment
   * `Cmd-/` to uncomment a block in both JetBrains IDEs/VSCode will produce valid Starlark now
* Fix issue with extension load (can't be in function)
* Add some more reference links
* Add `auto_init` + `trigger_mode` to `k8s_resource` example
* Tweak language/explanations


<img width="1481" alt="Screenshot of starter Tiltfile log output in web UI" src="https://user-images.githubusercontent.com/841263/149562110-05251837-b14d-4335-84cb-db67b5696da6.png">

