### PR TITLE
web: add bulk action buttons for disabling resources in Table View

### DIFF
--- a/web/src/ApiButton.test.tsx
+++ b/web/src/ApiButton.test.tsx
@@ -24,6 +24,7 @@ import {
   boolField,
   hiddenField,
   makeUIButton,
+  mockUIButtonUpdates,
   textField,
 } from "./ApiButton.testhelpers"
 import { accessorsForTesting, tiltfileKeyContext } from "./BrowserStorage"
@@ -64,10 +65,7 @@ describe("ApiButton", () => {
     localStorage.clear()
     fetchMock.reset()
     mockAnalyticsCalls()
-    fetchMock.mock(
-      (url) => url.startsWith("/proxy/apis/tilt.dev/v1alpha1/uibuttons"),
-      JSON.stringify({})
-    )
+    mockUIButtonUpdates()
     Date.now = jest.fn(() => 1482363367071)
   })
 

--- a/web/src/ApiButton.testhelpers.tsx
+++ b/web/src/ApiButton.testhelpers.tsx
@@ -1,5 +1,5 @@
 import fetchMock, { MockCall } from "fetch-mock"
-import { ApiButtonType, UIBUTTON_NAV_COMPONENT_ID } from "./ApiButton"
+import { ApiButtonType, UIBUTTON_GLOBAL_COMPONENT_ID } from "./ApiButton"
 import { UIButton, UIInputSpec, UIInputStatus } from "./types"
 
 export function textField(
@@ -56,7 +56,7 @@ export function makeUIButton(args?: {
         componentType: args?.componentID
           ? ApiButtonType.Resource
           : ApiButtonType.Global,
-        componentID: args?.componentID ?? UIBUTTON_NAV_COMPONENT_ID,
+        componentID: args?.componentID ?? UIBUTTON_GLOBAL_COMPONENT_ID,
       },
       requiresConfirmation: args?.requiresConfirmation,
     },

--- a/web/src/ApiButton.testhelpers.tsx
+++ b/web/src/ApiButton.testhelpers.tsx
@@ -1,6 +1,5 @@
-type UIButton = Proto.v1alpha1UIButton
-type UIInputSpec = Proto.v1alpha1UIInputSpec
-type UIInputStatus = Proto.v1alpha1UIInputStatus
+import { ApiButtonType, UIBUTTON_NAV_COMPONENT_ID } from "./ApiButton"
+import { UIButton, UIInputSpec, UIInputStatus } from "./types"
 
 export function textField(
   name: string,
@@ -36,11 +35,13 @@ export function hiddenField(name: string, value: string): UIInputSpec {
   }
 }
 
+// TODO: Consider merging this test helper with `oneButton` in `testdata`
 export function makeUIButton(args?: {
   name?: string
   inputSpecs?: UIInputSpec[]
   inputStatuses?: UIInputStatus[]
   requiresConfirmation?: boolean
+  componentID?: string
 }): UIButton {
   return {
     metadata: {
@@ -51,8 +52,10 @@ export function makeUIButton(args?: {
       iconName: "flight_takeoff",
       inputs: args?.inputSpecs,
       location: {
-        componentType: "Global",
-        componentID: "nav",
+        componentType: args?.componentID
+          ? ApiButtonType.Resource
+          : ApiButtonType.Global,
+        componentID: args?.componentID ?? UIBUTTON_NAV_COMPONENT_ID,
       },
       requiresConfirmation: args?.requiresConfirmation,
     },

--- a/web/src/ApiButton.testhelpers.tsx
+++ b/web/src/ApiButton.testhelpers.tsx
@@ -1,3 +1,4 @@
+import fetchMock, { MockCall } from "fetch-mock"
 import { ApiButtonType, UIBUTTON_NAV_COMPONENT_ID } from "./ApiButton"
 import { UIButton, UIInputSpec, UIInputStatus } from "./types"
 
@@ -35,7 +36,7 @@ export function hiddenField(name: string, value: string): UIInputSpec {
   }
 }
 
-// TODO: Consider merging this test helper with `oneButton` in `testdata`
+// TODO (lizz): Consider merging this test helper with `oneButton` in `testdata`
 export function makeUIButton(args?: {
   name?: string
   inputSpecs?: UIInputSpec[]
@@ -63,4 +64,31 @@ export function makeUIButton(args?: {
       inputs: args?.inputStatuses,
     },
   }
+}
+
+export function mockUIButtonUpdates() {
+  fetchMock.mock(
+    (url) => url.startsWith("/proxy/apis/tilt.dev/v1alpha1/uibuttons"),
+    JSON.stringify({})
+  )
+}
+
+export function cleanupMockUIButtonUpdates() {
+  fetchMock.reset()
+}
+
+export function getUIButtonDataFromCall(call: MockCall): UIButton | undefined {
+  if (call.length < 2) {
+    return
+  }
+
+  const callRequest = call[1]
+
+  if (!callRequest?.body) {
+    return
+  }
+
+  const buttonData = JSON.parse(String(callRequest?.body))
+
+  return buttonData as UIButton
 }

--- a/web/src/ApiButton.tsx
+++ b/web/src/ApiButton.tsx
@@ -49,7 +49,7 @@ type ApiButtonProps = ButtonProps & {
   uiButton: UIButton
 }
 
-type ApiIconProps = { iconName?: string; iconSVG?: string }
+type ApiIconProps = { iconName?: string; iconSvg?: string }
 
 type ApiButtonInputProps = {
   spec: UIInputSpec
@@ -59,10 +59,14 @@ type ApiButtonInputProps = {
   analyticsTags: Tags
 }
 
-type ApiButtonElementProps = ApiButtonProps & {
+type ApiButtonElementProps = ButtonProps & {
+  text: string
   confirming: boolean
   disabled: boolean
-  tags: Tags
+  iconName?: string
+  iconSvg?: string
+  analyticsTags: Tags
+  analyticsName: string
 }
 
 // UIButtons for a location, sorted into types
@@ -72,11 +76,11 @@ export type ButtonSet = {
 }
 
 export enum ApiButtonType {
-  Nav = "Global",
+  Global = "Global",
   Resource = "Resource",
 }
 
-enum ApiButtonToggleState {
+export enum ApiButtonToggleState {
   On = "on",
   Off = "off",
 }
@@ -84,8 +88,9 @@ enum ApiButtonToggleState {
 // Constants
 export const UIBUTTON_SPEC_HASH = "uibuttonspec-hash"
 export const UIBUTTON_ANNOTATION_TYPE = "tilt.dev/uibutton-type"
+export const UIBUTTON_NAV_COMPONENT_ID = "nav"
 export const UIBUTTON_TOGGLE_DISABLE_TYPE = "DisableToggle"
-const UIBUTTON_TOGGLE_INPUT_NAME = "action"
+export const UIBUTTON_TOGGLE_INPUT_NAME = "action"
 
 // Styles
 const ApiButtonFormRoot = styled.div`
@@ -155,6 +160,12 @@ export const ApiButtonInputsToggleButton = styled(InstrumentedButton)`
     padding: 0 0;
   }
 `
+
+function isDisableToggleButton(b: UIButton) {
+  return (
+    annotations(b)[UIBUTTON_ANNOTATION_TYPE] === UIBUTTON_TOGGLE_DISABLE_TYPE
+  )
+}
 
 const svgElement = (src: string): React.ReactElement => {
   const node = convertFromString(src, {
@@ -243,14 +254,22 @@ type ApiButtonWithOptionsProps = {
   setInputValue: (name: string, value: any) => void
   getInputValue: (name: string) => any | undefined
   className?: string
+  text: string
 }
 
 function ApiButtonWithOptions(props: ApiButtonWithOptionsProps & ButtonProps) {
   const [open, setOpen] = useState(false)
   const anchorRef = useRef(null)
 
-  const { submit, uiButton, setInputValue, getInputValue, ...buttonProps } =
-    props
+  const {
+    submit,
+    uiButton,
+    setInputValue,
+    getInputValue,
+    text,
+    analyticsTags,
+    ...buttonProps
+  } = props
 
   return (
     <>
@@ -267,7 +286,8 @@ function ApiButtonWithOptions(props: ApiButtonWithOptionsProps & ButtonProps) {
             setOpen((prevOpen) => !prevOpen)
           }}
           analyticsName="ui.web.uibutton.inputMenu"
-          aria-label={`Open ${props.uiButton.spec?.text} options`}
+          analyticsTags={analyticsTags}
+          aria-label={`Open ${text} options`}
           {...buttonProps}
         >
           <ArrowDropDownIcon />
@@ -279,7 +299,7 @@ function ApiButtonWithOptions(props: ApiButtonWithOptionsProps & ButtonProps) {
           setOpen(false)
         }}
         anchorEl={anchorRef.current}
-        title={`Options for ${props.uiButton.spec?.text}`}
+        title={`Options for ${text}`}
       >
         <ApiButtonForm {...props} />
       </FloatDialog>
@@ -287,12 +307,12 @@ function ApiButtonWithOptions(props: ApiButtonWithOptionsProps & ButtonProps) {
   )
 }
 
-export const ApiIcon = (props: ApiIconProps) => {
-  if (props.iconSVG) {
+export const ApiIcon = ({ iconName, iconSvg }: ApiIconProps) => {
+  if (iconSvg) {
     // the material SvgIcon handles accessibility/sizing/colors well but can't accept a raw SVG string
     // create a ReactElement by parsing the source and then use that as the component, passing through
     // the props so that it's correctly styled
-    const svgEl = svgElement(props.iconSVG)
+    const svgEl = svgElement(iconSvg)
     const svg = (props: React.PropsWithChildren<any>) => {
       // merge the props from material-ui while keeping the children of the actual SVG
       return React.cloneElement(svgEl, { ...props }, ...svgEl.props.children)
@@ -304,10 +324,10 @@ export const ApiIcon = (props: ApiIconProps) => {
     )
   }
 
-  if (props.iconName) {
+  if (iconName) {
     return (
       <ApiIconRoot>
-        <Icon>{props.iconName}</Icon>
+        <Icon>{iconName}</Icon>
       </ApiIconRoot>
     )
   }
@@ -353,7 +373,7 @@ function buttonStatusWithInputs(
   return result
 }
 
-async function updateButtonStatus(
+export async function updateButtonStatus(
   button: UIButton,
   inputValues: { [name: string]: any }
 ) {
@@ -410,8 +430,15 @@ function getButtonTags(button: UIButton): Tags {
   return tags
 }
 
-function ApiCancelButton(props: ApiButtonElementProps) {
-  const { confirming, onClick, tags, uiButton, ...buttonProps } = props
+export function ApiCancelButton(props: ApiButtonElementProps) {
+  const {
+    confirming,
+    onClick,
+    analyticsTags,
+    text,
+    analyticsName,
+    ...buttonProps
+  } = props
 
   // Don't display the cancel confirmation button if the button
   // group's state isn't confirming
@@ -419,7 +446,6 @@ function ApiCancelButton(props: ApiButtonElementProps) {
     return null
   }
 
-  const buttonDisplayText: string = uiButton.spec?.text ?? "Button"
   // To pass classes to a MUI component, it's necessary to use `classes`, instead of `className`
   const classes: Partial<ClassNameMap<ButtonClassKey>> = {
     root: "confirming rightButtonInGroup",
@@ -427,9 +453,9 @@ function ApiCancelButton(props: ApiButtonElementProps) {
 
   return (
     <ApiButtonElementRoot
-      analyticsName={"ui.web.uibutton"}
-      aria-label={`Cancel ${buttonDisplayText}`}
-      analyticsTags={{ confirm: "false", ...tags }}
+      analyticsName={analyticsName}
+      aria-label={`Cancel ${text}`}
+      analyticsTags={{ confirm: "false", ...analyticsTags }}
       classes={classes}
       onClick={onClick}
       {...buttonProps}
@@ -440,11 +466,12 @@ function ApiCancelButton(props: ApiButtonElementProps) {
 }
 
 // The inner content of an ApiSubmitButton
-function ApiSubmitButtonContent(
+export function ApiSubmitButtonContent(
   props: PropsWithChildren<{
     confirming: boolean
-    uiButton: UIButton
     displayButtonText: string
+    iconName?: string
+    iconSvg?: string
   }>
 ) {
   if (props.confirming) {
@@ -457,10 +484,7 @@ function ApiSubmitButtonContent(
 
   return (
     <>
-      <ApiIcon
-        iconName={props.uiButton.spec?.iconName}
-        iconSVG={props.uiButton.spec?.iconSVG}
-      />
+      <ApiIcon iconName={props.iconName} iconSvg={props.iconSvg} />
       <ApiButtonLabel>{props.displayButtonText}</ApiButtonLabel>
     </>
   )
@@ -475,18 +499,26 @@ function ApiSubmitButtonContent(
 // using assistive tech like screenreaders will know they need to confirm.
 // (Screenreaders should announce the "confirm submit" button to users because
 // the `aria-label` changes when the "submit" button is clicked.)
-function ApiSubmitButton(props: PropsWithChildren<ApiButtonElementProps>) {
-  const { confirming, disabled, onClick, tags, uiButton, ...buttonProps } =
-    props
+export function ApiSubmitButton(
+  props: PropsWithChildren<ApiButtonElementProps>
+) {
+  const {
+    analyticsName,
+    analyticsTags,
+    confirming,
+    disabled,
+    onClick,
+    iconName,
+    iconSvg,
+    text,
+    ...buttonProps
+  } = props
 
   // Determine display text and accessible button label based on confirmation state
-  const buttonText = uiButton.spec?.text || "Button"
-  const displayButtonText = confirming ? "Confirm" : buttonText
-  const ariaLabel = confirming
-    ? `Confirm ${buttonText}`
-    : `Trigger ${buttonText}`
+  const displayButtonText = confirming ? "Confirm" : text
+  const ariaLabel = confirming ? `Confirm ${text}` : `Trigger ${Text}`
 
-  const analyticsTags = { ...tags }
+  const tags = { ...analyticsTags }
   if (confirming) {
     analyticsTags.confirm = "true"
   }
@@ -500,8 +532,8 @@ function ApiSubmitButton(props: PropsWithChildren<ApiButtonElementProps>) {
   // Note: button text is not included in analytics name since that can be user data
   return (
     <ApiButtonElementRoot
-      analyticsName={"ui.web.uibutton"}
-      analyticsTags={analyticsTags}
+      analyticsName={analyticsName}
+      analyticsTags={tags}
       aria-label={ariaLabel}
       classes={classes}
       disabled={disabled}
@@ -511,7 +543,8 @@ function ApiSubmitButton(props: PropsWithChildren<ApiButtonElementProps>) {
       <ApiSubmitButtonContent
         confirming={confirming}
         displayButtonText={displayButtonText}
-        uiButton={uiButton}
+        iconName={iconName}
+        iconSvg={iconSvg}
       >
         {props.children}
       </ApiSubmitButtonContent>
@@ -545,6 +578,7 @@ export function ApiButton(props: PropsWithChildren<ApiButtonProps>) {
   const tags = useMemo(() => getButtonTags(uiButton), [uiButton])
   const componentType = uiButton.spec?.location?.componentType as ApiButtonType
   const disabled = loading || uiButton.spec?.disabled || false
+  const buttonText = uiButton.spec?.text || "Button"
 
   const onClick = async () => {
     if (uiButton.spec?.requiresConfirmation && !confirming) {
@@ -571,7 +605,7 @@ export function ApiButton(props: PropsWithChildren<ApiButtonProps>) {
     }
 
     const snackbarLogsLink =
-      componentType === ApiButtonType.Nav ? (
+      componentType === ApiButtonType.Global ? (
         <LogLink to="/r/(all)/overview">Global Logs</LogLink>
       ) : (
         <LogLink
@@ -592,18 +626,23 @@ export function ApiButton(props: PropsWithChildren<ApiButtonProps>) {
 
   const submitButton = (
     <ApiSubmitButton
+      text={buttonText}
       confirming={confirming}
       disabled={disabled}
+      iconName={uiButton.spec?.iconName}
+      iconSvg={uiButton.spec?.iconSVG}
       onClick={onClick}
-      tags={tags}
-      {...props}
+      analyticsName="ui.web.uibutton"
+      analyticsTags={tags}
+      {...buttonProps}
     >
       {props.children}
     </ApiSubmitButton>
   )
 
   // show the options button if there are any non-hidden inputs
-  if (uiButton.spec?.inputs?.filter((i) => !i.hidden)?.length) {
+  const visibleInputs = uiButton.spec?.inputs?.filter((i) => !i.hidden) || []
+  if (visibleInputs.length) {
     const setInputValue = (name: string, value: any) => {
       // Copy to a new object so that the reference changes to force a rerender.
       setInputValues({ ...inputValues, [name]: value })
@@ -617,13 +656,14 @@ export function ApiButton(props: PropsWithChildren<ApiButtonProps>) {
         uiButton={uiButton}
         setInputValue={setInputValue}
         getInputValue={getInputValue}
-        aria-label={uiButton.spec?.text}
+        aria-label={buttonText}
         analyticsTags={tags}
         // use-case-wise, it'd probably be better to leave the options button enabled
         // regardless of the submit button's state.
         // However, that's currently a low-impact difference, and this is a really
         // cheap way to ensure the styling matches.
         disabled={disabled}
+        text={buttonText}
         {...buttonProps}
       />
     )
@@ -632,16 +672,17 @@ export function ApiButton(props: PropsWithChildren<ApiButtonProps>) {
       <ApiButtonRoot
         className={className}
         disableRipple={true}
-        aria-label={uiButton.spec?.text}
+        aria-label={buttonText}
         disabled={disabled}
       >
         {submitButton}
         <ApiCancelButton
+          analyticsName="ui.web.uibutton"
+          analyticsTags={tags}
+          text={buttonText}
           confirming={confirming}
           disabled={disabled}
           onClick={() => setConfirming(false)}
-          tags={tags}
-          uiButton={uiButton}
           {...buttonProps}
         />
       </ApiButtonRoot>
@@ -651,7 +692,7 @@ export function ApiButton(props: PropsWithChildren<ApiButtonProps>) {
 
 export function buttonsForComponent(
   buttons: UIButton[] | undefined,
-  componentType: string,
+  componentType: ApiButtonType,
   componentID: string | undefined
 ): ButtonSet {
   let result: ButtonSet = {
@@ -662,15 +703,16 @@ export function buttonsForComponent(
   }
 
   buttons.forEach((b) => {
-    if (
-      b.spec?.location?.componentType?.toUpperCase() ===
-        componentType.toUpperCase() &&
-      b.spec?.location?.componentID === componentID
-    ) {
-      if (
-        annotations(b)[UIBUTTON_ANNOTATION_TYPE] ===
-        UIBUTTON_TOGGLE_DISABLE_TYPE
-      ) {
+    const buttonType = b.spec?.location?.componentType || ""
+    const buttonID = b.spec?.location?.componentID || ""
+
+    const buttonTypesMatch =
+      buttonType.toUpperCase() === componentType.toUpperCase()
+    const buttonIDsMatch = buttonID === componentID
+
+    if (buttonTypesMatch && buttonIDsMatch) {
+      // Group the disable toggle buttons in their own category
+      if (isDisableToggleButton(b)) {
         result.toggleDisable = b
       } else {
         result.default.push(b)
@@ -679,4 +721,36 @@ export function buttonsForComponent(
   })
 
   return result
+}
+
+// TODO: i'll def want to write tests for this
+// also consider implementing this as a potential optimization in table view
+export function buttonsByComponent(buttons: UIButton[] | undefined) {
+  const buttonsByComponent: { [key: string]: ButtonSet } = {}
+
+  if (buttons === undefined) {
+    return buttonsByComponent
+  }
+
+  buttons.forEach((b) => {
+    const buttonID = b.spec?.location?.componentID || ""
+
+    // Disregard any buttons that aren't linked to a specific component or resource
+    if (!buttonID.length) {
+      return
+    }
+
+    if (!buttonsByComponent.hasOwnProperty(buttonID)) {
+      buttonsByComponent[buttonID] = { default: [] }
+    }
+
+    const buttonSet = buttonsByComponent[buttonID]
+    if (isDisableToggleButton(b)) {
+      buttonSet.toggleDisable = b
+    } else {
+      buttonSet.default.push(b)
+    }
+  })
+
+  return buttonsByComponent
 }

--- a/web/src/ApiButton.tsx
+++ b/web/src/ApiButton.tsx
@@ -731,8 +731,6 @@ export function buttonsForComponent(
   return result
 }
 
-// TODO: i'll def want to write tests for this
-// also consider implementing this as a potential optimization in table view
 export function buttonsByComponent(buttons: UIButton[] | undefined) {
   const buttonsByComponent: { [key: string]: ButtonSet } = {}
 

--- a/web/src/ApiButton.tsx
+++ b/web/src/ApiButton.tsx
@@ -49,7 +49,7 @@ type ApiButtonProps = ButtonProps & {
   uiButton: UIButton
 }
 
-type ApiIconProps = { iconName?: string; iconSvg?: string }
+type ApiIconProps = { iconName?: string; iconSVG?: string }
 
 type ApiButtonInputProps = {
   spec: UIInputSpec
@@ -64,7 +64,7 @@ type ApiButtonElementProps = ButtonProps & {
   confirming: boolean
   disabled: boolean
   iconName?: string
-  iconSvg?: string
+  iconSVG?: string
   analyticsTags: Tags
   analyticsName: string
 }
@@ -315,12 +315,12 @@ function ApiButtonWithOptions(props: ApiButtonWithOptionsProps & ButtonProps) {
   )
 }
 
-export const ApiIcon = ({ iconName, iconSvg }: ApiIconProps) => {
-  if (iconSvg) {
+export const ApiIcon = ({ iconName, iconSVG }: ApiIconProps) => {
+  if (iconSVG) {
     // the material SvgIcon handles accessibility/sizing/colors well but can't accept a raw SVG string
     // create a ReactElement by parsing the source and then use that as the component, passing through
     // the props so that it's correctly styled
-    const svgEl = svgElement(iconSvg)
+    const svgEl = svgElement(iconSVG)
     const svg = (props: React.PropsWithChildren<any>) => {
       // merge the props from material-ui while keeping the children of the actual SVG
       return React.cloneElement(svgEl, { ...props }, ...svgEl.props.children)
@@ -479,7 +479,7 @@ export function ApiSubmitButtonContent(
     confirming: boolean
     displayButtonText: string
     iconName?: string
-    iconSvg?: string
+    iconSVG?: string
   }>
 ) {
   if (props.confirming) {
@@ -492,7 +492,7 @@ export function ApiSubmitButtonContent(
 
   return (
     <>
-      <ApiIcon iconName={props.iconName} iconSvg={props.iconSvg} />
+      <ApiIcon iconName={props.iconName} iconSVG={props.iconSVG} />
       <ApiButtonLabel>{props.displayButtonText}</ApiButtonLabel>
     </>
   )
@@ -517,7 +517,7 @@ export function ApiSubmitButton(
     disabled,
     onClick,
     iconName,
-    iconSvg,
+    iconSVG,
     text,
     ...buttonProps
   } = props
@@ -552,7 +552,7 @@ export function ApiSubmitButton(
         confirming={confirming}
         displayButtonText={displayButtonText}
         iconName={iconName}
-        iconSvg={iconSvg}
+        iconSVG={iconSVG}
       >
         {props.children}
       </ApiSubmitButtonContent>
@@ -638,7 +638,7 @@ export function ApiButton(props: PropsWithChildren<ApiButtonProps>) {
       confirming={confirming}
       disabled={disabled}
       iconName={uiButton.spec?.iconName}
-      iconSvg={uiButton.spec?.iconSVG}
+      iconSVG={uiButton.spec?.iconSVG}
       onClick={onClick}
       analyticsName="ui.web.uibutton"
       analyticsTags={tags}

--- a/web/src/ApiButton.tsx
+++ b/web/src/ApiButton.tsx
@@ -121,37 +121,45 @@ export const LogLink = styled(Link)`
   padding-left: ${SizeUnit(0.5)};
 `
 
-const ApiButtonElementRoot = styled(InstrumentedButton)`
-  &.confirming {
+export const confirmingButtonStateMixin = `
+&.confirming {
+  background-color: ${Color.red};
+  border-color: ${Color.gray};
+  color: ${Color.black};
+
+  &:hover,
+  &:active,
+  &:focus {
     background-color: ${Color.red};
-    border-color: ${Color.gray};
+    border-color: ${Color.redLight};
     color: ${Color.black};
-
-    &:hover,
-    &:active,
-    &:focus {
-      background-color: ${Color.red};
-      border-color: ${Color.redLight};
-      color: ${Color.black};
-    }
-
-    .fillStd {
-      fill: ${Color.black} !important; /* TODO (lizz): find this style source! */
-    }
   }
 
-  /* Manually manage the border that both left and right
-     buttons share on the edge between them, so border
-     color changes work as expected */
-  &.leftButtonInGroup {
-    border-right: 0;
-
-    &:active + .rightButtonInGroup,
-    &:focus + .rightButtonInGroup,
-    &:hover + .rightButtonInGroup {
-      border-left-color: ${Color.redLight};
-    }
+  .fillStd {
+    fill: ${Color.black} !important; /* TODO (lizz): find this style source! */
   }
+}
+`
+
+/* Manually manage the border that both left and right
+ * buttons share on the edge between them, so border
+ * color changes work as expected
+ */
+export const confirmingButtonGroupBorderMixin = `
+&.leftButtonInGroup {
+  border-right: 0;
+
+  &:active + .rightButtonInGroup,
+  &:focus + .rightButtonInGroup,
+  &:hover + .rightButtonInGroup {
+    border-left-color: ${Color.redLight};
+  }
+}
+`
+
+const ApiButtonElementRoot = styled(InstrumentedButton)`
+  ${confirmingButtonStateMixin}
+  ${confirmingButtonGroupBorderMixin}
 `
 
 export const ApiButtonInputsToggleButton = styled(InstrumentedButton)`
@@ -516,11 +524,11 @@ export function ApiSubmitButton(
 
   // Determine display text and accessible button label based on confirmation state
   const displayButtonText = confirming ? "Confirm" : text
-  const ariaLabel = confirming ? `Confirm ${text}` : `Trigger ${Text}`
+  const ariaLabel = confirming ? `Confirm ${text}` : `Trigger ${text}`
 
   const tags = { ...analyticsTags }
   if (confirming) {
-    analyticsTags.confirm = "true"
+    tags.confirm = "true"
   }
 
   // To pass classes to a MUI component, it's necessary to use `classes`, instead of `className`

--- a/web/src/ApiButton.tsx
+++ b/web/src/ApiButton.tsx
@@ -88,7 +88,7 @@ export enum ApiButtonToggleState {
 // Constants
 export const UIBUTTON_SPEC_HASH = "uibuttonspec-hash"
 export const UIBUTTON_ANNOTATION_TYPE = "tilt.dev/uibutton-type"
-export const UIBUTTON_NAV_COMPONENT_ID = "nav"
+export const UIBUTTON_GLOBAL_COMPONENT_ID = "nav"
 export const UIBUTTON_TOGGLE_DISABLE_TYPE = "DisableToggle"
 export const UIBUTTON_TOGGLE_INPUT_NAME = "action"
 

--- a/web/src/BulkApiButton.test.tsx
+++ b/web/src/BulkApiButton.test.tsx
@@ -1,57 +1,341 @@
-import { ApiButtonToggleState } from "./ApiButton"
-import { canBulkButtonBeToggled, canButtonBeToggled } from "./BulkApiButton"
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { AnalyticsAction, AnalyticsType } from "./analytics"
+import {
+  cleanupMockAnalyticsCalls,
+  expectIncrs,
+  mockAnalyticsCalls,
+  nonAnalyticsCalls,
+} from "./analytics_test_helpers"
+import { ApiButtonToggleState, ApiButtonType } from "./ApiButton"
+import {
+  getUIButtonDataFromCall,
+  mockUIButtonUpdates,
+} from "./ApiButton.testhelpers"
+import {
+  BulkApiButton,
+  canBulkButtonBeToggled,
+  canButtonBeToggled,
+} from "./BulkApiButton"
+import { BulkAction } from "./OverviewTableBulkActions"
+import { flushPromises } from "./promise"
 import { disableButton, oneButton } from "./testdata"
 
 const NON_TOGGLE_BUTTON = oneButton(0, "database")
-const DISABLE_BUTTON = disableButton("frontend", true)
-const ENABLE_BUTTON = disableButton("backend", false)
+const DISABLE_BUTTON_DB = disableButton("database", true)
+const DISABLE_BUTTON_FRONTEND = disableButton("frontend", true)
+const ENABLE_BUTTON_BACKEND = disableButton("backend", false)
+const TEST_UIBUTTONS = [
+  DISABLE_BUTTON_DB,
+  DISABLE_BUTTON_FRONTEND,
+  ENABLE_BUTTON_BACKEND,
+]
 
 describe("BulkApiButton", () => {
-  describe("canButtonBeToggled", () => {
-    it("returns true when there is no target toggle state", () => {
-      expect(canButtonBeToggled(DISABLE_BUTTON)).toBe(true)
+  beforeEach(() => {
+    mockAnalyticsCalls()
+    mockUIButtonUpdates()
+  })
+
+  afterEach(() => {
+    cleanupMockAnalyticsCalls()
+  })
+
+  it("is disabled when there are no UIButtons", () => {
+    render(
+      <BulkApiButton
+        bulkAction={BulkAction.Disable}
+        buttonText="I cannot be clicked"
+        requiresConfirmation={false}
+        uiButtons={[]}
+      />
+    )
+
+    const bulkButton = screen.getByLabelText("Trigger I cannot be clicked")
+
+    expect(bulkButton).toBeTruthy()
+    expect((bulkButton as HTMLButtonElement).disabled).toBe(true)
+  })
+
+  it("is disabled when there are no UIButtons that can be toggled to the target toggle state", () => {
+    render(
+      <BulkApiButton
+        bulkAction={BulkAction.Disable}
+        buttonText="I cannot be toggled that way"
+        requiresConfirmation={false}
+        targetToggleState={ApiButtonToggleState.On}
+        uiButtons={[DISABLE_BUTTON_DB]}
+      />
+    )
+
+    const bulkButton = screen.getByLabelText(
+      "Trigger I cannot be toggled that way"
+    )
+
+    expect(bulkButton).toBeTruthy()
+    expect((bulkButton as HTMLButtonElement).disabled).toBe(true)
+  })
+
+  it("is enabled when there are UIButtons", () => {
+    render(
+      <BulkApiButton
+        bulkAction={BulkAction.Disable}
+        buttonText="Run lint"
+        requiresConfirmation={false}
+        uiButtons={[NON_TOGGLE_BUTTON]}
+      />
+    )
+
+    const bulkButton = screen.getByLabelText("Trigger Run lint")
+
+    expect(bulkButton).toBeTruthy()
+    expect((bulkButton as HTMLButtonElement).disabled).toBe(false)
+  })
+
+  it("is enabled when there are UIButtons that can be toggled to the target toggle state", () => {
+    render(
+      <BulkApiButton
+        bulkAction={BulkAction.Disable}
+        buttonText="Enable resources"
+        requiresConfirmation={false}
+        targetToggleState={ApiButtonToggleState.On}
+        uiButtons={[DISABLE_BUTTON_DB, ENABLE_BUTTON_BACKEND]}
+      />
+    )
+
+    const bulkButton = screen.getByLabelText("Trigger Enable resources")
+
+    expect(bulkButton).toBeTruthy()
+    expect((bulkButton as HTMLButtonElement).disabled).toBe(false)
+  })
+
+  describe("when it's clicked", () => {
+    let mockCallback: jest.Mock
+
+    beforeEach(async () => {
+      mockCallback = jest.fn()
+      render(
+        <BulkApiButton
+          bulkAction={BulkAction.Disable}
+          buttonText="Turn everything off"
+          onClickCallback={mockCallback}
+          requiresConfirmation={false}
+          targetToggleState={ApiButtonToggleState.Off}
+          uiButtons={TEST_UIBUTTONS}
+        />
+      )
+
+      const bulkButton = screen.getByLabelText("Trigger Turn everything off")
+      userEvent.click(bulkButton)
+
+      // Wait for the async calls to complete
+      await waitFor(flushPromises)
     })
 
-    it("returns false when button is not a toggle button", () => {
-      expect(canButtonBeToggled(NON_TOGGLE_BUTTON)).toBe(false)
+    it("triggers all buttons that can be toggled when it's clicked", () => {
+      const buttonUpdateCalls = nonAnalyticsCalls()
+
+      // Out of the three test buttons, only two of them can be toggled to the target toggle state
+      expect(buttonUpdateCalls.length).toBe(2)
+
+      const buttonUpdateNames = buttonUpdateCalls.map(
+        (call) => getUIButtonDataFromCall(call)?.metadata?.name
+      )
+
+      expect(buttonUpdateNames).toStrictEqual([
+        DISABLE_BUTTON_DB.metadata?.name,
+        DISABLE_BUTTON_FRONTEND.metadata?.name,
+      ])
     })
 
-    it("returns false when button is already in the target toggle state", () => {
-      expect(canButtonBeToggled(DISABLE_BUTTON, ApiButtonToggleState.On)).toBe(
-        false
+    it("generates the correct analytics payload", () => {
+      expectIncrs({
+        name: "ui.web.bulkButton",
+        tags: {
+          action: AnalyticsAction.Click,
+          bulkAction: BulkAction.Disable,
+          bulkCount: "3",
+          toggleValue: ApiButtonToggleState.On,
+          component: ApiButtonType.Global,
+          type: AnalyticsType.Grid,
+        },
+      })
+    })
+
+    it("calls a specified onClick callback", () => {
+      expect(mockCallback).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe("when it requires confirmation", () => {
+    beforeEach(async () => {
+      render(
+        <BulkApiButton
+          bulkAction={BulkAction.Disable}
+          buttonText="Click everything when I'm sure"
+          requiresConfirmation={true}
+          uiButtons={TEST_UIBUTTONS}
+        />
       )
-      expect(canButtonBeToggled(ENABLE_BUTTON, ApiButtonToggleState.Off)).toBe(
-        false
+
+      const bulkButton = screen.getByLabelText(
+        "Trigger Click everything when I'm sure"
+      )
+      userEvent.click(bulkButton)
+    })
+
+    it("displays confirm and cancel buttons when clicked once", () => {
+      expect(
+        screen.getByLabelText("Confirm Click everything when I'm sure")
+      ).toBeTruthy()
+      expect(
+        screen.getByLabelText("Cancel Click everything when I'm sure")
+      ).toBeTruthy()
+    })
+
+    it("triggers all buttons when `Confirm` is clicked", async () => {
+      userEvent.click(
+        screen.getByLabelText("Confirm Click everything when I'm sure")
+      )
+
+      await waitFor(flushPromises)
+
+      const buttonUpdateCalls = nonAnalyticsCalls()
+      expect(buttonUpdateCalls.length).toBe(3)
+
+      const buttonUpdateNames = buttonUpdateCalls.map(
+        (call) => getUIButtonDataFromCall(call)?.metadata?.name
+      )
+
+      expect(buttonUpdateNames).toStrictEqual([
+        DISABLE_BUTTON_DB.metadata?.name,
+        DISABLE_BUTTON_FRONTEND.metadata?.name,
+        ENABLE_BUTTON_BACKEND.metadata?.name,
+      ])
+    })
+
+    it("does NOT trigger any buttons when `Cancel` is clicked", async () => {
+      userEvent.click(
+        screen.getByLabelText("Cancel Click everything when I'm sure")
+      )
+
+      // There shouldn't be any async calls made when canceling, but wait in case
+      await waitFor(flushPromises)
+
+      expect(
+        screen.getByLabelText("Trigger Click everything when I'm sure")
+      ).toBeTruthy()
+    })
+
+    it("generates the correct analytics payload for confirmation", async () => {
+      userEvent.click(
+        screen.getByLabelText("Confirm Click everything when I'm sure")
+      )
+      await waitFor(flushPromises)
+
+      expectIncrs(
+        {
+          name: "ui.web.bulkButton",
+          tags: {
+            action: AnalyticsAction.Click,
+            bulkAction: BulkAction.Disable,
+            bulkCount: "3",
+            component: ApiButtonType.Global,
+            type: AnalyticsType.Grid,
+          },
+        },
+        {
+          name: "ui.web.bulkButton",
+          tags: {
+            action: AnalyticsAction.Click,
+            bulkAction: BulkAction.Disable,
+            bulkCount: "3",
+            confirm: "true",
+            component: ApiButtonType.Global,
+            type: AnalyticsType.Grid,
+          },
+        }
       )
     })
 
-    it("returns true when button is not in the target toggle state", () => {
-      expect(canButtonBeToggled(DISABLE_BUTTON, ApiButtonToggleState.Off)).toBe(
-        true
+    it("generates the correct analytics payload for cancelation", () => {
+      userEvent.click(
+        screen.getByLabelText("Cancel Click everything when I'm sure")
       )
-      expect(canButtonBeToggled(ENABLE_BUTTON, ApiButtonToggleState.On)).toBe(
-        true
+
+      expectIncrs(
+        {
+          name: "ui.web.bulkButton",
+          tags: {
+            action: AnalyticsAction.Click,
+            bulkAction: BulkAction.Disable,
+            bulkCount: "3",
+            component: ApiButtonType.Global,
+            type: AnalyticsType.Grid,
+          },
+        },
+        {
+          name: "ui.web.bulkButton",
+          tags: {
+            action: AnalyticsAction.Click,
+            bulkAction: BulkAction.Disable,
+            bulkCount: "3",
+            confirm: "false",
+            component: ApiButtonType.Global,
+            type: AnalyticsType.Grid,
+          },
+        }
       )
     })
   })
 
-  describe("canBulkButtonBeToggled", () => {
-    it("returns false if no buttons in the list of buttons can be toggled", () => {
-      expect(
-        canBulkButtonBeToggled(
-          [NON_TOGGLE_BUTTON, DISABLE_BUTTON],
-          ApiButtonToggleState.On
-        )
-      ).toBe(false)
+  describe("helpers", () => {
+    describe("canButtonBeToggled", () => {
+      it("returns true when there is no target toggle state", () => {
+        expect(canButtonBeToggled(DISABLE_BUTTON_FRONTEND)).toBe(true)
+      })
+
+      it("returns false when button is not a toggle button", () => {
+        expect(canButtonBeToggled(NON_TOGGLE_BUTTON)).toBe(false)
+      })
+
+      it("returns false when button is already in the target toggle state", () => {
+        expect(
+          canButtonBeToggled(DISABLE_BUTTON_FRONTEND, ApiButtonToggleState.On)
+        ).toBe(false)
+        expect(
+          canButtonBeToggled(ENABLE_BUTTON_BACKEND, ApiButtonToggleState.Off)
+        ).toBe(false)
+      })
+
+      it("returns true when button is not in the target toggle state", () => {
+        expect(
+          canButtonBeToggled(DISABLE_BUTTON_FRONTEND, ApiButtonToggleState.Off)
+        ).toBe(true)
+        expect(
+          canButtonBeToggled(ENABLE_BUTTON_BACKEND, ApiButtonToggleState.On)
+        ).toBe(true)
+      })
     })
 
-    it("returns true if at least one button in the list of buttons can be toggled", () => {
-      expect(
-        canBulkButtonBeToggled(
-          [NON_TOGGLE_BUTTON, DISABLE_BUTTON, ENABLE_BUTTON],
-          ApiButtonToggleState.On
-        )
-      ).toBe(true)
+    describe("canBulkButtonBeToggled", () => {
+      it("returns false if no buttons in the list of buttons can be toggled", () => {
+        expect(
+          canBulkButtonBeToggled(
+            [NON_TOGGLE_BUTTON, DISABLE_BUTTON_FRONTEND],
+            ApiButtonToggleState.On
+          )
+        ).toBe(false)
+      })
+
+      it("returns true if at least one button in the list of buttons can be toggled", () => {
+        expect(
+          canBulkButtonBeToggled(
+            [NON_TOGGLE_BUTTON, DISABLE_BUTTON_FRONTEND, ENABLE_BUTTON_BACKEND],
+            ApiButtonToggleState.On
+          )
+        ).toBe(true)
+      })
     })
   })
 })

--- a/web/src/BulkApiButton.test.tsx
+++ b/web/src/BulkApiButton.test.tsx
@@ -1,0 +1,57 @@
+import { ApiButtonToggleState } from "./ApiButton"
+import { canBulkButtonBeToggled, canButtonBeToggled } from "./BulkApiButton"
+import { disableButton, oneButton } from "./testdata"
+
+const NON_TOGGLE_BUTTON = oneButton(0, "database")
+const DISABLE_BUTTON = disableButton("frontend", true)
+const ENABLE_BUTTON = disableButton("backend", false)
+
+describe("BulkApiButton", () => {
+  describe("canButtonBeToggled", () => {
+    it("returns true when there is no target toggle state", () => {
+      expect(canButtonBeToggled(DISABLE_BUTTON)).toBe(true)
+    })
+
+    it("returns false when button is not a toggle button", () => {
+      expect(canButtonBeToggled(NON_TOGGLE_BUTTON)).toBe(false)
+    })
+
+    it("returns false when button is already in the target toggle state", () => {
+      expect(canButtonBeToggled(DISABLE_BUTTON, ApiButtonToggleState.On)).toBe(
+        false
+      )
+      expect(canButtonBeToggled(ENABLE_BUTTON, ApiButtonToggleState.Off)).toBe(
+        false
+      )
+    })
+
+    it("returns true when button is not in the target toggle state", () => {
+      expect(canButtonBeToggled(DISABLE_BUTTON, ApiButtonToggleState.Off)).toBe(
+        true
+      )
+      expect(canButtonBeToggled(ENABLE_BUTTON, ApiButtonToggleState.On)).toBe(
+        true
+      )
+    })
+  })
+
+  describe("canBulkButtonBeToggled", () => {
+    it("returns false if no buttons in the list of buttons can be toggled", () => {
+      expect(
+        canBulkButtonBeToggled(
+          [NON_TOGGLE_BUTTON, DISABLE_BUTTON],
+          ApiButtonToggleState.On
+        )
+      ).toBe(false)
+    })
+
+    it("returns true if at least one button in the list of buttons can be toggled", () => {
+      expect(
+        canBulkButtonBeToggled(
+          [NON_TOGGLE_BUTTON, DISABLE_BUTTON, ENABLE_BUTTON],
+          ApiButtonToggleState.On
+        )
+      ).toBe(true)
+    })
+  })
+})

--- a/web/src/BulkApiButton.tsx
+++ b/web/src/BulkApiButton.tsx
@@ -1,0 +1,190 @@
+import { ButtonProps } from "@material-ui/core"
+import React, { useState } from "react"
+import {
+  ApiButtonRoot,
+  ApiButtonToggleState,
+  ApiCancelButton,
+  ApiSubmitButton,
+  UIBUTTON_TOGGLE_INPUT_NAME,
+  updateButtonStatus,
+} from "./ApiButton"
+import { useHudErrorContext } from "./HudErrorContext"
+import { BulkAction } from "./OverviewTableBulkActions"
+import { UIButton } from "./types"
+
+/**
+ * TODO: Add a note here about:
+ * - Forking the ApiButton code
+ * - Possibilities for future refactoring (possible that other bulk actions may not be `UIButton`s)
+ */
+
+// Types
+
+type BulkApiButtonProps = ButtonProps & {
+  bulkAction: BulkAction
+  buttonText: string
+  className?: string
+  onClickCallback?: () => void
+  requiresConfirmation: boolean
+  targetToggleState?: ApiButtonToggleState
+  uiButtons: UIButton[]
+}
+
+// Styles
+
+// Helpers
+function canButtonBeToggled(
+  uiButton: UIButton,
+  targetToggleState?: ApiButtonToggleState
+) {
+  if (!targetToggleState) {
+    return true
+  }
+
+  const toggleInput = uiButton.spec?.inputs?.find(
+    (input) => input.name === UIBUTTON_TOGGLE_INPUT_NAME
+  )
+
+  if (!toggleInput) {
+    return false
+  }
+
+  const toggleValue = toggleInput.hidden?.value
+
+  // A button can be toggled if it's state doesn't match the target state
+  return toggleValue !== undefined && toggleValue !== targetToggleState
+}
+
+// A bulk button can be toggled if some buttons have values that don't match the target toggle state
+// ex: all buttons are not toggle buttons => bulk button cannot be toggled
+// ex: all buttons are on and target toggle is on => bulk button cannot be toggled
+// ex: some buttons are off and target toggle is on => bulk button can be toggled
+function canBulkButtonBeToggled(
+  uiButtons: UIButton[],
+  targetToggleState: ApiButtonToggleState
+) {
+  const individualButtonsCanBeToggled = uiButtons.map((b) =>
+    canButtonBeToggled(b, targetToggleState)
+  )
+
+  return individualButtonsCanBeToggled.some(
+    (canBeToggled) => canBeToggled === true
+  )
+}
+
+// TODO: Add unit tests for this...
+// Or possibly re-write if it's too confusing
+function isBulkButtonDisabled(
+  uiButtons: UIButton[],
+  targetToggleState?: ApiButtonToggleState
+) {
+  // Bulk button is disabled if there are no UIButtons to trigger
+  if (uiButtons.length === 0) {
+    return true
+  }
+
+  // If there's a target toggle state, calculate whether the bulk button
+  // is disabled based on the toggle values of all UIButtons
+  if (targetToggleState) {
+    const isDisabled = !canBulkButtonBeToggled(uiButtons, targetToggleState)
+    return isDisabled
+  }
+
+  return false
+}
+
+async function bulkUpdateButtonStatus(uiButtons: UIButton[]) {
+  const buttonClicks: Promise<void>[] = uiButtons.map((button) =>
+    updateButtonStatus(button, {})
+  )
+
+  try {
+    await Promise.all(buttonClicks)
+  } catch (err) {
+    throw err
+  }
+}
+
+export function BulkApiButton(props: BulkApiButtonProps) {
+  const {
+    bulkAction,
+    buttonText,
+    className,
+    targetToggleState,
+    requiresConfirmation,
+    onClickCallback,
+    uiButtons,
+    ...buttonProps
+  } = props
+
+  const { setError } = useHudErrorContext()
+
+  const [loading, setLoading] = useState(false)
+  const [confirming, setConfirming] = useState(false)
+
+  // TODO: Create analytics tags
+
+  const bulkActionDisabled = isBulkButtonDisabled(uiButtons, targetToggleState)
+
+  const disabled = loading || bulkActionDisabled || false
+
+  const onClick = async () => {
+    if (requiresConfirmation && !confirming) {
+      setConfirming(true)
+      return
+    }
+
+    if (confirming) {
+      setConfirming(false)
+    }
+
+    setLoading(true)
+
+    try {
+      // If there's a target toggle state, filter out buttons that
+      // already have that toggle state. If they're not filtered out
+      // updating them will toggle them to a non-target state.
+      const buttonsToUpdate = uiButtons.filter((button) =>
+        canButtonBeToggled(button, targetToggleState)
+      )
+      await bulkUpdateButtonStatus(buttonsToUpdate)
+    } catch (err) {
+      setError(`Error submitting button click: ${err}`)
+      return
+    } finally {
+      if (onClickCallback) {
+        onClickCallback()
+      }
+
+      setLoading(false)
+    }
+  }
+
+  return (
+    <ApiButtonRoot
+      className={className}
+      disableRipple={true}
+      aria-label={buttonText}
+      disabled={disabled}
+    >
+      <ApiSubmitButton
+        analyticsName="ui.web.bulkButton"
+        analyticsTags={{}}
+        confirming={confirming}
+        disabled={disabled}
+        onClick={onClick}
+        text={buttonText}
+        {...buttonProps}
+      ></ApiSubmitButton>
+      <ApiCancelButton
+        analyticsName="ui.web.bulkButton"
+        analyticsTags={{}}
+        confirming={confirming}
+        disabled={disabled}
+        onClick={() => setConfirming(false)}
+        text={buttonText}
+        {...buttonProps}
+      />
+    </ApiButtonRoot>
+  )
+}

--- a/web/src/BulkApiButton.tsx
+++ b/web/src/BulkApiButton.tsx
@@ -175,9 +175,7 @@ function isBulkButtonDisabled(
 async function bulkUpdateButtonStatus(uiButtons: UIButton[]) {
   try {
     await Promise.all(uiButtons.map((button) => updateButtonStatus(button, {})))
-    // console.log("all requests have finished")
   } catch (err) {
-    // console.log("yikes, there's been an error")
     throw err
   }
 }
@@ -291,7 +289,7 @@ export function BulkApiButton(props: BulkApiButtonProps) {
 
   const bulkActionDisabled = isBulkButtonDisabled(uiButtons, targetToggleState)
   const disabled = loading || bulkActionDisabled || false
-  const buttonGroupClassName = `${className} ${
+  const buttonGroupClassName = `${className || ""} ${
     disabled ? "isDisabled" : "isEnabled"
   }`
 
@@ -330,7 +328,6 @@ export function BulkApiButton(props: BulkApiButtonProps) {
       setLoading(false)
 
       if (onClickCallback) {
-        // console.log("finally, callback!")
         onClickCallback()
       }
     }

--- a/web/src/BulkApiButton.tsx
+++ b/web/src/BulkApiButton.tsx
@@ -1,25 +1,36 @@
-import { ButtonProps } from "@material-ui/core"
-import React, { useState } from "react"
+import { ButtonClassKey, ButtonGroup, ButtonProps } from "@material-ui/core"
+import { ClassNameMap } from "@material-ui/styles"
+import React, { useLayoutEffect, useState } from "react"
+import styled from "styled-components"
+import { AnalyticsType, Tags } from "./analytics"
 import {
-  ApiButtonRoot,
   ApiButtonToggleState,
-  ApiCancelButton,
-  ApiSubmitButton,
+  ApiButtonType,
+  confirmingButtonGroupBorderMixin,
+  confirmingButtonStateMixin,
   UIBUTTON_TOGGLE_INPUT_NAME,
   updateButtonStatus,
 } from "./ApiButton"
+import { ReactComponent as CloseSvg } from "./assets/svg/close.svg"
 import { useHudErrorContext } from "./HudErrorContext"
+import { InstrumentedButton } from "./instrumentedComponents"
 import { BulkAction } from "./OverviewTableBulkActions"
+import { AnimDuration, Color, Font, FontSize, SizeUnit } from "./style-helpers"
 import { UIButton } from "./types"
 
 /**
- * TODO: Add a note here about:
- * - Forking the ApiButton code
- * - Possibilities for future refactoring (possible that other bulk actions may not be `UIButton`s)
+ * The BulkApiButton is used to update multiple UIButtons with a single
+ * user action. It follows similar patterns as the core ApiButton component,
+ * but most of the data it receives, and its styling, is different.
+ * The BulkApiButton supports toggle and non-toggle buttons that may require
+ * confirmation.
+ *
+ * In the future, it may need to be expanded to share more of the UIButton
+ * options (like specifying an icon svg or having a form with inputs), or
+ * it may need to support non-UIButton bulk actions.
  */
 
 // Types
-
 type BulkApiButtonProps = ButtonProps & {
   bulkAction: BulkAction
   buttonText: string
@@ -30,7 +41,74 @@ type BulkApiButtonProps = ButtonProps & {
   uiButtons: UIButton[]
 }
 
+type BulkApiButtonElementProps = ButtonProps & {
+  text: string
+  confirming: boolean
+  disabled: boolean
+  analyticsTags: Tags
+  analyticsName: string
+}
+
 // Styles
+const BulkButtonElementRoot = styled(InstrumentedButton)`
+  border: 1px solid ${Color.grayLight};
+  border-radius: 4px;
+  background-color: ${Color.grayLighter};
+  color: ${Color.white};
+  font-family: ${Font.monospace};
+  font-size: ${FontSize.small};
+  padding: 0 ${SizeUnit(1 / 4)};
+  text-transform: capitalize;
+  transition: color ${AnimDuration.default} ease,
+    border ${AnimDuration.default} ease;
+
+  &:hover,
+  &:active,
+  &:focus {
+    background-color: ${Color.grayLighter};
+    color: ${Color.blue};
+  }
+
+  &.Mui-disabled {
+    border-color: ${Color.grayLight};
+    color: ${Color.gray6};
+  }
+
+  /* Use shared styles with ApiButton */
+  ${confirmingButtonStateMixin}
+  ${confirmingButtonGroupBorderMixin}
+`
+
+const BulkButtonGroup = styled(ButtonGroup)<{ disabled?: boolean }>`
+  ${(props) =>
+    props.disabled &&
+    `
+    cursor: not-allowed;
+  `}
+
+  /* Adjust the border radius of buttons to achieve the "rounded bar" look */
+  &.firstButtonGroupInRow {
+    ${BulkButtonElementRoot} {
+      border-top-right-radius: 0;
+      border-bottom-right-radius: 0;
+      border-right: 0;
+    }
+  }
+
+  &.middleButtonGroupInRow {
+    ${BulkButtonElementRoot} {
+      border-radius: 0;
+      border-right: 0;
+    }
+  }
+
+  &.lastButtonGroupInRow {
+    ${BulkButtonElementRoot} {
+      border-top-left-radius: 0;
+      border-bottom-left-radius: 0;
+    }
+  }
+`
 
 // Helpers
 function canButtonBeToggled(
@@ -55,10 +133,13 @@ function canButtonBeToggled(
   return toggleValue !== undefined && toggleValue !== targetToggleState
 }
 
-// A bulk button can be toggled if some buttons have values that don't match the target toggle state
-// ex: all buttons are not toggle buttons => bulk button cannot be toggled
-// ex: all buttons are on and target toggle is on => bulk button cannot be toggled
-// ex: some buttons are off and target toggle is on => bulk button can be toggled
+/**
+ * A bulk button can be toggled if some UIButtons have values that don't
+ * match the target toggle state.
+ * ex: some buttons are off and target toggle is on => bulk button can be toggled
+ * ex: all buttons are on and target toggle is on   => bulk button cannot be toggled
+ * ex: all buttons are not toggle buttons           => bulk button cannot be toggled
+ */
 function canBulkButtonBeToggled(
   uiButtons: UIButton[],
   targetToggleState: ApiButtonToggleState
@@ -72,8 +153,6 @@ function canBulkButtonBeToggled(
   )
 }
 
-// TODO: Add unit tests for this...
-// Or possibly re-write if it's too confusing
 function isBulkButtonDisabled(
   uiButtons: UIButton[],
   targetToggleState?: ApiButtonToggleState
@@ -105,6 +184,80 @@ async function bulkUpdateButtonStatus(uiButtons: UIButton[]) {
   }
 }
 
+function BulkSubmitButton(props: BulkApiButtonElementProps) {
+  const {
+    analyticsName,
+    analyticsTags,
+    confirming,
+    disabled,
+    onClick,
+    text,
+    ...buttonProps
+  } = props
+
+  // Determine display text and accessible button label based on confirmation state
+  const displayButtonText = confirming ? "Confirm" : text
+  const ariaLabel = confirming ? `Confirm ${text}` : `Trigger ${text}`
+
+  const tags = { ...analyticsTags }
+  if (confirming) {
+    tags.confirm = "true"
+  }
+
+  const isConfirmingClass = confirming ? "confirming leftButtonInGroup" : ""
+  const classes: Partial<ClassNameMap<ButtonClassKey>> = {
+    root: isConfirmingClass,
+  }
+
+  return (
+    <BulkButtonElementRoot
+      analyticsName={analyticsName}
+      analyticsTags={tags}
+      aria-label={ariaLabel}
+      classes={classes}
+      disabled={disabled}
+      onClick={onClick}
+      {...buttonProps}
+    >
+      {displayButtonText}
+    </BulkButtonElementRoot>
+  )
+}
+
+function BulkCancelButton(props: BulkApiButtonElementProps) {
+  const {
+    analyticsName,
+    analyticsTags,
+    confirming,
+    onClick,
+    text,
+    ...buttonProps
+  } = props
+
+  // Don't display the cancel confirmation button if the button
+  // group's state isn't confirming
+  if (!confirming) {
+    return null
+  }
+
+  const classes: Partial<ClassNameMap<ButtonClassKey>> = {
+    root: "confirming rightButtonInGroup",
+  }
+
+  return (
+    <BulkButtonElementRoot
+      analyticsName={analyticsName}
+      aria-label={`Cancel ${text}`}
+      analyticsTags={{ confirm: "false", ...analyticsTags }}
+      classes={classes}
+      onClick={onClick}
+      {...buttonProps}
+    >
+      <CloseSvg role="presentation" />
+    </BulkButtonElementRoot>
+  )
+}
+
 export function BulkApiButton(props: BulkApiButtonProps) {
   const {
     bulkAction,
@@ -122,11 +275,35 @@ export function BulkApiButton(props: BulkApiButtonProps) {
   const [loading, setLoading] = useState(false)
   const [confirming, setConfirming] = useState(false)
 
-  // TODO: Create analytics tags
+  const analyticsTags: Tags = {
+    component: ApiButtonType.Global,
+    type: AnalyticsType.Grid,
+    bulkCount: String(uiButtons.length),
+    bulkAction,
+  }
+
+  if (targetToggleState) {
+    // The `toggleValue` reflects the value of the buttons
+    // when they are clicked, not their updated values
+    analyticsTags.toggleValue =
+      targetToggleState === ApiButtonToggleState.On
+        ? ApiButtonToggleState.Off
+        : ApiButtonToggleState.On
+  }
 
   const bulkActionDisabled = isBulkButtonDisabled(uiButtons, targetToggleState)
-
   const disabled = loading || bulkActionDisabled || false
+  const buttonGroupClassName = `${className} ${
+    disabled ? "isDisabled" : "isEnabled"
+  }`
+
+  // If the bulk action isn't available while the bulk button
+  // is in a confirmation state, reset the confirmation state
+  useLayoutEffect(() => {
+    if (bulkActionDisabled && confirming) {
+      setConfirming(false)
+    }
+  }, [bulkActionDisabled, confirming])
 
   const onClick = async () => {
     if (requiresConfirmation && !confirming) {
@@ -143,13 +320,13 @@ export function BulkApiButton(props: BulkApiButtonProps) {
     try {
       // If there's a target toggle state, filter out buttons that
       // already have that toggle state. If they're not filtered out
-      // updating them will toggle them to a non-target state.
+      // updating them will toggle them to an unintended state.
       const buttonsToUpdate = uiButtons.filter((button) =>
         canButtonBeToggled(button, targetToggleState)
       )
       await bulkUpdateButtonStatus(buttonsToUpdate)
     } catch (err) {
-      setError(`Error submitting button click: ${err}`)
+      setError(`Error triggering ${bulkAction} action: ${err}`)
       return
     } finally {
       if (onClickCallback) {
@@ -161,30 +338,30 @@ export function BulkApiButton(props: BulkApiButtonProps) {
   }
 
   return (
-    <ApiButtonRoot
-      className={className}
+    <BulkButtonGroup
+      className={buttonGroupClassName}
       disableRipple={true}
       aria-label={buttonText}
       disabled={disabled}
     >
-      <ApiSubmitButton
+      <BulkSubmitButton
         analyticsName="ui.web.bulkButton"
-        analyticsTags={{}}
+        analyticsTags={analyticsTags}
         confirming={confirming}
         disabled={disabled}
         onClick={onClick}
         text={buttonText}
         {...buttonProps}
-      ></ApiSubmitButton>
-      <ApiCancelButton
+      ></BulkSubmitButton>
+      <BulkCancelButton
         analyticsName="ui.web.bulkButton"
-        analyticsTags={{}}
+        analyticsTags={analyticsTags}
         confirming={confirming}
         disabled={disabled}
         onClick={() => setConfirming(false)}
         text={buttonText}
         {...buttonProps}
       />
-    </ApiButtonRoot>
+    </BulkButtonGroup>
   )
 }

--- a/web/src/BulkApiButton.tsx
+++ b/web/src/BulkApiButton.tsx
@@ -111,20 +111,20 @@ const BulkButtonGroup = styled(ButtonGroup)<{ disabled?: boolean }>`
 `
 
 // Helpers
-function canButtonBeToggled(
+export function canButtonBeToggled(
   uiButton: UIButton,
   targetToggleState?: ApiButtonToggleState
 ) {
-  if (!targetToggleState) {
-    return true
-  }
-
   const toggleInput = uiButton.spec?.inputs?.find(
     (input) => input.name === UIBUTTON_TOGGLE_INPUT_NAME
   )
 
   if (!toggleInput) {
     return false
+  }
+
+  if (!targetToggleState) {
+    return true
   }
 
   const toggleValue = toggleInput.hidden?.value
@@ -140,7 +140,7 @@ function canButtonBeToggled(
  * ex: all buttons are on and target toggle is on   => bulk button cannot be toggled
  * ex: all buttons are not toggle buttons           => bulk button cannot be toggled
  */
-function canBulkButtonBeToggled(
+export function canBulkButtonBeToggled(
   uiButtons: UIButton[],
   targetToggleState: ApiButtonToggleState
 ) {
@@ -173,13 +173,11 @@ function isBulkButtonDisabled(
 }
 
 async function bulkUpdateButtonStatus(uiButtons: UIButton[]) {
-  const buttonClicks: Promise<void>[] = uiButtons.map((button) =>
-    updateButtonStatus(button, {})
-  )
-
   try {
-    await Promise.all(buttonClicks)
+    await Promise.all(uiButtons.map((button) => updateButtonStatus(button, {})))
+    // console.log("all requests have finished")
   } catch (err) {
+    // console.log("yikes, there's been an error")
     throw err
   }
 }
@@ -329,11 +327,12 @@ export function BulkApiButton(props: BulkApiButtonProps) {
       setError(`Error triggering ${bulkAction} action: ${err}`)
       return
     } finally {
+      setLoading(false)
+
       if (onClickCallback) {
+        // console.log("finally, callback!")
         onClickCallback()
       }
-
-      setLoading(false)
     }
   }
 

--- a/web/src/CustomNav.tsx
+++ b/web/src/CustomNav.tsx
@@ -5,7 +5,7 @@ import {
   ApiButtonType,
   ApiIcon,
   buttonsForComponent,
-  UIBUTTON_NAV_COMPONENT_ID,
+  UIBUTTON_GLOBAL_COMPONENT_ID,
 } from "./ApiButton"
 import { MenuButtonLabeled, MenuButtonMixin } from "./GlobalNav"
 import { Color, SizeUnit } from "./style-helpers"
@@ -52,7 +52,7 @@ export function CustomNav(props: CustomNavProps) {
   const buttons = buttonsForComponent(
     props.view.uiButtons,
     ApiButtonType.Global,
-    UIBUTTON_NAV_COMPONENT_ID
+    UIBUTTON_GLOBAL_COMPONENT_ID
   ).default
 
   return (

--- a/web/src/CustomNav.tsx
+++ b/web/src/CustomNav.tsx
@@ -66,7 +66,7 @@ export function CustomNav(props: CustomNavProps) {
           >
             <ApiIcon
               iconName={b.spec?.iconName || "smart_button"}
-              iconSvg={b.spec?.iconSVG}
+              iconSVG={b.spec?.iconSVG}
             />
           </CustomNavButton>
         </MenuButtonLabeled>

--- a/web/src/CustomNav.tsx
+++ b/web/src/CustomNav.tsx
@@ -1,6 +1,12 @@
 import React from "react"
 import styled from "styled-components"
-import { ApiButton, ApiIcon, buttonsForComponent } from "./ApiButton"
+import {
+  ApiButton,
+  ApiButtonType,
+  ApiIcon,
+  buttonsForComponent,
+  UIBUTTON_NAV_COMPONENT_ID,
+} from "./ApiButton"
 import { MenuButtonLabeled, MenuButtonMixin } from "./GlobalNav"
 import { Color, SizeUnit } from "./style-helpers"
 
@@ -45,8 +51,8 @@ const CustomNavButton = styled(ApiButton)`
 export function CustomNav(props: CustomNavProps) {
   const buttons = buttonsForComponent(
     props.view.uiButtons,
-    "global",
-    "nav"
+    ApiButtonType.Global,
+    UIBUTTON_NAV_COMPONENT_ID
   ).default
 
   return (
@@ -60,7 +66,7 @@ export function CustomNav(props: CustomNavProps) {
           >
             <ApiIcon
               iconName={b.spec?.iconName || "smart_button"}
-              iconSVG={b.spec?.iconSVG}
+              iconSvg={b.spec?.iconSVG}
             />
           </CustomNavButton>
         </MenuButtonLabeled>

--- a/web/src/OverviewResourcePane.tsx
+++ b/web/src/OverviewResourcePane.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from "react"
 import SplitPane from "react-split-pane"
 import styled from "styled-components"
 import { Alert, combinedAlerts } from "./alerts"
-import { buttonsForComponent } from "./ApiButton"
+import { ApiButtonType, buttonsForComponent } from "./ApiButton"
 import HeaderBar from "./HeaderBar"
 import { LogUpdateAction, LogUpdateEvent, useLogStore } from "./LogStore"
 import OverviewResourceDetails from "./OverviewResourceDetails"
@@ -84,7 +84,11 @@ export default function OverviewResourcePane(props: OverviewResourcePaneProps) {
     resources.forEach((r) => alerts.push(...combinedAlerts(r, logStore)))
   }
 
-  const buttons = buttonsForComponent(props.view.uiButtons, "resource", name)
+  const buttons = buttonsForComponent(
+    props.view.uiButtons,
+    ApiButtonType.Resource,
+    name
+  )
 
   return (
     <OverviewResourcePaneRoot>

--- a/web/src/OverviewTable.tsx
+++ b/web/src/OverviewTable.tsx
@@ -118,6 +118,12 @@ const OverviewTableRoot = styled.section`
   margin-right: ${SizeUnit(1 / 2)};
 `
 
+const OverviewTableMenu = styled.section`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+`
+
 const ResourceTable = styled.table`
   margin-top: ${SizeUnit(0.5)};
   border-collapse: collapse;
@@ -727,8 +733,10 @@ function OverviewTableContent(props: OverviewTableProps) {
 export default function OverviewTable(props: OverviewTableProps) {
   return (
     <OverviewTableRoot aria-label="Resources overview">
-      <OverviewTableResourceNameFilter />
-      <OverviewTableBulkActions uiButtons={props.view.uiButtons} />
+      <OverviewTableMenu>
+        <OverviewTableResourceNameFilter />
+        <OverviewTableBulkActions uiButtons={props.view.uiButtons} />
+      </OverviewTableMenu>
       <OverviewTableContent {...props} />
     </OverviewTableRoot>
   )

--- a/web/src/OverviewTable.tsx
+++ b/web/src/OverviewTable.tsx
@@ -17,7 +17,7 @@ import {
 import styled from "styled-components"
 import { buildAlerts, runtimeAlerts } from "./alerts"
 import { AnalyticsType } from "./analytics"
-import { buttonsForComponent } from "./ApiButton"
+import { ApiButtonType, buttonsForComponent } from "./ApiButton"
 import Features, { Flag, useFeatures } from "./feature"
 import { Hold } from "./Hold"
 import {
@@ -28,6 +28,7 @@ import {
   UNLABELED_LABEL,
 } from "./labels"
 import { LogAlertIndex, useLogAlertIndex } from "./LogStore"
+import { OverviewTableBulkActions } from "./OverviewTableBulkActions"
 import {
   getTableColumns,
   ResourceTableHeaderTip,
@@ -332,7 +333,11 @@ function uiResourceToCell(
   let currentBuildStartTime = res.currentBuild?.startTime ?? ""
   let isBuilding = !isZeroTime(currentBuildStartTime)
   let hasBuilt = lastBuild !== null
-  let buttons = buttonsForComponent(allButtons, "resource", r.metadata?.name)
+  let buttons = buttonsForComponent(
+    allButtons,
+    ApiButtonType.Resource,
+    r.metadata?.name
+  )
   let analyticsTags = { target: resourceTargetType(r) }
   // Consider a resource `selectable` if it can be disabled
   const selectable = !!buttons.toggleDisable
@@ -723,6 +728,7 @@ export default function OverviewTable(props: OverviewTableProps) {
   return (
     <OverviewTableRoot aria-label="Resources overview">
       <OverviewTableResourceNameFilter />
+      <OverviewTableBulkActions uiButtons={props.view.uiButtons} />
       <OverviewTableContent {...props} />
     </OverviewTableRoot>
   )

--- a/web/src/OverviewTableBulkActions.test.tsx
+++ b/web/src/OverviewTableBulkActions.test.tsx
@@ -1,0 +1,153 @@
+import {
+  render,
+  screen,
+  waitForElementToBeRemoved,
+} from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import fetchMock from "fetch-mock"
+import React from "react"
+import {
+  cleanupMockAnalyticsCalls,
+  mockAnalyticsCalls,
+} from "./analytics_test_helpers"
+import { buttonsByComponent } from "./ApiButton"
+import Features, { FeaturesProvider, Flag } from "./feature"
+import {
+  BulkAction,
+  buttonsByAction,
+  OverviewTableBulkActions,
+} from "./OverviewTableBulkActions"
+import { ResourceSelectionProvider } from "./ResourceSelectionContext"
+import { disableButton, oneButton } from "./testdata"
+
+const TEST_SELECTIONS = ["frontend", "backend"]
+
+const TEST_UIBUTTONS = [
+  oneButton(0, "database"),
+  disableButton("frontend", true),
+  oneButton(2, "frontend"),
+  disableButton("backend", false),
+]
+
+const OverviewTableBulkActionsTestWrapper = (props: {
+  flagEnabled: boolean
+  resourceSelections: string[]
+}) => {
+  const { flagEnabled, resourceSelections } = props
+  const features = new Features({ [Flag.BulkDisableResources]: flagEnabled })
+  return (
+    <FeaturesProvider value={features}>
+      <ResourceSelectionProvider initialValuesForTesting={resourceSelections}>
+        <OverviewTableBulkActions uiButtons={TEST_UIBUTTONS} />
+      </ResourceSelectionProvider>
+    </FeaturesProvider>
+  )
+}
+
+describe("OverviewTableBulkActions", () => {
+  beforeEach(() => {
+    mockAnalyticsCalls()
+    fetchMock.mock(
+      (url) => url.startsWith("/proxy/apis/tilt.dev/v1alpha1/uibuttons"),
+      JSON.stringify({})
+    )
+  })
+
+  afterEach(() => {
+    cleanupMockAnalyticsCalls()
+  })
+
+  describe("when bulk actions are NOT enabled", () => {
+    it("does NOT display", () => {
+      render(
+        <OverviewTableBulkActionsTestWrapper
+          flagEnabled={false}
+          resourceSelections={TEST_SELECTIONS}
+        />
+      )
+
+      expect(screen.queryByLabelText("Bulk resource actions")).toBeNull()
+    })
+  })
+
+  describe("when bulk actions are enabled", () => {
+    describe("when there are NO resources selected", () => {
+      it("does NOT display", () => {
+        render(
+          <OverviewTableBulkActionsTestWrapper
+            flagEnabled={true}
+            resourceSelections={[]}
+          />
+        )
+
+        expect(screen.queryByLabelText("Bulk resource actions")).toBeNull()
+      })
+    })
+
+    describe("when there are resources selected", () => {
+      beforeEach(() => {
+        render(
+          <OverviewTableBulkActionsTestWrapper
+            flagEnabled={true}
+            resourceSelections={TEST_SELECTIONS}
+          />
+        )
+      })
+
+      it("does display", () => {
+        expect(screen.queryByLabelText("Bulk resource actions")).not.toBeNull()
+      })
+
+      it("displays the selected resource count", () => {
+        expect(
+          screen.queryByText(`${TEST_SELECTIONS.length} selected`)
+        ).not.toBeNull()
+      })
+
+      it("renders an 'Enable' button that does NOT require confirmation", () => {
+        const enableButton = screen.queryByLabelText("Trigger Enable")
+        expect(enableButton).toBeTruthy()
+
+        // Clicking the button should NOT bring up a confirmation step
+        userEvent.click(enableButton as HTMLElement)
+
+        expect(screen.queryByLabelText("Confirm Enable")).toBeNull()
+      })
+
+      it("renders a 'Disable' button that does require confirmation", () => {
+        const disableButton = screen.queryByLabelText("Trigger Disable")
+        expect(disableButton).toBeTruthy()
+
+        // Clicking the button should bring up a confirmation step
+        userEvent.click(disableButton as HTMLElement)
+
+        expect(screen.queryByLabelText("Confirm Disable")).toBeTruthy()
+        expect(screen.queryByLabelText("Cancel Disable")).toBeTruthy()
+      })
+
+      it("clears the selected resources after a button has been clicked", async () => {
+        const enableButton = screen.queryByLabelText("Trigger Enable")
+        expect(enableButton).toBeTruthy()
+
+        // Click the enable button, since there's not the extra confirmation step
+        userEvent.click(enableButton as HTMLElement)
+
+        // Expect that the component doesn't appear any more since there are no selections
+        await waitForElementToBeRemoved(
+          screen.queryByLabelText("Bulk resource actions")
+        )
+      })
+    })
+  })
+
+  describe("buttonsByAction", () => {
+    it("groups UIButtons by the bulk action they perform", () => {
+      const componentButtons = buttonsByComponent(TEST_UIBUTTONS)
+      const actionButtons = buttonsByAction(componentButtons, TEST_SELECTIONS)
+
+      expect(actionButtons).toStrictEqual({
+        [BulkAction.Disable]: [TEST_UIBUTTONS[1], TEST_UIBUTTONS[3]],
+      })
+    })
+  })
+})

--- a/web/src/OverviewTableBulkActions.test.tsx
+++ b/web/src/OverviewTableBulkActions.test.tsx
@@ -4,13 +4,13 @@ import {
   waitForElementToBeRemoved,
 } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
-import fetchMock from "fetch-mock"
 import React from "react"
 import {
   cleanupMockAnalyticsCalls,
   mockAnalyticsCalls,
 } from "./analytics_test_helpers"
 import { buttonsByComponent } from "./ApiButton"
+import { mockUIButtonUpdates } from "./ApiButton.testhelpers"
 import Features, { FeaturesProvider, Flag } from "./feature"
 import {
   BulkAction,
@@ -47,10 +47,7 @@ const OverviewTableBulkActionsTestWrapper = (props: {
 describe("OverviewTableBulkActions", () => {
   beforeEach(() => {
     mockAnalyticsCalls()
-    fetchMock.mock(
-      (url) => url.startsWith("/proxy/apis/tilt.dev/v1alpha1/uibuttons"),
-      JSON.stringify({})
-    )
+    mockUIButtonUpdates()
   })
 
   afterEach(() => {
@@ -104,14 +101,18 @@ describe("OverviewTableBulkActions", () => {
         ).not.toBeNull()
       })
 
-      it("renders an 'Enable' button that does NOT require confirmation", () => {
+      it("renders an 'Enable' button that does NOT require confirmation", async () => {
         const enableButton = screen.queryByLabelText("Trigger Enable")
         expect(enableButton).toBeTruthy()
 
         // Clicking the button should NOT bring up a confirmation step
         userEvent.click(enableButton as HTMLElement)
 
-        expect(screen.queryByLabelText("Confirm Enable")).toBeNull()
+        // Clicking an action button will remove the selected resources
+        // and the bulk action bar will no longer appear
+        await waitForElementToBeRemoved(
+          screen.queryByLabelText("Trigger Enable")
+        )
       })
 
       it("renders a 'Disable' button that does require confirmation", () => {

--- a/web/src/OverviewTableBulkActions.tsx
+++ b/web/src/OverviewTableBulkActions.tsx
@@ -1,0 +1,85 @@
+import React, { useMemo } from "react"
+import { ApiButtonToggleState, buttonsByComponent } from "./ApiButton"
+import { BulkApiButton } from "./BulkApiButton"
+import { Flag, useFeatures } from "./feature"
+import { useResourceSelection } from "./ResourceSelectionContext"
+import SrOnly from "./SrOnly"
+import { UIButton } from "./types"
+
+type OverviewTableBulkActionsProps = {
+  uiButtons?: UIButton[]
+}
+
+type ActionButtons = { [key in BulkAction]: UIButton[] }
+
+export enum BulkAction {
+  Disable = "disable", // Enable / disable are states of the same toggle, so use a single name
+}
+
+function SelectedCount({ count }: { count: number }) {
+  if (!count) {
+    return null
+  }
+
+  return (
+    <p>
+      {count} <SrOnly>resources</SrOnly> selected
+    </p>
+  )
+}
+
+export function OverviewTableBulkActions({
+  uiButtons,
+}: OverviewTableBulkActionsProps) {
+  const features = useFeatures()
+  const { selected, clearSelections } = useResourceSelection()
+
+  const resourceButtons = useMemo(
+    () => buttonsByComponent(uiButtons),
+    [uiButtons]
+  )
+
+  const actionButtons = useMemo(() => {
+    const buttonsByAction: ActionButtons = {
+      [BulkAction.Disable]: [],
+    }
+
+    selected.forEach((resource) => {
+      const buttonSet = resourceButtons[resource]
+      if (buttonSet && buttonSet.toggleDisable) {
+        buttonsByAction[BulkAction.Disable].push(buttonSet.toggleDisable)
+      }
+    })
+
+    return buttonsByAction
+  }, [selected, uiButtons])
+
+  // Don't render the bulk actions is feature flag is off
+  if (!features.isEnabled(Flag.BulkDisableResources)) {
+    return null
+  }
+
+  const onClickCallback = () => clearSelections()
+
+  return (
+    <>
+      <BulkApiButton
+        bulkAction={BulkAction.Disable}
+        buttonText="Enable"
+        requiresConfirmation={false}
+        uiButtons={actionButtons[BulkAction.Disable]}
+        targetToggleState={ApiButtonToggleState.On}
+        onClickCallback={onClickCallback}
+      />
+      <BulkApiButton
+        bulkAction={BulkAction.Disable}
+        buttonText="Disable"
+        requiresConfirmation={true}
+        uiButtons={actionButtons[BulkAction.Disable]}
+        targetToggleState={ApiButtonToggleState.Off}
+        onClickCallback={onClickCallback}
+      />
+      <SelectedCount count={selected.length} />
+    </>
+  )
+}

--- a/web/src/OverviewTableBulkActions.tsx
+++ b/web/src/OverviewTableBulkActions.tsx
@@ -1,9 +1,11 @@
 import React, { useMemo } from "react"
+import styled from "styled-components"
 import { ApiButtonToggleState, buttonsByComponent } from "./ApiButton"
 import { BulkApiButton } from "./BulkApiButton"
 import { Flag, useFeatures } from "./feature"
 import { useResourceSelection } from "./ResourceSelectionContext"
 import SrOnly from "./SrOnly"
+import { Color, FontSize, SizeUnit } from "./style-helpers"
 import { UIButton } from "./types"
 
 type OverviewTableBulkActionsProps = {
@@ -16,15 +18,29 @@ export enum BulkAction {
   Disable = "disable", // Enable / disable are states of the same toggle, so use a single name
 }
 
-function SelectedCount({ count }: { count: number }) {
+const BulkActionMenu = styled.div`
+  align-items: center;
+  display: flex;
+  flex-direction: row;
+  margin-left: ${SizeUnit(2)};
+  white-space: nowrap;
+`
+
+const SelectedCount = styled.p`
+  margin: ${SizeUnit(0.25)};
+  font-size: ${FontSize.small};
+  color: ${Color.gray7};
+`
+
+function BulkSelectedCount({ count }: { count: number }) {
   if (!count) {
     return null
   }
 
   return (
-    <p>
+    <SelectedCount>
       {count} <SrOnly>resources</SrOnly> selected
-    </p>
+    </SelectedCount>
   )
 }
 
@@ -54,18 +70,24 @@ export function OverviewTableBulkActions({
     return buttonsByAction
   }, [selected, uiButtons])
 
+  // TODO (lizz): Do more testing to investigate "memory leak" warning
+  // from unmounting this component when its `setState` hooks haven't
+  // finished running
+
   // Don't render the bulk actions is feature flag is off
-  if (!features.isEnabled(Flag.BulkDisableResources)) {
+  // or if there are no selections
+  if (!features.isEnabled(Flag.BulkDisableResources) || selected.length === 0) {
     return null
   }
 
   const onClickCallback = () => clearSelections()
 
   return (
-    <>
+    <BulkActionMenu>
       <BulkApiButton
         bulkAction={BulkAction.Disable}
         buttonText="Enable"
+        className="firstButtonGroupInRow"
         requiresConfirmation={false}
         uiButtons={actionButtons[BulkAction.Disable]}
         targetToggleState={ApiButtonToggleState.On}
@@ -74,12 +96,13 @@ export function OverviewTableBulkActions({
       <BulkApiButton
         bulkAction={BulkAction.Disable}
         buttonText="Disable"
+        className="lastButtonGroupInRow"
         requiresConfirmation={true}
         uiButtons={actionButtons[BulkAction.Disable]}
         targetToggleState={ApiButtonToggleState.Off}
         onClickCallback={onClickCallback}
       />
-      <SelectedCount count={selected.length} />
-    </>
+      <BulkSelectedCount count={selected.length} />
+    </BulkActionMenu>
   )
 }

--- a/web/src/OverviewTableColumns.tsx
+++ b/web/src/OverviewTableColumns.tsx
@@ -66,7 +66,7 @@ export type RowValues = {
   triggerMode: TriggerMode
   buttons: UIButton[]
   analyticsTags: Tags
-  selectable: boolean
+  selectable: boolean // TODO: rename this?
 }
 
 /**
@@ -440,7 +440,7 @@ export function TableWidgetsColumn({ row }: CellProps<RowValues>) {
       <CustomActionButton key={b.metadata?.name} uiButton={b}>
         <ApiIcon
           iconName={b.spec?.iconName || "smart_button"}
-          iconSVG={b.spec?.iconSVG}
+          iconSvg={b.spec?.iconSVG}
         />
       </CustomActionButton>
     )

--- a/web/src/OverviewTableColumns.tsx
+++ b/web/src/OverviewTableColumns.tsx
@@ -66,7 +66,7 @@ export type RowValues = {
   triggerMode: TriggerMode
   buttons: UIButton[]
   analyticsTags: Tags
-  selectable: boolean // TODO: rename this?
+  selectable: boolean
 }
 
 /**
@@ -440,7 +440,7 @@ export function TableWidgetsColumn({ row }: CellProps<RowValues>) {
       <CustomActionButton key={b.metadata?.name} uiButton={b}>
         <ApiIcon
           iconName={b.spec?.iconName || "smart_button"}
-          iconSvg={b.spec?.iconSVG}
+          iconSVG={b.spec?.iconSVG}
         />
       </CustomActionButton>
     )

--- a/web/src/style-helpers.ts
+++ b/web/src/style-helpers.ts
@@ -57,7 +57,6 @@ export enum FontSize {
 }
 
 let unit = 32
-let heightUnit = unit // For cases when `Height.unit` shadows `unit`
 
 export function SizeUnit(multiplier: number) {
   return `${unit * multiplier}px`

--- a/web/src/testdata.tsx
+++ b/web/src/testdata.tsx
@@ -1,9 +1,11 @@
 import { Href, UnregisterCallback } from "history"
 import { RouteComponentProps } from "react-router-dom"
 import {
+  ApiButtonToggleState,
   ApiButtonType,
   UIBUTTON_ANNOTATION_TYPE,
   UIBUTTON_TOGGLE_DISABLE_TYPE,
+  UIBUTTON_TOGGLE_INPUT_NAME,
 } from "./ApiButton"
 import {
   ResourceName,
@@ -393,6 +395,15 @@ export function disableButton(
         componentID: resourceName,
         componentType: ApiButtonType.Resource,
       },
+      inputs: [
+        {
+          name: UIBUTTON_TOGGLE_INPUT_NAME,
+          hidden: {
+            value: enabled ? ApiButtonToggleState.On : ApiButtonToggleState.Off,
+          },
+        },
+      ],
+      requiresConfirmation: true,
     },
   }
 }


### PR DESCRIPTION
This PR adds a new `BulkApiButton` component and an `OverviewBulkActions` component, so users can enable and disable multiple resources at a time from Table View.

Because the data model and styling are pretty different for bulk buttons, I opted to fork the `ApiButton` code and customize  it based on what functionality is needed for bulk actions now. In the future, I could see the `BulkApiButton` supporting other `UIButton` properties, like inputs and custom icons, or even supporting non-`UIButton` tasks, like starring resources or triggering updates.

![2022-01-26 16 10 28](https://user-images.githubusercontent.com/23283986/151250513-d2c61635-37a5-4cb6-a5f8-2a4bf4aed025.gif)

The **`BulkApiButton`** renders a configurable html button that, when clicked, updates a list of `UIButton`s in the Tilt API. The bulk button can be configured to require confirmation, as well as only update `UIButton`s that can be toggled to a specific state (either `"off"` or `"on"`). If there's no target/desired toggle state specified, a bulk button will update all the `UIButton`s passed to it.

The **`OverviewBulkActions`** menu displays enable and disable buttons, as well as a selection count, whenever resources are selected in Table View. It will only display when the bulk disable feature flag is on.

![2022-01-26 16 11 44](https://user-images.githubusercontent.com/23283986/151252018-ed2c4c93-0599-4483-b1a0-a854cfa729b5.gif)

The unit tests for both new components use `react-testing-library`, based on feedback in #5389. (Overall, I really like the new testing library!) I did some minor refactoring to the `ApiButton` components and added helper functions to make sharing code easier. I also updated references to the same string values, so they use enums or string constants.

The best way to test is a `Tiltfile` with the bulk feature flag enabled and spinning up the web UI. Storybook will display the buttons, but the button states won't update on button press.

ps. This PR is larger than I originally intended! Let me know if it's hard to review and I'll see what I can split it into.

[Closes ch12974](https://app.shortcut.com/windmill/story/12974/implement-enable-and-disable-button-controls).