### PR TITLE
controllers: make the portforward reconciler level-triggered rather than edge-triggered

### DIFF
--- a/internal/controllers/fake/fixture.go
+++ b/internal/controllers/fake/fixture.go
@@ -3,6 +3,7 @@ package fake
 import (
 	"context"
 	"io"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -57,8 +58,9 @@ type ControllerFixtureBuilder struct {
 }
 
 func NewControllerFixtureBuilder(t testing.TB) *ControllerFixtureBuilder {
-	out := bufsync.NewThreadSafeBuffer()
+	outBuf := bufsync.NewThreadSafeBuffer()
 
+	out := io.MultiWriter(outBuf, os.Stdout)
 	ctx, ma, _ := testutils.ForkedCtxAndAnalyticsForTest(out)
 
 	ctx, cancel := context.WithCancel(ctx)
@@ -68,7 +70,7 @@ func NewControllerFixtureBuilder(t testing.TB) *ControllerFixtureBuilder {
 		t:      t,
 		ctx:    ctx,
 		cancel: cancel,
-		out:    out,
+		out:    outBuf,
 		ma:     ma,
 		Client: NewFakeTiltClient(),
 		Store:  NewTestingStore(out),


### PR DESCRIPTION
Hello @milas, @landism,

Please review the following commits I made in branch nicks/portforward:

2ef95c5c3ea8fccbdd087a3fb87ad4b27235a774 (2022-02-15 17:23:51 -0500)
controllers: make the portforward reconciler level-triggered rather than edge-triggered
i was chasing down a flaky test and it was easier just to fix the reconciler

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics