### PR TITLE
tiltfile: fetch extensions inside tiltfile state scratch dir

### DIFF
--- a/internal/tiltfile/tiltextension/github_fetcher.go
+++ b/internal/tiltfile/tiltextension/github_fetcher.go
@@ -3,13 +3,13 @@ package tiltextension
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"time"
 
 	"github.com/tilt-dev/go-get"
 
+	"github.com/tilt-dev/tilt/internal/watch"
 	"github.com/tilt-dev/tilt/pkg/logger"
 )
 
@@ -22,12 +22,12 @@ type TempDirDownloader struct {
 	rootDir string
 }
 
-func NewTempDirDownloader() (*TempDirDownloader, error) {
-	dir, err := ioutil.TempDir("", "tilt-extensions")
+func NewTempDirDownloader(dir *watch.TempDir) (*TempDirDownloader, error) {
+	extdir, err := dir.NewDir("tilt-extensions")
 	if err != nil {
 		return nil, err
 	}
-	return &TempDirDownloader{rootDir: dir}, nil
+	return &TempDirDownloader{rootDir: extdir.Path()}, nil
 }
 
 func (d *TempDirDownloader) RootDir() string {

--- a/internal/tiltfile/tiltfile_state.go
+++ b/internal/tiltfile/tiltfile_state.go
@@ -202,7 +202,11 @@ func (s *tiltfileState) print(_ *starlark.Thread, msg string) {
 func (s *tiltfileState) loadManifests(tf *v1alpha1.Tiltfile) ([]model.Manifest, starkit.Model, error) {
 	s.logger.Infof("Loading Tiltfile at: %s", tf.Spec.Path)
 
-	dlr, err := tiltextension.NewTempDirDownloader()
+	dir, err := s.tempDir()
+	if err != nil {
+		return nil, starkit.Model{}, err
+	}
+	dlr, err := tiltextension.NewTempDirDownloader(dir)
 	if err != nil {
 		return nil, starkit.Model{}, err
 	}


### PR DESCRIPTION
Since the tiltfile state's scratchDir is deleted when Tilt exits, this should eliminate most tilt-extension directory leakage issus in #5291.
