### PR TITLE
buildcontrol: correctly handle live update image graphs

### DIFF
--- a/internal/engine/buildcontrol/build_control.go
+++ b/internal/engine/buildcontrol/build_control.go
@@ -578,7 +578,7 @@ func HoldLiveUpdateTargetsHandledByReconciler(state store.EngineState, mts []*st
 			}
 		}
 
-		allChangesHandledByReconciler := true
+		allHandledByLiveUpdate := true
 		iTargets := mt.Manifest.ImageTargets
 		for _, iTarget := range iTargets {
 			bs, hasBuildStatus := mt.State.BuildStatuses[iTarget.ID()]
@@ -587,23 +587,69 @@ func HoldLiveUpdateTargetsHandledByReconciler(state store.EngineState, mts []*st
 				continue
 			}
 
-			isHandledByReconciler := !liveupdate.IsEmptySpec(iTarget.LiveUpdateSpec) &&
-				iTarget.LiveUpdateReconciler
-			if !isHandledByReconciler {
-				allChangesHandledByReconciler = false
-				break
+			handlers := findLiveUpdateHandlers(iTarget, mt, &state)
+			if len(handlers) == 0 {
+				allHandledByLiveUpdate = false
 			}
 
-			// Live update should hold back a target if it's not failing.
-			lu := state.LiveUpdates[iTarget.LiveUpdateName]
-			isFailing := lu != nil && lu.Status.Failed != nil
-			if isFailing {
-				allChangesHandledByReconciler = false
+			for _, lu := range handlers {
+				isFailing := lu.Status.Failed != nil
+				if isFailing {
+					allHandledByLiveUpdate = false
+				}
+			}
+
+			if !allHandledByLiveUpdate {
+				break
 			}
 		}
 
-		if allChangesHandledByReconciler {
+		if allHandledByLiveUpdate {
 			holds.AddHold(mt, store.Hold{Reason: store.HoldReasonReconciling})
 		}
 	}
+}
+
+// Find all the live update objects responsible for syncing this image.
+//
+// Base image live updates are modeled with a LiveUpdate object attached to
+// each deploy image.
+//
+// The LiveUpdate watches:
+// - The Deploy image's container
+// - The Base image's filewatch
+//
+// The Tiltfile assembler will guarantee that there will be one LiveUpdate
+// object for each deployed image, and they will all sync in the same way.
+func findLiveUpdateHandlers(changedImage model.ImageTarget, mt *store.ManifestTarget, state *store.EngineState) []*v1alpha1.LiveUpdate {
+	result := []*v1alpha1.LiveUpdate{}
+
+	for _, candidate := range mt.Manifest.ImageTargets {
+		isHandledByReconciler := !liveupdate.IsEmptySpec(candidate.LiveUpdateSpec) &&
+			candidate.LiveUpdateReconciler
+		if !isHandledByReconciler {
+			continue
+		}
+
+		lu := state.LiveUpdates[candidate.LiveUpdateName]
+		if lu == nil {
+			continue
+		}
+
+		isHandled := false
+		for _, source := range lu.Spec.Sources {
+			// Relies on the assumption that image targets create filewatches
+			// with the same name.
+			if source.FileWatch == changedImage.ID().String() {
+				isHandled = true
+				break
+			}
+		}
+
+		if isHandled {
+			result = append(result, lu)
+		}
+	}
+
+	return result
 }

--- a/internal/engine/buildcontrol/build_control_test.go
+++ b/internal/engine/buildcontrol/build_control_test.go
@@ -265,6 +265,60 @@ func TestTwoK8sTargetsWithBaseImage(t *testing.T) {
 	f.assertNextTargetToBuild("sancho-two")
 }
 
+func TestLiveUpdateHold(t *testing.T) {
+	f := newTestFixture(t)
+	defer f.TearDown()
+
+	srcFile := f.JoinPath("src", "a.txt")
+	f.WriteFile(srcFile, "hello")
+	luSpec := v1alpha1.LiveUpdateSpec{
+		BasePath: f.Path(),
+		Syncs:    []v1alpha1.LiveUpdateSync{{LocalPath: "src", ContainerPath: "/src"}},
+	}
+
+	baseImage := newDockerImageTarget("sancho-base")
+	sanchoImage := newDockerImageTarget("sancho").
+		WithLiveUpdateSpec("sancho", luSpec).
+		WithImageMapDeps([]string{baseImage.ImageMapName()})
+
+	sancho := f.upsertManifest(manifestbuilder.New(f, "sancho").
+		WithImageTargets(baseImage, sanchoImage).
+		WithK8sYAML(testyaml.SanchoYAML).
+		Build())
+
+	f.assertNextTargetToBuild("sancho")
+	sancho.State.AddCompletedBuild(model.BuildRecord{
+		StartTime:  time.Now(),
+		FinishTime: time.Now(),
+	})
+
+	resource := &k8sconv.KubernetesResource{
+		FilteredPods: []v1alpha1.Pod{
+			*readyPod("pod-1", sanchoImage.Refs.ClusterRef()),
+		},
+	}
+	f.st.KubernetesResources["sancho"] = resource
+
+	sancho.State.MutableBuildStatus(sanchoImage.ID()).PendingFileChanges[srcFile] = time.Now()
+	f.assertNoTargetNextToBuild()
+	f.assertHold("sancho", store.HoldReasonReconciling)
+
+	// If the live update is failing, we have to rebuild.
+	f.st.LiveUpdates["sancho"] = &v1alpha1.LiveUpdate{
+		Spec:   luSpec,
+		Status: v1alpha1.LiveUpdateStatus{Failed: &v1alpha1.LiveUpdateStateFailed{Reason: "fake-reason"}},
+	}
+	f.assertNextTargetToBuild("sancho")
+
+	// reset to a good state.
+	delete(f.st.LiveUpdates, "sancho")
+	f.assertNoTargetNextToBuild()
+
+	// If the base image has a change, we have to rebuild.
+	sancho.State.MutableBuildStatus(baseImage.ID()).PendingFileChanges[srcFile] = time.Now()
+	f.assertNextTargetToBuild("sancho")
+}
+
 func TestTwoK8sTargetsWithBaseImagePrebuilt(t *testing.T) {
 	f := newTestFixture(t)
 	defer f.TearDown()


### PR DESCRIPTION
Hello @milas,

Please review the following commits I made in branch nicks/buildcontrol:

056b8a4637cc5d5154d233afbf931893a41d56c2 (2022-01-24 16:19:06 -0500)
buildcontrol: correctly handle live update image graphs
fixes https://github.com/tilt-dev/tilt/issues/5382

c1ec0acf7efea120d85dbefe197f1ecef587012f (2022-01-24 10:45:43 -0500)
Revert "Revert "buildcontrol: adjust how we determine image rebuilds (#5393)" (#5401)"
This reverts commit 089f6e0a95392f1143656c8d4c59c3ba1996d806.

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics