### PR TITLE
Linting fix:  gocritic for replaceall and commentFormatting

### DIFF
--- a/integration/fixture_test.go
+++ b/integration/fixture_test.go
@@ -287,7 +287,7 @@ func (f *fixture) ReplaceContents(fileBaseName, original, replacement string) {
 		f.originalFiles[file] = contents
 	}
 
-	newContents := strings.Replace(contents, original, replacement, -1)
+	newContents := strings.ReplaceAll(contents, original, replacement)
 	if newContents == contents {
 		f.t.Fatalf("Could not find contents %q to replace in file %s: %s", original, fileBaseName, contents)
 	}

--- a/integration/tilt_ci_test.go
+++ b/integration/tilt_ci_test.go
@@ -133,7 +133,6 @@ func generateLocalResources() []localResource {
 }
 
 func (lr localResource) String() string {
-	//args := make(map[string]string)
 	var args []string
 	args = append(args, fmt.Sprintf("name=%q", lr.name))
 	var autoInitArgVal string

--- a/internal/build/pipeline_state.go
+++ b/internal/build/pipeline_state.go
@@ -112,7 +112,7 @@ func (ps *PipelineState) Printf(ctx context.Context, format string, a ...interfa
 		l.Infof(format, a...)
 	} else {
 		message := fmt.Sprintf(format, a...)
-		message = strings.Replace(message, "\n", "\n"+buildStepOutputPrefix, -1)
+		message = strings.ReplaceAll(message, "\n", "\n"+buildStepOutputPrefix)
 		l.Infof("%s%s", buildStepOutputPrefix, message)
 	}
 }

--- a/internal/build/pipeline_state_test.go
+++ b/internal/build/pipeline_state_test.go
@@ -94,5 +94,5 @@ func assertSnapshot(t *testing.T, output string) {
 }
 
 func normalize(str string) string {
-	return strings.Replace(str, "\r\n", "\n", -1)
+	return strings.ReplaceAll(str, "\r\n", "\n")
 }

--- a/internal/controllers/core/tiltfile/api.go
+++ b/internal/controllers/core/tiltfile/api.go
@@ -488,7 +488,7 @@ func toCmdImageObjects(tlr *tiltfile.TiltfileLoadResult, disableSources disableS
 			}
 
 			// TODO(nick): Add DisableSource to image builds.
-			//di.Spec.DisableSource = disableSources[m.Name]
+			// di.Spec.DisableSource = disableSources[m.Name]
 
 			result[name] = ci
 		}

