### PR TITLE
tiltfile: add config.set_disabled_resources

### DIFF
--- a/internal/tiltfile/config/config.go
+++ b/internal/tiltfile/config/config.go
@@ -15,6 +15,7 @@ import (
 const UserConfigFileName = "tilt_config.json"
 
 type Settings struct {
+	disableAll       bool
 	enabledResources []model.ManifestName
 	configDef        ConfigDef
 

--- a/internal/tiltfile/config/config.go
+++ b/internal/tiltfile/config/config.go
@@ -61,6 +61,7 @@ func (e *Plugin) OnStart(env *starkit.Environment) error {
 		f    starkit.Function
 	}{
 		{"config.set_enabled_resources", setEnabledResources},
+		{"config.clear_enabled_resources", clearEnabledResources},
 		{"config.parse", e.parse},
 		{"config.define_string_list", configSettingDefinitionBuiltin(func() configValue {
 			return &stringList{}

--- a/internal/tiltfile/config/config_test.go
+++ b/internal/tiltfile/config/config_test.go
@@ -69,7 +69,7 @@ config.parse()`
 	}
 }
 
-func TestDisableAllResources(t *testing.T) {
+func TestClearEnabledResources(t *testing.T) {
 	args := strings.Split("united states canada mexico panama haiti jamaica peru", " ")
 
 	f := NewFixture(t, args, "")
@@ -85,6 +85,20 @@ func TestDisableAllResources(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Len(t, actual, 0)
+}
+
+func TestClearEnabledResourcesWithArgs(t *testing.T) {
+	args := strings.Split("united states canada mexico panama haiti jamaica peru", " ")
+
+	f := NewFixture(t, args, "")
+	defer f.TearDown()
+
+	f.File("Tiltfile", "config.clear_enabled_resources('foo')")
+
+	_, err := f.ExecFile("Tiltfile")
+	require.Error(t, err)
+
+	require.Contains(t, err.Error(), "got 1 arguments, want at most 0")
 }
 
 func TestParsePositional(t *testing.T) {

--- a/internal/tiltfile/config/config_test.go
+++ b/internal/tiltfile/config/config_test.go
@@ -75,7 +75,7 @@ func TestDisableAllResources(t *testing.T) {
 	f := NewFixture(t, args, "")
 	defer f.TearDown()
 
-	f.File("Tiltfile", "config.set_enabled_resources(None)")
+	f.File("Tiltfile", "config.clear_enabled_resources()")
 
 	result, err := f.ExecFile("Tiltfile")
 	require.NoError(t, err)

--- a/internal/tiltfile/config/config_test.go
+++ b/internal/tiltfile/config/config_test.go
@@ -69,6 +69,24 @@ config.parse()`
 	}
 }
 
+func TestDisableAllResources(t *testing.T) {
+	args := strings.Split("united states canada mexico panama haiti jamaica peru", " ")
+
+	f := NewFixture(t, args, "")
+	defer f.TearDown()
+
+	f.File("Tiltfile", "config.set_enabled_resources(None)")
+
+	result, err := f.ExecFile("Tiltfile")
+	require.NoError(t, err)
+
+	manifests := []model.Manifest{{Name: "a"}, {Name: "b"}}
+	actual, err := MustState(result).EnabledResources(f.Tiltfile(), manifests)
+	require.NoError(t, err)
+
+	require.Len(t, actual, 0)
+}
+
 func TestParsePositional(t *testing.T) {
 	args := strings.Split("united states canada mexico panama haiti jamaica peru", " ")
 

--- a/internal/tiltfile/config/resources.go
+++ b/internal/tiltfile/config/resources.go
@@ -46,8 +46,14 @@ func setEnabledResources(thread *starlark.Thread, fn *starlark.Builtin, args sta
 }
 
 func clearEnabledResources(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-	err := starkit.SetState(thread, func(settings Settings) Settings {
+	err := starkit.UnpackArgs(thread, fn.Name(), args, kwargs)
+	if err != nil {
+		return starlark.None, err
+	}
+
+	err = starkit.SetState(thread, func(settings Settings) Settings {
 		settings.disableAll = true
+		settings.enabledResources = nil
 		return settings
 	})
 	return starlark.None, err


### PR DESCRIPTION
Add a way to specify that all resources should be disabled, giving a "resource catalog" experience.

`config.set_enabled_resources([])` currently acts as `tilt up` with `argv == []`, i.e., it enables all resources. We probably don't want to change this since it'll break basic use cases like the first [tiltfile config example](https://docs.tilt.dev/tiltfile_config.html#run-only-some-services-reimplement-default-tilt-behavior).

`config.set_enabled_resources(None)` was previously an error, but will now indicate that all resources should be disabled.
