### PR TITLE
web: add disabled resource status count to summary 

### DIFF
--- a/web/src/HeaderBar.tsx
+++ b/web/src/HeaderBar.tsx
@@ -11,10 +11,9 @@ import {
 } from "./ResourceStatusSummary"
 import { useSnapshotAction } from "./snapshot"
 import { AnimDuration, Color, Font, FontSize, SizeUnit } from "./style-helpers"
-import { TargetType } from "./types"
 import { showUpdate } from "./UpdateDialog"
 
-const HeaderBarRoot = styled.div`
+const HeaderBarRoot = styled.header`
   display: flex;
   align-items: center;
   padding-left: ${SizeUnit(1)};
@@ -65,10 +64,6 @@ export default function HeaderBar(props: HeaderBarProps) {
   let runningBuild = session?.runningTiltBuild
   let suggestedVersion = session?.suggestedTiltVersion
   let resources = view?.uiResources || []
-  let hasK8s = resources.some((r) => {
-    let specs = r.status?.specs ?? []
-    return specs.some((spec) => spec.type === TargetType.K8s)
-  })
 
   let globalNavProps = {
     isSnapshot,
@@ -93,7 +88,11 @@ export default function HeaderBar(props: HeaderBarProps) {
       <AllResourcesLink to={pb.encpath`/r/(all)/overview`}>
         All Resources
       </AllResourcesLink>
-      <AllResourceStatusSummary resources={resources} />
+      <AllResourceStatusSummary
+        displayText="Resources"
+        labelText="Status summary for all resources"
+        resources={resources}
+      />
       <CustomNav view={props.view} />
       <GlobalNav {...globalNavProps} />
     </HeaderBarRoot>

--- a/web/src/OverviewResourceBar.tsx
+++ b/web/src/OverviewResourceBar.tsx
@@ -46,7 +46,11 @@ export default function OverviewResourceBar(props: OverviewResourceBarProps) {
 
   return (
     <OverviewResourceBarRoot>
-      <AllResourceStatusSummary resources={resources} />
+      <AllResourceStatusSummary
+        displayText="Resources"
+        labelText="Status summary for all resources"
+        resources={resources}
+      />
       <GlobalNav {...globalNavProps} />
     </OverviewResourceBarRoot>
   )

--- a/web/src/OverviewTable.tsx
+++ b/web/src/OverviewTable.tsx
@@ -586,7 +586,7 @@ function TableGroup(props: TableGroupProps) {
         <ResourceGroupSummaryIcon role="presentation" />
         <OverviewGroupName>{formattedLabel}</OverviewGroupName>
         <TableGroupStatusSummary
-          aria-label={`Status summary for ${label} group`}
+          labelText={`Status summary for ${label} group`}
           resources={tableProps.data}
         />
       </OverviewGroupSummary>

--- a/web/src/ResourceStatusSummary.test.tsx
+++ b/web/src/ResourceStatusSummary.test.tsx
@@ -27,11 +27,12 @@ function expectStatusCounts(
 }
 
 const testCounts: StatusCounts = {
-  total: 11,
+  totalEnabled: 11,
   healthy: 0,
   warning: 2,
   unhealthy: 4,
   pending: 0,
+  disabled: 2,
 }
 
 it("shows the counts it's given", () => {
@@ -40,7 +41,8 @@ it("shows the counts it's given", () => {
       <ResourceGroupStatus
         counts={testCounts}
         healthyLabel="healthy"
-        label="resources"
+        displayText="resources"
+        labelText="Testing resource status summary"
         unhealthyLabel="unhealthy"
         warningLabel="warning"
         linkToLogFilters={true}
@@ -48,12 +50,13 @@ it("shows the counts it's given", () => {
     </MemoryRouter>
   )
 
-  // "healthy" gets the denominator (total)
+  // "healthy" gets the denominator (totalEnabled)
   // 0 counts are not rendered, except for "healthy"
   expectStatusCounts(root, [
     { label: "unhealthy", counts: [4] },
     { label: "warning", counts: [2] },
     { label: "healthy", counts: [0, 11] },
+    { label: "disabled", counts: [2] },
   ])
 })
 
@@ -63,7 +66,8 @@ it("links to warning and unhealthy resources when `linkToLogFilters` is true", (
       <ResourceGroupStatus
         counts={testCounts}
         healthyLabel="healthy"
-        label="resources"
+        displayText="resources"
+        labelText="Testing resource status summary"
         unhealthyLabel="unhealthy"
         warningLabel="warning"
         linkToLogFilters={true}
@@ -90,7 +94,8 @@ it("does NOT link to warning and unhealthy resources when `linkToLogFilters` is 
       <ResourceGroupStatus
         counts={testCounts}
         healthyLabel="healthy"
-        label="resources"
+        displayText="resources"
+        labelText="Testing resource status summary"
         unhealthyLabel="unhealthy"
         warningLabel="warning"
         linkToLogFilters={false}

--- a/web/src/SidebarResources.tsx
+++ b/web/src/SidebarResources.tsx
@@ -241,7 +241,7 @@ function SidebarGroupListSection(props: { label: string } & SidebarProps) {
         <ResourceGroupSummaryIcon role="presentation" />
         <SidebarGroupName>{formattedLabel}</SidebarGroupName>
         <SidebarGroupStatusSummary
-          aria-label={`Status summary for ${props.label} group`}
+          labelText={`Status summary for ${props.label} group`}
           resources={props.items}
         />
       </SidebarGroupSummary>


### PR DESCRIPTION
This PR adds a count of disabled resources to the resource status summary component. The total resource count doesn't include the disabled resources, and the status summary will display if the (enabled) resource count or the disabled count is > 0.

![Screen Shot 2022-01-28 at 4 18 33 PM](https://user-images.githubusercontent.com/23283986/151634476-d9cf651e-1b4b-4bdc-a2f0-49d50e5f8ef7.png)

I also added more semantic html (like replacing `div`s with `li`s) and aria markup, so it's more accessible to assistive tech. (There are more improvements we can make in the future to make sure the visual information is also accessible over text and audio, but I didn't want the scope of this PR to creep.)

[Closes ch12978](https://app.shortcut.com/windmill/story/12978/display-disabled-resource-count-in-status-summary).