### PR TITLE
web: add a show/hide toggle for disabled resources

### DIFF
--- a/web/src/OverviewSidebarOptions.test.tsx
+++ b/web/src/OverviewSidebarOptions.test.tsx
@@ -11,7 +11,7 @@ import {
   TwoResourcesTwoTests,
 } from "./OverviewResourceSidebar.stories"
 import {
-  AlertsOnTopToggle,
+  CheckboxToggle,
   OverviewSidebarOptions,
 } from "./OverviewSidebarOptions"
 import {
@@ -29,8 +29,14 @@ const resourceListOptionsAccessor = accessorsForTesting<ResourceListOptions>(
   RESOURCE_LIST_OPTIONS_KEY,
   sessionStorage
 )
+/**
+ * TODO (lizz): These tests behave more like integration tests
+ * and test the SidebarOptions component within the larger `SidebarResources`
+ * component. The tests should be moved over to that component's test suite
+ * and refactored with the react-testing-library changes.
+ */
 
-export function assertSidebarItemsAndOptions(
+function assertSidebarItemsAndOptions(
   root: ReactWrapper,
   names: string[],
   expectAlertsOnTop: boolean,
@@ -48,7 +54,7 @@ export function assertSidebarItemsAndOptions(
 
   let optSetter = sidebar.find(OverviewSidebarOptions)
   expect(optSetter).toHaveLength(1)
-  expect(optSetter.find(AlertsOnTopToggle).hasClass("is-enabled")).toEqual(
+  expect(optSetter.find(CheckboxToggle).prop("checked")).toEqual(
     expectAlertsOnTop
   )
   if (expectedResourceNameFilter !== undefined) {
@@ -58,8 +64,6 @@ export function assertSidebarItemsAndOptions(
   }
 }
 
-const allNames = ["(Tiltfile)", "vigoda", "snack", "beep", "boop"]
-
 describe("overview sidebar options", () => {
   beforeEach(() => {
     mockAnalyticsCalls()
@@ -68,37 +72,6 @@ describe("overview sidebar options", () => {
   afterEach(() => {
     cleanupMockAnalyticsCalls()
     localStorage.clear()
-  })
-
-  it("shows all resources by default", () => {
-    const root = mount(TwoResourcesTwoTests())
-    assertSidebarItemsAndOptions(root, allNames, false)
-  })
-
-  it("applies the name filter", () => {
-    // 'B p' tests both case insensitivity and a multi-term query
-    resourceListOptionsAccessor.set({
-      ...DEFAULT_OPTIONS,
-      resourceNameFilter: "B p",
-    })
-    const root = mount(
-      <MemoryRouter>
-        <tiltfileKeyContext.Provider value="test">
-          <ResourceListOptionsProvider>
-            <StarredResourcesContextProvider>
-              {TwoResourcesTwoTests()}
-            </StarredResourcesContextProvider>
-          </ResourceListOptionsProvider>
-        </tiltfileKeyContext.Provider>
-      </MemoryRouter>
-    )
-
-    assertSidebarItemsAndOptions(
-      root,
-      ["beep", "boop"],
-      DEFAULT_OPTIONS.alertsOnTop,
-      "B p"
-    )
   })
 
   it("says no matches found", () => {
@@ -152,7 +125,7 @@ it("toggles/untoggles Alerts On Top sorting when button clicked", () => {
   ]
   assertSidebarItemsAndOptions(root, origOrder, false)
 
-  let aotToggle = root.find(AlertsOnTopToggle)
+  let aotToggle = root.find(CheckboxToggle)
   aotToggle.simulate("click")
 
   assertSidebarItemsAndOptions(root, alertsOnTopOrder, true)

--- a/web/src/OverviewSidebarOptions.tsx
+++ b/web/src/OverviewSidebarOptions.tsx
@@ -1,13 +1,15 @@
+import { FormControlLabel } from "@material-ui/core"
 import React from "react"
 import styled from "styled-components"
-import { InstrumentedButton } from "./instrumentedComponents"
+import { AnalyticsType } from "./analytics"
+import { Flag, useFeatures } from "./feature"
+import { InstrumentedCheckbox } from "./instrumentedComponents"
 import { useResourceListOptions } from "./ResourceListOptionsContext"
 import { ResourceNameFilter } from "./ResourceNameFilter"
 import {
   Color,
   Font,
   FontSize,
-  mixinResetButtonStyle,
   mixinResetListStyle,
   SizeUnit,
 } from "./style-helpers"
@@ -15,8 +17,8 @@ import {
 const OverviewSidebarOptionsRoot = styled.div`
   display: flex;
   justify-content: space-between;
-  font-family: ${Font.sansSerif};
-  font-size: ${FontSize.smallester};
+  font-family: ${Font.monospace};
+  font-size: ${FontSize.smallest};
   padding-left: ${SizeUnit(0.5)};
   padding-right: ${SizeUnit(0.5)};
   color: ${Color.offWhite};
@@ -24,52 +26,74 @@ const OverviewSidebarOptionsRoot = styled.div`
 `
 
 const OverviewSidebarOptionsButtonsRoot = styled.div`
-  display: flex;
-  justify-content: space-between;
   align-items: center;
-  justify-content: flex-end;
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-start;
+  width: 100%;
 `
 
 export const FilterOptionList = styled.ul`
   ${mixinResetListStyle};
   display: flex;
   align-items: center;
-  user-select: none; // Prevent unsightly highlighting on the label
+  user-select: none; /* Prevent unsightly highlighting on the label */
 `
 
-const toggleBorderRadius = "3px"
+export const SidebarOptionsLabel = styled(FormControlLabel)`
+  .MuiFormControlLabel-label.MuiTypography-body1 {
+    line-height: 1;
+  }
+`
 
-export const AlertsOnTopToggle = styled(InstrumentedButton)`
-  ${mixinResetButtonStyle};
-  color: ${Color.grayLightest};
-  background-color: ${Color.gray};
-  padding: ${SizeUnit(0.125)} ${SizeUnit(0.25)};
-  border-radius: ${toggleBorderRadius};
-  font-size: 12px;
-
-  &.is-enabled {
-    color: ${Color.grayDarkest};
-    background-color: ${Color.offWhite};
+export const CheckboxToggle = styled(InstrumentedCheckbox)`
+  &.MuiCheckbox-root,
+  &.Mui-checked {
+    color: ${Color.gray6};
   }
 `
 
 export function OverviewSidebarOptions() {
   const { options, setOptions } = useResourceListOptions()
+  const features = useFeatures()
 
-  function setAlertsOnTop(alertsOnTop: boolean) {
-    setOptions({ alertsOnTop })
-  }
+  const disableResourcesEnabled = features.isEnabled(Flag.DisableResources)
+  const disabledResourcesToggle = disableResourcesEnabled ? (
+    <SidebarOptionsLabel
+      control={
+        <CheckboxToggle
+          analyticsName="ui.web.disabledResourcesToggle"
+          analyticsTags={{ type: AnalyticsType.Detail }}
+          size="small"
+          checked={options.showDisabledResources}
+          onClick={(_e) =>
+            setOptions({
+              showDisabledResources: !options.showDisabledResources,
+            })
+          }
+        />
+      }
+      label="Show disabled resources"
+    />
+  ) : null
 
   return (
     <OverviewSidebarOptionsRoot>
       <OverviewSidebarOptionsButtonsRoot>
-        <AlertsOnTopToggle
-          className={options.alertsOnTop ? "is-enabled" : ""}
-          onClick={(_e) => setAlertsOnTop(!options.alertsOnTop)}
-          analyticsName="ui.web.alertsOnTopToggle"
-        >
-          Alerts on Top
-        </AlertsOnTopToggle>
+        {disabledResourcesToggle}
+        <SidebarOptionsLabel
+          control={
+            <CheckboxToggle
+              analyticsName="ui.web.alertsOnTopToggle"
+              size="small"
+              checked={options.alertsOnTop}
+              onClick={(_e) =>
+                setOptions({ alertsOnTop: !options.alertsOnTop })
+              }
+            />
+          }
+          label="Alerts on top"
+        />
       </OverviewSidebarOptionsButtonsRoot>
       <ResourceNameFilter />
     </OverviewSidebarOptionsRoot>

--- a/web/src/OverviewTableDisplayOptions.tsx
+++ b/web/src/OverviewTableDisplayOptions.tsx
@@ -1,0 +1,53 @@
+import { FormControlLabel } from "@material-ui/core"
+import React from "react"
+import styled from "styled-components"
+import { AnalyticsType } from "./analytics"
+import { Flag, useFeatures } from "./feature"
+import { InstrumentedCheckbox } from "./instrumentedComponents"
+import { useResourceListOptions } from "./ResourceListOptionsContext"
+import { Color, Font, FontSize } from "./style-helpers"
+
+const DisplayOptions = styled.div`
+  margin-left: auto;
+  font-family: ${Font.monospace};
+  font-size: ${FontSize.smallest};
+`
+
+const DisplayOptionCheckbox = styled(InstrumentedCheckbox)`
+  &.MuiCheckbox-root,
+  &.Mui-checked {
+    color: ${Color.gray6};
+  }
+`
+
+export function OverviewTableDisplayOptions() {
+  const features = useFeatures()
+  const { options, setOptions } = useResourceListOptions()
+
+  // Since the only option here is related to the Disable Resources feature,
+  // don't render if the feature isn't enabled
+  if (!features.isEnabled(Flag.DisableResources)) {
+    return null
+  }
+
+  return (
+    <DisplayOptions>
+      <FormControlLabel
+        control={
+          <DisplayOptionCheckbox
+            analyticsName="ui.web.disabledResourcesToggle"
+            analyticsTags={{ type: AnalyticsType.Grid }}
+            size="small"
+            checked={options.showDisabledResources}
+            onClick={(_e) =>
+              setOptions({
+                showDisabledResources: !options.showDisabledResources,
+              })
+            }
+          />
+        }
+        label="Show disabled resources"
+      />
+    </DisplayOptions>
+  )
+}

--- a/web/src/ResourceListOptionsContext.tsx
+++ b/web/src/ResourceListOptionsContext.tsx
@@ -16,6 +16,7 @@ export const RESOURCE_LIST_OPTIONS_KEY = "sidebar_options"
 export type ResourceListOptions = {
   alertsOnTop: boolean // Note: this is only used/implemented in OverviewSidebar
   resourceNameFilter: string
+  showDisabledResources: boolean
 }
 
 type ResourceListOptionsContext = {
@@ -26,6 +27,7 @@ type ResourceListOptionsContext = {
 export const DEFAULT_OPTIONS: ResourceListOptions = {
   alertsOnTop: false,
   resourceNameFilter: "",
+  showDisabledResources: false,
 }
 
 const ResourceListOptionsContext = createContext<ResourceListOptionsContext>({
@@ -41,6 +43,7 @@ function maybeUpgradeSavedOptions(savedOptions: ResourceListOptions) {
   return {
     ...savedOptions,
     resourceNameFilter: savedOptions.resourceNameFilter ?? "",
+    showDisabledResources: savedOptions.showDisabledResources ?? false,
   }
 }
 

--- a/web/src/ResourceNameFilter.tsx
+++ b/web/src/ResourceNameFilter.tsx
@@ -79,6 +79,7 @@ export function ResourceNameFilter(props: { className?: string }) {
   }
 
   let inputProps: Partial<StandardInputProps> = {
+    "aria-label": "Filter resources by name",
     startAdornment: (
       <InputAdornment position="start">
         <SearchSvg fill={Color.grayLightest} />
@@ -104,7 +105,6 @@ export function ResourceNameFilter(props: { className?: string }) {
 
   return (
     <ResourceNameFilterTextField
-      aria-label="Filter resources by name"
       className={props.className}
       value={resourceNameFilter ?? ""}
       onChange={(e) => setResourceNameFilter(e.target.value)}

--- a/web/src/SidebarResources.tsx
+++ b/web/src/SidebarResources.tsx
@@ -35,7 +35,7 @@ import SidebarItemView, {
 import SidebarKeyboardShortcuts from "./SidebarKeyboardShortcuts"
 import { Color, Font, FontSize, SizeUnit } from "./style-helpers"
 import { triggerUpdate } from "./trigger"
-import { ResourceView } from "./types"
+import { ResourceStatus, ResourceView } from "./types"
 
 export type SidebarProps = {
   items: SidebarItem[]
@@ -324,10 +324,23 @@ function applyOptionsToItems(
   options: ResourceListOptions
 ): SidebarItem[] {
   let itemsToDisplay: SidebarItem[] = [...items]
-  if (options.resourceNameFilter) {
-    itemsToDisplay = itemsToDisplay.filter((item) =>
-      matchesResourceName(item.name, options.resourceNameFilter)
-    )
+
+  const itemsShouldBeFiltered =
+    options.resourceNameFilter.length > 0 || !options.showDisabledResources
+
+  if (itemsShouldBeFiltered) {
+    itemsToDisplay = itemsToDisplay.filter((item) => {
+      const itemIsDisabled = item.runtimeStatus === ResourceStatus.Disabled
+      if (!options.showDisabledResources && itemIsDisabled) {
+        return false
+      }
+
+      if (options.resourceNameFilter) {
+        return matchesResourceName(item.name, options.resourceNameFilter)
+      }
+
+      return true
+    })
   }
 
   if (options.alertsOnTop) {


### PR DESCRIPTION
This PR adds a "Show disabled resources" option to Detail View and Table View, so people can opt into viewing disabled resources. Like the alerts and resource name filter, it persists in session storage. The option will only display if the `"disable_resources"` feature is enabled.

I also refactored how Detail View and Table View loop over resources to apply options and feature flags to minimize how many iterations the component is doing.

_Side note:_ I've found writing tests with react-testing-library is much easier than enzyme! But refactoring entire test suites takes time. This PR has a combo of new tests written with react-testing-library and new enzyme tests that were easy to copy-paste from existing tests. If this is confusing or undesirable, I'm happy to address, but for speed, I think this is okay.

![Screen Shot 2022-02-09 at 7 08 45 PM](https://user-images.githubusercontent.com/23283986/153312350-9af2d6cd-9972-47d4-835b-43d0685eba8a.png)