### PR TITLE
engine: fix build graph structure error on LU-only targets

### DIFF
--- a/internal/engine/buildcontrol/extractors.go
+++ b/internal/engine/buildcontrol/extractors.go
@@ -31,7 +31,31 @@ func extractImageAndK8sTargets(specs []model.TargetSpec) (iTargets []model.Image
 // If there are images that can be updated in-place in a container, return
 // a state tree of what needs to be updated.
 func extractImageTargetsForLiveUpdates(specs []model.TargetSpec, stateSet store.BuildStateSet) ([]liveUpdateStateTree, error) {
-	g, err := model.NewTargetGraph(specs)
+	// HACK(milas): LU-only targets are NOT dependencies of the deploy target
+	// 	(there is no build); this breaks the Live Update DAG logic which wants
+	// 	the deploy target (K8sTarget/DockerComposeTarget) as the root node with
+	// 	ImageTargets as dependencies, which can then themselves have more
+	// 	ImageTargets as dependencies for base images. As a workaround, these
+	// 	are _removed_ from the spec list for the graph and then always included
+	//  in the collection of deployed images considered for Live Update ops.
+	// 	Moving forward, this will be a non-issue, as the API reconcilers are
+	// 	designed to work independently, but this keeps compatibility for the
+	// 	v1 Live Update (currently always used for Docker Compose and only if
+	// 	a feature flag is explicitly disabled for K8s) and prevents a scary
+	// 	error in the v2 case.
+	var luOnlyTargets []model.ImageTarget
+	specsForGraph := make([]model.TargetSpec, 0, len(specs))
+	for _, spec := range specs {
+		if iTarget, ok := spec.(model.ImageTarget); ok && iTarget.IsLiveUpdateOnly {
+			luOnlyTargets = append(luOnlyTargets, iTarget)
+		} else {
+			// * any image targets that have a build (i.e. not LU-only)
+			// * all other targets (e.g. K8sTarget, DockerComposeTarget)
+			specsForGraph = append(specsForGraph, spec)
+		}
+	}
+
+	g, err := model.NewTargetGraph(specsForGraph)
 	if err != nil {
 		return nil, errors.Wrap(err, "extractImageTargetsForLiveUpdates")
 	}
@@ -43,6 +67,8 @@ func extractImageTargetsForLiveUpdates(specs []model.TargetSpec, stateSet store.
 	result := make([]liveUpdateStateTree, 0)
 
 	deployedImages := g.DeployedImages()
+	deployedImages = append(deployedImages, luOnlyTargets...)
+
 	for _, iTarget := range deployedImages {
 		state := stateSet[iTarget.ID()]
 		// If this is a normal image build, it must have info about the deployed image.


### PR DESCRIPTION
Historically, the engine builds a lightweight DAG for the targets
in a manifest. A sanity check is done up-front to ensure there's
a single root node (the "deploy" target, i.e. `K8sTarget` or
`DockerComposeTarget` for the cases relevant to this bug). That
node can then have children, which will be `ImageTarget`s, and
for completeness sake, those can recursively have further child
`ImageTarget`s for base images.

Live Update-only targets are currently modeled in the engine as
`ImageTarget`s with a special `IsLiveUpdateOnly` flag which causes
the engine to skip the (non-existant) build. Because there is no
build, there is no `ImageMap`.

As part of API migration, the deploy targets mentioned above are
now driven by their API specs as the source of truth, and both
`KubernetesApplySpec` and `DockerComposeUpSpec` include an
`ImageMaps` field, which is used when building the DAG.

This means that LU-only targets were no longer represented as a
dependency of the deploy target. In reality, this is correct!
~~However, the DAG sanity check now fails as a result. The changes
here are to add (engine-only) tracking of the LU-only targets,
which are then merged with the `ImageMap` dependencies for DAG
assembly.~~

~~While this is less than ideal because we've been working hard to
eliminate "secret"/special bits of state like this and drive all
the things from the API models, I'm not sure what a good alternative
is right now, as removing the single root-node invariant will
require pretty extensive testing to ensure that things behave
correctly.~~

However, the DAG sanity check now fails as a result. The change
here is to temporarily remove the LU-only targets from the set
before building the DAG, and then add them back in to the list
of deployed images.

Once API migration work is further along (e.g. Docker Compose
Live Update happens via reconciler), the DAG logic and this hack
will go away.

Fixes #5447.