### PR TITLE
tiltfile: unknown resource_dep is a warning instead of error

### DIFF
--- a/internal/tiltfile/tiltfile_state.go
+++ b/internal/tiltfile/tiltfile_state.go
@@ -318,7 +318,7 @@ to your Tiltfile. Otherwise, switch k8s contexts and restart Tilt.`, kubeContext
 		manifests = append(manifests, yamlManifest)
 	}
 
-	err = validateResourceDependencies(manifests)
+	err = s.validateResourceDependencies(manifests)
 	if err != nil {
 		return nil, starkit.Model{}, err
 	}
@@ -1629,7 +1629,7 @@ func (s *tiltfileState) tempDir() (*fwatch.TempDir, error) {
 	return s.scratchDir, nil
 }
 
-func validateResourceDependencies(ms []model.Manifest) error {
+func (s *tiltfileState) validateResourceDependencies(ms []model.Manifest) error {
 	// make sure that:
 	// 1. all deps exist
 	// 2. we have a DAG
@@ -1647,7 +1647,8 @@ func validateResourceDependencies(ms []model.Manifest) error {
 				return fmt.Errorf("resource %s specified a dependency on itself", m.Name)
 			}
 			if _, ok := knownResources[b]; !ok {
-				return fmt.Errorf("resource %s specified a dependency on unknown resource %s", m.Name, b)
+				logger.Get(s.ctx).Warnf("resource %s specified a dependency on unknown resource %s - dependency ignored", m.Name, b)
+				continue
 			}
 			edges[m.Name] = append(edges[m.Name], b)
 		}

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -4878,7 +4878,7 @@ func TestDependsOnMissingResource(t *testing.T) {
 local_resource('bar', 'echo bar', resource_deps=['foo'])
 `)
 
-	f.loadErrString("resource bar specified a dependency on unknown resource fo")
+	f.loadAssertWarnings("resource bar specified a dependency on unknown resource foo - dependency ignored")
 }
 
 func TestDependsOnSelf(t *testing.T) {


### PR DESCRIPTION
### Problem

You run your Tiltfile and get an error like "resource X specified a dependency on unknown resource Y". You know you created a resource named "Y". How do you validate that? At the moment, you have to remove your resource_deps and see what resources come out of Tilt. You're also might suspect a bug in Tilt (and you very well might be right! but there's frustratingly little to go on).

### Solution

When we generate this error, also include the list of resources Tilt knows about, so that the user can see what resources Tilt is expecting to see there and narrow down the problem.