### PR TITLE
engine: fix flaky TestCancelBuild

### DIFF
--- a/internal/engine/buildcontroller.go
+++ b/internal/engine/buildcontroller.go
@@ -159,6 +159,9 @@ func (c *BuildController) cleanUpCanceledBuilds(st store.RStore) {
 	defer st.RUnlockState()
 
 	for _, ms := range state.ManifestStates() {
+		if ms.CurrentBuild.Empty() {
+			continue
+		}
 		disabled := ms.DisableState == v1alpha1.DisableStateDisabled
 		canceled := false
 		if cancelButton, ok := state.UIButtons[uibutton.CancelButtonName(ms.Name.String())]; ok {


### PR DESCRIPTION
When BuildController starts a build, it synchronously adds the cancel func to its internal state.

When BuildController checks if a build needs canceling, it checks that internal state (which, again, was updated synchronously) against the store's ManifestState (which is updated asynchronously), leaving a brief window where the controller is aware a build is cancelable from its internal state, but has not yet picked up the new ManifestState, and LastClickedAt and ms.CurrentBuild.StartTime are both zero.

(the absence of this check was theoretically fine before because `c.cleanupBuildContext` is a no-op for a build that's not running, but this is probably better to have either way)