### PR TITLE
cli: fix `tilt docker-prune` command panic

### DIFF
--- a/integration/docker_prune/Tiltfile
+++ b/integration/docker_prune/Tiltfile
@@ -1,0 +1,14 @@
+# -*- mode: Python -*-
+
+include('../Tiltfile')
+
+docker_build('gcr.io/tilt-dev/image-for-prune', '.', dockerfile_contents='FROM nginx\n')
+
+k8s_yaml('pod.yaml')
+
+# we want to set unrealistically aggressive prune settings (i.e. will prune
+# EVERYTHING for this Tiltfile) for the purposes of testing
+# however, since `tilt ci` will run prune, we only set the opts when explicitly
+# running `tilt docker-prune` so we can control it for assert purposes
+if config.tilt_subcommand == 'docker-prune':
+    docker_prune_settings(keep_recent=0, max_age_mins=-1, num_builds=9999)

--- a/integration/docker_prune/pod.yaml
+++ b/integration/docker_prune/pod.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: site
+spec:
+  containers:
+    - name: site
+      image: gcr.io/tilt-dev/image-for-prune
+      imagePullPolicy: IfNotPresent

--- a/integration/docker_prune_test.go
+++ b/integration/docker_prune_test.go
@@ -1,0 +1,30 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCLI_DockerPrune(t *testing.T) {
+	f := newK8sFixture(t, "docker_prune")
+	defer f.TearDown()
+	f.SetRestrictedCredentials()
+
+	f.TiltCI()
+
+	ctx, cancel := context.WithTimeout(f.ctx, time.Minute)
+	defer cancel()
+
+	c := f.tilt.cmd(ctx, []string{"docker-prune", "--debug"}, nil)
+	t.Logf("Running command: %s", c.String())
+	out, err := c.CombinedOutput()
+	require.NoErrorf(t, err, "Error while running command. Output:\n%s\n", string(out))
+	assert.Contains(t, string(out), "[Docker Prune] removed 2 caches")
+}

