### PR TITLE
cli: add tilt enable/disable

### DIFF
--- a/internal/cli/api_utils.go
+++ b/internal/cli/api_utils.go
@@ -1,0 +1,28 @@
+package cli
+
+import (
+	"context"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
+)
+
+func newClient(ctx context.Context) (client.Client, error) {
+	getter, err := wireClientGetter(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	cfg, err := getter.ToRESTConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	ctrlclient, err := client.New(cfg, client.Options{Scheme: v1alpha1.NewScheme()})
+	if err != nil {
+		return nil, err
+	}
+
+	return ctrlclient, err
+}

--- a/internal/cli/args.go
+++ b/internal/cli/args.go
@@ -13,7 +13,6 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/kubectl/pkg/cmd/util/editor"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/tilt-dev/tilt/internal/analytics"
 	engineanalytics "github.com/tilt-dev/tilt/internal/engine/analytics"
@@ -62,25 +61,6 @@ i.e., those specifying which resources to run and/or handled by a Tiltfile calli
 	cmd.Flags().BoolVar(&c.clear, "clear", false, "Clear the Tiltfile args, as if you'd run tilt with no args")
 
 	return cmd
-}
-
-func newClient(ctx context.Context) (client.Client, error) {
-	getter, err := wireClientGetter(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	cfg, err := getter.ToRESTConfig()
-	if err != nil {
-		return nil, err
-	}
-
-	ctrlclient, err := client.New(cfg, client.Options{Scheme: v1alpha1.NewScheme()})
-	if err != nil {
-		return nil, err
-	}
-
-	return ctrlclient, err
 }
 
 func parseEditResult(b []byte) ([]string, error) {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -73,6 +73,8 @@ up-to-date in real-time. Think 'docker build && kubectl apply' or 'docker-compos
 	addCommand(rootCmd, newPatchCmd())
 	addCommand(rootCmd, newWaitCmd())
 	addCommand(rootCmd, &demoCmd{})
+	addCommand(rootCmd, newEnableCmd())
+	addCommand(rootCmd, newDisableCmd())
 
 	rootCmd.AddCommand(analytics.NewCommand())
 	rootCmd.AddCommand(newDumpCmd(rootCmd))

--- a/internal/cli/disable.go
+++ b/internal/cli/disable.go
@@ -1,0 +1,84 @@
+package cli
+
+import (
+	"context"
+	"strconv"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
+	"github.com/tilt-dev/tilt/internal/analytics"
+	engineanalytics "github.com/tilt-dev/tilt/internal/engine/analytics"
+	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
+	"github.com/tilt-dev/tilt/pkg/model"
+)
+
+type disableCmd struct {
+	all bool
+}
+
+func newDisableCmd() *disableCmd {
+	return &disableCmd{}
+}
+
+func (c *disableCmd) name() model.TiltSubcommand { return "disable" }
+
+func (c *disableCmd) register() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:                   "disable {-all | <resource>...}",
+		DisableFlagsInUseLine: true,
+		Short:                 "Disables resources",
+		Long: `Disables the specified resources in Tilt.
+
+# disables the resources named 'frontend' and 'backend'
+tilt disable frontend backend
+
+# disables all resources
+tilt disable --all`,
+	}
+
+	cmd.Flags().BoolVar(&c.all, "all", false, "Disable all resources")
+
+	addConnectServerFlags(cmd)
+
+	return cmd
+}
+
+func (c *disableCmd) run(ctx context.Context, args []string) error {
+	ctrlclient, err := newClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	if c.all {
+		if len(args) > 0 {
+			return errors.New("cannot use --all with resource names")
+		}
+	} else if len(args) == 0 {
+		return errors.New("must specify at least one resource")
+	}
+
+	a := analytics.Get(ctx)
+	cmdTags := engineanalytics.CmdTags(map[string]string{})
+	cmdTags["all"] = strconv.FormatBool(c.all)
+	a.Incr("cmd.disable", cmdTags.AsMap())
+	defer a.Flush(time.Second)
+
+	names := make(map[string]bool)
+	for _, name := range args {
+		names[name] = true
+	}
+
+	unselectedState := v1alpha1.DisableStatePending
+	if c.all {
+		unselectedState = v1alpha1.DisableStateDisabled
+	}
+
+	err = changeEnabledResources(ctx, ctrlclient, args, v1alpha1.DisableStateDisabled, unselectedState)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/internal/cli/disable.go
+++ b/internal/cli/disable.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/tilt-dev/tilt/internal/analytics"
 	engineanalytics "github.com/tilt-dev/tilt/internal/engine/analytics"
-	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
 	"github.com/tilt-dev/tilt/pkg/model"
 )
 
