### PR TITLE
demo: fix perpetual "Waiting for cluster" in some setups

### DIFF
--- a/internal/cli/demo.go
+++ b/internal/cli/demo.go
@@ -81,7 +81,7 @@ func (c *demoCmd) run(ctx context.Context, args []string) error {
 	a.Incr("cmd.demo", map[string]string{})
 	defer a.Flush(time.Second)
 
-	client, err := wireDockerClusterClient(ctx)
+	client, err := wireDockerLocalClient(ctx)
 	if err != nil {
 		return errors.Wrap(err, "Failed to init Docker client")
 	}


### PR DESCRIPTION
This should always use the _local_ Docker client rather than the
cluster client because we're creating our own ephemeral cluster
and doing that e.g. inside of minikube's Docker is unlikely to
be what anyone wants beyond resulting in the UI getting perpetually
stuck at "Waiting for cluster" because it's launched an inaccessible
ephemeral cluster with comical levels of nested virtualization/
containerization.