--- a/internal/cli/docker_prune.go
+++ b/internal/cli/docker_prune.go
@@ -2,15 +2,18 @@ package cli
 
 import (
 	"context"
-	"os"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
 
 	"github.com/tilt-dev/tilt/internal/analytics"
+	"github.com/tilt-dev/tilt/internal/container"
 	ctrltiltfile "github.com/tilt-dev/tilt/internal/controllers/apis/tiltfile"
+	apitiltfile "github.com/tilt-dev/tilt/internal/controllers/core/tiltfile"
 	"github.com/tilt-dev/tilt/internal/docker"
 	"github.com/tilt-dev/tilt/internal/engine/dockerprune"
+	"github.com/tilt-dev/tilt/internal/k8s"
 	"github.com/tilt-dev/tilt/internal/tiltfile"
 	"github.com/tilt-dev/tilt/pkg/logger"
 	"github.com/tilt-dev/tilt/pkg/model"
@@ -22,12 +25,14 @@ type dockerPruneCmd struct {
 
 type dpDeps struct {
 	dCli docker.Client
+	kCli k8s.Client
 	tfl  tiltfile.TiltfileLoader
 }
 
-func newDPDeps(dCli docker.Client, tfl tiltfile.TiltfileLoader) dpDeps {
+func newDPDeps(dCli docker.Client, kCli k8s.Client, tfl tiltfile.TiltfileLoader) dpDeps {
 	return dpDeps{
 		dCli: dCli,
+		kCli: kCli,
 		tfl:  tfl,
 	}
 }
@@ -50,9 +55,9 @@ func (c *dockerPruneCmd) run(ctx context.Context, args []string) error {
 	a.Incr("cmd.dockerPrune", nil)
 	defer a.Flush(time.Second)
 
-	// (Most relevant output from dockerpruner is at the `debug` level)
-	l := logger.NewLogger(logger.DebugLvl, os.Stdout)
-	ctx = logger.WithLogger(ctx, l)
+	// // (Most relevant output from dockerpruner is at the `debug` level)
+	// l := logger.NewLogger(logger.DebugLvl, os.Stdout)
+	// ctx = logger.WithLogger(ctx, l)
 
 	deps, err := wireDockerPrune(ctx, a, "docker-prune")
 	if err != nil {
@@ -64,7 +69,10 @@ func (c *dockerPruneCmd) run(ctx context.Context, args []string) error {
 		return tlr.Error
 	}
 
-	imgSelectors := model.LocalRefSelectorsForManifests(tlr.Manifests)
+	imgSelectors, err := resolveImageSelectors(ctx, deps.kCli, &tlr)
+	if err != nil {
+		return err
+	}
 
 	dp := dockerprune.NewDockerPruner(deps.dCli)
 
@@ -72,4 +80,27 @@ func (c *dockerPruneCmd) run(ctx context.Context, args []string) error {
 	dp.Prune(ctx, tlr.DockerPruneSettings.MaxAge, tlr.DockerPruneSettings.KeepRecent, imgSelectors)
 
 	return nil
+}
+
+func resolveImageSelectors(ctx context.Context, kCli k8s.Client, tlr *tiltfile.TiltfileLoadResult) ([]container.RefSelector, error) {
+	registry := apitiltfile.DecideRegistry(ctx, kCli, tlr)
+	for _, m := range tlr.Manifests {
+		if err := m.InferImagePropertiesFromCluster(registry); err != nil {
+			return nil, err
+		}
+	}
+
+	imgSelectors := model.LocalRefSelectorsForManifests(tlr.Manifests)
+	if len(imgSelectors) != 0 && logger.Get(ctx).Level().ShouldDisplay(logger.DebugLvl) {
+		var sb strings.Builder
+		for _, is := range imgSelectors {
+			sb.WriteString("  - ")
+			sb.WriteString(is.RefFamiliarString())
+			sb.WriteRune('\n')
+		}
+
+		logger.Get(ctx).Debugf("Running Docker Prune for images:\n%s", sb.String())
+	}
+
+	return imgSelectors, nil
 }

--- a/internal/cli/wire_gen.go
+++ b/internal/cli/wire_gen.go
@@ -166,7 +166,7 @@ func wireDockerPrune(ctx context.Context, analytics2 *analytics.TiltAnalytics, s
 	processExecer := localexec.NewProcessExecer(localexecEnv)
 	defaults := _wireDefaultsValue
 	tiltfileLoader := tiltfile.ProvideTiltfileLoader(analytics2, plugin, versionPlugin, configPlugin, dockerComposeClient, webHost, processExecer, defaults, env)
-	cliDpDeps := newDPDeps(switchCli, tiltfileLoader)
+	cliDpDeps := newDPDeps(switchCli, client, tiltfileLoader)
 	return cliDpDeps, nil
 }
 

--- a/internal/engine/dockerprune/docker_pruner.go
+++ b/internal/engine/dockerprune/docker_pruner.go
@@ -13,7 +13,6 @@ import (
 	"github.com/docker/docker/api/types/filters"
 
 	"github.com/tilt-dev/tilt/internal/container"
-
 	"github.com/tilt-dev/tilt/pkg/model"
 
 	"github.com/tilt-dev/tilt/internal/engine/buildcontrol"
@@ -302,7 +301,7 @@ func (dp *DockerPruner) sufficientVersionError() error {
 }
 
 func prettyPrintImagesPruneReport(report types.ImagesPruneReport, l logger.Logger) {
-	if len(report.ImagesDeleted) == 0 && !l.Level().ShouldDisplay(logger.DebugLvl) {
+	if len(report.ImagesDeleted) == 0 && !l.Level().ShouldDisplay(logger.InfoLvl) {
 		return
 	}
 
@@ -326,7 +325,7 @@ func prettyStringImgDeleteItem(img types.ImageDeleteResponseItem) string {
 }
 
 func prettyPrintCachePruneReport(report *types.BuildCachePruneReport, l logger.Logger) {
-	if len(report.CachesDeleted) == 0 && !l.Level().ShouldDisplay(logger.DebugLvl) {
+	if len(report.CachesDeleted) == 0 && !l.Level().ShouldDisplay(logger.InfoLvl) {
 		return
 	}
 
@@ -338,7 +337,7 @@ func prettyPrintCachePruneReport(report *types.BuildCachePruneReport, l logger.L
 }
 
 func prettyPrintContainersPruneReport(report types.ContainersPruneReport, l logger.Logger) {
-	if len(report.ContainersDeleted) == 0 && !l.Level().ShouldDisplay(logger.DebugLvl) {
+	if len(report.ContainersDeleted) == 0 && !l.Level().ShouldDisplay(logger.InfoLvl) {
 		return
 	}
 

--- a/internal/engine/dockerprune/docker_pruner.go
+++ b/internal/engine/dockerprune/docker_pruner.go
@@ -13,6 +13,7 @@ import (
 	"github.com/docker/docker/api/types/filters"
 
 	"github.com/tilt-dev/tilt/internal/container"
+
 	"github.com/tilt-dev/tilt/pkg/model"
 
 	"github.com/tilt-dev/tilt/internal/engine/buildcontrol"
@@ -301,7 +302,7 @@ func (dp *DockerPruner) sufficientVersionError() error {
 }
 
 func prettyPrintImagesPruneReport(report types.ImagesPruneReport, l logger.Logger) {
-	if len(report.ImagesDeleted) == 0 && !l.Level().ShouldDisplay(logger.InfoLvl) {
+	if len(report.ImagesDeleted) == 0 && !l.Level().ShouldDisplay(logger.VerboseLvl) {
 		return
 	}
 
@@ -325,7 +326,7 @@ func prettyStringImgDeleteItem(img types.ImageDeleteResponseItem) string {
 }
 
 func prettyPrintCachePruneReport(report *types.BuildCachePruneReport, l logger.Logger) {
-	if len(report.CachesDeleted) == 0 && !l.Level().ShouldDisplay(logger.InfoLvl) {
+	if len(report.CachesDeleted) == 0 && !l.Level().ShouldDisplay(logger.VerboseLvl) {
 		return
 	}
 
@@ -337,7 +338,7 @@ func prettyPrintCachePruneReport(report *types.BuildCachePruneReport, l logger.L
 }
 
 func prettyPrintContainersPruneReport(report types.ContainersPruneReport, l logger.Logger) {
-	if len(report.ContainersDeleted) == 0 && !l.Level().ShouldDisplay(logger.InfoLvl) {
+	if len(report.ContainersDeleted) == 0 && !l.Level().ShouldDisplay(logger.VerboseLvl) {
 		return
 	}
 


### PR DESCRIPTION
Re-use the logic from the reconciler directly to determine the
registry (based on the cluster + `default_registry` in Tiltfile)
in the CLI code.

This addresses a crash resulting from the image properties not being
present, as they're inferred + populated during Tiltfile
reconciliation, which does not occur here.

In the future, we'll likely want this (and other similar commands
such as `tilt alpha tiltfile-result`) to launch a headless apiserver
and wait for a condition, i.e. Tiltfile loaded, before reading the
objects from the apiserver to do work.

Fixes #5370.