### PR TITLE
web: let anser colorize ansi logs

### DIFF
--- a/web/src/OverviewLogPane.tsx
+++ b/web/src/OverviewLogPane.tsx
@@ -114,7 +114,8 @@ function newLineEl(
   let spacer = "\n"
   code.innerHTML = anser.linkify(
     anser.ansiToHtml(anser.escapeForHtml(line.text) + spacer, {
-      use_classes: true,
+      // Let anser colorize the html as it appears from various consoles
+      use_classes: false,
     })
   )
   span.appendChild(code)


### PR DESCRIPTION
This PR simply disables the `use_classes` option when converting ANSI logs to HTML.

While previously only the ANSI classes in https://github.com/tilt-dev/tilt/blob/master/web/src/AnsiLine.scss had any form of colorization support, disabling the `use_classes` option allows any ANSI log to be colorized properly.

![image](https://user-images.githubusercontent.com/446365/151647872-420ca193-fd8e-450c-87dc-e17876defe82.png)
