### PR TITLE
buildcontrol: adjust how we determine image rebuilds

### DIFF
--- a/internal/engine/buildcontrol/build_control_test.go
+++ b/internal/engine/buildcontrol/build_control_test.go
@@ -265,6 +265,60 @@ func TestTwoK8sTargetsWithBaseImage(t *testing.T) {
 	f.assertNextTargetToBuild("sancho-two")
 }
 
+func TestLiveUpdateHold(t *testing.T) {
+	f := newTestFixture(t)
+	defer f.TearDown()
+
+	srcFile := f.JoinPath("src", "a.txt")
+	f.WriteFile(srcFile, "hello")
+	luSpec := v1alpha1.LiveUpdateSpec{
+		BasePath: f.Path(),
+		Syncs:    []v1alpha1.LiveUpdateSync{{LocalPath: "src", ContainerPath: "/src"}},
+	}
+
+	baseImage := newDockerImageTarget("sancho-base")
+	sanchoImage := newDockerImageTarget("sancho").
+		WithLiveUpdateSpec("sancho", luSpec).
+		WithImageMapDeps([]string{baseImage.ImageMapName()})
+
+	sancho := f.upsertManifest(manifestbuilder.New(f, "sancho").
+		WithImageTargets(baseImage, sanchoImage).
+		WithK8sYAML(testyaml.SanchoYAML).
+		Build())
+
+	f.assertNextTargetToBuild("sancho")
+	sancho.State.AddCompletedBuild(model.BuildRecord{
+		StartTime:  time.Now(),
+		FinishTime: time.Now(),
+	})
+
+	resource := &k8sconv.KubernetesResource{
+		FilteredPods: []v1alpha1.Pod{
+			*readyPod("pod-1", sanchoImage.Refs.ClusterRef()),
+		},
+	}
+	f.st.KubernetesResources["sancho"] = resource
+
+	sancho.State.MutableBuildStatus(sanchoImage.ID()).PendingFileChanges[srcFile] = time.Now()
+	f.assertNoTargetNextToBuild()
+	f.assertHold("sancho", store.HoldReasonReconciling)
+
+	// If the live update is failing, we have to rebuild.
+	f.st.LiveUpdates["sancho"] = &v1alpha1.LiveUpdate{
+		Spec:   luSpec,
+		Status: v1alpha1.LiveUpdateStatus{Failed: &v1alpha1.LiveUpdateStateFailed{Reason: "fake-reason"}},
+	}
+	f.assertNextTargetToBuild("sancho")
+
+	// reset to a good state.
+	delete(f.st.LiveUpdates, "sancho")
+	f.assertNoTargetNextToBuild()
+
+	// If the base image has a change, we have to rebuild.
+	sancho.State.MutableBuildStatus(baseImage.ID()).PendingFileChanges[srcFile] = time.Now()
+	f.assertNextTargetToBuild("sancho")
+}
+
 func TestTwoK8sTargetsWithBaseImagePrebuilt(t *testing.T) {
 	f := newTestFixture(t)
 	defer f.TearDown()


### PR DESCRIPTION
Hello @milas,

Please review the following commits I made in branch nicks/issue5382:

4aed451754a4c80c7f1f799bff4cec7edc4c5fb9 (2022-01-19 12:31:34 -0500)
buildcontrol: adjust how we determine image rebuilds
Fixes https://github.com/tilt-dev/tilt/issues/5382

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics