### PR TITLE
apiset: make ObjectSet.AddSetForType merge instead of replace

### DIFF
--- a/internal/controllers/apiset/apiset.go
+++ b/internal/controllers/apiset/apiset.go
@@ -17,8 +17,18 @@ func (s ObjectSet) Add(o Object) {
 	s.GetOrCreateTypedSet(o)[o.GetName()] = o
 }
 
+// `o` is only used to indicate the type - it does not get added to the set
 func (s ObjectSet) AddSetForType(o Object, set TypedObjectSet) {
-	s[o.GetGroupVersionResource().String()] = set
+	gvk := o.GetGroupVersionResource()
+	dst := s[gvk.String()]
+	if dst == nil {
+		s[gvk.String()] = set
+		return
+	}
+
+	for k, v := range set {
+		dst[k] = v
+	}
 }
 
 func (s ObjectSet) GetOrCreateTypedSet(o Object) TypedObjectSet {

--- a/internal/controllers/apiset/apiset_test.go
+++ b/internal/controllers/apiset/apiset_test.go
@@ -1,0 +1,53 @@
+package apiset
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
+)
+
+func TestAddSetForTypeNoExistingEntries(t *testing.T) {
+	a := &v1alpha1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "a"}}
+	b := &v1alpha1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "b"}}
+	c := &v1alpha1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "c"}}
+	set := make(ObjectSet)
+	set.Add(a)
+
+	newObjs := make(TypedObjectSet)
+	newObjs["b"] = b
+	newObjs["c"] = c
+
+	set.AddSetForType(&v1alpha1.ConfigMap{}, newObjs)
+
+	var observed []*v1alpha1.ConfigMap
+	for _, v := range set.GetSetForType(&v1alpha1.ConfigMap{}) {
+		observed = append(observed, v.(*v1alpha1.ConfigMap))
+	}
+
+	require.ElementsMatch(t, []*v1alpha1.ConfigMap{a, b, c}, observed)
+
+}
+
+func TestAddSetForTypeKeepsOldEntries(t *testing.T) {
+	a := &v1alpha1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "a"}}
+	b := &v1alpha1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "b"}}
+	c := &v1alpha1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "c"}}
+	set := make(ObjectSet)
+	set.Add(a)
+
+	newObjs := make(TypedObjectSet)
+	newObjs["b"] = b
+	newObjs["c"] = c
+
+	set.AddSetForType(&v1alpha1.ConfigMap{}, newObjs)
+
+	var observed []*v1alpha1.ConfigMap
+	for _, v := range set.GetSetForType(&v1alpha1.ConfigMap{}) {
+		observed = append(observed, v.(*v1alpha1.ConfigMap))
+	}
+
+	require.ElementsMatch(t, []*v1alpha1.ConfigMap{a, b, c}, observed)
+}

--- a/internal/controllers/core/tiltfile/api.go
+++ b/internal/controllers/core/tiltfile/api.go
@@ -233,22 +233,9 @@ func toAPIObjects(
 			result.AddSetForType(obj, tlr.ObjectSet.GetSetForType(obj))
 		}
 
-		kaMap := result.GetOrCreateTypedSet(&v1alpha1.KubernetesApply{})
-		for k, obj := range toKubernetesApplyObjects(tlr, disableSources) {
-			kaMap[k] = obj
-		}
-
-		cmMap := result.GetOrCreateTypedSet(&v1alpha1.ConfigMap{})
-		for k, obj := range toDisableConfigMaps(disableSources, tlr.EnabledManifests) {
-			cmMap[k] = obj
-		}
-
-		updateCmds := toCmdObjects(tlr, disableSources)
-		cmdMap := result.GetOrCreateTypedSet(&v1alpha1.Cmd{})
-		for key, cmd := range updateCmds {
-			cmdMap[key] = cmd
-		}
-
+		result.AddSetForType(&v1alpha1.KubernetesApply{}, toKubernetesApplyObjects(tlr, disableSources))
+		result.AddSetForType(&v1alpha1.ConfigMap{}, toDisableConfigMaps(disableSources, tlr.EnabledManifests))
+		result.AddSetForType(&v1alpha1.Cmd{}, toCmdObjects(tlr, disableSources))
 		result.AddSetForType(&v1alpha1.ToggleButton{}, toToggleButtons(tlr, disableSources))
 		result.AddSetForType(&v1alpha1.Cluster{}, toClusterObjects(nn, tlr, defaultK8sConnection))
 	}
@@ -271,10 +258,7 @@ func toAPIObjects(
 		watchInputs.TiltfilePath = tf.Spec.Path
 	}
 
-	fwMap := result.GetOrCreateTypedSet(&v1alpha1.FileWatch{})
-	for k, fw := range ToFileWatchObjects(watchInputs, disableSources) {
-		fwMap[k] = fw
-	}
+	result.AddSetForType(&v1alpha1.FileWatch{}, ToFileWatchObjects(watchInputs, disableSources))
 
 	return result
 }


### PR DESCRIPTION
### Problem

`ObjectSet.AddSetForType` will blow away any existing objects of the given type, but it's also much easier to read/write than looping over objects.

In [the Tiltfile reconciler](https://github.com/tilt-dev/tilt/blob/06758a2cff2dc808a54a9d24acd0896beb46cef2/internal/controllers/core/tiltfile/api.go#L227-L253), which has all of the uses of this method, we have a mix of calls to `ObjectSet.AddSetForType` and looping over a map and calling Add on objects individually, depending on whether the type had already been added. I added an easy-to-miss bug adding UIButtons here - my buttons blew away any buttons that were added by the Tiltfile. (similarly, if we add ToggleButton to [typesWithTiltfileBuiltins](https://github.com/tilt-dev/tilt/blob/06758a2cff2dc808a54a9d24acd0896beb46cef2/internal/controllers/core/tiltfile/api.go#L232-L234), any ToggleButtons from the Tiltfile will get deleted by the later call to `AddSetForType`)

### Solution

Make `AddSetForType` merge instead of replace. (which also makes that part of api.go cleaner!)