### PR TITLE
features: turn on Disable Resources feature flag by default

### DIFF
--- a/internal/feature/flags.go
+++ b/internal/feature/flags.go
@@ -71,12 +71,12 @@ var MainDefaults = Defaults{
 		Status:  Active,
 	},
 	DisableResources: Value{
-		Enabled: false,
+		Enabled: true,
 		Status:  Active,
 	},
 	BulkDisableResources: Value{
 		Enabled: false,
-		Status:  Active,
+		Status:  Obsolete,
 	},
 }
 

--- a/web/src/OverviewResourceSidebar.stories.tsx
+++ b/web/src/OverviewResourceSidebar.stories.tsx
@@ -53,7 +53,7 @@ export default {
       defaultValue: true,
     },
     disableResourcesEnabled: {
-      name: "See disabled resources",
+      name: "See disabled resources and bulk actions",
       control: {
         type: "boolean",
       },

--- a/web/src/OverviewTable.stories.tsx
+++ b/web/src/OverviewTable.stories.tsx
@@ -24,8 +24,6 @@ export default {
       const features = new Features({
         [Flag.Labels]: context?.args?.labelsEnabled ?? true,
         [Flag.DisableResources]: context?.args?.disableResourcesEnabled ?? true,
-        [Flag.BulkDisableResources]:
-          context?.args?.bulkDisableResourcesEnabled ?? true,
       })
       return (
         <MemoryRouter initialEntries={["/"]}>
@@ -55,14 +53,7 @@ export default {
       defaultValue: true,
     },
     disableResourcesEnabled: {
-      name: "See disabled resources",
-      control: {
-        type: "boolean",
-      },
-      defaultValue: true,
-    },
-    bulkDisableResourcesEnabled: {
-      name: "See bulk disabling functionality",
+      name: "See disabled resources and bulk actions",
       control: {
         type: "boolean",
       },

--- a/web/src/OverviewTable.test.tsx
+++ b/web/src/OverviewTable.test.tsx
@@ -69,21 +69,18 @@ const tableViewWithSettings = ({
   view,
   labelsEnabled,
   disableResourcesEnabled,
-  bulkActionsEnabled,
   resourceListOptions,
   resourceSelections,
 }: {
   view: TestDataView
   labelsEnabled?: boolean
   disableResourcesEnabled?: boolean
-  bulkActionsEnabled?: boolean
   resourceListOptions?: ResourceListOptions
   resourceSelections?: string[]
 }) => {
   const features = new Features({
     [Flag.Labels]: labelsEnabled ?? true,
     [Flag.DisableResources]: disableResourcesEnabled ?? true,
-    [Flag.BulkDisableResources]: bulkActionsEnabled ?? true,
   })
   return (
     <MemoryRouter initialEntries={["/"]}>
@@ -749,81 +746,85 @@ describe("when disable resources feature is NOT enabled", () => {
   })
 })
 
-describe("when bulk disable resources feature is enabled", () => {
-  let view: TestDataView
-  let wrapper: ReactWrapper<OverviewTableProps, typeof OverviewTable>
+describe("bulk disable actions", () => {
+  describe("when disable resources feature is enabled", () => {
+    let view: TestDataView
+    let wrapper: ReactWrapper<OverviewTableProps, typeof OverviewTable>
 
-  beforeEach(() => {
-    view = nResourceView(4)
-    wrapper = mount(tableViewWithSettings({ view, bulkActionsEnabled: true }))
-  })
-
-  it("renders the `Select` column", () => {
-    expect(wrapper.find(TableSelectionColumn).length).toBeGreaterThan(0)
-  })
-
-  it("renders a checkbox for every resource that is selectable", () => {
-    const expectedCheckBoxDisplay = {
-      "(Tiltfile)": false,
-      _1: true,
-      _2: true,
-      _3: true,
-    }
-    const actualCheckboxDisplay: { [key: string]: boolean } = {}
-    const rows = wrapper.find(ResourceTableRow).slice(1) // Ignore the header row
-    rows.forEach((row) => {
-      const name = row.find(TableNameColumn).text()
-      const checkbox = row.find(SelectionCheckbox)
-      actualCheckboxDisplay[name] = checkbox.length === 1
+    beforeEach(() => {
+      view = nResourceView(4)
+      wrapper = mount(
+        tableViewWithSettings({ view, disableResourcesEnabled: true })
+      )
     })
 
-    expect(actualCheckboxDisplay).toEqual(expectedCheckBoxDisplay)
+    it("renders the `Select` column", () => {
+      expect(wrapper.find(TableSelectionColumn).length).toBeGreaterThan(0)
+    })
+
+    it("renders a checkbox for every resource that is selectable", () => {
+      const expectedCheckBoxDisplay = {
+        "(Tiltfile)": false,
+        _1: true,
+        _2: true,
+        _3: true,
+      }
+      const actualCheckboxDisplay: { [key: string]: boolean } = {}
+      const rows = wrapper.find(ResourceTableRow).slice(1) // Ignore the header row
+      rows.forEach((row) => {
+        const name = row.find(TableNameColumn).text()
+        const checkbox = row.find(SelectionCheckbox)
+        actualCheckboxDisplay[name] = checkbox.length === 1
+      })
+
+      expect(actualCheckboxDisplay).toEqual(expectedCheckBoxDisplay)
+    })
+
+    it("selects a resource when checkbox is not checked", () => {
+      const checkbox = wrapper.find(SelectionCheckbox).at(0)
+      expect(checkbox).toBeTruthy()
+
+      checkbox.find("input").at(0).simulate("change")
+      wrapper.update()
+
+      const checkboxAfterClick = wrapper.find(SelectionCheckbox).at(0)
+      expect(checkboxAfterClick.prop("checked")).toBe(true)
+    })
+
+    it("deselects a resource when checkbox is checked", () => {
+      const checkbox = wrapper.find(SelectionCheckbox).at(0)
+      expect(checkbox).toBeTruthy()
+
+      // Click the checkbox once to get it to a selected state
+      checkbox.find("input").at(0).simulate("change")
+      wrapper.update()
+
+      const checkboxAfterFirstClick = wrapper.find(SelectionCheckbox).at(0)
+      expect(checkboxAfterFirstClick.prop("checked")).toBe(true)
+
+      // Click the checkbox a second time to deselect it
+      checkbox.find("input").at(0).simulate("change")
+      wrapper.update()
+
+      const checkboxAfterSecondClick = wrapper.find(SelectionCheckbox).at(0)
+      expect(checkboxAfterSecondClick.prop("checked")).toBe(false)
+    })
   })
 
-  it("selects a resource when checkbox is not checked", () => {
-    const checkbox = wrapper.find(SelectionCheckbox).at(0)
-    expect(checkbox).toBeTruthy()
+  describe("when disable resources feature is NOT enabled", () => {
+    it("does NOT render the `Select` column", () => {
+      const wrapper: ReactWrapper<OverviewTableProps, typeof OverviewTable> =
+        mount(
+          tableViewWithSettings({
+            view: nResourceView(5),
+            disableResourcesEnabled: false,
+          })
+        )
+      const firstColumnHeaderText = wrapper.find(ResourceTableRow).at(1).text()
 
-    checkbox.find("input").at(0).simulate("change")
-    wrapper.update()
-
-    const checkboxAfterClick = wrapper.find(SelectionCheckbox).at(0)
-    expect(checkboxAfterClick.prop("checked")).toBe(true)
-  })
-
-  it("deselects a resource when checkbox is checked", () => {
-    const checkbox = wrapper.find(SelectionCheckbox).at(0)
-    expect(checkbox).toBeTruthy()
-
-    // Click the checkbox once to get it to a selected state
-    checkbox.find("input").at(0).simulate("change")
-    wrapper.update()
-
-    const checkboxAfterFirstClick = wrapper.find(SelectionCheckbox).at(0)
-    expect(checkboxAfterFirstClick.prop("checked")).toBe(true)
-
-    // Click the checkbox a second time to deselect it
-    checkbox.find("input").at(0).simulate("change")
-    wrapper.update()
-
-    const checkboxAfterSecondClick = wrapper.find(SelectionCheckbox).at(0)
-    expect(checkboxAfterSecondClick.prop("checked")).toBe(false)
-  })
-})
-
-describe("when bulk disable resources feature is NOT enabled", () => {
-  it("does NOT render the `Select` column", () => {
-    const wrapper: ReactWrapper<OverviewTableProps, typeof OverviewTable> =
-      mount(
-        tableViewWithSettings({
-          view: nResourceView(5),
-          bulkActionsEnabled: false,
-        })
-      )
-    const firstColumnHeaderText = wrapper.find(ResourceTableRow).at(1).text()
-
-    expect(wrapper.find(TableSelectionColumn).length).toBe(0)
-    // Expect to see the Starred column first when the selection column isn't present
-    expect(firstColumnHeaderText.includes("star.svg")).toBe(true)
+      expect(wrapper.find(TableSelectionColumn).length).toBe(0)
+      // Expect to see the Starred column first when the selection column isn't present
+      expect(firstColumnHeaderText.includes("star.svg")).toBe(true)
+    })
   })
 })

--- a/web/src/OverviewTableBulkActions.test.tsx
+++ b/web/src/OverviewTableBulkActions.test.tsx
@@ -34,7 +34,7 @@ const OverviewTableBulkActionsTestWrapper = (props: {
   resourceSelections: string[]
 }) => {
   const { flagEnabled, resourceSelections } = props
-  const features = new Features({ [Flag.BulkDisableResources]: flagEnabled })
+  const features = new Features({ [Flag.DisableResources]: flagEnabled })
   return (
     <FeaturesProvider value={features}>
       <ResourceSelectionProvider initialValuesForTesting={resourceSelections}>
@@ -54,7 +54,7 @@ describe("OverviewTableBulkActions", () => {
     cleanupMockAnalyticsCalls()
   })
 
-  describe("when bulk actions are NOT enabled", () => {
+  describe("when disable resources are NOT enabled", () => {
     it("does NOT display", () => {
       render(
         <OverviewTableBulkActionsTestWrapper
@@ -67,7 +67,7 @@ describe("OverviewTableBulkActions", () => {
     })
   })
 
-  describe("when bulk actions are enabled", () => {
+  describe("when disable resources are enabled", () => {
     describe("when there are NO resources selected", () => {
       it("does NOT display", () => {
         render(

--- a/web/src/OverviewTableBulkActions.tsx
+++ b/web/src/OverviewTableBulkActions.tsx
@@ -87,7 +87,7 @@ export function OverviewTableBulkActions({
   )
 
   // Don't render if feature flag is off or if there are no selections
-  if (!features.isEnabled(Flag.BulkDisableResources) || selected.length === 0) {
+  if (!features.isEnabled(Flag.DisableResources) || selected.length === 0) {
     return null
   }
 

--- a/web/src/OverviewTableColumns.tsx
+++ b/web/src/OverviewTableColumns.tsx
@@ -600,8 +600,8 @@ export function getTableColumns(features?: Features) {
     return DEFAULT_COLUMNS
   }
 
-  // If bulk disable is enabled, render the selection column
-  if (features.isEnabled(Flag.BulkDisableResources)) {
+  // If disable resources is enabled, render the selection column
+  if (features.isEnabled(Flag.DisableResources)) {
     return [RESOURCE_SELECTION_COLUMN, ...DEFAULT_COLUMNS]
   }
 

--- a/web/src/OverviewTablePane.stories.tsx
+++ b/web/src/OverviewTablePane.stories.tsx
@@ -20,8 +20,6 @@ export default {
       const features = new Features({
         [Flag.Labels]: context?.args?.labelsEnabled ?? true,
         [Flag.DisableResources]: context?.args?.disableResourcesEnabled ?? true,
-        [Flag.BulkDisableResources]:
-          context?.args?.bulkDisableResourcesEnabled ?? true,
       })
       return (
         <MemoryRouter initialEntries={["/"]}>
@@ -51,14 +49,7 @@ export default {
       defaultValue: true,
     },
     disableResourcesEnabled: {
-      name: "See disabled resources",
-      control: {
-        type: "boolean",
-      },
-      defaultValue: true,
-    },
-    bulkDisableResourcesEnabled: {
-      name: "See bulk disabling functionality",
+      name: "See disabled resources and bulk actions",
       control: {
         type: "boolean",
       },

--- a/web/storybook.tiltfile
+++ b/web/storybook.tiltfile
@@ -8,7 +8,6 @@ version_settings(constraint='>=0.22.1')
 load("ext://uibutton", "cmd_button", "location")
 
 enable_feature("disable_resources")
-enable_feature("bulk_disable_resources")
 
 local_resource(
   'storybook',


### PR DESCRIPTION
This PR turns on the `DisableResources` flag by default and deprecates `BulkDisableResources` flag since it is no longer needed. All the frontend code that uses the bulk feature flag now uses the disable resources flag.

Disable resources will launch for everyone on the next release. 🎉 