### PR TITLE
Flags --hud and --legacy mutually exclusive

### DIFF
--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -91,6 +91,13 @@ local resources--i.e. those using serve_cmd--are terminated when you exit Tilt.
 	cmd.Flags().Lookup("logactions").Hidden = true
 	cmd.Flags().StringVar(&c.outputSnapshotOnExit, "output-snapshot-on-exit", "", "If specified, Tilt will dump a snapshot of its state to the specified path when it exits")
 
+	cmd.PreRunE = func(cmd *cobra.Command, args []string) error {
+		if c.legacy && c.hud {
+			return errors.New("flags --hud and --legacy are mutually exclusive. please select one or the other")
+		}
+		return nil
+	}
+
 	cmd.PreRun = func(cmd *cobra.Command, args []string) {
 		c.hudFlagExplicitlySet = cmd.Flag("hud").Changed
 	}

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -92,7 +92,7 @@ local resources--i.e. those using serve_cmd--are terminated when you exit Tilt.
 	cmd.Flags().StringVar(&c.outputSnapshotOnExit, "output-snapshot-on-exit", "", "If specified, Tilt will dump a snapshot of its state to the specified path when it exits")
 
 	cmd.PreRunE = func(cmd *cobra.Command, args []string) error {
-		if c.legacy && c.hud {
+		if c.legacy && c.hud && cmd.Flag("hud").Changed {
 			return errors.New("flags --hud and --legacy are mutually exclusive. please select one or the other")
 		}
 		return nil

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -95,11 +95,8 @@ local resources--i.e. those using serve_cmd--are terminated when you exit Tilt.
 		if c.legacy && c.hud && cmd.Flag("hud").Changed {
 			return errors.New("flags --hud and --legacy are mutually exclusive. please select one or the other")
 		}
-		return nil
-	}
-
-	cmd.PreRun = func(cmd *cobra.Command, args []string) {
 		c.hudFlagExplicitlySet = cmd.Flag("hud").Changed
+		return nil
 	}
 
 	return cmd

--- a/internal/cli/up_test.go
+++ b/internal/cli/up_test.go
@@ -28,7 +28,7 @@ func TestHudEnabled(t *testing.T) {
 			err := c.Flags().Parse(args)
 			require.NoError(t, err)
 
-			c.PreRun(c, args)
+			c.PreRunE(c, args)
 
 			require.Equal(t, test.expected, cmd.initialTermMode(true), test.args)
 		})


### PR DESCRIPTION
Improving UX by not allowing nonsensical combination of flags

As reported in #5455, it would be nice to remove the notion of 2 different modes for `--hud=true`.   It is true by default and it can be true by setting. Those 2 different conditions of being true have different experiences.   I would love to fix that if we can get some direction.   It is also worth pointing out that the terminal has 2 letters to go to legacy.   one that is explicitly displayed as an option `t` -- legacy terminal... but also one that looks to be historical as written in the [blog](https://blog.tilt.dev/2020/06/19/the-right-display-for-now.html) `h` which goes to hud.   This increases the confusion as hud and legacy seem to be called out separately but also seem to mean the same thing.   Clarity could make this PR meaningless.