### PR TITLE
docker: allow simultaneous k8s and compose orchestration

### DIFF
--- a/internal/cli/wire.go
+++ b/internal/cli/wire.go
@@ -286,6 +286,11 @@ func wireDockerLocalClient(ctx context.Context) (docker.LocalClient, error) {
 	return nil, nil
 }
 
+func wireDockerCompositeClient(ctx context.Context) (docker.CompositeClient, error) {
+	wire.Build(UpWireSet)
+	return nil, nil
+}
+
 func wireDownDeps(ctx context.Context, tiltAnalytics *analytics.TiltAnalytics, subcommand model.TiltSubcommand) (DownDeps, error) {
 	wire.Build(UpWireSet, ProvideDownDeps)
 	return DownDeps{}, nil

--- a/internal/controllers/core/tiltfile/api.go
+++ b/internal/controllers/core/tiltfile/api.go
@@ -532,26 +532,34 @@ func toClusterObjects(nn types.NamespacedName, tlr *tiltfile.TiltfileLoadResult,
 		return result
 	}
 
-	spec := v1alpha1.ClusterSpec{}
-	if tlr.Orchestrator() == model.OrchestratorK8s {
-		spec.Connection = &v1alpha1.ClusterConnection{
-			Kubernetes: defaultK8sConnection,
+	if tlr.HasOrchestrator(model.OrchestratorK8s) {
+		name := v1alpha1.ClusterNameDefault
+		result[name] = &v1alpha1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: name,
+			},
+			Spec: v1alpha1.ClusterSpec{
+				Connection: &v1alpha1.ClusterConnection{
+					Kubernetes: defaultK8sConnection,
+				},
+			},
 		}
-	} else if tlr.Orchestrator() == model.OrchestratorDC {
-		spec.Connection = &v1alpha1.ClusterConnection{
-			Docker: &v1alpha1.DockerClusterConnection{},
-		}
-	} else {
-		return result
 	}
 
-	name := v1alpha1.ClusterNameDefault
-	result[name] = &v1alpha1.Cluster{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
-		},
-		Spec: spec,
+	if tlr.HasOrchestrator(model.OrchestratorDC) {
+		dockerName := "docker"
+		result[dockerName] = &v1alpha1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: dockerName,
+			},
+			Spec: v1alpha1.ClusterSpec{
+				Connection: &v1alpha1.ClusterConnection{
+					Docker: &v1alpha1.DockerClusterConnection{},
+				},
+			},
+		}
 	}
+
 	return result
 }
 

