### PR TITLE
web: treat resources with a pending DisableStatus state as disabled

### DIFF
--- a/web/src/ResourceStatus.ts
+++ b/web/src/ResourceStatus.ts
@@ -1,5 +1,10 @@
 import { Font } from "./style-helpers"
-import { ResourceStatus, TargetType, UIResource } from "./types"
+import {
+  ResourceDisableState,
+  ResourceStatus,
+  TargetType,
+  UIResource,
+} from "./types"
 
 export const disabledResourceStyleMixin = `
 font-family: ${Font.sansSerif};
@@ -31,8 +36,12 @@ export function resourceIsDisabled(resource: UIResource | undefined): boolean {
     return false
   }
 
-  const disableCount = resource.status?.disableStatus?.disabledCount ?? 0
-  if (disableCount > 0) {
+  // Consider both "pending" and "disabled" states as disabled resources
+  const disableState = resource.status?.disableStatus?.state
+  if (
+    disableState === ResourceDisableState.Pending ||
+    disableState === ResourceDisableState.Disabled
+  ) {
     return true
   }
 

--- a/web/src/testdata.tsx
+++ b/web/src/testdata.tsx
@@ -8,6 +8,7 @@ import {
   UIBUTTON_TOGGLE_INPUT_NAME,
 } from "./ApiButton"
 import {
+  ResourceDisableState,
   ResourceName,
   TriggerMode,
   UIButton,
@@ -46,11 +47,13 @@ let runningTiltBuild = {
 const ENABLED_RESOURCE_STATUS: UIResourceStatus["disableStatus"] = {
   disabledCount: 0,
   enabledCount: 1,
+  state: ResourceDisableState.Enabled,
 }
 
 const DISABLED_RESOURCE_STATUS: UIResourceStatus["disableStatus"] = {
   disabledCount: 1,
   enabledCount: 0,
+  state: ResourceDisableState.Disabled,
 }
 
 const TEST_DATA_LABELS = [

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -59,6 +59,14 @@ export enum ResourceStatus {
 }
 
 // These constants are duplicated from the Go constants.
+export enum ResourceDisableState {
+  Disabled = "Disabled",
+  Enabled = "Enabled",
+  Error = "Error",
+  Pending = "",
+}
+
+// These constants are duplicated from the Go constants.
 export enum TargetType {
   Unspecified = "unspecified",
   Image = "image",


### PR DESCRIPTION
This PR uses `disableStatus.state` to determine a resource's disable status, instead of the `disableCount`. It treats both a "disabled" and "pending" disable state as if the resource were disabled. More details are available in #5496.

Note: I haven't been able to very consistently reproduce a `tilt up` experience where resources show up in the UI with a pending disable state, so I haven't been able to test this fix. If reviewers are able to test locally with the [debug-many-resources repo](https://github.com/lizzthabet/debug-many-resources), that'd be helpful. 

Closes #5496 