### PR TITLE
engine: store manifest enabled state in ManifestState

### DIFF
--- a/internal/engine/buildcontrol/build_control.go
+++ b/internal/engine/buildcontrol/build_control.go
@@ -264,10 +264,8 @@ func HoldTargetsWaitingOnDependencies(state store.EngineState, mts []*store.Mani
 
 func HoldDisabledTargets(state store.EngineState, mts []*store.ManifestTarget, holds HoldSet) {
 	for _, mt := range mts {
-		if uir, ok := state.UIResources[string(mt.Manifest.Name)]; ok {
-			if uir.Status.DisableStatus.DisabledCount > 0 {
-				holds.AddHold(mt, store.Hold{Reason: store.HoldReasonDisabled})
-			}
+		if !mt.State.Enabled {
+			holds.AddHold(mt, store.Hold{Reason: store.HoldReasonDisabled})
 		}
 	}
 }

--- a/internal/engine/buildcontrol/build_control_test.go
+++ b/internal/engine/buildcontrol/build_control_test.go
@@ -422,15 +422,8 @@ func TestHoldDisabled(t *testing.T) {
 	defer f.TearDown()
 
 	f.upsertLocalManifest("local")
-	f.st.UIResources = map[string]*v1alpha1.UIResource{
-		"local": {
-			Status: v1alpha1.UIResourceStatus{
-				DisableStatus: v1alpha1.DisableResourceStatus{
-					DisabledCount: 5,
-				},
-			},
-		},
-	}
+	f.st.ManifestTargets["local"].State.Enabled = false
+
 	f.assertHold("local", store.HoldReasonDisabled)
 	f.assertNoTargetNextToBuild()
 }

--- a/internal/engine/buildcontroller.go
+++ b/internal/engine/buildcontroller.go
@@ -161,9 +161,9 @@ func (c *BuildController) cleanupDisabledBuilds(st store.RStore) {
 	state := st.RLockState()
 	defer st.RUnlockState()
 
-	for _, uir := range state.UIResources {
-		if uir.Status.DisableStatus.DisabledCount > 0 {
-			c.cleanupBuildContext(model.ManifestName(uir.Name))
+	for _, ms := range state.ManifestStates() {
+		if !ms.Enabled {
+			c.cleanupBuildContext(ms.Name)
 		}
 	}
 }

--- a/internal/engine/dcwatch/disable_watcher.go
+++ b/internal/engine/dcwatch/disable_watcher.go
@@ -45,17 +45,13 @@ func (w *DisableSubscriber) OnChange(ctx context.Context, st store.RStore, summa
 		if !ok {
 			continue
 		}
-		if uir.Status.DisableStatus.DisabledCount > 0 {
-			manifest, exists := state.ManifestTargets[model.ManifestName(uir.Name)]
-			if !exists {
-				continue
-			}
-
-			if !manifest.State.IsDC() {
-				continue
-			}
-
-			rs := manifest.State.DCRuntimeState().RuntimeStatus()
+		manifest, exists := state.ManifestTargets[model.ManifestName(uir.Name)]
+		if !exists {
+			continue
+		}
+		ms := manifest.State
+		if !manifest.State.Enabled && ms.IsDC() {
+			rs := ms.DCRuntimeState().RuntimeStatus()
 			if rs == v1alpha1.RuntimeStatusOK || rs == v1alpha1.RuntimeStatusPending {
 				// for now, only disable one at a time
 				// https://app.shortcut.com/windmill/story/13140/support-logging-to-multiple-manifests

--- a/internal/store/engine_state.go
+++ b/internal/store/engine_state.go
@@ -494,6 +494,8 @@ type ManifestState struct {
 
 	// If the build was manually triggered, record why.
 	TriggerReason model.BuildReason
+
+	Enabled bool
 }
 
 func NewState() *EngineState {
@@ -515,6 +517,7 @@ func NewState() *EngineState {
 		model.MainTiltfileManifestName: &ManifestState{
 			Name:          model.MainTiltfileManifestName,
 			BuildStatuses: make(map[model.TargetID]*BuildStatus),
+			Enabled:       true,
 		},
 	}
 	ret.TiltfileConfigPaths = map[model.ManifestName][]string{}
@@ -537,12 +540,13 @@ func NewState() *EngineState {
 	return ret
 }
 
-func newManifestState(m model.Manifest) *ManifestState {
+func NewManifestState(m model.Manifest) *ManifestState {
 	mn := m.Name
 	ms := &ManifestState{
 		Name:                    mn,
 		BuildStatuses:           make(map[model.TargetID]*BuildStatus),
 		LiveUpdatedContainerIDs: container.NewIDSet(),
+		Enabled:                 true,
 	}
 
 	if m.IsK8s() {

--- a/internal/store/manifest_target.go
+++ b/internal/store/manifest_target.go
@@ -13,7 +13,7 @@ type ManifestTarget struct {
 func NewManifestTarget(m model.Manifest) *ManifestTarget {
 	return &ManifestTarget{
 		Manifest: m,
-		State:    newManifestState(m),
+		State:    NewManifestState(m),
 	}
 }
 

--- a/internal/store/tiltfiles/reducers.go
+++ b/internal/store/tiltfiles/reducers.go
@@ -15,6 +15,7 @@ func HandleTiltfileUpsertAction(state *store.EngineState, action TiltfileUpsertA
 		state.TiltfileStates[mn] = &store.ManifestState{
 			Name:          mn,
 			BuildStatuses: make(map[model.TargetID]*store.BuildStatus),
+			Enabled:       true,
 		}
 	}
 


### PR DESCRIPTION
A few places in the engine (the ones changed in this PR) need to know if a Manifest is enabled and were doing this by checking UIResource.DisableStatus.

As part of the tilt args / enable/disable work, I'm changing things so that all manifests are considered disabled when created and then become enabled when the api objects shake out. For the engine bits in this PR, that'd mean tests need to ensure enabled resources have both a UIResource and a ConfigMap.
It also felt kind of weird that, e.g., BuildController was coupled to UIResource.

This almost certainly isn't how we want to do this long term, but it seems like a better interim solution than what's already there and will make some upcoming changes less invasive.