### PR TITLE
scripts: add a couple script utilities

### DIFF
--- a/scripts/local-analytics.sh
+++ b/scripts/local-analytics.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+#
+# Run a dummy local analytics server that prints each metric in a formatted JSON
+# blob similar to the format it is stored in Tilt cloud.
+#
+# Run this script in one shell, then start Tilt like:
+#
+# TILT_ANALYTICS_URL=http://localhost:9988 tilt up
+
+port=${1-9988}
+running=1
+interrupt() { running=; }
+trap interrupt INT
+
+echo Analytics listening on http://localhost:$port
+
+jqscript='. as {$name, $machine, "git.origin": $gitorigin} | 
+  delpaths([["name"],["machine"],["git.origin"]]) | 
+  { $name, $machine, "git.origin": $gitorigin, time: (now | todate), tags: . }'
+
+while [ "$running" ]; do
+    echo -e "HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n" | \
+        nc -l $port | tail -1 | jq "$jqscript"
+done
+
+exit 0

--- a/scripts/release-metrics.sh
+++ b/scripts/release-metrics.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+#
+# Usage: ./scripts/release-metrics.sh > releases.csv
+#
+# Then import the csv into your favorite data analysis program.
+
+echo 'Release,Asset,Download Count,Published at'
+curl -s https://api.github.com/repos/tilt-dev/tilt/releases | \
+    jq -r '.[] | . as {name:$release,$published_at} | .assets[] | select(.name != "checksums.txt") | [$release,.name,.download_count,$published_at] | @csv'


### PR DESCRIPTION
Had these in my local repo and thought they might be useful to save:

- `./scripts/local-analytics.sh` to run a local analytics server
- `./scripts/release-metrics.sh` to generate csv of download counts from Github