@@ -70,12 +69,7 @@ func (c *disableCmd) run(ctx context.Context, args []string) error {
 		names[name] = true
 	}
 
-	unselectedState := v1alpha1.DisableStatePending
-	if c.all {
-		unselectedState = v1alpha1.DisableStateDisabled
-	}
-
-	err = changeEnabledResources(ctx, ctrlclient, args, v1alpha1.DisableStateDisabled, unselectedState)
+	err = changeEnabledResources(ctx, ctrlclient, args, enableOptions{enable: false, all: c.all, only: false})
 	if err != nil {
 		return err
 	}

--- a/internal/cli/disable_test.go
+++ b/internal/cli/disable_test.go
@@ -59,6 +59,7 @@ func TestDisable(t *testing.T) {
 			cmd := disableCmd{}
 			c := cmd.register()
 			err := c.Flags().Parse(tc.args)
+			require.NoError(t, err)
 			err = cmd.run(f.ctx, c.Flags().Args())
 			if tc.expectedError != "" {
 				require.Error(t, err)

--- a/internal/cli/disable_test.go
+++ b/internal/cli/disable_test.go
@@ -1,0 +1,75 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDisable(t *testing.T) {
+	for _, tc := range []struct {
+		name            string
+		args            []string
+		expectedEnabled []string
+		expectedError   string
+	}{
+		{
+			"normal",
+			[]string{"enabled_a", "enabled_b"},
+			[]string{"enabled_c", "(Tiltfile)"},
+			"",
+		},
+		{
+			"all",
+			[]string{"--all"},
+			[]string{"(Tiltfile)"},
+			"",
+		},
+		{
+			"all+names",
+			[]string{"--all", "enabled_b"},
+			nil,
+			"cannot use --all with resource names",
+		},
+		{
+			"no names",
+			nil,
+			nil,
+			"must specify at least one resource",
+		},
+		{
+			"nonexistent resource",
+			[]string{"foo"},
+			nil,
+			"no such resource \"foo\"",
+		},
+		{
+			"Tiltfile",
+			[]string{"(Tiltfile)"},
+			nil,
+			"(Tiltfile) cannot be enabled or disabled",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newEnableFixture(t)
+			defer f.TearDown()
+
+			f.createResources()
+
+			cmd := disableCmd{}
+			c := cmd.register()
+			err := c.Flags().Parse(tc.args)
+			err = cmd.run(f.ctx, c.Flags().Args())
+			if tc.expectedError != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.expectedError)
+				// if there's an error, expect enabled states to remain the same
+				tc.expectedEnabled = []string{"enabled_a", "enabled_b", "enabled_c", "(Tiltfile)"}
+			} else {
+				require.NoError(t, err)
+			}
+
+			require.ElementsMatch(t, tc.expectedEnabled, f.enabledResources())
+		})
+	}
+}

