### PR TITLE
Revert "buildcontrol: adjust how we determine image rebuilds (#5393)"

### DIFF
--- a/internal/engine/buildcontrol/build_control.go
+++ b/internal/engine/buildcontrol/build_control.go
@@ -569,41 +569,20 @@ func HoldLiveUpdateTargetsHandledByReconciler(state store.EngineState, mts []*st
 			continue
 		}
 
-		// Changes to the deploy target can't be live-updated.
-		if mt.Manifest.DeployTarget != nil {
-			bs, hasBuildStatus := mt.State.BuildStatuses[mt.Manifest.DeployTarget.ID()]
-			hasPendingChanges := hasBuildStatus && len(bs.PendingFileChanges) > 0
-			if hasPendingChanges {
-				continue
-			}
-		}
-
-		allChangesHandledByReconciler := true
 		iTargets := mt.Manifest.ImageTargets
 		for _, iTarget := range iTargets {
-			bs, hasBuildStatus := mt.State.BuildStatuses[iTarget.ID()]
-			hasPendingChanges := hasBuildStatus && len(bs.PendingFileChanges) > 0
-			if !hasPendingChanges {
-				continue
-			}
-
 			isHandledByReconciler := !liveupdate.IsEmptySpec(iTarget.LiveUpdateSpec) &&
 				iTarget.LiveUpdateReconciler
 			if !isHandledByReconciler {
-				allChangesHandledByReconciler = false
-				break
+				continue
 			}
 
 			// Live update should hold back a target if it's not failing.
 			lu := state.LiveUpdates[iTarget.LiveUpdateName]
 			isFailing := lu != nil && lu.Status.Failed != nil
-			if isFailing {
-				allChangesHandledByReconciler = false
+			if !isFailing {
+				holds.AddHold(mt, store.Hold{Reason: store.HoldReasonReconciling})
 			}
-		}
-
-		if allChangesHandledByReconciler {
-			holds.AddHold(mt, store.Hold{Reason: store.HoldReasonReconciling})
 		}
 	}
 }


### PR DESCRIPTION
Hello @milas,

Please review the following commits I made in branch nicks/issue5400:

7428c380a34b341c846bb67c2d220529a919b50e (2022-01-21 18:59:19 -0500)
Revert "buildcontrol: adjust how we determine image rebuilds (#5393)"
This reverts commit 86116938738c516194e3dbf6dbb0e1b1745a2041.

fixes https://github.com/tilt-dev/tilt/issues/5400

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics