### PR TITLE
Kustomize: specify custom executable path

### DIFF
--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -547,6 +547,8 @@ func TestKustomizeBin(t *testing.T) {
 echo %%* > %s
 kustomize.exe %%*
 `, sentinel))
+		// convert backslashes in path
+		wrapper = strings.ReplaceAll(wrapper, "\\", "/")
 	} else {
 		wrapper = f.WriteFile("kustomize", fmt.Sprintf(`#!/bin/sh
 echo "$@" > %s

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -543,22 +543,22 @@ func TestKustomizeBin(t *testing.T) {
 	sentinel := f.WriteFile("kustomize.txt", "")
 	var wrapper string
 	if runtime.GOOS == "windows" {
-		wrapper = f.WriteFile("kustomize.bat", `@echo off
-echo %* > `+sentinel+`
-kustomize.exe %*
-`)
+		wrapper = f.WriteFile("kustomize.bat", fmt.Sprintf(`@echo off
+echo %%* > %s
+kustomize.exe %%*
+`, sentinel))
 	} else {
-		wrapper = f.WriteFile("kustomize", `#!/bin/sh
-echo "$@" > `+sentinel+`
+		wrapper = f.WriteFile("kustomize", fmt.Sprintf(`#!/bin/sh
+echo "$@" > %s
 exec kustomize "$@"
-`)
+`, sentinel))
 		_ = os.Chmod(wrapper, 0755)
 	}
 
-	f.file("Tiltfile", `
-k8s_yaml(kustomize(".", kustomize_bin="`+wrapper+`"))
+	f.file("Tiltfile", fmt.Sprintf(`
+k8s_yaml(kustomize(".", kustomize_bin="%s"))
 k8s_resource("the-deployment", "foo")
-`)
+`, wrapper))
 	f.load()
 	sentinelContents, err := os.ReadFile(sentinel)
 	assert.Nil(t, err)

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -541,15 +541,14 @@ func TestKustomizeBin(t *testing.T) {
 	f.file("deployment.yaml", kustomizeDeploymentText)
 	f.file("service.yaml", kustomizeServiceText)
 	sentinel := f.WriteFile("kustomize.txt", "")
-	kbin := f.WriteFile("kustomize", `#!/bin/sh
+	wrapper := f.WriteFile("kustomize", `#!/bin/sh
 echo "$@" > `+sentinel+`
-shift
-exec kubectl kustomize "$@"
+exec kustomize "$@"
 `)
-	_ = os.Chmod(kbin, 0755)
+	_ = os.Chmod(wrapper, 0755)
 
 	f.file("Tiltfile", `
-k8s_yaml(kustomize(".", kustomize_bin="`+kbin+`"))
+k8s_yaml(kustomize(".", kustomize_bin="`+wrapper+`"))
 k8s_resource("the-deployment", "foo")
 `)
 	f.load()

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -564,7 +564,7 @@ k8s_resource("the-deployment", "foo")
 	f.load()
 	sentinelContents, err := os.ReadFile(sentinel)
 	assert.Nil(t, err)
-	assert.EqualValues(t, "build .\n", string(sentinelContents))
+	assert.EqualValues(t, "build .", strings.Trim(string(sentinelContents), " \r\n"))
 }
 
 func TestKustomizeError(t *testing.T) {


### PR DESCRIPTION
Enable kustomize executable path to be kustomized. Fixes #5412.
