### PR TITLE
web: add resource selection checkbox for table groups

### DIFF
--- a/web/src/OverviewTable.tsx
+++ b/web/src/OverviewTable.tsx
@@ -462,8 +462,11 @@ export function ResourceTableHeadRow({
 }: ResourceTableHeadRowProps) {
   const calculateToggleProps = (column: HeaderGroup<RowValues>) => {
     // If a column header is JSX, fall back on using its id as a descriptive title
+    // and capitalize for consistency
     const columnHeader =
-      typeof column.Header === "string" ? column.Header : column.id
+      typeof column.Header === "string"
+        ? column.Header
+        : `${column.id[0]?.toUpperCase()}${column.id?.slice(1)}`
 
     // Warning! Toggle props are not typed or documented well within react-table.
     // Modify toggle props with caution.

--- a/web/src/ResourceSelectionContext.tsx
+++ b/web/src/ResourceSelectionContext.tsx
@@ -7,8 +7,8 @@ import { createContext, PropsWithChildren, useContext, useState } from "react"
 type ResourceSelectionContext = {
   selected: string[]
   isSelected: (resourceName: string) => boolean
-  select: (resourceName: string) => void
-  deselect: (resourceName: string) => void
+  select: (...resourceNames: string[]) => void
+  deselect: (...resourceNames: string[]) => void
   clearSelections: () => void
 }
 
@@ -18,10 +18,10 @@ const ResourceSelectionContext = createContext<ResourceSelectionContext>({
     console.warn("Resource selections context is not set.")
     return false
   },
-  select: (_resourceName: string) => {
+  select: (..._resourceNames: string[]) => {
     console.warn("Resource selections context is not set.")
   },
-  deselect: (_resourceName: string) => {
+  deselect: (..._resourceNames: string[]) => {
     console.warn("Resource selections context is not set.")
   },
   clearSelections: () => {
@@ -45,13 +45,15 @@ export function ResourceSelectionProvider(
     return selectedResources.includes(resourceName)
   }
 
-  function select(resourceName: string) {
-    return setSelectedResources([...selectedResources, resourceName])
+  function select(...resourceNames: string[]) {
+    // Filter out resources that are already selected
+    const newSelections = resourceNames.filter((r) => !isSelected(r))
+    return setSelectedResources([...selectedResources, ...newSelections])
   }
 
-  function deselect(resourceName: string) {
+  function deselect(...resourceNames: string[]) {
     return setSelectedResources(
-      selectedResources.filter((r) => r !== resourceName)
+      selectedResources.filter((r) => !resourceNames.includes(r))
     )
   }
 


### PR DESCRIPTION
This PR adds a checkbox to the resource selection column header for each table displayed in Table View. The header checkbox will select or deselect all resources in its table. It will display as unchecked, indeterminate (partially checked), or checked, depending on the resources in its table.

Here's a sample of what those states look like:
![Screen Shot 2022-02-02 at 6 36 06 PM](https://user-images.githubusercontent.com/23283986/152259642-a8f40978-7af6-40df-85b1-138bab9452b8.png)

I'd like to refactor the `ResourceSelectionContext` tests and possibly the `OverviewTable` tests to use React Testing Library in a separate PR, so that this one can be reviewed and potentially make into the next release in time.

[Closes ch12975](https://app.shortcut.com/windmill/story/12975/add-checkbox-for-resource-groups).