### PR TITLE
tiltfile: warn if default registry has been set but will be ignored

### DIFF
--- a/internal/controllers/core/tiltfile/reconciler.go
+++ b/internal/controllers/core/tiltfile/reconciler.go
@@ -429,7 +429,7 @@ func DecideRegistry(ctx context.Context, kCli k8s.Client, tlr *tiltfile.Tiltfile
 
 		if !tlr.DefaultRegistry.Empty() {
 			// The user has specified a default registry in their Tiltfile, but it will be ignored.
-			logger.Get(ctx).Warnf("Default registry specified, but will be ignored in favour of auto-detected registry.")
+			logger.Get(ctx).Warnf("Default registry specified, but will be ignored in favor of auto-detected registry.")
 		}
 
 		return registry

--- a/internal/controllers/core/tiltfile/reconciler.go
+++ b/internal/controllers/core/tiltfile/reconciler.go
@@ -426,6 +426,12 @@ func DecideRegistry(ctx context.Context, kCli k8s.Client, tlr *tiltfile.Tiltfile
 		// If we've found a local registry in the cluster at run-time, use that
 		// instead of the default_registry (if any) declared in the Tiltfile
 		logger.Get(ctx).Infof("Auto-detected local registry from environment: %s", registry)
+
+		if !tlr.DefaultRegistry.Empty() {
+			// The user has specified a default registry in their Tiltfile, but it will be ignored.
+			logger.Get(ctx).Warnf("Default registry specified, but will be ignored in favour of auto-detected registry.")
+		}
+
 		return registry
 	}
 

--- a/internal/controllers/core/tiltfile/reconciler.go
+++ b/internal/controllers/core/tiltfile/reconciler.go
@@ -429,7 +429,7 @@ func DecideRegistry(ctx context.Context, kCli k8s.Client, tlr *tiltfile.Tiltfile
 
 		if !tlr.DefaultRegistry.Empty() {
 			// The user has specified a default registry in their Tiltfile, but it will be ignored.
-			logger.Get(ctx).Warnf("Default registry specified, but will be ignored in favor of auto-detected registry.")
+			logger.Get(ctx).Infof("Default registry specified, but will be ignored in favor of auto-detected registry.")
 		}
 
 		return registry


### PR DESCRIPTION
This suggested change addresses the possible lack of feedback discussed in #5446 