### PR TITLE
Linting fix: gocritic singleCaseSwitch, ifElseChain, elseif

### DIFF
--- a/internal/controllers/core/filewatch/controller_test.go
+++ b/internal/controllers/core/filewatch/controller_test.go
@@ -46,8 +46,7 @@ func NewTestingStore(out io.Writer) *testStore {
 
 func (s *testStore) Dispatch(action store.Action) {
 	s.TestingStore.Dispatch(action)
-	switch action := action.(type) {
-	case store.LogAction:
+	if action, ok := action.(store.LogAction); ok {
 		_, _ = s.out.Write(action.Message())
 	}
 }

--- a/internal/controllers/core/portforward/reconciler_test.go
+++ b/internal/controllers/core/portforward/reconciler_test.go
@@ -147,15 +147,16 @@ func TestMultipleForwardsForOnePod(t *testing.T) {
 	var contexts []context.Context
 	for _, call := range f.kCli.PortForwardCalls() {
 		assert.Equal(t, "pod-pf_foo", call.PodID.String())
-		if call.RemotePort == 8080 {
+		switch call.RemotePort {
+		case 8080:
 			seen8080 = true
 			contexts = append(contexts, call.Context)
 			assert.Equal(t, "hostA", call.Host, "unexpected host for port forward to 8080")
-		} else if call.RemotePort == 8081 {
+		case 8081:
 			seen8081 = true
 			contexts = append(contexts, call.Context)
 			assert.Equal(t, "hostB", call.Host, "unexpected host for port forward to 8081")
-		} else {
+		default:
 			t.Fatalf("found port forward call to unexpected remotePort: %+v", call)
 		}
 	}

--- a/internal/controllers/fake/store.go
+++ b/internal/controllers/fake/store.go
@@ -20,8 +20,7 @@ func NewTestingStore(out io.Writer) *testStore {
 
 func (s *testStore) Dispatch(action store.Action) {
 	s.TestingStore.Dispatch(action)
-	switch action := action.(type) {
-	case store.LogAction:
+	if action, ok := action.(store.LogAction); ok {
 		_, _ = s.out.Write(action.Message())
 	}
 }

--- a/internal/dockerignore/ignore_test.go
+++ b/internal/dockerignore/ignore_test.go
@@ -156,10 +156,8 @@ func (tf *testFixture) AssertResult(path string, expectedMatches bool) {
 	isIgnored, err := tf.tester.Matches(path)
 	if err != nil {
 		tf.t.Fatal(err)
-	} else {
-		if assert.NoError(tf.t, err) {
-			assert.Equalf(tf.t, expectedMatches, isIgnored, "Expected isIgnored to be %t for file %s, got %t", expectedMatches, path, isIgnored)
-		}
+	} else if assert.NoError(tf.t, err) {
+		assert.Equalf(tf.t, expectedMatches, isIgnored, "Expected isIgnored to be %t for file %s, got %t", expectedMatches, path, isIgnored)
 	}
 }
 
@@ -167,10 +165,8 @@ func (tf *testFixture) AssertResultEntireDir(path string, expectedMatches bool) 
 	isIgnored, err := tf.tester.MatchesEntireDir(path)
 	if err != nil {
 		tf.t.Fatal(err)
-	} else {
-		if assert.NoError(tf.t, err) {
-			assert.Equalf(tf.t, expectedMatches, isIgnored, "Expected isIgnored to be %t for file %s, got %t", expectedMatches, path, isIgnored)
-		}
+	} else if assert.NoError(tf.t, err) {
+		assert.Equalf(tf.t, expectedMatches, isIgnored, "Expected isIgnored to be %t for file %s, got %t", expectedMatches, path, isIgnored)
 	}
 }
 

--- a/internal/engine/build_and_deployer_test.go
+++ b/internal/engine/build_and_deployer_test.go
@@ -779,8 +779,7 @@ func NewTestingStore(out io.Writer) *testStore {
 func (s *testStore) Dispatch(action store.Action) {
 	s.TestingStore.Dispatch(action)
 
-	switch action := action.(type) {
-	case store.LogAction:
+	if action, ok := action.(store.LogAction); ok {
 		_, _ = s.out.Write(action.Message())
 	}
 }

--- a/internal/engine/buildcontrol/local_target_build_and_deployer.go
+++ b/internal/engine/buildcontrol/local_target_build_and_deployer.go
@@ -115,8 +115,7 @@ func (bd *LocalTargetBuildAndDeployer) BuildAndDeploy(ctx context.Context, st st
 func (bd *LocalTargetBuildAndDeployer) extract(specs []model.TargetSpec) []model.LocalTarget {
 	var targs []model.LocalTarget
 	for _, s := range specs {
-		switch s := s.(type) {
-		case model.LocalTarget:
+		if s, ok := s.(model.LocalTarget); ok {
 			targs = append(targs, s)
 		}
 	}

--- a/internal/engine/buildcontrol/local_target_build_and_deployer_test.go
+++ b/internal/engine/buildcontrol/local_target_build_and_deployer_test.go
@@ -142,8 +142,7 @@ func NewTestingStore(out io.Writer) *testStore {
 func (s *testStore) Dispatch(action store.Action) {
 	s.TestingStore.Dispatch(action)
 
-	switch action := action.(type) {
-	case store.LogAction:
+	if action, ok := action.(store.LogAction); ok {
 		_, _ = s.out.Write(action.Message())
 	}
 }

--- a/internal/git/gitignore_test.go
+++ b/internal/git/gitignore_test.go
@@ -77,10 +77,8 @@ func (tf *testFixture) AssertResult(description, path string, expectedMatches bo
 		isIgnored, err := tf.tester.Matches(path)
 		if expectError {
 			assert.Error(t, err)
-		} else {
-			if assert.NoError(t, err) {
-				assert.Equal(t, expectedMatches, isIgnored)
-			}
+		} else if assert.NoError(t, err) {
+			assert.Equal(t, expectedMatches, isIgnored)
 		}
 	})
 }

--- a/internal/rty/interactive_tester.go
+++ b/internal/rty/interactive_tester.go
@@ -227,8 +227,7 @@ func (i *InteractiveTester) displayAndMaybeWrite(name string, actual, expected C
 		}
 
 		ev := screen.PollEvent()
-		switch ev := ev.(type) {
-		case *tcell.EventKey:
+		if ev, ok := ev.(*tcell.EventKey); ok {
 			switch ev.Rune() {
 			case 'y':
 				return true, i.writeGoldenFile(name, actual)

--- a/internal/store/build_result.go
+++ b/internal/store/build_result.go
@@ -140,16 +140,14 @@ func NewK8sDeployResult(id model.TargetID, filter *k8sconv.KubernetesApplyFilter
 }
 
 func LocalImageRefFromBuildResult(r BuildResult) string {
-	switch r := r.(type) {
-	case ImageBuildResult:
+	if r, ok := r.(ImageBuildResult); ok {
 		return r.ImageMapStatus.ImageFromLocal
 	}
 	return ""
 }
 
 func ClusterImageRefFromBuildResult(r BuildResult) string {
-	switch r := r.(type) {
-	case ImageBuildResult:
+	if r, ok := r.(ImageBuildResult); ok {
 		return r.ImageMapStatus.ImageFromCluster
 	}
 	return ""

--- a/pkg/apis/core/v1alpha1/togglebutton_types.go
+++ b/pkg/apis/core/v1alpha1/togglebutton_types.go
@@ -169,10 +169,8 @@ func (in *ToggleButton) Validate(ctx context.Context) field.ErrorList {
 	var result field.ErrorList
 	if in.Spec.StateSource.ConfigMap == nil {
 		result = append(result, field.Invalid(field.NewPath("Spec", "StateSource"), in.Spec.StateSource, "must specify exactly one kind of StateSource"))
-	} else {
-		if in.Spec.StateSource.ConfigMap.OffValue == in.Spec.StateSource.ConfigMap.OnValue {
-			result = append(result, field.Invalid(field.NewPath("Spec", "StateSource", "ConfigMap"), in.Spec.StateSource.ConfigMap, "OnValue and OffValue must differ"))
-		}
+	} else if in.Spec.StateSource.ConfigMap.OffValue == in.Spec.StateSource.ConfigMap.OnValue {
+		result = append(result, field.Invalid(field.NewPath("Spec", "StateSource", "ConfigMap"), in.Spec.StateSource.ConfigMap, "OnValue and OffValue must differ"))
 	}
 	return result
 }


### PR DESCRIPTION
In the process of adding linting fixes currently working on gocritic.  This fixes:

- singleCaseSwitch: should rewrite switch statement to if statement
- ifElseChain: rewrite if-else to switch statement    
- elseif: can replace 'else {if cond {}}' with 'else if cond {}'

Several of these fixes make the code easier to read and reason about.