### PR TITLE
api: fix tiltfile reconciler_test compilation

### DIFF
--- a/internal/controllers/core/tiltfile/reconciler_test.go
+++ b/internal/controllers/core/tiltfile/reconciler_test.go
@@ -600,7 +600,7 @@ func newBlockingTiltfileLoader() blockingTiltfileLoader {
 	return blockingTiltfileLoader{completionChan: make(chan struct{})}
 }
 
-func (b blockingTiltfileLoader) Load(ctx context.Context, tf *v1alpha1.Tiltfile) tiltfile.TiltfileLoadResult {
+func (b blockingTiltfileLoader) Load(ctx context.Context, tf *v1alpha1.Tiltfile, prevResult *tiltfile.TiltfileLoadResult) tiltfile.TiltfileLoadResult {
 	select {
 	case <-ctx.Done():
 	case <-b.completionChan:


### PR DESCRIPTION
#5471 had changes relevant to #5473, but #5473 didn't run CI with those changes merged, so master broke when it was merged.

Merging this without waiting for approval since it's trivial and master is broken.