### PR TITLE
Fix local-prefixes on linters imports

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -42,7 +42,7 @@ linters-settings:
           - Debugf
           - PrintColorf
   goimports:
-    local-prefixes: github.com/tilt-dev/tilt
+    local-prefixes: github.com/tilt-dev
   misspell:
     # Correct spellings using locale preferences for US or UK.
     # Default is to use a neutral variety of English.

--- a/integration/analytics_test.go
+++ b/integration/analytics_test.go
@@ -11,9 +11,9 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/tilt-dev/wmclient/pkg/analytics"
 
 	"github.com/tilt-dev/tilt/internal/testutils/tempdir"
+	"github.com/tilt-dev/wmclient/pkg/analytics"
 )
 
 const WindmillDirEnvVarName = "WINDMILL_DIR"

--- a/integration/stats_server.go
+++ b/integration/stats_server.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/gorilla/mux"
+
 	"github.com/tilt-dev/wmclient/pkg/analytics"
 )
 

--- a/internal/analytics/tilt_analytics_test.go
+++ b/internal/analytics/tilt_analytics_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+
 	"github.com/tilt-dev/wmclient/pkg/analytics"
 )
 

--- a/internal/cli/args_test.go
+++ b/internal/cli/args_test.go
@@ -10,12 +10,12 @@ import (
 
 	"github.com/alessio/shellescape"
 	"github.com/stretchr/testify/require"
-	"github.com/tilt-dev/wmclient/pkg/analytics"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
 	"github.com/tilt-dev/tilt/pkg/model"
+	"github.com/tilt-dev/wmclient/pkg/analytics"
 )
 
 func TestArgsClear(t *testing.T) {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -9,13 +9,12 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
-	"github.com/tilt-dev/wmclient/pkg/analytics"
-
-	"github.com/tilt-dev/tilt/pkg/model"
 
 	tiltanalytics "github.com/tilt-dev/tilt/internal/analytics"
 	"github.com/tilt-dev/tilt/internal/output"
 	"github.com/tilt-dev/tilt/pkg/logger"
+	"github.com/tilt-dev/tilt/pkg/model"
+	"github.com/tilt-dev/wmclient/pkg/analytics"
 )
 
 var debug bool

--- a/internal/cli/client/getter.go
+++ b/internal/cli/client/getter.go
@@ -27,7 +27,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/tilt-dev/wmclient/pkg/dirs"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/discovery"
@@ -35,6 +34,8 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/restmapper"
 	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/tilt-dev/wmclient/pkg/dirs"
 )
 
 // Composes the set of values necessary