--- a/internal/cli/enable.go
+++ b/internal/cli/enable.go
@@ -1,0 +1,174 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	"github.com/tilt-dev/tilt/internal/analytics"
+	engineanalytics "github.com/tilt-dev/tilt/internal/engine/analytics"
+	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
+	"github.com/tilt-dev/tilt/pkg/model"
+)
+
+type enableCmd struct {
+	all  bool
+	only bool
+}
+
+func newEnableCmd() *enableCmd {
+	return &enableCmd{}
+}
+
+func (c *enableCmd) name() model.TiltSubcommand { return "enable" }
+
+func (c *enableCmd) register() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:                   "enable {-all | [--only] <resource>...}",
+		DisableFlagsInUseLine: true,
+		Short:                 "Enables resources",
+		Long: `Enables the specified resources in Tilt.
+
+# enables the resources named 'frontend' and 'backend'
+tilt enable frontend backend
+
+# enables frontend and backend and disables all others
+tilt enable --only frontend backend
+
+# enables all resources
+tilt enable --all
+`,
+	}
+
+	addConnectServerFlags(cmd)
+	cmd.Flags().BoolVar(&c.only, "only", false, "Enable the specified resources, disable all others")
+	cmd.Flags().BoolVar(&c.all, "all", false, "Enable all resources")
+
+	return cmd
+}
+
+func (c *enableCmd) run(ctx context.Context, args []string) error {
+	ctrlclient, err := newClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	if c.all {
+		if c.only {
+			return errors.New("cannot use --all with --only")
+		} else if len(args) > 0 {
+			return errors.New("cannot use --all with resource names")
+		}
+	} else if len(args) == 0 {
+		return errors.New("must specify at least one resource")
+	}
+
+	a := analytics.Get(ctx)
+	cmdTags := engineanalytics.CmdTags(map[string]string{})
+	cmdTags["only"] = strconv.FormatBool(c.only)
+	cmdTags["all"] = strconv.FormatBool(c.all)
+	a.Incr("cmd.enable", cmdTags.AsMap())
+	defer a.Flush(time.Second)
+
+	names := make(map[string]bool)
+	for _, name := range args {
+		names[name] = true
+	}
+
+	unselectedState := v1alpha1.DisableStatePending
+	if c.only {
+		unselectedState = v1alpha1.DisableStateDisabled
+	} else if c.all {
+		unselectedState = v1alpha1.DisableStateEnabled
+	}
+	err = changeEnabledResources(ctx, ctrlclient, args, v1alpha1.DisableStateEnabled, unselectedState)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Changes which resources are enabled in Tilt.
+// For resources in `selectedResources`, ensures their disabled state is `selectedState`.
+// For all other resources:
+// - if `unselectedState` is Enabled or Disabled, ensure their disabled state is that
+// - otherwise, ignore them
+func changeEnabledResources(
+	ctx context.Context,
+	cli client.Client,
+	selectedResources []string,
+	selectedState v1alpha1.DisableState,
+	unselectedState v1alpha1.DisableState,
+) error {
+	var uirs v1alpha1.UIResourceList
+	err := cli.List(ctx, &uirs)
+	if err != nil {
+		return err
+	}
+
+	// before making any changes, validate that all selected names actually exist
+	uirByName := make(map[string]v1alpha1.UIResource)
+	for _, uir := range uirs.Items {
+		uirByName[uir.Name] = uir
+	}
+	selectedResourcesByName := make(map[string]bool)
+	for _, name := range selectedResources {
+		uir, ok := uirByName[name]
+		if !ok {
+			return fmt.Errorf("no such resource %q", name)
+		}
+		if len(uir.Status.DisableStatus.Sources) == 0 {
+			return fmt.Errorf("%s cannot be enabled or disabled", name)
+		}
+		selectedResourcesByName[name] = true
+	}
+
+	for _, uir := range uirs.Items {
+		// resources w/o disable sources are always enabled (e.g., (Tiltfile))
+		if len(uir.Status.DisableStatus.Sources) == 0 {
+			continue
+		}
+
+		newState := unselectedState
+		if selectedResourcesByName[uir.Name] {
+			newState = selectedState
+		}
+
+		var newIsDisabled bool
+		switch newState {
+		case v1alpha1.DisableStateEnabled:
+			newIsDisabled = false
+		case v1alpha1.DisableStateDisabled:
+			newIsDisabled = true
+		default:
+			continue
+		}
+
+		for _, source := range uir.Status.DisableStatus.Sources {
+			if source.ConfigMap == nil {
+				return fmt.Errorf("internal error: resource %s's DisableSource does not have a ConfigMap'", uir.Name)
+			}
+			cm := &v1alpha1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: source.ConfigMap.Name}}
+			_, err := controllerutil.CreateOrUpdate(ctx, cli, cm, func() error {
+				if cm.Data == nil {
+					cm.Data = make(map[string]string)
+				}
+				cm.Data[source.ConfigMap.Key] = strconv.FormatBool(newIsDisabled)
+				return nil
+			})
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}

--- a/internal/cli/enable_test.go
+++ b/internal/cli/enable_test.go
@@ -74,6 +74,7 @@ func TestEnable(t *testing.T) {
 			cmd := enableCmd{}
 			c := cmd.register()
 			err := c.Flags().Parse(tc.args)
+			require.NoError(t, err)
 			err = cmd.run(f.ctx, c.Flags().Args())
 			if tc.expectedError != "" {
 				require.Error(t, err)

--- a/internal/cli/enable_test.go
+++ b/internal/cli/enable_test.go
@@ -1,0 +1,156 @@
+package cli
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/tilt-dev/tilt/internal/controllers/apis/uiresource"
+	"github.com/tilt-dev/tilt/internal/testutils/uiresourcebuilder"
+	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
+	"github.com/tilt-dev/tilt/pkg/model"
+)
+
+func TestEnable(t *testing.T) {
+	for _, tc := range []struct {
+		name            string
+		args            []string
+		expectedEnabled []string
+		expectedError   string
+	}{
+		{
+			"normal",
+			[]string{"disabled_b", "disabled_c"},
+			[]string{"enabled_a", "enabled_b", "enabled_c", "disabled_b", "disabled_c", "(Tiltfile)"},
+			"",
+		},
+		{
+			"only",
+			[]string{"--only", "disabled_b"},
+			[]string{"disabled_b", "(Tiltfile)"},
+			"",
+		},
+		{
+			"all",
+			[]string{"--all"},
+			[]string{"enabled_a", "enabled_b", "enabled_c", "disabled_a", "disabled_b", "disabled_c", "(Tiltfile)"},
+			"",
+		},
+		{
+			"all+names",
+			[]string{"--all", "enabled_b"},
+			nil,
+			"cannot use --all with resource names",
+		},
+		{
+			"no names",
+			nil,
+			nil,
+			"must specify at least one resource",
+		},
+		{
+			"nonexistent resource",
+			[]string{"foo"},
+			nil,
+			"no such resource \"foo\"",
+		},
+		{
+			"Tiltfile",
+			[]string{"(Tiltfile)"},
+			nil,
+			"(Tiltfile) cannot be enabled or disabled",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newEnableFixture(t)
+			defer f.TearDown()
+
+			f.createResources()
+
+			cmd := enableCmd{}
+			c := cmd.register()
+			err := c.Flags().Parse(tc.args)
+			err = cmd.run(f.ctx, c.Flags().Args())
+			if tc.expectedError != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.expectedError)
+				// if there's an error, the set of enabled resources shouldn't change
+				tc.expectedEnabled = []string{"enabled_a", "enabled_b", "enabled_c", "(Tiltfile)"}
+			} else {
+				require.NoError(t, err)
+			}
+
+			require.ElementsMatch(t, tc.expectedEnabled, f.enabledResources())
+		})
+	}
+}
+
+type enableFixture struct {
+	*serverFixture
+}
+
+func newEnableFixture(t *testing.T) enableFixture {
+	return enableFixture{newServerFixture(t)}
+}
+
+// makes 7 resources: enabled_a, enabled_b, enabled_c, disabled_a, disabled_b, disabled_c, (Tiltfile)
+// The first six are initially enabled/disabled according to their names
+// (Tiltfile) is always enabled
+func (f enableFixture) createResources() {
+	for _, isDisabled := range []bool{true, false} {
+		for _, n := range []string{"a", "b", "c"} {
+			name := fmt.Sprintf("enabled_%s", n)
+			if isDisabled {
+				name = fmt.Sprintf("disabled_%s", n)
+			}
+
+			source := v1alpha1.DisableSource{
+				ConfigMap: &v1alpha1.ConfigMapDisableSource{
+					Name: fmt.Sprintf("disable-%s", name),
+					Key:  "isDisabled",
+				},
+			}
+
+			uir := uiresourcebuilder.New(name).WithDisableSource(source).Build()
+			err := f.client.Create(f.ctx, uir)
+			require.NoError(f.T(), err)
+
+			cm := v1alpha1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: source.ConfigMap.Name},
+				Data:       map[string]string{source.ConfigMap.Key: strconv.FormatBool(isDisabled)},
+			}
+			err = f.client.Create(f.ctx, &cm)
+			require.NoError(f.T(), err)
+		}
+	}
+
+	uir := uiresourcebuilder.New(string(model.MainTiltfileManifestName)).Build()
+	err := f.client.Create(f.ctx, uir)
+	require.NoError(f.T(), err)
+}
+
+func (f enableFixture) enabledResources() []string {
+	var result []string
+
+	var uirs v1alpha1.UIResourceList
+	err := f.client.List(f.ctx, &uirs)
+	require.NoError(f.T(), err)
+	for _, uir := range uirs.Items {
+		drs, err := uiresource.DisableResourceStatus(func(name string) (v1alpha1.ConfigMap, error) {
+			var cm v1alpha1.ConfigMap
+			err := f.client.Get(f.ctx, types.NamespacedName{Name: name}, &cm)
+			return cm, err
+		}, uir.Status.DisableStatus.Sources)
+		require.NoError(f.T(), err)
+
+		if drs.State == v1alpha1.DisableStateEnabled {
+			result = append(result, uir.Name)
+		}
+	}
+
+	return result
+}

