### PR TITLE
tiltfile: fix disable_snapshots()

### DIFF
--- a/internal/feature/flags.go
+++ b/internal/feature/flags.go
@@ -50,7 +50,9 @@ var MainDefaults = Defaults{
 	},
 	Snapshots: Value{
 		Enabled: true,
-		Status:  Obsolete,
+		// Snapshots FF is used by disable_snapshots() which hides the button
+		// in the web UI
+		Status: Active,
 	},
 	UpdateHistory: Value{
 		Enabled: false,


### PR DESCRIPTION
Under the hood, `disable_snapshots()` is just a convenience wrapper
for `disable_feature("snapshots")`. As a result, when the FF was
moved to `Obsolete`, it started producing a warning and the FF value
couldn't be set.

We can't suppress the error/warning, as when the obsolete error is
returned, no value is stored, so the FF is flipped back to `Active`.

Arguably, this is a "misuse" of feature flags, but it's not worth the
headache to refactor it away to do something different right now, yet
there are a non-negligible number of repos using `disable_snapshots()`,
so leaving it as-is doesn't seem viable either.

There's an existing test, `TestDisableSnapshots`, which should have
caught this, but the `tiltfile` fixture was using a hardcoded set of
feature flags different than at runtime; these have now been unified
and are extended by tests explicitly testing FF functionality by adding
in test-specific flags as needed.

Fixes #5395.