--- a/internal/cli/demo.go
+++ b/internal/cli/demo.go
@@ -11,8 +11,8 @@ import (
 	"github.com/fatih/color"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"github.com/tilt-dev/go-get"
 
+	"github.com/tilt-dev/go-get"
 	"github.com/tilt-dev/tilt/internal/analytics"
 	"github.com/tilt-dev/tilt/internal/cli/demo"
 	"github.com/tilt-dev/tilt/pkg/logger"

--- a/internal/cli/get_test.go
+++ b/internal/cli/get_test.go
@@ -10,8 +10,6 @@ import (
 	"github.com/phayes/freeport"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/tilt-dev/wmclient/pkg/analytics"
-	"github.com/tilt-dev/wmclient/pkg/dirs"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -23,6 +21,8 @@ import (
 	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
 	"github.com/tilt-dev/tilt/pkg/assets"
 	"github.com/tilt-dev/tilt/pkg/model"
+	"github.com/tilt-dev/wmclient/pkg/analytics"
+	"github.com/tilt-dev/wmclient/pkg/dirs"
 )
 
 func TestGet(t *testing.T) {

--- a/internal/controllers/core/cluster/reconciler_test.go
+++ b/internal/controllers/core/cluster/reconciler_test.go
@@ -5,12 +5,10 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/tilt-dev/wmclient/pkg/analytics"
+	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-
-	"github.com/stretchr/testify/assert"
 
 	"github.com/tilt-dev/tilt/internal/controllers/apicmp"
 	"github.com/tilt-dev/tilt/internal/controllers/fake"
@@ -19,6 +17,7 @@ import (
 	"github.com/tilt-dev/tilt/internal/store"
 	"github.com/tilt-dev/tilt/internal/timecmp"
 	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
+	"github.com/tilt-dev/wmclient/pkg/analytics"
 )
 
 func TestKubernetesError(t *testing.T) {

--- a/internal/controllers/core/cmd/controller.go
+++ b/internal/controllers/core/cmd/controller.go
@@ -10,8 +10,6 @@ import (
 	"time"
 
 	"github.com/jonboulle/clockwork"
-	"github.com/tilt-dev/probe/pkg/probe"
-	"github.com/tilt-dev/probe/pkg/prober"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -23,6 +21,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
+	"github.com/tilt-dev/probe/pkg/probe"
+	"github.com/tilt-dev/probe/pkg/prober"
 	"github.com/tilt-dev/tilt/internal/controllers/apicmp"
 	"github.com/tilt-dev/tilt/internal/controllers/apis/configmap"
 	"github.com/tilt-dev/tilt/internal/controllers/apis/restarton"

--- a/internal/controllers/core/extensionrepo/reconciler.go
+++ b/internal/controllers/core/extensionrepo/reconciler.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/tilt-dev/go-get"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -16,6 +15,7 @@ import (
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	"github.com/tilt-dev/go-get"
 	"github.com/tilt-dev/tilt/internal/controllers/apicmp"
 	"github.com/tilt-dev/tilt/internal/store"
 	"github.com/tilt-dev/tilt/internal/xdg"

--- a/internal/controllers/core/extensionrepo/reconciler_test.go
+++ b/internal/controllers/core/extensionrepo/reconciler_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/tilt-dev/wmclient/pkg/os/temp"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -18,6 +17,7 @@ import (
 	"github.com/tilt-dev/tilt/internal/testutils/tempdir"
 	"github.com/tilt-dev/tilt/internal/xdg"
 	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
+	"github.com/tilt-dev/wmclient/pkg/os/temp"
 )
 
 func TestInvalidRepo(t *testing.T) {

--- a/internal/controllers/core/filewatch/controller.go
+++ b/internal/controllers/core/filewatch/controller.go
@@ -18,25 +18,21 @@ import (
 	"sync"
 	"time"
 
+	"github.com/jonboulle/clockwork"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
-	"github.com/jonboulle/clockwork"
-
+	"github.com/tilt-dev/fsnotify"
 	"github.com/tilt-dev/tilt/internal/controllers/apicmp"
 	"github.com/tilt-dev/tilt/internal/controllers/apis/configmap"
-	"github.com/tilt-dev/tilt/internal/controllers/indexer"
-
-	"github.com/tilt-dev/fsnotify"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/builder"
-
-	ctrl "sigs.k8s.io/controller-runtime"
-	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
-
 	"github.com/tilt-dev/tilt/internal/controllers/core/filewatch/fsevent"
+	"github.com/tilt-dev/tilt/internal/controllers/indexer"
 	"github.com/tilt-dev/tilt/internal/ignore"
 	"github.com/tilt-dev/tilt/internal/store"
 	"github.com/tilt-dev/tilt/internal/store/filewatches"

--- a/internal/controllers/core/tiltfile/reconciler_test.go
+++ b/internal/controllers/core/tiltfile/reconciler_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/tilt-dev/wmclient/pkg/analytics"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/workqueue"
@@ -34,6 +33,7 @@ import (
 	"github.com/tilt-dev/tilt/internal/tiltfile"
 	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
 	"github.com/tilt-dev/tilt/pkg/model"
+	"github.com/tilt-dev/wmclient/pkg/analytics"
 )
 
 func TestDefault(t *testing.T) {

--- a/internal/controllers/fake/fixture.go
+++ b/internal/controllers/fake/fixture.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/tilt-dev/wmclient/pkg/analytics"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -16,10 +15,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/tilt-dev/tilt-apiserver/pkg/server/builder/resource"
-
 	"github.com/tilt-dev/tilt/internal/store"
 	"github.com/tilt-dev/tilt/internal/testutils"
 	"github.com/tilt-dev/tilt/internal/testutils/bufsync"
+	"github.com/tilt-dev/wmclient/pkg/analytics"
 )
 
 // controller just exists to prevent an import cycle for controllers.

--- a/internal/dockerignore/ignore.go
+++ b/internal/dockerignore/ignore.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 
 	"github.com/docker/docker/builder/dockerignore"
-	tiltDockerignore "github.com/tilt-dev/dockerignore"
 
+	tiltDockerignore "github.com/tilt-dev/dockerignore"
 	"github.com/tilt-dev/tilt/internal/ospath"
 )
 

--- a/internal/engine/actions.go
+++ b/internal/engine/actions.go
@@ -3,7 +3,6 @@ package engine
 import (
 	"time"
 
-	"github.com/tilt-dev/wmclient/pkg/analytics"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
 
@@ -11,6 +10,7 @@ import (
 	"github.com/tilt-dev/tilt/internal/store"
 	"github.com/tilt-dev/tilt/internal/token"
 	"github.com/tilt-dev/tilt/pkg/model"
+	"github.com/tilt-dev/wmclient/pkg/analytics"
 )
 
 func NewErrorAction(err error) store.ErrorAction {

--- a/internal/engine/analytics/analytics_reporter_test.go
+++ b/internal/engine/analytics/analytics_reporter_test.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/tilt-dev/wmclient/pkg/analytics"
 
 	tiltanalytics "github.com/tilt-dev/tilt/internal/analytics"
 	"github.com/tilt-dev/tilt/internal/container"
@@ -17,6 +16,7 @@ import (
 	"github.com/tilt-dev/tilt/internal/store"
 	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
 	"github.com/tilt-dev/tilt/pkg/model"
+	"github.com/tilt-dev/wmclient/pkg/analytics"
 )
 
 var (

--- a/internal/engine/analytics/analytics_updater_test.go
+++ b/internal/engine/analytics/analytics_updater_test.go
@@ -4,13 +4,12 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/stretchr/testify/assert"
-	"github.com/tilt-dev/wmclient/pkg/analytics"
+	"github.com/stretchr/testify/require"
 
 	tiltanalytics "github.com/tilt-dev/tilt/internal/analytics"
 	"github.com/tilt-dev/tilt/internal/store"
+	"github.com/tilt-dev/wmclient/pkg/analytics"
 )
 
 func TestOnChange(t *testing.T) {

--- a/internal/engine/buildcontrol/image_build_and_deployer_test.go
+++ b/internal/engine/buildcontrol/image_build_and_deployer_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/opencontainers/go-digest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/tilt-dev/wmclient/pkg/dirs"
 	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -37,6 +36,7 @@ import (
 	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
 	"github.com/tilt-dev/tilt/pkg/logger"
 	"github.com/tilt-dev/tilt/pkg/model"
+	"github.com/tilt-dev/wmclient/pkg/dirs"
 )
 
 func TestDeployTwinImages(t *testing.T) {

--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/davecgh/go-spew/spew"
-	"github.com/tilt-dev/wmclient/pkg/analytics"
 
 	tiltanalytics "github.com/tilt-dev/tilt/internal/analytics"
 	"github.com/tilt-dev/tilt/internal/container"
@@ -37,6 +36,7 @@ import (
 	"github.com/tilt-dev/tilt/internal/token"
 	"github.com/tilt-dev/tilt/pkg/logger"
 	"github.com/tilt-dev/tilt/pkg/model"
+	"github.com/tilt-dev/wmclient/pkg/analytics"
 )
 
 // TODO(nick): maybe this should be called 'BuildEngine' or something?

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/tilt-dev/wmclient/pkg/analytics"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -108,6 +107,7 @@ import (
 	"github.com/tilt-dev/tilt/pkg/model"
 	"github.com/tilt-dev/tilt/pkg/model/logstore"
 	proto_webview "github.com/tilt-dev/tilt/pkg/webview"
+	"github.com/tilt-dev/wmclient/pkg/analytics"
 )
 
 var originalWD string

--- a/internal/hud/server/server.go
+++ b/internal/hud/server/server.go
@@ -16,7 +16,6 @@ import (
 	_ "github.com/gorilla/websocket"
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	jsoniter "github.com/json-iterator/go"
-	"github.com/tilt-dev/wmclient/pkg/analytics"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	tiltanalytics "github.com/tilt-dev/tilt/internal/analytics"
@@ -27,6 +26,7 @@ import (
 	"github.com/tilt-dev/tilt/pkg/assets"
 	"github.com/tilt-dev/tilt/pkg/model"
 	proto_webview "github.com/tilt-dev/tilt/pkg/webview"
+	"github.com/tilt-dev/wmclient/pkg/analytics"
 )
 
 const TiltTokenCookieName = "Tilt-Token"

--- a/internal/hud/server/server_test.go
+++ b/internal/hud/server/server_test.go
@@ -18,7 +18,6 @@ import (
 	grpcRuntime "github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/tilt-dev/wmclient/pkg/analytics"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -36,6 +35,7 @@ import (
 	"github.com/tilt-dev/tilt/pkg/assets"
 	"github.com/tilt-dev/tilt/pkg/model"
 	proto_webview "github.com/tilt-dev/tilt/pkg/webview"
+	"github.com/tilt-dev/wmclient/pkg/analytics"
 )
 
 func TestHandleAnalyticsEmptyRequest(t *testing.T) {

--- a/internal/hud/webview/analytics_nudge_test.go
+++ b/internal/hud/webview/analytics_nudge_test.go
@@ -5,10 +5,10 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/tilt-dev/wmclient/pkg/analytics"
 
 	"github.com/tilt-dev/tilt/internal/store"
 	"github.com/tilt-dev/tilt/pkg/model"
+	"github.com/tilt-dev/wmclient/pkg/analytics"
 )
 
 func TestNeedsNudgeRedManifest(t *testing.T) {

--- a/internal/k8s/registry.go
+++ b/internal/k8s/registry.go
@@ -6,11 +6,11 @@ import (
 	"net"
 	"sync"
 
-	"github.com/tilt-dev/localregistry-go"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apiv1 "k8s.io/client-go/kubernetes/typed/core/v1"
 
+	"github.com/tilt-dev/localregistry-go"
 	"github.com/tilt-dev/tilt/internal/container"
 	"github.com/tilt-dev/tilt/pkg/logger"
 )

--- a/internal/store/actions.go
+++ b/internal/store/actions.go
@@ -5,12 +5,12 @@ import (
 	"strings"
 	"time"
 
-	"github.com/tilt-dev/wmclient/pkg/analytics"
 	v1 "k8s.io/api/core/v1"
 
 	"github.com/tilt-dev/tilt/pkg/logger"
 	"github.com/tilt-dev/tilt/pkg/model"
 	"github.com/tilt-dev/tilt/pkg/model/logstore"
+	"github.com/tilt-dev/wmclient/pkg/analytics"
 )
 
 type ErrorAction struct {

--- a/internal/tiltfile/analytics/analytics.go
+++ b/internal/tiltfile/analytics/analytics.go
@@ -1,11 +1,11 @@
 package analytics
 
 import (
-	"github.com/tilt-dev/wmclient/pkg/analytics"
 	"go.starlark.net/starlark"
 
 	"github.com/tilt-dev/tilt/internal/tiltfile/starkit"
 	"github.com/tilt-dev/tilt/internal/tiltfile/value"
+	"github.com/tilt-dev/wmclient/pkg/analytics"
 )
 
 type Settings struct {

--- a/internal/tiltfile/tiltfile.go
+++ b/internal/tiltfile/tiltfile.go
@@ -8,15 +8,11 @@ import (
 	"strconv"
 	"time"
 
-	wmanalytics "github.com/tilt-dev/wmclient/pkg/analytics"
 	"go.starlark.net/starlark"
 
+	"github.com/tilt-dev/tilt/internal/analytics"
 	"github.com/tilt-dev/tilt/internal/container"
 	"github.com/tilt-dev/tilt/internal/controllers/apiset"
-	"github.com/tilt-dev/tilt/internal/tiltfile/tiltextension"
-	"github.com/tilt-dev/tilt/internal/tiltfile/v1alpha1"
-
-	"github.com/tilt-dev/tilt/internal/analytics"
 	"github.com/tilt-dev/tilt/internal/dockercompose"
 	"github.com/tilt-dev/tilt/internal/feature"
 	"github.com/tilt-dev/tilt/internal/k8s"
@@ -31,12 +27,15 @@ import (
 	"github.com/tilt-dev/tilt/internal/tiltfile/secretsettings"
 	"github.com/tilt-dev/tilt/internal/tiltfile/starkit"
 	"github.com/tilt-dev/tilt/internal/tiltfile/telemetry"
+	"github.com/tilt-dev/tilt/internal/tiltfile/tiltextension"
 	"github.com/tilt-dev/tilt/internal/tiltfile/updatesettings"
+	"github.com/tilt-dev/tilt/internal/tiltfile/v1alpha1"
 	"github.com/tilt-dev/tilt/internal/tiltfile/value"
 	"github.com/tilt-dev/tilt/internal/tiltfile/version"
 	"github.com/tilt-dev/tilt/internal/tiltfile/watch"
 	corev1alpha1 "github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
 	"github.com/tilt-dev/tilt/pkg/model"
+	wmanalytics "github.com/tilt-dev/wmclient/pkg/analytics"
 )
 
 const FileName = "Tiltfile"

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/tilt-dev/wmclient/pkg/analytics"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -46,6 +45,7 @@ import (
 	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
 	"github.com/tilt-dev/tilt/pkg/logger"
 	"github.com/tilt-dev/tilt/pkg/model"
+	"github.com/tilt-dev/wmclient/pkg/analytics"
 )
 
 type localResourceLinks []model.Link

--- a/internal/token/token.go
+++ b/internal/token/token.go
@@ -4,6 +4,7 @@ import (
 	"os"
 
 	"github.com/google/uuid"
+
 	"github.com/tilt-dev/wmclient/pkg/dirs"
 )
 

--- a/internal/token/token_test.go
+++ b/internal/token/token_test.go
@@ -4,9 +4,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/tilt-dev/wmclient/pkg/dirs"
 
 	"github.com/tilt-dev/tilt/internal/testutils/tempdir"
+	"github.com/tilt-dev/wmclient/pkg/dirs"
 )
 
 func TestGetOrCreateToken(t *testing.T) {

--- a/internal/watch/watcher_naive.go
+++ b/internal/watch/watcher_naive.go
@@ -12,8 +12,8 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
-	"github.com/tilt-dev/fsnotify"
 
+	"github.com/tilt-dev/fsnotify"
 	"github.com/tilt-dev/tilt/internal/ospath"
 	"github.com/tilt-dev/tilt/pkg/logger"
 )


### PR DESCRIPTION
Fix local-prefixes on linters imports then resolved imports to be as expected.

I've made this configuration mistake in the past and quite familiar with it.    The order of import expectations is that each group should be alphabetized and the groups are:

1. go core deps
2. 3rd party deps
3. internal to project deps

I was going to make an entry for the contributes but didn't see a logical place to drop that information.  It is fairly well adopted in OSS go projects but may add value in the contrib MD.  With some guidance, I'm happy to add to this PR or another import expectations.

Signed-off-by: Ken Sipe <kensipe@gmail.com>