--- a/internal/controllers/apis/configmap/disable.go
+++ b/internal/controllers/apis/configmap/disable.go
@@ -54,7 +54,7 @@ func DisableStatus(getCM func(name string) (v1alpha1.ConfigMap, error), disableS
 func MaybeNewDisableStatus(ctx context.Context, client client.Client, disableSource *v1alpha1.DisableSource, prevStatus *v1alpha1.DisableStatus) (*v1alpha1.DisableStatus, error) {
 	getCM := func(name string) (v1alpha1.ConfigMap, error) {
 		var cm v1alpha1.ConfigMap
-		err := client.Get(ctx, types.NamespacedName{Name: disableSource.ConfigMap.Name}, &cm)
+		err := client.Get(ctx, types.NamespacedName{Name: name}, &cm)
 		return cm, err
 	}
 

--- a/internal/controllers/apis/uiresource/disable.go
+++ b/internal/controllers/apis/uiresource/disable.go
@@ -1,0 +1,50 @@
+package uiresource
+
+import (
+	"github.com/tilt-dev/tilt/internal/controllers/apis/configmap"
+	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
+)
+
+func DisableResourceStatus(getCM func(name string) (v1alpha1.ConfigMap, error), disableSources []v1alpha1.DisableSource) (v1alpha1.DisableResourceStatus, error) {
+	var result v1alpha1.DisableResourceStatus
+	if len(disableSources) == 0 {
+		result.State = v1alpha1.DisableStateEnabled
+		return result, nil
+	}
+
+	errorCount := 0
+	pendingCount := 0
+	for _, source := range disableSources {
+
+		dr, _, err := configmap.DisableStatus(getCM, &source)
+		if err != nil {
+			return v1alpha1.DisableResourceStatus{}, err
+		}
+		switch dr {
+		case v1alpha1.DisableStateEnabled:
+			result.EnabledCount += 1
+		case v1alpha1.DisableStateDisabled:
+			result.DisabledCount += 1
+		case v1alpha1.DisableStatePending:
+			pendingCount += 1
+		case v1alpha1.DisableStateError:
+			// TODO(matt) - there are arguments for incrementing any of the three fields in this case, or adding an ErrorCount field
+			// but none seem compelling. We could add an ErrorCount later, but that's just another case to handle downstream.
+			result.DisabledCount += 1
+			errorCount += 1
+		}
+	}
+	result.State = v1alpha1.DisableStatePending
+
+	if errorCount > 0 {
+		result.State = v1alpha1.DisableStateError
+	} else if pendingCount > 0 {
+		result.State = v1alpha1.DisableStatePending
+	} else if result.DisabledCount > 0 {
+		result.State = v1alpha1.DisableStateDisabled
+	} else if result.EnabledCount > 0 {
+		result.State = v1alpha1.DisableStateEnabled
+	}
+	result.Sources = disableSources
+	return result, nil
+}


### PR DESCRIPTION
Some CLI ergonomics that should feel a lot nicer than `tilt args` for use cases that don't involve Tiltfile arg parsing.

```
# enables the resources named 'frontend' and 'backend'
tilt enable frontend backend

# enables frontend and backend and disables all others
tilt enable --only frontend backend

# enables all resources
tilt enable --all

# disables the resources named 'frontend' and 'backend'
tilt disable frontend backend

# disables all resources
tilt disable --all
```