### PR TITLE
Linting fix: gocritic assignOp, unlambda, typeSwitchVar

### DIFF
--- a/internal/controllers/core/extensionrepo/reconciler_test.go
+++ b/internal/controllers/core/extensionrepo/reconciler_test.go
@@ -170,7 +170,7 @@ func (d *fakeDownloader) DestinationPath(pkg string) string {
 }
 
 func (d *fakeDownloader) Download(pkg string) (string, error) {
-	d.downloadCount = d.downloadCount + 1
+	d.downloadCount += 1
 	if d.downloadError != nil {
 		return "", fmt.Errorf("download error %d: %v", d.downloadCount, d.downloadError)
 	}

--- a/internal/controllers/core/filewatch/fsevent/factories.go
+++ b/internal/controllers/core/filewatch/fsevent/factories.go
@@ -12,13 +12,9 @@ type WatcherMaker func(paths []string, ignore watch.PathMatcher, l logger.Logger
 type TimerMaker func(d time.Duration) <-chan time.Time
 
 func ProvideWatcherMaker() WatcherMaker {
-	return func(paths []string, ignore watch.PathMatcher, l logger.Logger) (watch.Notify, error) {
-		return watch.NewWatcher(paths, ignore, l)
-	}
+	return watch.NewWatcher
 }
 
 func ProvideTimerMaker() TimerMaker {
-	return func(t time.Duration) <-chan time.Time {
-		return time.After(t)
-	}
+	return time.After
 }

--- a/internal/controllers/core/filewatch/watcher.go
+++ b/internal/controllers/core/filewatch/watcher.go
@@ -61,7 +61,7 @@ func (w *watcher) cleanupWatch(ctx context.Context) {
 		logger.Get(ctx).Debugf("Failed to close notifier for %q: %v", w.name.String(), err)
 	}
 
-	w.restartBackoff = w.restartBackoff * 2
+	w.restartBackoff *= 2
 	if w.restartBackoff > maxRestartBackoff {
 		w.restartBackoff = maxRestartBackoff
 	}

--- a/internal/controllers/core/podlogstream/podlogstreamcontroller.go
+++ b/internal/controllers/core/podlogstream/podlogstreamcontroller.go
@@ -325,7 +325,7 @@ func (c *Controller) consumeLogs(watch *podLogWatch, st store.RStore) {
 		if exitError != nil {
 			// TODO(nick): Should this be Warnf/Errorf?
 			logger.Get(ctx).Infof("Error streaming %s logs: %v", pID, exitError)
-			watch.debounce = watch.debounce * 2
+			watch.debounce *= 2
 			if watch.debounce > maxDebounceDuration {
 				watch.debounce = maxDebounceDuration
 			}

--- a/internal/docker/exploding.go
+++ b/internal/docker/exploding.go
@@ -74,7 +74,7 @@ func (c explodingClient) ImageList(ctx context.Context, options types.ImageListO
 func (c explodingClient) ImageRemove(ctx context.Context, imageID string, options types.ImageRemoveOptions) ([]types.ImageDeleteResponseItem, error) {
 	return nil, c.err
 }
-func (c explodingClient) NewVersionError(APIrequired, feature string) error {
+func (c explodingClient) NewVersionError(apiRequired, feature string) error {
 	return c.err
 }
 func (c explodingClient) BuildCachePrune(ctx context.Context, opts types.BuildCachePruneOptions) (*types.BuildCachePruneReport, error) {

--- a/internal/docker/fake_client.go
+++ b/internal/docker/fake_client.go
@@ -311,16 +311,16 @@ func (c *FakeClient) ImageRemove(ctx context.Context, imageID string, options ty
 	}, nil
 }
 
-func (c *FakeClient) NewVersionError(APIrequired, feature string) error {
+func (c *FakeClient) NewVersionError(apiRequired, feature string) error {
 	if c.ThrowNewVersionError {
 		c.ThrowNewVersionError = false
-		return c.VersionError(APIrequired, feature)
+		return c.VersionError(apiRequired, feature)
 	}
 	return nil
 }
 
-func (c *FakeClient) VersionError(APIrequired, feature string) error {
-	return fmt.Errorf("%q requires API version %s, but the Docker daemon API version is... something else", feature, APIrequired)
+func (c *FakeClient) VersionError(apiRequired, feature string) error {
+	return fmt.Errorf("%q requires API version %s, but the Docker daemon API version is... something else", feature, apiRequired)
 }
 
 func (c *FakeClient) BuildCachePrune(ctx context.Context, opts types.BuildCachePruneOptions) (*types.BuildCachePruneReport, error) {

--- a/internal/docker/switch.go
+++ b/internal/docker/switch.go
@@ -95,8 +95,8 @@ func (c *switchCli) ImageList(ctx context.Context, options types.ImageListOption
 func (c *switchCli) ImageRemove(ctx context.Context, imageID string, options types.ImageRemoveOptions) ([]types.ImageDeleteResponseItem, error) {
 	return c.client().ImageRemove(ctx, imageID, options)
 }
-func (c *switchCli) NewVersionError(APIrequired, feature string) error {
-	return c.client().NewVersionError(APIrequired, feature)
+func (c *switchCli) NewVersionError(apiRequired, feature string) error {
+	return c.client().NewVersionError(apiRequired, feature)
 }
 func (c *switchCli) BuildCachePrune(ctx context.Context, opts types.BuildCachePruneOptions) (*types.BuildCachePruneReport, error) {
 	return c.client().BuildCachePrune(ctx, opts)

--- a/internal/engine/buildcontrol/image_build_and_deployer_test.go
+++ b/internal/engine/buildcontrol/image_build_and_deployer_test.go
@@ -551,8 +551,8 @@ func TestBuildAndDeployUsesCorrectRef(t *testing.T) {
 		expectBuilt    []string
 		expectDeployed []string
 	}{
-		{"docker build", func(f Fixture) model.Manifest { return NewSanchoDockerBuildManifest(f) }, false, expectedImages, expectedImages},
-		{"docker build + distinct clusterRef", func(f Fixture) model.Manifest { return NewSanchoDockerBuildManifest(f) }, true, expectedImages, expectedImagesClusterRef},
+		{"docker build", NewSanchoDockerBuildManifest, false, expectedImages, expectedImages},
+		{"docker build + distinct clusterRef", NewSanchoDockerBuildManifest, true, expectedImages, expectedImagesClusterRef},
 		{"custom build", NewSanchoCustomBuildManifest, false, expectedImages, expectedImages},
 		{"custom build + distinct clusterRef", NewSanchoCustomBuildManifest, true, expectedImages, expectedImagesClusterRef},
 		{"live multi stage", NewSanchoLiveUpdateMultiStageManifest, false, append(expectedImages, "foo.com/sancho-base"), expectedImages},

--- a/internal/k8s/entity.go
+++ b/internal/k8s/entity.go
@@ -106,8 +106,8 @@ func (e K8sEntity) Clean() {
 	}
 }
 
-func (e K8sEntity) SetUID(UID string) {
-	e.Meta().SetUID(types.UID(UID))
+func (e K8sEntity) SetUID(uid string) {
+	e.Meta().SetUID(types.UID(uid))
 }
 
 func (e K8sEntity) Name() string {

--- a/internal/k8s/statefulset.go
+++ b/internal/k8s/statefulset.go
@@ -15,18 +15,16 @@ import (
 //
 // Tilt should change all statefulsets to use a parallel policy.
 func InjectParallelPodManagementPolicy(entity K8sEntity) K8sEntity {
-	switch entity.Obj.(type) {
+	entity = entity.DeepCopy()
+	switch o := entity.Obj.(type) {
 	case *v1.StatefulSet:
-		entity = entity.DeepCopy()
-		entity.Obj.(*v1.StatefulSet).Spec.PodManagementPolicy = v1.ParallelPodManagement
+		o.Spec.PodManagementPolicy = v1.ParallelPodManagement
 		return entity
 	case *v1beta1.StatefulSet:
-		entity = entity.DeepCopy()
-		entity.Obj.(*v1beta1.StatefulSet).Spec.PodManagementPolicy = v1beta1.ParallelPodManagement
+		o.Spec.PodManagementPolicy = v1beta1.ParallelPodManagement
 		return entity
 	case *v1beta2.StatefulSet:
-		entity = entity.DeepCopy()
-		entity.Obj.(*v1beta2.StatefulSet).Spec.PodManagementPolicy = v1beta2.ParallelPodManagement
+		o.Spec.PodManagementPolicy = v1beta2.ParallelPodManagement
 		return entity
 	}
 	return entity

--- a/internal/k8s/statefulset.go
+++ b/internal/k8s/statefulset.go
@@ -15,16 +15,18 @@ import (
 //
 // Tilt should change all statefulsets to use a parallel policy.
 func InjectParallelPodManagementPolicy(entity K8sEntity) K8sEntity {
-	entity = entity.DeepCopy()
-	switch o := entity.Obj.(type) {
+	switch entity.Obj.(type) {
 	case *v1.StatefulSet:
-		o.Spec.PodManagementPolicy = v1.ParallelPodManagement
+		entity = entity.DeepCopy()
+		entity.Obj.(*v1.StatefulSet).Spec.PodManagementPolicy = v1.ParallelPodManagement
 		return entity
 	case *v1beta1.StatefulSet:
-		o.Spec.PodManagementPolicy = v1beta1.ParallelPodManagement
+		entity = entity.DeepCopy()
+		entity.Obj.(*v1beta1.StatefulSet).Spec.PodManagementPolicy = v1beta1.ParallelPodManagement
 		return entity
 	case *v1beta2.StatefulSet:
-		o.Spec.PodManagementPolicy = v1beta2.ParallelPodManagement
+		entity = entity.DeepCopy()
+		entity.Obj.(*v1beta2.StatefulSet).Spec.PodManagementPolicy = v1beta2.ParallelPodManagement
 		return entity
 	}
 	return entity

--- a/internal/rty/scroll_test.go
+++ b/internal/rty/scroll_test.go
@@ -76,7 +76,7 @@ func TestTextScroll(t *testing.T) {
 	sl = NewTextScrollLayout("bar2")
 	s := ""
 	for i := 1; i <= 20; i++ {
-		s = s + fmt.Sprintf("%d\n", i)
+		s += fmt.Sprintf("%d\n", i)
 	}
 	sl.Add(TextString(s))
 	ts := i.rty.TextScroller(sl.name)

--- a/internal/rty/text.go
+++ b/internal/rty/text.go
@@ -150,7 +150,7 @@ func (l *StringLayout) render(w Writer, width int, height int) (int, int, error)
 				if w != nil {
 					w.SetContent(nextX, nextY, r, nil)
 				}
-				nextX = nextX + 1
+				nextX += 1
 			}
 		}
 	}

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -6138,13 +6138,13 @@ func (f *fixture) loadAllowWarnings(args ...string) {
 func unusedImageWarning(unusedImage string, suggestedImages []string, configType string) string {
 	ret := fmt.Sprintf("Image not used in any %s config:\n    ✕ %s", configType, unusedImage)
 	if len(suggestedImages) > 0 {
-		ret = ret + "\nDid you mean…"
+		ret += "\nDid you mean…"
 		for _, s := range suggestedImages {
-			ret = ret + fmt.Sprintf("\n    - %s", s)
+			ret += fmt.Sprintf("\n    - %s", s)
 		}
 	}
-	ret = ret + "\nSkipping this image build"
-	ret = ret + fmt.Sprintf("\nIf this is deliberate, suppress this warning with: update_settings(suppress_unused_image_warnings=[%q])", unusedImage)
+	ret += "\nSkipping this image build"
+	ret += fmt.Sprintf("\nIf this is deliberate, suppress this warning with: update_settings(suppress_unused_image_warnings=[%q])", unusedImage)
 	return ret
 }
 

--- a/pkg/logger/prefixed_logger.go
+++ b/pkg/logger/prefixed_logger.go
@@ -46,7 +46,7 @@ func (i *prefixedLogger) handleLog(level Level, fields Fields, buf []byte) error
 	output = strings.ReplaceAll(output, "\n", "\n"+i.prefix)
 
 	if endsInNewline {
-		output = output + "\n"
+		output += "\n"
 		i.indentBeforeNextWrite = true
 	} else {
 		i.indentBeforeNextWrite = false


### PR DESCRIPTION
In the process of adding linting fixes currently working on gocritic.  This fixes:

- typeSwitchVar: which cleans up switch statement code with variable assignment 
- assignOp: which cleans up modifications to a var to not stutter
- unlamba: which removes an anonymous function which does nothing but enclose a function of the same signature
- removal of params that start with a capitalization

