### PR TITLE
Deprecate --hud in favor of --legacy

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -34,7 +34,7 @@ def go_vendor():
 
 all_go_files = get_all_go_files(".")
 
-go("Tilt", "cmd/tilt/main.go", all_go_files, srv="cd /tmp/ && ./tilt up --hud=false --web-mode=prod --port=9765")
+go("Tilt", "cmd/tilt/main.go", all_go_files, srv="cd /tmp/ && ./tilt up --legacy=false --web-mode=prod --port=9765")
 go_test_changes(all_go_files)
 go_lint(all_go_files)
 go_vendor()

--- a/integration/tilt.go
+++ b/integration/tilt.go
@@ -110,7 +110,7 @@ func (d *TiltDriver) Up(ctx context.Context, command UpCommand, out io.Writer, a
 	}
 	mandatoryArgs := []string{string(command),
 		// Can't attach a HUD or install browsers in headless mode
-		"--hud=false",
+		"--legacy=false",
 
 		// Debug logging for integration tests
 		"--debug",

--- a/internal/cli/args.go
+++ b/internal/cli/args.go
@@ -59,7 +59,7 @@ EDITOR=nano tilt args
 # note: "--" here indicates the end of the tilt args and the start of the tiltfile args
 tilt args -- --foo=bar frontend backend
 
-Note that this does not affect built-in Tilt args (e.g. --hud, --host), but rather the extra args that come after,
+Note that this does not affect built-in Tilt args (e.g. --legacy, --host), but rather the extra args that come after,
 i.e., those specifying which resources to run and/or handled by a Tiltfile calling config.parse.
 `,
 	}

--- a/internal/cli/up_test.go
+++ b/internal/cli/up_test.go
@@ -16,7 +16,7 @@ func TestHudEnabled(t *testing.T) {
 		expected store.TerminalMode
 	}{
 		{"old behavior: no --hud", "", store.TerminalModePrompt},
-		{"old behavior: --hud", "--hud", store.TerminalModeHUD},
+		{"old behavior: --legacy", "--legacy", store.TerminalModeHUD},
 		{"old behavior: --stream=true", "--stream=true", store.TerminalModeStream},
 	} {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
Improving UX and reducing confusion around `hud` and `legacy` in favor of `legacy` as noted in  Issue #5455 
Internally, it is still referenced as hud or legacy hud, but it exposed to users as `legacy`.  

The change is much easier to reason about on startup of `up` or `demo`.
`hud` is marked as deprecated which requires a sleep pause in order to display.  1 sec seemed too fast to notice and guessed 3 was reasonable but looking for feedback.
Additionally I guess that 3 major release versions was a reasonable deprecation window, looking for guidance there.

This PR does not handle consolidation of key navigation from prompts yet.

Signed-off-by: Ken Sipe <kensipe@gmail.com>