### PR TITLE
tiltfile: don't check enabled resources when loading failed

### DIFF
--- a/internal/tiltfile/tiltfile.go
+++ b/internal/tiltfile/tiltfile.go
@@ -8,7 +8,6 @@ import (
 	"strconv"
 	"time"
 
-	wmanalytics "github.com/tilt-dev/wmclient/pkg/analytics"
 	"go.starlark.net/starlark"
 
 	"github.com/tilt-dev/tilt/internal/analytics"
@@ -36,6 +35,7 @@ import (
 	"github.com/tilt-dev/tilt/internal/tiltfile/watch"
 	corev1alpha1 "github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
 	"github.com/tilt-dev/tilt/pkg/model"
+	wmanalytics "github.com/tilt-dev/wmclient/pkg/analytics"
 )
 
 const FileName = "Tiltfile"

--- a/internal/tiltfile/tiltfile.go
+++ b/internal/tiltfile/tiltfile.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"time"
 
+	wmanalytics "github.com/tilt-dev/wmclient/pkg/analytics"
 	"go.starlark.net/starlark"
 
 	"github.com/tilt-dev/tilt/internal/analytics"
@@ -35,7 +36,6 @@ import (
 	"github.com/tilt-dev/tilt/internal/tiltfile/watch"
 	corev1alpha1 "github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
 	"github.com/tilt-dev/tilt/pkg/model"
-	wmanalytics "github.com/tilt-dev/wmclient/pkg/analytics"
 )
 
 const FileName = "Tiltfile"
@@ -216,12 +216,9 @@ func (tfl tiltfileLoader) Load(ctx context.Context, tf *corev1alpha1.Tiltfile) T
 	tlr.UpdateSettings = us
 
 	configSettings, _ := config.GetState(result)
-	enabledManifests, err := configSettings.EnabledResources(tf, manifests)
-	if err != nil {
-		tlr.Error = err
-		return tlr
+	if tlr.Error == nil {
+		tlr.EnabledManifests, tlr.Error = configSettings.EnabledResources(tf, manifests)
 	}
-	tlr.EnabledManifests = enabledManifests
 
 	duration := time.Since(start)
 	if tlr.Error == nil {

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/tilt-dev/wmclient/pkg/analytics"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -47,6 +46,7 @@ import (
 	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
 	"github.com/tilt-dev/tilt/pkg/logger"
 	"github.com/tilt-dev/tilt/pkg/model"
+	"github.com/tilt-dev/wmclient/pkg/analytics"
 )
 
 type localResourceLinks []model.Link

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tilt-dev/wmclient/pkg/analytics"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -46,7 +47,6 @@ import (
 	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
 	"github.com/tilt-dev/tilt/pkg/logger"
 	"github.com/tilt-dev/tilt/pkg/model"
-	"github.com/tilt-dev/wmclient/pkg/analytics"
 )
 
 type localResourceLinks []model.Link
@@ -5929,6 +5929,15 @@ local_resource("test2", cmd="echo hi2", labels=["bar", "baz"])
 	f.assertNextManifest("test2", resourceLabels("bar", "baz"))
 }
 
+// https://github.com/tilt-dev/tilt/issues/5467
+func TestLoadErrorWithArgs(t *testing.T) {
+	f := newFixture(t)
+	defer f.TearDown()
+
+	f.file("Tiltfile", "asdf")
+	f.loadArgsErrString([]string{"foo"}, "undefined: asdf")
+}
+
 type fixture struct {
 	ctx context.Context
 	out *bytes.Buffer
@@ -6155,8 +6164,12 @@ func (f *fixture) loadAssertWarnings(warnings ...string) {
 }
 
 func (f *fixture) loadErrString(msgs ...string) {
+	f.loadArgsErrString(nil, msgs...)
+}
+
+func (f *fixture) loadArgsErrString(args []string, msgs ...string) {
 	f.t.Helper()
-	tlr := f.newTiltfileLoader().Load(f.ctx, ctrltiltfile.MainTiltfile(f.JoinPath("Tiltfile"), nil))
+	tlr := f.newTiltfileLoader().Load(f.ctx, ctrltiltfile.MainTiltfile(f.JoinPath("Tiltfile"), args))
 	err := tlr.Error
 
 	if err == nil {


### PR DESCRIPTION
fixes #5467