--- a/internal/controllers/core/tiltfile/api.go
+++ b/internal/controllers/core/tiltfile/api.go
@@ -547,10 +547,10 @@ func toClusterObjects(nn types.NamespacedName, tlr *tiltfile.TiltfileLoadResult,
 	}
 
 	if tlr.HasOrchestrator(model.OrchestratorDC) {
-		dockerName := "docker"
-		result[dockerName] = &v1alpha1.Cluster{
+		name := v1alpha1.ClusterNameDocker
+		result[name] = &v1alpha1.Cluster{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: dockerName,
+				Name: name,
 			},
 			Spec: v1alpha1.ClusterSpec{
 				Connection: &v1alpha1.ClusterConnection{

--- a/internal/docker/client.go
+++ b/internal/docker/client.go
@@ -82,6 +82,9 @@ type Client interface {
 	// Set the orchestrator we're talking to. This is only relevant to switchClient,
 	// which can talk to either the Local or in-cluster docker daemon.
 	SetOrchestrator(orc model.Orchestrator)
+	// Return a client suitable for use with the given orchestrator. Only
+	// relevant for the switchClient which has clients for both types.
+	ForOrchestrator(orc model.Orchestrator) Client
 
 	ContainerInspect(ctx context.Context, contianerID string) (types.ContainerJSON, error)
 	ContainerList(ctx context.Context, options types.ContainerListOptions) ([]types.Container, error)
@@ -382,6 +385,9 @@ func (c *Cli) initAuthConfigs(ctx context.Context) {
 
 func (c *Cli) CheckConnected() error                  { return nil }
 func (c *Cli) SetOrchestrator(orc model.Orchestrator) {}
+func (c *Cli) ForOrchestrator(orc model.Orchestrator) Client {
+	return c
+}
 func (c *Cli) Env() Env {
 	return c.env
 }

--- a/internal/docker/client.go
+++ b/internal/docker/client.go
@@ -34,6 +34,7 @@ import (
 
 	"github.com/tilt-dev/tilt/internal/container"
 	"github.com/tilt-dev/tilt/internal/docker/buildkit"
+	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
 	"github.com/tilt-dev/tilt/pkg/logger"
 	"github.com/tilt-dev/tilt/pkg/model"
 )
@@ -107,6 +108,15 @@ type Client interface {
 	NewVersionError(APIrequired, feature string) error
 	BuildCachePrune(ctx context.Context, opts types.BuildCachePruneOptions) (*types.BuildCachePruneReport, error)
 	ContainersPrune(ctx context.Context, pruneFilters filters.Args) (types.ContainersPruneReport, error)
+}
+
+// Add-on interface for a client that manages multiple clients transparently.
+type CompositeClient interface {
+	Client
+	DefaultLocalClient() Client
+	DefaultClusterClient() Client
+	ClientFor(cluster v1alpha1.Cluster) Client
+	HasMultipleClients() bool
 }
 
 type ExitError struct {

--- a/internal/docker/exploding.go
+++ b/internal/docker/exploding.go
@@ -26,6 +26,9 @@ func newExplodingClient(err error) explodingClient {
 
 func (c explodingClient) SetOrchestrator(orc model.Orchestrator) {
 }
+func (c explodingClient) ForOrchestrator(orc model.Orchestrator) Client {
+	return c
+}
 func (c explodingClient) CheckConnected() error {
 	return c.err
 }

--- a/internal/docker/fake_client.go
+++ b/internal/docker/fake_client.go
@@ -149,6 +149,9 @@ func NewFakeClient() *FakeClient {
 func (c *FakeClient) SetOrchestrator(orc model.Orchestrator) {
 	c.Orchestrator = orc
 }
+func (c *FakeClient) ForOrchestrator(orc model.Orchestrator) Client {
+	return c
+}
 func (c *FakeClient) CheckConnected() error {
 	return c.CheckConnectedErr
 }

--- a/internal/docker/wire.go
+++ b/internal/docker/wire.go
@@ -17,7 +17,7 @@ var SwitchWireSet = wire.NewSet(
 	ProvideSwitchCli,
 	ProvideLocalEnv,
 	ProvideClusterEnv,
-	wire.Bind(new(Client), new(*switchCli)))
+	wire.Bind(new(Client), new(CompositeClient)))
 
 // Bind a docker client that talks to the in-cluster Docker daemon.
 var ClusterWireSet = wire.NewSet(

--- a/internal/engine/buildcontrol/docker_compose_build_and_deployer.go
+++ b/internal/engine/buildcontrol/docker_compose_build_and_deployer.go
@@ -145,7 +145,7 @@ func (bd *DockerComposeBuildAndDeployer) BuildAndDeploy(ctx context.Context, st 
 
 	var cluster v1alpha1.Cluster
 	// If the cluster fetch fails, that's OK.
-	_ = bd.ctrlClient.Get(ctx, ktypes.NamespacedName{Name: "docker"}, &cluster)
+	_ = bd.ctrlClient.Get(ctx, ktypes.NamespacedName{Name: v1alpha1.ClusterNameDocker}, &cluster)
 
 	imageMapSet := make(map[ktypes.NamespacedName]*v1alpha1.ImageMap, len(plan.dockerComposeTarget.Spec.ImageMaps))
 	for _, iTarget := range iTargets {

--- a/internal/engine/buildcontrol/docker_compose_build_and_deployer.go
+++ b/internal/engine/buildcontrol/docker_compose_build_and_deployer.go
@@ -41,7 +41,7 @@ func NewDockerComposeBuildAndDeployer(dcc dockercompose.DockerComposeClient, dc 
 	ctrlClient ctrlclient.Client) *DockerComposeBuildAndDeployer {
 	return &DockerComposeBuildAndDeployer{
 		dcc:        dcc,
-		dc:         dc,
+		dc:         dc.ForOrchestrator(model.OrchestratorDC),
 		ib:         ib,
 		clock:      c,
 		ctrlClient: ctrlClient,
@@ -114,6 +114,8 @@ func (bd *DockerComposeBuildAndDeployer) BuildAndDeploy(ctx context.Context, st 
 		})
 	}()
 
+	ctx = docker.WithOrchestrator(ctx, model.OrchestratorDC)
+
 	iTargets := plan.tiltManagedImageTargets
 	q, err := NewImageTargetQueue(ctx, plan.tiltManagedImageTargets, currentState, bd.ib.CanReuseRef)
 	if err != nil {
@@ -140,6 +142,10 @@ func (bd *DockerComposeBuildAndDeployer) BuildAndDeploy(ctx context.Context, st 
 		}
 		ps.EndPipelineStep(ctx)
 	}
+
+	var cluster v1alpha1.Cluster
+	// If the cluster fetch fails, that's OK.
+	_ = bd.ctrlClient.Get(ctx, ktypes.NamespacedName{Name: "docker"}, &cluster)
 
 	imageMapSet := make(map[ktypes.NamespacedName]*v1alpha1.ImageMap, len(plan.dockerComposeTarget.Spec.ImageMaps))
 	for _, iTarget := range iTargets {
@@ -171,7 +177,7 @@ func (bd *DockerComposeBuildAndDeployer) BuildAndDeploy(ctx context.Context, st 
 		// NOTE(maia): we assume that this func takes one DC target and up to one image target
 		// corresponding to that service. If this func ever supports specs for more than one
 		// service at once, we'll have to match up image build results to DC target by ref.
-		refs, stages, err := bd.ib.Build(ctx, iTarget, nil, imageMapSet, ps)
+		refs, stages, err := bd.ib.Build(ctx, iTarget, &cluster, imageMapSet, ps)
 		if err != nil {
 			dockerimage.MaybeUpdateStatus(ctx, bd.ctrlClient, iTarget, dockerimage.ToCompletedFailStatus(iTarget, startTime, stages, err))
 			cmdimage.MaybeUpdateStatus(ctx, bd.ctrlClient, iTarget, cmdimage.ToCompletedFailStatus(iTarget, startTime, err))

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -2387,7 +2387,7 @@ func TestDockerComposeStartsEventWatcher(t *testing.T) {
 	// Actual behavior is that we init with zero manifests, and add in manifests
 	// after Tiltfile loads. Mimic that here.
 	f.Start([]model.Manifest{})
-	f.ensureCluster()
+	f.ensureClusterNamed("docker")
 
 	f.store.Dispatch(ctrltiltfile.ConfigsReloadedAction{
 		Name:       model.MainTiltfileManifestName,
@@ -4614,10 +4614,14 @@ func (s fixtureSub) OnChange(ctx context.Context, st store.RStore, _ store.Chang
 }
 
 func (f *testFixture) ensureCluster() {
+	f.ensureClusterNamed(v1alpha1.ClusterNameDefault)
+}
+
+func (f *testFixture) ensureClusterNamed(name string) {
 	f.t.Helper()
 	err := f.ctrlClient.Create(f.ctx, &v1alpha1.Cluster{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "default",
+			Name: name,
 		},
 		Spec: v1alpha1.ClusterSpec{
 			Connection: &v1alpha1.ClusterConnection{

--- a/internal/tiltfile/tiltfile.go
+++ b/internal/tiltfile/tiltfile.go
@@ -64,15 +64,15 @@ type TiltfileLoadResult struct {
 	BuiltinCalls []starkit.BuiltinCall `json:"-"`
 }
 
-func (r TiltfileLoadResult) Orchestrator() model.Orchestrator {
+func (r TiltfileLoadResult) HasOrchestrator(orc model.Orchestrator) bool {
 	for _, manifest := range r.Manifests {
-		if manifest.IsK8s() {
-			return model.OrchestratorK8s
-		} else if manifest.IsDC() {
-			return model.OrchestratorDC
+		if manifest.IsK8s() && orc == model.OrchestratorK8s {
+			return true
+		} else if manifest.IsDC() && orc == model.OrchestratorDC {
+			return true
 		}
 	}
-	return model.OrchestratorUnknown
+	return false
 }
 
 func (r TiltfileLoadResult) WithAllManifestsEnabled() TiltfileLoadResult {

--- a/internal/tiltfile/tiltfile_docker_compose_test.go
+++ b/internal/tiltfile/tiltfile_docker_compose_test.go
@@ -385,7 +385,7 @@ docker_compose('docker-compose2.yml')`
 	assert.Equal(t, 2, len(f.loadResult.Manifests))
 }
 
-func TestDockerComposeAndK8sNotSupported(t *testing.T) {
+func TestDockerComposeAndK8sSupported(t *testing.T) {
 	f := newFixture(t)
 	defer f.TearDown()
 
@@ -395,8 +395,9 @@ func TestDockerComposeAndK8sNotSupported(t *testing.T) {
 k8s_yaml('bar.yaml')`
 	f.file("Tiltfile", tf)
 
-	f.loadErrString("can't declare both k8s " +
-		"resources/entities and docker-compose resources")
+	f.load()
+
+	assert.Equal(t, 2, len(f.loadResult.Manifests))
 }
 
 func TestDockerComposeResourceCreationFromAbsPath(t *testing.T) {

--- a/pkg/apis/core/v1alpha1/cluster_types.go
+++ b/pkg/apis/core/v1alpha1/cluster_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 The Tilt Dev Authors
+Copyright 2021, 2022 The Tilt Dev Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ import (
 )
 
 const ClusterNameDefault = "default"
+const ClusterNameDocker = "docker"
 
 // +genclient
 // +genclient:nonNamespaced


### PR DESCRIPTION
 This is an experimental/spike on supporting K8s and DC orchestration simultaneously for #5482. I took a naive approach and am probably overlooking some issues, but I thought I'd put it up for review in any case.

With these changes, I was able to get simultaneous deploys working for the tilt-example-docker-compose project and a Kind cluster. I suspect using Minikube/Microk8s with a separate cluster Docker daemon might still cause issues.
https://github.com/tilt-dev/tilt-example-docker-compose/blob/nicksieger/dc-and-k8s/Tiltfile