--- a/internal/engine/build_and_deployer.go
+++ b/internal/engine/build_and_deployer.go
@@ -93,7 +93,7 @@ func (composite *CompositeBuildAndDeployer) BuildAndDeploy(ctx context.Context, 
 			lastUnexpectedErr = err
 			if isLiveUpdate {
 				// Indent the error message.
-				errMsg := strings.Replace(strings.TrimSpace(fmt.Sprintf("%v", err)), "\n", "\n\t", -1)
+				errMsg := strings.ReplaceAll(strings.TrimSpace(fmt.Sprintf("%v", err)), "\n", "\n\t")
 				l.Warnf("Live Update failed with unexpected error:\n\t%s\n"+
 					"Falling back to a full image build + deploy", errMsg)
 			} else if i+1 < len(composite.builders) {

--- a/internal/engine/k8srollout/podmonitor_test.go
+++ b/internal/engine/k8srollout/podmonitor_test.go
@@ -227,5 +227,5 @@ func assertSnapshot(t *testing.T, output string) {
 }
 
 func normalize(s string) string {
-	return strings.Replace(s, "\r\n", "\n", -1)
+	return strings.ReplaceAll(s, "\r\n", "\n")
 }

--- a/internal/engine/telemetry/controller_test.go
+++ b/internal/engine/telemetry/controller_test.go
@@ -236,7 +236,7 @@ func (tcf *tcFixture) assertCmdOutput(expected string) {
 }
 
 func normalize(s string) string {
-	return strings.Replace(s, "\r\n", "\n", -1)
+	return strings.ReplaceAll(s, "\r\n", "\n")
 }
 
 func (tcf *tcFixture) assertSpansPresent() {

--- a/internal/hud/server/apiserver.go
+++ b/internal/hud/server/apiserver.go
@@ -60,7 +60,7 @@ func ProvideMemConn() apiserver.ConnProvider {
 }
 
 func ProvideKeyCert(apiServerName model.APIServerName, host model.WebHost, port model.WebPort, base xdg.Base) (options.GeneratableKeyCert, error) {
-	pairName := strings.Replace(fmt.Sprintf("%s_%d", host, port), string(filepath.Separator), "_", -1)
+	pairName := strings.ReplaceAll(fmt.Sprintf("%s_%d", host, port), string(filepath.Separator), "_")
 	exampleCert, err := base.CacheFile(filepath.Join("certs", string(apiServerName), pairName))
 	if err != nil {
 		return options.GeneratableKeyCert{}, err

--- a/internal/hud/server/server.go
+++ b/internal/hud/server/server.go
@@ -358,7 +358,7 @@ func (s *HeadsUpServer) HandleNewSnapshot(w http.ResponseWriter, req *http.Reque
 		Url: s.uploader.IDToSnapshotURL(id),
 	}
 
-	//encode URL to JSON format
+	// encode URL to JSON format
 	urlJS, err := json.Marshal(responsePayload)
 	if err != nil {
 		msg := fmt.Sprintf("Error to marshal url JSON response %v", err)
@@ -367,7 +367,7 @@ func (s *HeadsUpServer) HandleNewSnapshot(w http.ResponseWriter, req *http.Reque
 		return
 	}
 
-	//write URL to header
+	// write URL to header
 	w.WriteHeader(http.StatusOK)
 	_, err = w.Write(urlJS)
 	if err != nil {

--- a/internal/k8s/jsonpath/jsonpath.go
+++ b/internal/k8s/jsonpath/jsonpath.go
@@ -457,7 +457,7 @@ func (j *JSONPath) evalFilter(input []Value, node *FilterNode) ([]Value, error) 
 			temp := []Value{Wrap(value.Index(i))}
 			lefts, err := j.evalList(temp, node.Left)
 
-			//case exists
+			// case exists
 			if node.Operator == "exists" {
 				if len(lefts) > 0 {
 					results = append(results, Wrap(value.Index(i)))

--- a/internal/k8s/jsonpath/parser.go
+++ b/internal/k8s/jsonpath/parser.go
@@ -426,7 +426,7 @@ func (p *Parser) parseField(cur *ListNode) error {
 	if value == "*" {
 		cur.append(newWildcard())
 	} else {
-		cur.append(newField(strings.Replace(value, "\\", "", -1)))
+		cur.append(newField(strings.ReplaceAll(value, "\\", "")))
 	}
 	return p.parseInsideAction(cur)
 }

--- a/internal/k8s/testyaml/testyaml.go
+++ b/internal/k8s/testyaml/testyaml.go
@@ -1593,8 +1593,8 @@ spec:
       - name: NAME
         image: IMAGE
 `
-	result = strings.Replace(result, "NAME", name, -1)
-	result = strings.Replace(result, "IMAGE", imageName, -1)
+	result = strings.ReplaceAll(result, "NAME", name)
+	result = strings.ReplaceAll(result, "IMAGE", imageName)
 	return result
 }
 

--- a/internal/rty/interactive_tester.go
+++ b/internal/rty/interactive_tester.go
@@ -263,7 +263,7 @@ type caseCell struct {
 }
 
 func (i *InteractiveTester) filename(name string) string {
-	return filepath.Join(testDataDir, strings.Replace(name, "/", "_", -1)+".gob")
+	return filepath.Join(testDataDir, strings.ReplaceAll(name, "/", "_")+".gob")
 }
 
 func (i *InteractiveTester) loadGoldenFile(name string) Canvas {

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -893,7 +893,7 @@ docker_build('gcr.io/foo', 'foo')
 k8s_yaml('foo.yaml')
 k8s_resource('foo', port_forwards=EXPR)
 `
-			s = strings.Replace(s, "EXPR", c.expr, -1)
+			s = strings.ReplaceAll(s, "EXPR", c.expr)
 			f.file("Tiltfile", s)
 
 			if c.errorMsg != "" {
@@ -984,7 +984,7 @@ k8s_resource('foo', links=EXPR)
 k8s_resource('foo') # test that subsequent calls don't clear the links
 `
 
-			s = strings.Replace(s, "EXPR", c.expr, -1)
+			s = strings.ReplaceAll(s, "EXPR", c.expr)
 			f.file("Tiltfile", s)
 
 			if c.errorMsg != "" {
@@ -1014,7 +1014,7 @@ dc_resource('foo', links=EXPR)
 dc_resource('foo') # test that subsequent calls don't clear the links
 `
 
-			s = strings.Replace(s, "EXPR", c.expr, -1)
+			s = strings.ReplaceAll(s, "EXPR", c.expr)
 			f.file("Tiltfile", s)
 
 			if c.errorMsg != "" {
@@ -6019,9 +6019,9 @@ func (f *fixture) yaml(path string, entities ...k8sOpts) {
 		case deploymentHelper:
 			s := testyaml.SnackYaml
 			if e.image != "" {
-				s = strings.Replace(s, testyaml.SnackImage, e.image, -1)
+				s = strings.ReplaceAll(s, testyaml.SnackImage, e.image)
 			}
-			s = strings.Replace(s, testyaml.SnackName, e.name, -1)
+			s = strings.ReplaceAll(s, testyaml.SnackName, e.name)
 			objs, err := k8s.ParseYAMLFromString(s)
 			if err != nil {
 				f.t.Fatal(err)
@@ -6058,7 +6058,7 @@ func (f *fixture) yaml(path string, entities ...k8sOpts) {
 			entityObjs = append(entityObjs, objs...)
 		case serviceHelper:
 			s := testyaml.DoggosServiceYaml
-			s = strings.Replace(s, testyaml.DoggosName, e.name, -1)
+			s = strings.ReplaceAll(s, testyaml.DoggosName, e.name)
 			objs, err := k8s.ParseYAMLFromString(s)
 			if err != nil {
 				f.t.Fatal(err)
@@ -6077,7 +6077,7 @@ func (f *fixture) yaml(path string, entities ...k8sOpts) {
 
 		case secretHelper:
 			s := testyaml.SecretYaml
-			s = strings.Replace(s, testyaml.SecretName, e.name, -1)
+			s = strings.ReplaceAll(s, testyaml.SecretName, e.name)
 			objs, err := k8s.ParseYAMLFromString(s)
 			if err != nil {
 				f.t.Fatal(err)
@@ -6086,7 +6086,7 @@ func (f *fixture) yaml(path string, entities ...k8sOpts) {
 			entityObjs = append(entityObjs, objs...)
 		case namespaceHelper:
 			s := testyaml.MyNamespaceYAML
-			s = strings.Replace(s, testyaml.MyNamespaceName, e.namespace, -1)
+			s = strings.ReplaceAll(s, testyaml.MyNamespaceName, e.namespace)
 			objs, err := k8s.ParseYAMLFromString(s)
 			if err != nil {
 				f.t.Fatal(err)

--- a/pkg/logger/prefixed_logger.go
+++ b/pkg/logger/prefixed_logger.go
@@ -43,7 +43,7 @@ func (i *prefixedLogger) handleLog(level Level, fields Fields, buf []byte) error
 		output = output[:len(output)-1]
 	}
 
-	output = strings.Replace(output, "\n", "\n"+i.prefix, -1)
+	output = strings.ReplaceAll(output, "\n", "\n"+i.prefix)
 
 	if endsInNewline {
 		output = output + "\n"


### PR DESCRIPTION
There is a preference to use `replaceAll` over `replace` with a `-1`.  `replaceAll` is more readable and expressive and is simply a wrapper around the latter func.  It is easier when reading to reason about.

gocritic also wants `//comment` to be `// comment` which does look better.  Additionally this change makes the comments consistent with all other comments in the code base.

Signed-off-by: Ken Sipe <kensipe@gmail.com>