### PR TITLE
engine: fix dc disable flaky test

### DIFF
--- a/internal/engine/dcwatch/disable_watcher.go
+++ b/internal/engine/dcwatch/disable_watcher.go
@@ -109,7 +109,11 @@ func (w *DisableSubscriber) OnChange(ctx context.Context, st store.RStore, summa
 			// docker-compose rm can take 5-10 seconds
 			// we sleep a bit here so that if a bunch of resources are disabled in bulk, we do them all at once rather
 			// than starting the first one we see, and then getting the rest in a second docker-compose rm call
-			w.clock.Sleep(disableDebounceDelay)
+			select {
+			case <-ctx.Done():
+				return
+			case <-w.clock.After(disableDebounceDelay):
+			}
 
 			w.Reconcile(ctx)
 			w.mu.Lock()

--- a/internal/engine/dcwatch/disable_watcher_test.go
+++ b/internal/engine/dcwatch/disable_watcher_test.go
@@ -35,7 +35,7 @@ func TestDockerComposeDebounce(t *testing.T) {
 
 	f.onChange()
 
-	f.clock.BlockUntil(1)
+	f.clock.BlockUntil(2)
 	f.clock.Advance(20 * disableDebounceDelay)
 
 	call := f.rmCall(1)
@@ -185,6 +185,8 @@ func newDWFixture(t *testing.T) *dwFixture {
 	log := bufsync.NewThreadSafeBuffer()
 	out := io.MultiWriter(log, os.Stdout)
 	ctx := logger.WithLogger(context.Background(), logger.NewTestLogger(out))
+	ctx, cancel := context.WithCancel(ctx)
+	t.Cleanup(cancel)
 	dcClient := dockercompose.NewFakeDockerComposeClient(t, ctx)
 	clock := clockwork.NewFakeClock()
 	watcher := NewDisableSubscriber(dcClient, clock)


### PR DESCRIPTION
1 -> 2 is the only actual fix here (we call OnChange twice so there should be two waiting on the clock - I'm surprised I was able to pass with `-count 100` as it was!). The rest is to make sure tests clean up their goroutines so that if/when things do time out, we only get stacks relevant to the failing test.