### PR TITLE
engine: fix flaky TestPodUnexpectedContainerStartsImageBuildOutOfOrderEvents

### DIFF
--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -4571,8 +4571,9 @@ func (f *testFixture) setK8sApplyResult(name model.ManifestName, hash k8s.PodTem
 	var ka v1alpha1.KubernetesApply
 	require.NoError(f.t, f.ctrlClient.Get(f.ctx, types.NamespacedName{Name: string(name)}, &ka))
 
+	patchBase := ctrlclient.MergeFrom(ka.DeepCopy())
 	ka.Status = status
-	require.NoError(f.t, f.ctrlClient.Status().Update(f.ctx, &ka))
+	require.NoError(f.t, f.ctrlClient.Status().Patch(f.ctx, &ka, patchBase))
 
 	st := f.store.LockMutableStateForTesting()
 	ms, _ := st.ManifestState(name)


### PR DESCRIPTION
(and presumably other tests that use this method)

I was getting pretty consistent failures with
`go test ./internal/engine -run TestPodUnexpectedContainerStartsImageBuildOutOfOrderEvents -count 100  -failfast`:

`Operation cannot be fulfilled on [kubernetesapplys.tilt.dev](http://kubernetesapplys.tilt.dev/) "foobar": the object has been modified; please apply your changes to the latest version and try again`

We might want to change the test client to automatically retry on this type of error, as we'd get with an actual controller, but this is simple enough for now.