### PR TITLE
Add Additional Linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -65,6 +65,7 @@ linters:
     - staticcheck
     - structcheck
     - misspell
+    - varcheck
 issues:
   exclude-rules:
     - linters:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -65,7 +65,8 @@ linters:
     - staticcheck
     - structcheck
     - misspell
-    - varcheck
+    - unconvert
+    - unused
 issues:
   exclude-rules:
     - linters:
@@ -77,3 +78,6 @@ issues:
     - path: _test\.go
       linters:
         - errcheck
+    - path: types.go
+      linters:
+        - unconvert

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -62,6 +62,7 @@ linters:
     - govet
     - ineffassign
     - megacheck
+    - staticcheck
     - structcheck
     - misspell
 issues:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -58,6 +58,7 @@ linters:
     - errcheck
     - exportloopref
     - goimports
+    - gosimple
     - govet
     - ineffassign
     - megacheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -71,3 +71,6 @@ issues:
     - linters:
         - gosimple
       text: "S1008:"
+    - path: _test\.go
+      linters:
+        - errcheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -56,13 +56,13 @@ linters:
   enable:
     - deadcode
     - errcheck
-    - megacheck
-    - govet
-    - goimports
-    - structcheck
-    - ineffassign
-    - misspell
     - exportloopref
+    - goimports
+    - govet
+    - ineffassign
+    - megacheck
+    - structcheck
+    - misspell
 issues:
   exclude-rules:
     - linters:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -67,6 +67,7 @@ linters:
     - misspell
     - unconvert
     - unused
+    - varcheck
 issues:
   exclude-rules:
     - linters:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -26,7 +26,7 @@ output:
 # all available settings of specific linters
 linters-settings:
   errcheck:
-    # report about not checking of errors in type assetions: `a := b.(MyStruct)`;
+    # report about not checking of errors in type assertions: `a := b.(MyStruct)`;
     # default is false: such cases aren't reported by default.
     check-type-assertions: false
 

--- a/internal/build/buildkit_printer.go
+++ b/internal/build/buildkit_printer.go
@@ -280,6 +280,6 @@ func (b *buildkitPrinter) flushLogs(vl *vertexAndLogs) {
 	for vl.logsPrinted < len(vl.logs) {
 		l := vl.logs[vl.logsPrinted]
 		vl.logsPrinted++
-		vl.logger.Write(logger.InfoLvl, []byte(l.msg))
+		vl.logger.Write(logger.InfoLvl, l.msg)
 	}
 }

--- a/internal/cli/docker.go
+++ b/internal/cli/docker.go
@@ -13,7 +13,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/tilt-dev/tilt/internal/analytics"
-	"github.com/tilt-dev/tilt/internal/docker"
 	"github.com/tilt-dev/tilt/pkg/model"
 )
 
@@ -53,7 +52,7 @@ func (c *dockerCmd) run(ctx context.Context, args []string) error {
 	if builder == types.BuilderBuildKit {
 		buildkitEnv = "DOCKER_BUILDKIT=1"
 	}
-	env := append([]string{buildkitEnv}, docker.Env(dockerEnv).AsEnviron()...)
+	env := append([]string{buildkitEnv}, dockerEnv.AsEnviron()...)
 	fmt.Fprintf(os.Stderr,
 		"Running Docker command as:\n%s docker %s\n---\n",
 		strings.Join(env, " "),

--- a/internal/controllers/core/cmd/probe_test.go
+++ b/internal/controllers/core/cmd/probe_test.go
@@ -55,7 +55,7 @@ func TestProbeFromSpecTCP(t *testing.T) {
 				} else {
 					assert.Equal(t, "localhost", manager.tcpHost)
 				}
-				assert.Equal(t, int(tc.port), int(manager.tcpPort))
+				assert.Equal(t, int(tc.port), manager.tcpPort)
 			}
 		})
 	}

