### PR TITLE
tiltfile: duplicate resources should consistently be an error

### DIFF
--- a/internal/controllers/core/tiltfile/reducers.go
+++ b/internal/controllers/core/tiltfile/reducers.go
@@ -145,7 +145,12 @@ func HandleConfigsReloaded(
 			continue
 		}
 
-		if !ok {
+		// Create a new manifest if it changed types.
+		createNew := !ok ||
+			mt.Manifest.IsK8s() != m.IsK8s() ||
+			mt.Manifest.IsLocal() != m.IsLocal() ||
+			mt.Manifest.IsDC() != m.IsDC()
+		if createNew {
 			mt = store.NewManifestTarget(m)
 		}
 

--- a/internal/tiltfile/k8s_custom_deploy_test.go
+++ b/internal/tiltfile/k8s_custom_deploy_test.go
@@ -146,6 +146,39 @@ docker_build('image-a', '.')
 	assert.Equal(t, []string{"image-a"}, spec.ImageMaps)
 }
 
+func TestK8sCustomDeployConflict(t *testing.T) {
+	f := newFixture(t)
+	defer f.TearDown()
+
+	f.file("Tiltfile", `
+k8s_custom_deploy('foo',
+                  apply_cmd='apply',
+                  delete_cmd='delete',
+                  deps=[])
+k8s_custom_deploy('foo',
+                  apply_cmd='apply',
+                  delete_cmd='delete',
+                  deps=[])
+`)
+
+	f.loadErrString(`k8s_resource named "foo" already exists`)
+}
+
+func TestK8sCustomDeployLocalResourceConflict(t *testing.T) {
+	f := newFixture(t)
+	defer f.TearDown()
+
+	f.file("Tiltfile", `
+k8s_custom_deploy('foo',
+                  apply_cmd='apply',
+                  delete_cmd='delete',
+                  deps=[])
+local_resource('foo', 'foo')
+`)
+
+	f.loadErrString(`k8s_resource named "foo" already exists`)
+}
+
 func assertK8sApplyCmdEqual(f *fixture, expected model.Cmd, actual *v1alpha1.KubernetesApplyCmd) bool {
 	t := f.t
 	t.Helper()

--- a/internal/tiltfile/local_resource.go
+++ b/internal/tiltfile/local_resource.go
@@ -114,7 +114,7 @@ func (s *tiltfileState) localResource(thread *starlark.Thread, fn *starlark.Buil
 		probeSpec = nil
 	}
 
-	res := localResource{
+	res := &localResource{
 		name:           string(name),
 		updateCmd:      updateCmd,
 		serveCmd:       serveCmd,
@@ -132,12 +132,12 @@ func (s *tiltfileState) localResource(thread *starlark.Thread, fn *starlark.Buil
 	}
 
 	// check for duplicate resources by name and throw error if found
-	for _, elem := range s.localResources {
-		if elem.name == res.name {
-			return starlark.None, fmt.Errorf("Local resource %s has been defined multiple times", res.name)
-		}
+	err = s.checkResourceConflict(res.name)
+	if err != nil {
+		return nil, err
 	}
 	s.localResources = append(s.localResources, res)
+	s.localByName[res.name] = res
 
 	return starlark.None, nil
 }

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -1566,7 +1566,7 @@ local_resource('foo', 'echo foo')
 local_resource('foo', 'echo foo')
 `)
 
-	f.loadErrString("Local resource foo has been defined multiple times")
+	f.loadErrString(`local_resource named "foo" already exists`)
 }
 
 // These tests are for behavior that we specifically enabled in Starlark
@@ -3244,7 +3244,7 @@ k8s_yaml(['foo.yaml', 'bar.yaml'])
 k8s_resource('foo', new_name='bar')
 `)
 
-	f.loadErrString("\"foo\" to \"bar\"", "already exists a resource with that name")
+	f.loadErrString("\"foo\" to \"bar\"", "already exists")
 }
 
 func TestK8sResourceRenameConflictingNames(t *testing.T) {


### PR DESCRIPTION
Hello @nicksieger, @landism,

Please review the following commits I made in branch nicks/dupe-resource:

1098d9395efb9c97985043a43c4c038552aaf8d4 (2022-01-18 20:14:09 -0500)
tiltfile: duplicate resources should consistently be an error

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics