### PR TITLE
web: refactor how resource selection state is stored and calculated

### DIFF
--- a/web/src/OverviewTableBulkActions.test.tsx
+++ b/web/src/OverviewTableBulkActions.test.tsx
@@ -144,7 +144,10 @@ describe("OverviewTableBulkActions", () => {
   describe("buttonsByAction", () => {
     it("groups UIButtons by the bulk action they perform", () => {
       const componentButtons = buttonsByComponent(TEST_UIBUTTONS)
-      const actionButtons = buttonsByAction(componentButtons, TEST_SELECTIONS)
+      const actionButtons = buttonsByAction(
+        componentButtons,
+        new Set(TEST_SELECTIONS)
+      )
 
       expect(actionButtons).toStrictEqual({
         [BulkAction.Disable]: [TEST_UIBUTTONS[1], TEST_UIBUTTONS[3]],

--- a/web/src/OverviewTableBulkActions.tsx
+++ b/web/src/OverviewTableBulkActions.tsx
@@ -41,7 +41,7 @@ const SelectedCount = styled.p`
 // Helpers
 export function buttonsByAction(
   resourceButtons: { [key: string]: ButtonSet },
-  selectedResources: string[]
+  selectedResources: Set<string>
 ) {
   const actionButtons: ActionButtons = {
     [BulkAction.Disable]: [],
@@ -87,7 +87,7 @@ export function OverviewTableBulkActions({
   )
 
   // Don't render if feature flag is off or if there are no selections
-  if (!features.isEnabled(Flag.DisableResources) || selected.length === 0) {
+  if (!features.isEnabled(Flag.DisableResources) || selected.size === 0) {
     return null
   }
 
@@ -113,7 +113,7 @@ export function OverviewTableBulkActions({
         targetToggleState={ApiButtonToggleState.Off}
         onClickCallback={onClickCallback}
       />
-      <BulkSelectedCount count={selected.length} />
+      <BulkSelectedCount count={selected.size} />
     </BulkActionMenu>
   )
 }

--- a/web/src/ResourceSelectionContext.tsx
+++ b/web/src/ResourceSelectionContext.tsx
@@ -5,7 +5,7 @@ import { createContext, PropsWithChildren, useContext, useState } from "react"
  */
 
 type ResourceSelectionContext = {
-  selected: string[]
+  selected: Set<string>
   isSelected: (resourceName: string) => boolean
   select: (...resourceNames: string[]) => void
   deselect: (...resourceNames: string[]) => void
@@ -13,7 +13,7 @@ type ResourceSelectionContext = {
 }
 
 const ResourceSelectionContext = createContext<ResourceSelectionContext>({
-  selected: [],
+  selected: new Set(),
   isSelected: (_resourceName: string) => {
     console.warn("Resource selections context is not set.")
     return false
@@ -38,27 +38,27 @@ export function useResourceSelection(): ResourceSelectionContext {
 export function ResourceSelectionProvider(
   props: PropsWithChildren<{ initialValuesForTesting?: string[] }>
 ) {
-  const selections = props.initialValuesForTesting || []
+  const selections = new Set(props.initialValuesForTesting) || new Set()
   const [selectedResources, setSelectedResources] = useState(selections)
 
   function isSelected(resourceName: string) {
-    return selectedResources.includes(resourceName)
+    return selectedResources.has(resourceName)
   }
 
   function select(...resourceNames: string[]) {
-    // Filter out resources that are already selected
-    const newSelections = resourceNames.filter((r) => !isSelected(r))
-    return setSelectedResources([...selectedResources, ...newSelections])
+    const newSelections = new Set<string>(selectedResources)
+    resourceNames.forEach((name) => newSelections.add(name))
+    return setSelectedResources(newSelections)
   }
 
   function deselect(...resourceNames: string[]) {
-    return setSelectedResources(
-      selectedResources.filter((r) => !resourceNames.includes(r))
-    )
+    const newSelections = new Set<string>(selectedResources)
+    resourceNames.forEach((name) => newSelections.delete(name))
+    return setSelectedResources(newSelections)
   }
 
   function clearSelections() {
-    setSelectedResources([])
+    setSelectedResources(new Set())
   }
 
   const contextValue: ResourceSelectionContext = {


### PR DESCRIPTION
This PR refactors the `ResourceSelectionContext`, so that adding, removing, and determining whether or not a resource is selected is more performant. (Funnily enough, this was my first implementation, but I refactored to use arrays instead of sets because I thought it might be a premature optimization. 🤦🏻‍♂️ Now, I know it's not!)

This refactor won't make Table View rendering that much faster for Tilt sessions that display a lot of resources, but I can see a noticeable difference in how responsive the UI is when selecting and deselecting resources.

As a bonus, this PR also moves the `ResourcesSelectionContext` tests over to react testing library.