--- a/internal/controllers/core/kubernetesdiscovery/portforwards.go
+++ b/internal/controllers/core/kubernetesdiscovery/portforwards.go
@@ -119,10 +119,10 @@ func populateContainerPorts(pf *v1alpha1.PortForward, pod *v1alpha1.Pod) {
 	cPorts := store.AllPodContainerPorts(*pod)
 	for i, forward := range pf.Spec.Forwards {
 		if forward.ContainerPort == 0 && len(cPorts) > 0 {
-			forward.ContainerPort = int32(cPorts[0])
+			forward.ContainerPort = cPorts[0]
 			for _, cPort := range cPorts {
 				if int(forward.LocalPort) == int(cPort) {
-					forward.ContainerPort = int32(cPort)
+					forward.ContainerPort = cPort
 					break
 				}
 			}

--- a/internal/controllers/core/kubernetesdiscovery/reconciler.go
+++ b/internal/controllers/core/kubernetesdiscovery/reconciler.go
@@ -266,7 +266,7 @@ func (w *Reconciler) addOrReplace(ctx context.Context, watcherKey watcherID, kd 
 	} else {
 		currentNamespaces, currentUIDs := namespacesAndUIDsFromSpec(kd.Spec.Watches)
 		for namespace := range currentNamespaces {
-			nsKey := newNsKey(cluster, string(namespace))
+			nsKey := newNsKey(cluster, namespace)
 			err := w.setupNamespaceWatch(ctx, nsKey, watcherKey, kCli)
 			if err != nil {
 				newWatcher.errorReason = err.Error()

--- a/internal/controllers/core/liveupdate/reconciler_test.go
+++ b/internal/controllers/core/liveupdate/reconciler_test.go
@@ -636,7 +636,7 @@ func (s *TestingStore) Dispatch(action store.Action) {
 	case buildcontrols.BuildCompleteAction:
 		s.lastCompletedAction = &action
 	case store.LogAction:
-		_, _ = logger.Get(s.ctx).Writer(action.Level()).Write([]byte(action.Message()))
+		_, _ = logger.Get(s.ctx).Writer(action.Level()).Write(action.Message())
 	}
 }
 

--- a/internal/controllers/core/podlogstream/podlogstreamcontroller.go
+++ b/internal/controllers/core/podlogstream/podlogstreamcontroller.go
@@ -430,7 +430,7 @@ func (c *Controller) ensureStatusActive(streamName types.NamespacedName, contain
 	isMatching := len(containers) == len(status.ContainerStatuses)
 	if isMatching {
 		for i, cs := range status.ContainerStatuses {
-			if string(containers[i].Name) != cs.Name {
+			if containers[i].Name != cs.Name {
 				isMatching = false
 				break
 			}
@@ -444,7 +444,7 @@ func (c *Controller) ensureStatusActive(streamName types.NamespacedName, contain
 	statuses := make([]ContainerLogStreamStatus, 0, len(containers))
 	for _, c := range containers {
 		statuses = append(statuses, ContainerLogStreamStatus{
-			Name: string(c.Name),
+			Name: c.Name,
 		})
 	}
 	status.ContainerStatuses = statuses

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -1356,7 +1356,7 @@ func TestHudUpdated(t *testing.T) {
 	assert.Equal(t, 2, len(f.fakeHud().LastView.Resources))
 	assert.Equal(t, store.MainTiltfileManifestName, f.fakeHud().LastView.Resources[0].Name)
 	rv := f.fakeHud().LastView.Resources[1]
-	assert.Equal(t, manifest.Name, model.ManifestName(rv.Name))
+	assert.Equal(t, manifest.Name, rv.Name)
 	f.assertAllBuildsConsumed()
 }
 
@@ -1510,8 +1510,8 @@ func TestPodEventContainerStatusWithoutImage(t *testing.T) {
 
 	// If we have no image target to match container by image ref, we just take the first one
 	container := podState.Containers[0]
-	assert.Equal(t, "great-container-id", string(container.ID))
-	assert.Equal(t, "first-container", string(container.Name))
+	assert.Equal(t, "great-container-id", container.ID)
+	assert.Equal(t, "first-container", container.Name)
 	assert.Equal(t, []int32{8080}, store.AllPodContainerPorts(podState))
 
 	err := f.Stop()
@@ -4290,7 +4290,7 @@ func (f *testFixture) PollUntil(msg string, isDone func() bool) {
 func (f *testFixture) WaitUntilManifest(msg string, name model.ManifestName, isDone func(store.ManifestTarget) bool) {
 	f.t.Helper()
 	f.WaitUntil(msg, func(es store.EngineState) bool {
-		mt, ok := es.ManifestTargets[model.ManifestName(name)]
+		mt, ok := es.ManifestTargets[name]
 		if !ok {
 			return false
 		}

--- a/internal/git/remote.go
+++ b/internal/git/remote.go
@@ -28,7 +28,7 @@ func gitOrigin(fromDir string) string {
 }
 
 func normalizeGitRemote(s string) string {
-	u, err := giturls.Parse(string(s))
+	u, err := giturls.Parse(s)
 	if err != nil {
 		return s
 	}

--- a/internal/hud/webview/convert_test.go
+++ b/internal/hud/webview/convert_test.go
@@ -189,8 +189,8 @@ func TestStateToViewTiltfileLog(t *testing.T) {
 	v := completeProtoView(t, *es)
 	_, ok := findResource("(Tiltfile)", v)
 	require.True(t, ok, "no resource named (Tiltfile) found")
-	assert.Equal(t, "hello", string(v.LogList.Segments[0].Text))
-	assert.Equal(t, "(Tiltfile)", string(v.LogList.Spans[string(spanID)].ManifestName))
+	assert.Equal(t, "hello", v.LogList.Segments[0].Text)
+	assert.Equal(t, "(Tiltfile)", v.LogList.Spans[string(spanID)].ManifestName)
 }
 
 func TestNeedsNudgeSet(t *testing.T) {
@@ -257,7 +257,7 @@ func TestReadinessCheckFailing(t *testing.T) {
 	v := completeProtoView(t, *state)
 	rv, ok := findResource(m.Name, v)
 	require.True(t, ok)
-	require.Equal(t, v1alpha1.RuntimeStatusPending, v1alpha1.RuntimeStatus(rv.RuntimeStatus))
+	require.Equal(t, v1alpha1.RuntimeStatusPending, rv.RuntimeStatus)
 	require.Equal(t, "False", string(readyCondition(rv).Status))
 }
 

--- a/internal/k8s/entity_test.go
+++ b/internal/k8s/entity_test.go
@@ -222,7 +222,7 @@ func TestSortEntities(t *testing.T) {
 			[]string{"PersistentVolume", "PersistentVolumeClaim", "ConfigMap", "Service", "StatefulSet", "Job", "Pod"},
 		},
 	} {
-		t.Run(string(test.name), func(t *testing.T) {
+		t.Run(test.name, func(t *testing.T) {
 			input := entitiesWithKinds(test.inputKindOrder)
 			sorted := SortedEntities(input)
 			assertKindOrder(t, test.expectedKindOrder, sorted, "sorted entities")
@@ -259,7 +259,7 @@ func TestMutableAndImmutableEntities(t *testing.T) {
 			[]string{},
 		},
 	} {
-		t.Run(string(test.name), func(t *testing.T) {
+		t.Run(test.name, func(t *testing.T) {
 			input := entitiesWithKinds(test.inputKindOrder)
 			mutable, immutable := MutableAndImmutableEntities(input)
 			assertKindOrder(t, test.expectedMutableKindOrder, mutable, "mutable entities")

--- a/internal/tiltfile/files.go
+++ b/internal/tiltfile/files.go
@@ -265,7 +265,7 @@ func (s *tiltfileState) helm(thread *starlark.Thread, fn *starlark.Builtin, args
 		return nil, err
 	}
 
-	yaml := filterHelmTestYAML(string(stdout))
+	yaml := filterHelmTestYAML(stdout)
 
 	if version == helmV3_0 {
 		// Helm v3.0 has a bug where it doesn't include CRDs in the template output

--- a/internal/tiltfile/helm.go
+++ b/internal/tiltfile/helm.go
@@ -148,7 +148,7 @@ func localSubchartDependencies(dat []byte) ([]string, error) {
 	var deps []string
 	var metadata chartMetadata
 
-	err := yaml.Unmarshal([]byte(dat), &metadata)
+	err := yaml.Unmarshal(dat, &metadata)
 	if err != nil {
 		return deps, err
 	}

--- a/internal/tiltfile/os/environ.go
+++ b/internal/tiltfile/os/environ.go
@@ -26,12 +26,12 @@ func (Environ) Delete(k starlark.Value) (v starlark.Value, found bool, err error
 		return starlark.None, false, nil
 	}
 
-	val, found := os.LookupEnv(string(str))
+	val, found := os.LookupEnv(str)
 	if !found {
 		return starlark.None, false, nil
 	}
 
-	os.Unsetenv(string(str))
+	os.Unsetenv(str)
 
 	return starlark.String(val), true, nil
 }
@@ -42,7 +42,7 @@ func (Environ) Get(k starlark.Value) (v starlark.Value, found bool, err error) {
 		return starlark.None, false, nil
 	}
 
-	val, found := os.LookupEnv(string(str))
+	val, found := os.LookupEnv(str)
 	return starlark.String(val), found, nil
 }
 
@@ -71,7 +71,7 @@ func (Environ) SetKey(k, v starlark.Value) error {
 		return fmt.Errorf("putenv() value must be a string, not %s", v.Type())
 	}
 
-	os.Setenv(string(kStr), string(vStr))
+	os.Setenv(kStr, vStr)
 	return nil
 }
 

--- a/internal/tiltfile/tiltfile_docker_compose_test.go
+++ b/internal/tiltfile/tiltfile_docker_compose_test.go
@@ -907,7 +907,7 @@ func (f *fixture) assertDcManifest(name model.ManifestName, opts ...interface{})
 	for _, opt := range opts {
 		switch opt := opt.(type) {
 		case dcServiceYAMLHelper:
-			assert.YAMLEq(f.t, opt.yaml, string(dcInfo.ServiceYAML), "docker compose YAML")
+			assert.YAMLEq(f.t, opt.yaml, dcInfo.ServiceYAML, "docker compose YAML")
 		case noImageHelper:
 			assert.Empty(f.t, m.ImageTargets, "Manifest should have had no ImageTargets")
 		case dockerComposeImageHelper:

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -6171,7 +6171,7 @@ func (f *fixture) assertNextManifest(name model.ManifestName, opts ...interface{
 	}
 
 	m := f.loadResult.Manifests[0]
-	if m.Name != model.ManifestName(name) {
+	if m.Name != name {
 		f.t.Fatalf("expected next manifest to be '%s' but found '%s'", name, m.Name)
 	}
 

--- a/internal/tiltfile/value/value.go
+++ b/internal/tiltfile/value/value.go
@@ -41,7 +41,7 @@ func ValueToAbsPath(thread *starlark.Thread, v starlark.Value) (string, error) {
 
 	str, ok := starlark.AsString(v)
 	if ok {
-		return starkit.AbsPath(thread, string(str)), nil
+		return starkit.AbsPath(thread, str), nil
 	}
 
 	return "", fmt.Errorf("expected path | string. Actual type: %T", v)


### PR DESCRIPTION
This PR includes the following:

* Fixed misspelling in comment
* Organized the linters used
* Added the following linters
    - gosimple
    - staticcheck
    - unconvert
    - unused
    - varcheck
 * Code updates to compile (mostly unnecessary casting)
 * Ignoring errcheck for tests

The staticcheck had an entry in `exclude-rules` however was never enabled as a linter.  

I would recommended turning up errcheck but results in much work to-do.  Worth ignoring on tests but not in base code IMO.    There is a lot to-do around cyclomatic complexity.  The numbers are high with the greatest concern around untested code.  Some of this seems pulled from other projects or inspired by other projects.  It is worth adding there is a high number of unused params as well.

Happy to trim this PR down... or add more if desired.  IMO quality of a project and consistency of contributed code increases with the addition of good linters. 

Love the concept behind this project!