### PR TITLE
web: add a small show more button in each section with more than 20 items (try 2)

### DIFF
--- a/web/src/SrOnly.tsx
+++ b/web/src/SrOnly.tsx
@@ -12,6 +12,10 @@ import React, { ElementType, PropsWithChildren } from "react"
  * that allows useful content to be present in the DOM (and therefore
  * available to screen-readers), but not visible to sighted users.
  * https://material-ui.com/api/typography/
+ *
+ * Using this may cause layout problems, see discussion here:
+ * https://github.com/tilt-dev/tilt/pull/5504
+ * Prefer aria-label when possible.
  */
 
 // Note: types are copy-pasta'd and adapted from Typography.d.ts

--- a/web/src/analytics.ts
+++ b/web/src/analytics.ts
@@ -7,6 +7,8 @@ import {
   TermState,
 } from "./logfilters"
 
+export const emptyTags = Object.freeze({})
+
 export type Tags = {
   [key: string]: string | undefined
   action?: AnalyticsAction | Action


### PR DESCRIPTION
Hello @lizzthabet,

Please review the following commits I made in branch nicks/revert2:

b2d6f0e4a9d863b91e64a0f5b1ff7cdfa9ee60d3 (2022-02-15 18:24:09 -0500)
web: add a small show more button in each section with more than 20 items (try 2)
I had to remove the SrOnly screenreader text because it was causing major layout problems

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics