### PR TITLE
buildcontrol: liveupdate holds should handle triggers

### DIFF
--- a/internal/engine/buildcontroller.go
+++ b/internal/engine/buildcontroller.go
@@ -246,15 +246,7 @@ func buildStateSet(ctx context.Context, manifest model.Manifest,
 		result[id] = buildState
 	}
 
-	// If the user manually triggers the build and there are no pending changes,
-	// assume they want a full build, since there are there no file changes to sync.
-	// (If there ARE pending changes but the resource is automatic, then a LiveUpdate
-	// (if configured) is already queued, so assume the user wants to trigger a
-	// full build instead.)
-	isLiveUpdateEligibleTrigger := reason.HasTrigger() &&
-		reason.Has(model.BuildReasonFlagChangedFiles) &&
-		!manifest.TriggerMode.AutoOnChange()
-	isFullBuildTrigger := reason.HasTrigger() && !isLiveUpdateEligibleTrigger
+	isFullBuildTrigger := reason.HasTrigger() && !buildcontrol.IsLiveUpdateEligibleTrigger(manifest, reason)
 	if isFullBuildTrigger {
 		for k, v := range result {
 			result[k] = v.WithFullBuildTriggered(true)

--- a/pkg/model/build_reason.go
+++ b/pkg/model/build_reason.go
@@ -48,6 +48,16 @@ func (r BuildReason) HasTrigger() bool {
 	return false
 }
 
+func (r BuildReason) WithoutTriggers() BuildReason {
+	result := int(r)
+	for _, v := range triggerBuildReasons {
+		if r.Has(v) {
+			result -= int(v)
+		}
+	}
+	return BuildReason(result)
+}
+
 func (r BuildReason) IsCrashOnly() bool {
 	return r == BuildReasonFlagCrash
 }


### PR DESCRIPTION
Hello @milas, @landism,

Please review the following commits I made in branch nicks/buildcontrol2:

dd2648abe515c9445f6289287ea5deacbb8ef662 (2022-02-14 13:13:43 -0500)
buildcontrol: liveupdate holds should handle triggers
fixes https://github.com/tilt-dev/tilt/issues/5492

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics