### PR TITLE
scripts: automatically tag the extension repo as part of the release process

### DIFF
--- a/scripts/release-ci.sh
+++ b/scripts/release-ci.sh
@@ -43,3 +43,4 @@ VERSION=$(git describe --abbrev=0 --tags)
 ./scripts/release-update-tilt-docs-repo.sh "$VERSION"
 ./scripts/record-release.sh "$VERSION"
 ./scripts/release-update-homebrew-core.sh "$VERSION"
+./scripts/release-update-extension-repo.sh "$VERSION"

--- a/scripts/release-update-extension-repo.sh
+++ b/scripts/release-update-extension-repo.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+#
+# Add a new tag to the extension repo.
+#
+# Usage:
+# scripts/release-update-extension-repo.sh $VERSION
+# where VERSION is of the form v0.1.0
+
+set -euo pipefail
+
+if [[ "${GITHUB_TOKEN-}" == "" ]]; then
+    echo "Missing GITHUB_TOKEN"
+    exit 1
+fi
+
+VERSION="$1"
+VERSION_PATTERN="^v[0-9]+\\.[0-9]+\\.[0-9]+$"
+if ! [[ $VERSION =~ $VERSION_PATTERN ]]; then
+    echo "Version did not match expected pattern. Actual: $VERSION"
+    exit 1
+fi
+
+DIR=$(dirname "$0")
+cd "$DIR/.."
+
+ROOT=$(mktemp -d)
+git clone https://tilt-releaser:"$GITHUB_TOKEN"@github.com/tilt-dev/tilt-extensions "$ROOT"
+
+set -x
+cd "$ROOT"
+git fetch --tags
+git tag -a "$VERSION" -m "$VERSION"
+git push origin "$VERSION"
+
+rm -fR "$ROOT"


### PR DESCRIPTION
Hello @landism, @lizzthabet,

Please review the following commits I made in branch nicks/extensionrepo:

03332aef10ce63d7201c9c32077c28f6e7a53710 (2022-02-04 11:36:11 -0500)
scripts: automatically tag the extension repo as part of the release process

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics