### PR TITLE
cli: tilt args output indicates when there is no change

### DIFF
--- a/internal/cli/args.go
+++ b/internal/cli/args.go
@@ -116,8 +116,7 @@ func parseEditResult(b []byte) ([]string, error) {
 }
 
 func (c *argsCmd) run(ctx context.Context, args []string) error {
-	logLvl := logger.Get(ctx).Level()
-	ctx = logger.WithLogger(ctx, logger.NewLogger(logLvl, c.streams.ErrOut))
+	ctx = logger.WithLogger(ctx, logger.NewLogger(logger.Get(ctx).Level(), c.streams.ErrOut))
 
 	ctrlclient, err := newClient(ctx)
 	if err != nil {
@@ -159,7 +158,7 @@ func (c *argsCmd) run(ctx context.Context, args []string) error {
 	defer a.Flush(time.Second)
 
 	if sliceutils.StringSliceEquals(tf.Spec.Args, args) {
-		logger.Get(ctx).Infof("Tilt is already running with those args. No action taken.")
+		logger.Get(ctx).Infof("Tilt is already running with those args -- no action taken")
 		return nil
 	}
 	tf.Spec.Args = args
@@ -169,7 +168,7 @@ func (c *argsCmd) run(ctx context.Context, args []string) error {
 		return err
 	}
 
-	logger.Get(ctx).Infof("changed config args for Tilt running at %s to %v", apiHost(), args)
+	logger.Get(ctx).Infof("Changed config args for Tilt running at %s to %v", apiHost(), args)
 
 	return nil
 }

--- a/internal/cli/args_test.go
+++ b/internal/cli/args_test.go
@@ -87,7 +87,7 @@ func TestArgsNoChange(t *testing.T) {
 	require.NoError(t, err)
 	err = cmd.run(f.ctx, c.Flags().Args())
 	require.NoError(t, err)
-	require.Contains(t, out.String(), "No action taken")
+	require.Contains(t, out.String(), "no action taken")
 }
 
 func TestArgsEdit(t *testing.T) {


### PR DESCRIPTION
### Problem

If `tilt args` specifies the existing args value, then nothing happens. The Tiltfile is not re-executed, and the set of enabled resources is not changed. This might make a user think their command didn't work.

### Solution

Explicitly tell the user the command didn't do anything.