### PR TITLE
engine: fix flaky test: TestMultipleChangesOnlyDeployOneManifest

### DIFF
--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -881,6 +881,9 @@ func TestMultipleChangesOnlyDeployOneManifest(t *testing.T) {
 	f.useRealTiltfileLoader()
 
 	f.WriteFile("Tiltfile", `
+# ensure builds happen in deterministic order
+update_settings(max_parallel_updates=1)
+
 docker_build("gcr.io/windmill-public-containers/servantes/snack", "./snack", dockerfile="Dockerfile1")
 docker_build("gcr.io/windmill-public-containers/servantes/doggos", "./doggos", dockerfile="Dockerfile2")
 


### PR DESCRIPTION
This test creates two manifests and then asserts their builds happen in the order they were defined, but with parallel builds, they occasionally happen in the other order.