### PR TITLE
api: ensure API times used for trigger comparisons

### DIFF
--- a/internal/controllers/apis/trigger/trigger.go
+++ b/internal/controllers/apis/trigger/trigger.go
@@ -167,7 +167,7 @@ func LastStartEvent(ctx context.Context, cli client.Reader, startOn *v1alpha1.St
 		}
 
 		lastEventTime := b.Status.LastClickedAt
-		if timecmp.AfterOrEqual(lastEventTime, startOn.StartAfter) && !timecmp.BeforeOrEqual(lastEventTime, latestTime) {
+		if timecmp.AfterOrEqual(lastEventTime, startOn.StartAfter) && timecmp.After(lastEventTime, latestTime) {
 			latestTime = lastEventTime
 			latestButton = b
 		}
@@ -202,7 +202,7 @@ func LastRestartEvent(ctx context.Context, cli client.Reader, restartOn *v1alpha
 
 	for _, fw := range fws {
 		lastEventTime := fw.Status.LastEventTime
-		if !timecmp.BeforeOrEqual(lastEventTime, cur) {
+		if timecmp.After(lastEventTime, cur) {
 			cur = lastEventTime
 		}
 	}
@@ -216,7 +216,7 @@ func LastRestartEvent(ctx context.Context, cli client.Reader, restartOn *v1alpha
 		}
 
 		lastEventTime := b.Status.LastClickedAt
-		if !timecmp.BeforeOrEqual(lastEventTime, cur) {
+		if timecmp.After(lastEventTime, cur) {
 			cur = lastEventTime
 			latestButton = b
 		}
@@ -237,7 +237,7 @@ func FilesChanged(restartOn *v1alpha1.RestartOnSpec, fileWatches []*v1alpha1.Fil
 		// Add files so that the most recent files are first.
 		for i := len(fw.Status.FileEvents) - 1; i >= 0; i-- {
 			e := fw.Status.FileEvents[i]
-			if !timecmp.BeforeOrEqual(e.Time, lastBuild) {
+			if timecmp.After(e.Time, lastBuild) {
 				filesChanged = append(filesChanged, e.SeenFiles...)
 			}
 		}
@@ -271,7 +271,7 @@ func LastStopEvent(ctx context.Context, cli client.Reader, stopOn *v1alpha1.Stop
 		}
 
 		lastEventTime := b.Status.LastClickedAt
-		if !timecmp.BeforeOrEqual(lastEventTime, latestTime) {
+		if timecmp.After(lastEventTime, latestTime) {
 			latestTime = lastEventTime
 			latestButton = b
 		}

--- a/internal/controllers/apis/trigger/trigger.go
+++ b/internal/controllers/apis/trigger/trigger.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -14,6 +15,7 @@ import (
 
 	"github.com/tilt-dev/tilt/internal/controllers/indexer"
 	"github.com/tilt-dev/tilt/internal/sliceutils"
+	"github.com/tilt-dev/tilt/internal/timecmp"
 	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
 )
 
@@ -82,21 +84,20 @@ func registerWatches(builder *builder.Builder, idxer *indexer.Indexer, typesToWa
 	}
 }
 
-// Fetch all the buttons that this object depends on.
+// fetchButtons retrieves all the buttons that this object depends on.
 //
 // If a button isn't in the API server yet, it will simply be missing from the map.
 //
 // Other errors reaching the API server will be returned to the caller.
 //
 // TODO(nick): If the user typos a button name, there's currently no feedback
-// that this is happening. This is probably the correct product behavior (in particular:
-// resources should still run if their restarton button has been deleted).
-// We might eventually need some sort of StartOnStatus/RestartOnStatus to express errors
-// in lookup.
-func Buttons(ctx context.Context, client client.Reader, buttonNames []string) (map[string]*v1alpha1.UIButton, error) {
-	result := make(map[string]*v1alpha1.UIButton, len(buttonNames))
+// 	that this is happening. This is probably the correct product behavior (in particular:
+// 	resources should still run if one of their triggers has been deleted).
+// 	We might eventually need trigger statuses to express errors in lookup.
+func fetchButtons(ctx context.Context, client client.Reader, buttonNames []string) (map[string]*v1alpha1.UIButton, error) {
+	buttons := make(map[string]*v1alpha1.UIButton, len(buttonNames))
 	for _, n := range buttonNames {
-		_, exists := result[n]
+		_, exists := buttons[n]
 		if exists {
 			continue
 		}
@@ -109,23 +110,22 @@ func Buttons(ctx context.Context, client client.Reader, buttonNames []string) (m
 			}
 			return nil, err
 		}
-		result[n] = b
+		buttons[n] = b
 	}
-	return result, nil
+	return buttons, nil
 }
 
-// Fetch all the filewatches that this object depends on.
+// fetchFileWatches retrieves all the filewatches that this object depends on.
 //
-// If a filewatch isn't in the API server yet, it will simply be missing from the map.
+// If a filewatch isn't in the API server yet, it will simply be missing from the slice.
 //
 // Other errors reaching the API server will be returned to the caller.
 //
 // TODO(nick): If the user typos a filewatch name, there's currently no feedback
-// that this is happening. This is probably the correct product behavior (in particular:
-// resources should still run if their restarton filewatch has been deleted).
-// We might eventually need some sort of RestartOnStatus to express errors
-// in lookup.
-func FileWatches(ctx context.Context, client client.Reader, fwNames []string) ([]*v1alpha1.FileWatch, error) {
+// 	that this is happening. This is probably the correct product behavior (in particular:
+// 	resources should still run if one of their triggers has been deleted).
+// 	We might eventually need trigger statuses to express errors in lookup.
+func fetchFileWatches(ctx context.Context, client client.Reader, fwNames []string) ([]*v1alpha1.FileWatch, error) {
 	result := []*v1alpha1.FileWatch{}
 	for _, n := range fwNames {
 		fw := &v1alpha1.FileWatch{}
@@ -141,27 +141,34 @@ func FileWatches(ctx context.Context, client client.Reader, fwNames []string) ([
 	return result, nil
 }
 
-// Fetch the last time a start was requested from this target's dependencies.
+// LastStartEvent determines the last time a start was requested from this target's dependencies.
 //
-// Returns the most recent trigger time. If the most recent trigger is a button,
+// Returns the most recent start time. If the most recent start is from a button,
 // return the button. Some consumers use the button for text inputs.
-func LastStartEvent(ctx context.Context, cli client.Reader, startOn *v1alpha1.StartOnSpec) (time.Time, *v1alpha1.UIButton, error) {
+func LastStartEvent(ctx context.Context, cli client.Reader, startOn *v1alpha1.StartOnSpec) (metav1.MicroTime, *v1alpha1.UIButton, error) {
 	if startOn == nil {
-		return time.Time{}, nil, nil
+		return metav1.MicroTime{}, nil, nil
 	}
 
-	buttons, err := Buttons(ctx, cli, startOn.UIButtons)
+	buttons, err := fetchButtons(ctx, cli, startOn.UIButtons)
 	if err != nil {
-		return time.Time{}, nil, err
+		return metav1.MicroTime{}, nil, err
 	}
 
-	latestTime := time.Time{}
+	var latestTime metav1.MicroTime
 	var latestButton *v1alpha1.UIButton
 
-	for _, b := range buttons {
+	// ensure predictable iteration order by using the list from the spec
+	// (currently, missing buttons are simply ignored)
+	for _, buttonName := range startOn.UIButtons {
+		b := buttons[buttonName]
+		if b == nil {
+			continue
+		}
+
 		lastEventTime := b.Status.LastClickedAt
-		if !lastEventTime.Time.Before(startOn.StartAfter.Time) && lastEventTime.Time.After(latestTime) {
-			latestTime = lastEventTime.Time
+		if timecmp.AfterOrEqual(lastEventTime, startOn.StartAfter) && !timecmp.BeforeOrEqual(lastEventTime, latestTime) {
+			latestTime = lastEventTime
 			latestButton = b
 		}
 	}
@@ -169,38 +176,48 @@ func LastStartEvent(ctx context.Context, cli client.Reader, startOn *v1alpha1.St
 	return latestTime, latestButton, nil
 }
 
-// Fetch the last time a restart was requested from this target's dependencies.
+// LastRestartEvent determines the last time a restart was requested from this target's dependencies.
 //
-// Returns the most recent trigger time. If the most recent trigger is a button,
-// return the button. Some consumers use the button for text inputs.
-func LastRestartEvent(ctx context.Context, cli client.Reader, restartOn *v1alpha1.RestartOnSpec) (time.Time, *v1alpha1.UIButton, []*v1alpha1.FileWatch, error) {
+// Returns the most recent restart time.
+//
+// If the most recent restart is from a button, return the button. Some consumers use the button for text inputs.
+// If the most recent restart is from a FileWatch, return the FileWatch. Some consumers use the FileWatch to
+// determine if they should re-run or not to avoid repeated failures.
+func LastRestartEvent(ctx context.Context, cli client.Reader, restartOn *v1alpha1.RestartOnSpec) (metav1.MicroTime, *v1alpha1.UIButton, []*v1alpha1.FileWatch, error) {
 	var fws []*v1alpha1.FileWatch
 	if restartOn == nil {
-		return time.Time{}, nil, fws, nil
+		return metav1.MicroTime{}, nil, fws, nil
 	}
-	buttons, err := Buttons(ctx, cli, restartOn.UIButtons)
+	buttons, err := fetchButtons(ctx, cli, restartOn.UIButtons)
 	if err != nil {
-		return time.Time{}, nil, fws, err
+		return metav1.MicroTime{}, nil, fws, err
 	}
-	fws, err = FileWatches(ctx, cli, restartOn.FileWatches)
+	fws, err = fetchFileWatches(ctx, cli, restartOn.FileWatches)
 	if err != nil {
-		return time.Time{}, nil, fws, err
+		return metav1.MicroTime{}, nil, fws, err
 	}
 
-	cur := time.Time{}
+	var cur metav1.MicroTime
 	var latestButton *v1alpha1.UIButton
 
 	for _, fw := range fws {
 		lastEventTime := fw.Status.LastEventTime
-		if lastEventTime.Time.After(cur) {
-			cur = lastEventTime.Time
+		if !timecmp.BeforeOrEqual(lastEventTime, cur) {
+			cur = lastEventTime
 		}
 	}
 
-	for _, b := range buttons {
+	// ensure predictable iteration order by using the list from the spec
+	// (currently, missing buttons are simply ignored)
+	for _, buttonName := range restartOn.UIButtons {
+		b := buttons[buttonName]
+		if b == nil {
+			continue
+		}
+
 		lastEventTime := b.Status.LastClickedAt
-		if lastEventTime.Time.After(cur) {
-			cur = lastEventTime.Time
+		if !timecmp.BeforeOrEqual(lastEventTime, cur) {
+			cur = lastEventTime
 			latestButton = b
 		}
 	}
@@ -208,7 +225,7 @@ func LastRestartEvent(ctx context.Context, cli client.Reader, restartOn *v1alpha
 	return cur, latestButton, fws, nil
 }
 
-// Fetch the set of files that have changed since the given timestamp.
+// FilesChanged determines the set of files that have changed since the given timestamp.
 // We err on the side of undercounting (i.e., skipping files that may have triggered
 // this build but are not sure).
 func FilesChanged(restartOn *v1alpha1.RestartOnSpec, fileWatches []*v1alpha1.FileWatch, lastBuild time.Time) []string {
@@ -220,7 +237,7 @@ func FilesChanged(restartOn *v1alpha1.RestartOnSpec, fileWatches []*v1alpha1.Fil
 		// Add files so that the most recent files are first.
 		for i := len(fw.Status.FileEvents) - 1; i >= 0; i-- {
 			e := fw.Status.FileEvents[i]
-			if e.Time.Time.After(lastBuild) {
+			if !timecmp.BeforeOrEqual(e.Time, lastBuild) {
 				filesChanged = append(filesChanged, e.SeenFiles...)
 			}
 		}
@@ -228,27 +245,34 @@ func FilesChanged(restartOn *v1alpha1.RestartOnSpec, fileWatches []*v1alpha1.Fil
 	return sliceutils.DedupedAndSorted(filesChanged)
 }
 
-// Fetch the last time a start was requested from this target's dependencies.
+// LastStopEvent determines the latest time a stop was requested from this target's dependencies.
 //
-// Returns the most recent trigger time. If the most recent trigger is a button,
+// Returns the most recent stop time. If the most recent stop is from a button,
 // return the button. Some consumers use the button for text inputs.
-func LastStopEvent(ctx context.Context, cli client.Reader, stopOn *v1alpha1.StopOnSpec) (time.Time, *v1alpha1.UIButton, error) {
+func LastStopEvent(ctx context.Context, cli client.Reader, stopOn *v1alpha1.StopOnSpec) (metav1.MicroTime, *v1alpha1.UIButton, error) {
 	if stopOn == nil {
-		return time.Time{}, nil, nil
+		return metav1.MicroTime{}, nil, nil
 	}
 
-	buttons, err := Buttons(ctx, cli, stopOn.UIButtons)
+	buttons, err := fetchButtons(ctx, cli, stopOn.UIButtons)
 	if err != nil {
-		return time.Time{}, nil, err
+		return metav1.MicroTime{}, nil, err
 	}
 
-	latestTime := time.Time{}
+	var latestTime metav1.MicroTime
 	var latestButton *v1alpha1.UIButton
 
-	for _, b := range buttons {
+	// ensure predictable iteration order by using the list from the spec
+	// (currently, missing buttons are simply ignored)
+	for _, buttonName := range stopOn.UIButtons {
+		b := buttons[buttonName]
+		if b == nil {
+			continue
+		}
+
 		lastEventTime := b.Status.LastClickedAt
-		if lastEventTime.Time.After(latestTime) {
-			latestTime = lastEventTime.Time
+		if !timecmp.BeforeOrEqual(lastEventTime, latestTime) {
+			latestTime = lastEventTime
 			latestButton = b
 		}
 	}

--- a/internal/controllers/core/cmd/controller.go
+++ b/internal/controllers/core/cmd/controller.go
@@ -200,8 +200,8 @@ func (c *Controller) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	lastRestartOnEventTime := proc.lastRestartOnEventTime
 	lastStartOnEventTime := proc.lastStartOnEventTime
 
-	restartOnTriggered := !timecmp.BeforeOrEqual(te.lastRestartEventTime, lastRestartOnEventTime)
-	startOnTriggered := !timecmp.BeforeOrEqual(te.lastStartEventTime, lastStartOnEventTime)
+	restartOnTriggered := timecmp.After(te.lastRestartEventTime, lastRestartOnEventTime)
+	startOnTriggered := timecmp.After(te.lastStartEventTime, lastStartOnEventTime)
 	execSpecChanged := !cmdExecEqual(lastSpec, cmd.Spec)
 
 	if !disabled {
@@ -333,7 +333,7 @@ func (c *Controller) runInternal(ctx context.Context,
 	proc.lastStartOnEventTime = te.lastStartEventTime
 
 	var inputs []input
-	if !timecmp.BeforeOrEqual(proc.lastRestartOnEventTime, proc.lastStartOnEventTime) {
+	if timecmp.After(proc.lastRestartOnEventTime, proc.lastStartOnEventTime) {
 		inputs = inputsFromButton(te.lastRestartButton)
 	} else {
 		inputs = inputsFromButton(te.lastStartButton)

--- a/internal/controllers/core/cmd/controller.go
+++ b/internal/controllers/core/cmd/controller.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/jonboulle/clockwork"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -23,12 +22,14 @@ import (
 
 	"github.com/tilt-dev/probe/pkg/probe"
 	"github.com/tilt-dev/probe/pkg/prober"
+
 	"github.com/tilt-dev/tilt/internal/controllers/apicmp"
 	"github.com/tilt-dev/tilt/internal/controllers/apis/configmap"
 	"github.com/tilt-dev/tilt/internal/controllers/apis/trigger"
 	"github.com/tilt-dev/tilt/internal/controllers/indexer"
 	"github.com/tilt-dev/tilt/internal/engine/local"
 	"github.com/tilt-dev/tilt/internal/store"
+	"github.com/tilt-dev/tilt/internal/timecmp"
 	"github.com/tilt-dev/tilt/pkg/apis"
 	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
 	"github.com/tilt-dev/tilt/pkg/logger"
@@ -127,9 +128,9 @@ func inputsFromButton(button *v1alpha1.UIButton) []input {
 }
 
 type triggerEvents struct {
-	lastRestartEventTime time.Time
+	lastRestartEventTime metav1.MicroTime
 	lastRestartButton    *v1alpha1.UIButton
-	lastStartEventTime   time.Time
+	lastStartEventTime   metav1.MicroTime
 	lastStartButton      *v1alpha1.UIButton
 }
 
@@ -167,8 +168,8 @@ func (c *Controller) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		// it didn't previously run.
 		c.stop(name)
 		proc.spec = v1alpha1.CmdSpec{}
-		proc.lastStartOnEventTime = time.Time{}
-		proc.lastRestartOnEventTime = time.Time{}
+		proc.lastStartOnEventTime = metav1.MicroTime{}
+		proc.lastRestartOnEventTime = metav1.MicroTime{}
 	}
 
 	if cmd.Annotations[v1alpha1.AnnotationManagedBy] == "local_resource" {
@@ -199,8 +200,8 @@ func (c *Controller) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	lastRestartOnEventTime := proc.lastRestartOnEventTime
 	lastStartOnEventTime := proc.lastStartOnEventTime
 
-	restartOnTriggered := te.lastRestartEventTime.After(lastRestartOnEventTime)
-	startOnTriggered := te.lastStartEventTime.After(lastStartOnEventTime)
+	restartOnTriggered := !timecmp.BeforeOrEqual(te.lastRestartEventTime, lastRestartOnEventTime)
+	startOnTriggered := !timecmp.BeforeOrEqual(te.lastStartEventTime, lastStartOnEventTime)
 	execSpecChanged := !cmdExecEqual(lastSpec, cmd.Spec)
 
 	if !disabled {
@@ -332,7 +333,7 @@ func (c *Controller) runInternal(ctx context.Context,
 	proc.lastStartOnEventTime = te.lastStartEventTime
 
 	var inputs []input
-	if proc.lastRestartOnEventTime.After(proc.lastStartOnEventTime) {
+	if !timecmp.BeforeOrEqual(proc.lastRestartOnEventTime, proc.lastStartOnEventTime) {
 		inputs = inputsFromButton(te.lastRestartButton)
 	} else {
 		inputs = inputsFromButton(te.lastStartButton)
@@ -552,8 +553,8 @@ type currentProcess struct {
 	probeWorker *probe.Worker
 	isServer    bool
 
-	lastRestartOnEventTime time.Time
-	lastStartOnEventTime   time.Time
+	lastRestartOnEventTime metav1.MicroTime
+	lastStartOnEventTime   metav1.MicroTime
 
 	// We have a lock that ONLY protects the status.
 	statusMu       sync.Mutex

--- a/internal/controllers/core/cmd/controller_test.go
+++ b/internal/controllers/core/cmd/controller_test.go
@@ -939,7 +939,7 @@ func (f *fixture) triggerFileWatch(name string) {
 
 func (f *fixture) triggerButton(name string, ts time.Time) {
 	f.updateButton(name, func(b *v1alpha1.UIButton) {
-		b.Status.LastClickedAt = metav1.NewMicroTime(ts)
+		b.Status.LastClickedAt = apis.NewMicroTime(ts)
 	})
 }
 

--- a/internal/controllers/core/kubernetesapply/reconciler.go
+++ b/internal/controllers/core/kubernetesapply/reconciler.go
@@ -255,7 +255,7 @@ func (r *Reconciler) shouldDeployOnReconcile(
 		}
 	}
 
-	if !timecmp.BeforeOrEqual(lastRestartEvent, result.Status.LastApplyTime) {
+	if timecmp.After(lastRestartEvent, result.Status.LastApplyTime) {
 		return true
 	}
 

--- a/internal/controllers/core/kubernetesapply/reconciler.go
+++ b/internal/controllers/core/kubernetesapply/reconciler.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"sync"
-	"time"
 
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
@@ -208,7 +207,7 @@ func (r *Reconciler) shouldDeployOnReconcile(
 	nn types.NamespacedName,
 	ka *v1alpha1.KubernetesApply,
 	imageMaps map[types.NamespacedName]*v1alpha1.ImageMap,
-	lastRestartEvent time.Time,
+	lastRestartEvent metav1.MicroTime,
 ) bool {
 	if ka.Annotations[v1alpha1.AnnotationManagedBy] != "" {
 		// Until resource dependencies are expressed in the API,

--- a/internal/controllers/core/tiltfile/reconciler.go
+++ b/internal/controllers/core/tiltfile/reconciler.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/pkg/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -202,7 +203,15 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 //    (so that we don't keep re-running a failed build)
 // 4) OR the command-line args have changed since the last Tiltfile build
 // 5) OR user has manually triggered a Tiltfile build
-func (r *Reconciler) needsBuild(ctx context.Context, nn types.NamespacedName, tf *v1alpha1.Tiltfile, run *runStatus, fileWatches []*v1alpha1.FileWatch, triggerQueue *v1alpha1.ConfigMap, lastRestartEvent time.Time) *BuildEntry {
+func (r *Reconciler) needsBuild(
+	_ context.Context,
+	nn types.NamespacedName,
+	tf *v1alpha1.Tiltfile,
+	run *runStatus,
+	fileWatches []*v1alpha1.FileWatch,
+	triggerQueue *v1alpha1.ConfigMap,
+	lastRestartEvent metav1.MicroTime,
+) *BuildEntry {
 	var reason model.BuildReason
 	filesChanged := []string{}
 
@@ -221,7 +230,7 @@ func (r *Reconciler) needsBuild(ctx context.Context, nn types.NamespacedName, tf
 		filesChanged = trigger.FilesChanged(tf.Spec.RestartOn, fileWatches, lastStartTime)
 		if len(filesChanged) > 0 {
 			reason = reason.With(model.BuildReasonFlagChangedFiles)
-		} else if lastRestartEvent.After(lastStartTime) {
+		} else if !timecmp.BeforeOrEqual(lastRestartEvent, lastStartTime) {
 			reason = reason.With(model.BuildReasonFlagTriggerUnknown)
 		}
 	}

--- a/internal/controllers/core/tiltfile/reconciler.go
+++ b/internal/controllers/core/tiltfile/reconciler.go
@@ -230,7 +230,7 @@ func (r *Reconciler) needsBuild(
 		filesChanged = trigger.FilesChanged(tf.Spec.RestartOn, fileWatches, lastStartTime)
 		if len(filesChanged) > 0 {
 			reason = reason.With(model.BuildReasonFlagChangedFiles)
-		} else if !timecmp.BeforeOrEqual(lastRestartEvent, lastStartTime) {
+		} else if timecmp.After(lastRestartEvent, lastStartTime) {
 			reason = reason.With(model.BuildReasonFlagTriggerUnknown)
 		}
 	}

--- a/internal/engine/buildcontroller.go
+++ b/internal/engine/buildcontroller.go
@@ -166,7 +166,7 @@ func (c *BuildController) cleanUpCanceledBuilds(st store.RStore) {
 		canceled := false
 		if cancelButton, ok := state.UIButtons[uibutton.CancelButtonName(ms.Name.String())]; ok {
 			lastCancelClick := cancelButton.Status.LastClickedAt
-			canceled = timecmp.AfterOrEqual(lastCancelClick.Time, ms.CurrentBuild.StartTime)
+			canceled = timecmp.AfterOrEqual(lastCancelClick, ms.CurrentBuild.StartTime)
 		}
 		if disabled || canceled {
 			c.cleanupBuildContext(ms.Name)

--- a/internal/engine/k8swatch/event_watch_manager.go
+++ b/internal/engine/k8swatch/event_watch_manager.go
@@ -247,7 +247,7 @@ func (m *EventWatchManager) dispatchEventsLoop(ctx context.Context, of k8s.Owner
 			// TODO(nick): We might need to remove this check and optimize
 			// it in a different way. We want Tilt to be to attach to existing
 			// resources, and these resources might have pre-existing events.
-			if !timecmp.AfterOrEqual(event.ObjectMeta.CreationTimestamp, tiltStartTime) {
+			if timecmp.Before(event.ObjectMeta.CreationTimestamp, tiltStartTime) {
 				continue
 			}
 

--- a/internal/timecmp/cmp.go
+++ b/internal/timecmp/cmp.go
@@ -45,6 +45,16 @@ func Equal(a, b commonTime) bool {
 	return aNorm.Equal(bNorm)
 }
 
+// Before returns true if the normalized version of a is strictly before the normalized version of b.
+//
+// Values are normalized to the lowest granularity between the two values: seconds if either
+// is metav1.Time, microseconds if either is metav1.MicroTime, or monotonically-stripped if
+// both are time.Time. Nil time values are normalized to the zero-time.
+func Before(a, b commonTime) bool {
+	aNorm, bNorm := normalize(a, b)
+	return aNorm.Before(bNorm)
+}
+
 // BeforeOrEqual returns true if the normalized version of a is before or equal to the normalized version of b.
 //
 // Values are normalized to the lowest granularity between the two values: seconds if either
@@ -53,6 +63,16 @@ func Equal(a, b commonTime) bool {
 func BeforeOrEqual(a, b commonTime) bool {
 	aNorm, bNorm := normalize(a, b)
 	return aNorm.Before(bNorm) || aNorm.Equal(bNorm)
+}
+
+// After returns true if the normalized version of a is strictly after the normalized version of b.
+//
+// Values are normalized to the lowest granularity between the two values: seconds if either
+// is metav1.Time, microseconds if either is metav1.MicroTime, or monotonically-stripped if
+// both are time.Time. Nil time values are normalized to the zero-time.
+func After(a, b commonTime) bool {
+	aNorm, bNorm := normalize(a, b)
+	return aNorm.After(bNorm)
 }
 
 // AfterOrEqual returns true if the normalized version of a is after or equal to the normalized version of b.


### PR DESCRIPTION
The `trigger` package now returns `metav1.MicroTime` instead of
stdlib `time.Time` for trigger (start/restart/stop) timestamps.

There's a ripple effect for some internal state types on reconcilers
which went through the same conversion.

Comparisons are also all now made via the `timecmp` package using
the API types.

Primarily, this fixes flakiness for tests on Windows; it's fairly
unlikely that the cases here would cause unexpected behavior at
runtime because real world events (e.g. clicking a button) are not
performed instantaneously.

#### Testing
Previously, I'd pretty consistently see failures with just a few (~10) test runs for `TestCancelButton` (in `internal/engine`) on a Windows 11 machine.

After these changes, 500 runs passes:
```
PS C:\Users\User\tilt> go test ./internal/engine -run '^TestCancelButton$' -failfast -count 500
ok      github.com/tilt-dev/tilt/internal/engine        98.211s
```