### PR TITLE
tests: make test fixtures responsible for tearing themselves down

### DIFF
--- a/integration/analytics_test.go
+++ b/integration/analytics_test.go
@@ -35,6 +35,7 @@ func newAnalyticsFixture(t *testing.T) *analyticsFixture {
 
 	af.SetupAnalyticsServer()
 
+	t.Cleanup(af.TearDown)
 	return af
 }
 
@@ -54,8 +55,6 @@ func (af *analyticsFixture) TearDown() {
 	if err != nil {
 		af.t.Fatal(err)
 	}
-	af.tempDir.TearDown()
-	af.k8sFixture.TearDown()
 }
 
 type envVarValue struct {
@@ -99,7 +98,6 @@ func (af *analyticsFixture) SetOpt(opt analytics.Opt) {
 
 func TestOptedIn(t *testing.T) {
 	f := newAnalyticsFixture(t)
-	defer f.TearDown()
 
 	f.SetOpt(analytics.OptIn)
 
@@ -129,7 +127,6 @@ func TestOptedIn(t *testing.T) {
 
 func TestOptedOut(t *testing.T) {
 	f := newAnalyticsFixture(t)
-	defer f.TearDown()
 
 	f.SetOpt(analytics.OptOut)
 
@@ -144,7 +141,6 @@ func TestOptedOut(t *testing.T) {
 
 func TestOptDefault(t *testing.T) {
 	f := newAnalyticsFixture(t)
-	defer f.TearDown()
 
 	f.SetOpt(analytics.OptDefault)
 

--- a/integration/configmap_test.go
+++ b/integration/configmap_test.go
@@ -14,7 +14,6 @@ import (
 
 func TestConfigMap(t *testing.T) {
 	f := newK8sFixture(t, "configmap")
-	defer f.TearDown()
 
 	f.TiltUp()
 

--- a/integration/crash_test.go
+++ b/integration/crash_test.go
@@ -14,7 +14,6 @@ import (
 // Make sure that Tilt crashes if there are two tilts running on the same port.
 func TestCrash(t *testing.T) {
 	f := newK8sFixture(t, "oneup")
-	defer f.TearDown()
 
 	f.TiltUp()
 	time.Sleep(500 * time.Millisecond)

--- a/integration/crd_test.go
+++ b/integration/crd_test.go
@@ -17,7 +17,6 @@ import (
 
 func TestCRD(t *testing.T) {
 	f := newK8sFixture(t, "crd")
-	defer f.TearDown()
 
 	f.TiltUp()
 
@@ -45,7 +44,6 @@ func TestCRD(t *testing.T) {
 // yet handles 'not found' correctly
 func TestCRDNotFound(t *testing.T) {
 	f := newK8sFixture(t, "crd")
-	defer f.TearDown()
 
 	err := f.tilt.Down(f.ctx, ioutil.Discard)
 	require.NoError(t, err)
@@ -55,7 +53,6 @@ func TestCRDNotFound(t *testing.T) {
 // even when the CR doesn't exist.
 func TestCRDPartialNotFound(t *testing.T) {
 	f := newK8sFixture(t, "crd")
-	defer f.TearDown()
 
 	out, err := f.runCommand("kubectl", "apply", "-f", filepath.Join(f.dir, "crd.yaml"))
 	assert.NoError(t, err)

--- a/integration/dc_fixture_test.go
+++ b/integration/dc_fixture_test.go
@@ -21,13 +21,11 @@ type dcFixture struct {
 
 func newDCFixture(t *testing.T, dir string) *dcFixture {
 	f := newFixture(t, dir)
+	t.Cleanup(f.TearDown)
 	return &dcFixture{fixture: f}
 }
 
 func (f *dcFixture) TearDown() {
-	f.StartTearDown()
-	f.fixture.TearDown()
-
 	// Double check it's all dead
 	f.dockerKillAll("tilt")
 	_ = exec.CommandContext(f.ctx, "pkill", "docker-compose").Run()

--- a/integration/dcbuild_test.go
+++ b/integration/dcbuild_test.go
@@ -11,7 +11,6 @@ import (
 
 func TestDockerComposeImageBuild(t *testing.T) {
 	f := newDCFixture(t, "dcbuild")
-	defer f.TearDown()
 
 	f.dockerKillAll("tilt")
 	f.TiltUp()

--- a/integration/demo_test.go
+++ b/integration/demo_test.go
@@ -27,7 +27,6 @@ func TestTiltDemo(t *testing.T) {
 				t.Errorf("Could not chdir to sample project dir (%q): %v", m[0], err)
 			}
 		}
-		f.TearDown()
 	}()
 
 	var extraArgs []string

--- a/integration/disable_test.go
+++ b/integration/disable_test.go
@@ -15,7 +15,6 @@ import (
 
 func TestDisableK8s(t *testing.T) {
 	f := newK8sFixture(t, "disable")
-	defer f.TearDown()
 
 	f.TiltUp()
 
@@ -37,7 +36,6 @@ func TestDisableK8s(t *testing.T) {
 
 func TestDisableDC(t *testing.T) {
 	f := newDCFixture(t, "disable")
-	defer f.TearDown()
 
 	f.dockerKillAll("tilt")
 	f.TiltUp("-f", "Tiltfile.dc")

--- a/integration/docker_prune_test.go
+++ b/integration/docker_prune_test.go
@@ -15,7 +15,6 @@ import (
 
 func TestCLI_DockerPrune(t *testing.T) {
 	f := newK8sFixture(t, "docker_prune")
-	defer f.TearDown()
 	f.SetRestrictedCredentials()
 
 	t.Log("Running `tilt ci` to trigger a build")

--- a/integration/event_test.go
+++ b/integration/event_test.go
@@ -44,7 +44,6 @@ func markNodeSchedulable(f *k8sFixture, name string) {
 
 func TestEvent(t *testing.T) {
 	f := newK8sFixture(t, "event")
-	defer f.TearDown()
 
 	node := getNodeName(f)
 	markNodeUnschedulable(f, node)

--- a/integration/fixture_test.go
+++ b/integration/fixture_test.go
@@ -93,6 +93,7 @@ func newFixture(t *testing.T, dir string) *fixture {
 		installed = true
 	}
 
+	t.Cleanup(f.TearDown)
 	return f
 }
 

--- a/integration/idempotent_test.go
+++ b/integration/idempotent_test.go
@@ -15,7 +15,6 @@ import (
 // it attaches to the existing pods without redeploying
 func TestIdempotent(t *testing.T) {
 	f := newK8sFixture(t, "idempotent")
-	defer f.TearDown()
 
 	f.TiltCI("idempotent")
 

--- a/integration/imagetags_test.go
+++ b/integration/imagetags_test.go
@@ -11,7 +11,6 @@ import (
 
 func TestImageTags(t *testing.T) {
 	f := newK8sFixture(t, "imagetags")
-	defer f.TearDown()
 
 	f.TiltUp()
 

--- a/integration/job_test.go
+++ b/integration/job_test.go
@@ -15,7 +15,6 @@ import (
 // than a deployment (because it is immutable)
 func TestJob(t *testing.T) {
 	f := newK8sFixture(t, "job")
-	defer f.TearDown()
 	f.SetRestrictedCredentials()
 
 	f.TiltUp()

--- a/integration/k8s_custom_deploy_test.go
+++ b/integration/k8s_custom_deploy_test.go
@@ -24,7 +24,6 @@ func TestK8sCustomDeploy(t *testing.T) {
 	}
 
 	f := newK8sFixture(t, "k8s_custom_deploy")
-	defer f.TearDown()
 	f.SetRestrictedCredentials()
 
 	f.TiltUp()

--- a/integration/k8s_fixture_test.go
+++ b/integration/k8s_fixture_test.go
@@ -35,6 +35,7 @@ type k8sFixture struct {
 
 func newK8sFixture(t *testing.T, dir string) *k8sFixture {
 	f := newFixture(t, dir)
+
 	td := tempdir.NewTempDirFixture(t)
 
 	kf := &k8sFixture{fixture: f, tempDir: td}
@@ -50,6 +51,8 @@ func newK8sFixture(t *testing.T, dir string) *k8sFixture {
 	} else {
 		kf.ClearNamespace()
 	}
+
+	t.Cleanup(kf.TearDown)
 
 	return kf
 }
@@ -285,8 +288,6 @@ func (f *k8sFixture) SetRestrictedCredentials() {
 func (f *k8sFixture) TearDown() {
 	f.StartTearDown()
 	f.ClearNamespace()
-	f.fixture.TearDown()
-	f.tempDir.TearDown()
 }
 
 // waits for pods to be in a specified state, or times out and fails

--- a/integration/live_update_after_crash_rebuild_test.go
+++ b/integration/live_update_after_crash_rebuild_test.go
@@ -16,7 +16,6 @@ import (
 
 func TestLiveUpdateAfterCrashRebuild(t *testing.T) {
 	f := newK8sFixture(t, "live_update_after_crash_rebuild")
-	defer f.TearDown()
 
 	f.SetRestrictedCredentials()
 

--- a/integration/live_update_base_image_test.go
+++ b/integration/live_update_base_image_test.go
@@ -13,7 +13,6 @@ import (
 
 func TestLiveUpdateBaseImage(t *testing.T) {
 	f := newK8sFixture(t, "live_update_base_image")
-	defer f.TearDown()
 
 	f.TiltUp()
 

--- a/integration/live_update_only_test.go
+++ b/integration/live_update_only_test.go
@@ -15,7 +15,6 @@ import (
 
 func TestLiveUpdateOnly(t *testing.T) {
 	f := newK8sFixture(t, "live_update_only")
-	defer f.TearDown()
 	f.SetRestrictedCredentials()
 
 	f.TiltUp()

--- a/integration/live_update_selector_test.go
+++ b/integration/live_update_selector_test.go
@@ -13,7 +13,6 @@ import (
 
 func TestLiveUpdateSelector(t *testing.T) {
 	f := newK8sFixture(t, "live_update_selector")
-	defer f.TearDown()
 	f.SetRestrictedCredentials()
 
 	f.TiltUp()

--- a/integration/live_update_two_images_one_manifest_test.go
+++ b/integration/live_update_two_images_one_manifest_test.go
@@ -19,7 +19,6 @@ func TestLiveUpdateTwoImagesOneManifest(t *testing.T) {
 	t.SkipNow()
 
 	f := newK8sFixture(t, "live_update_two_images_one_manifest")
-	defer f.TearDown()
 
 	f.TiltUp()
 

--- a/integration/local_resource_test.go
+++ b/integration/local_resource_test.go
@@ -19,7 +19,6 @@ const cleanupTxt = "cleanup.txt"
 
 func TestLocalResource(t *testing.T) {
 	f := newFixture(t, "local_resource")
-	defer f.TearDown()
 
 	removeTestFiles := func() {
 		require.NoError(t, os.RemoveAll(f.testDirPath(cleanupTxt)))

--- a/integration/namespaceflag_test.go
+++ b/integration/namespaceflag_test.go
@@ -14,7 +14,6 @@ import (
 
 func TestNamespaceFlag(t *testing.T) {
 	f := newK8sFixture(t, "namespaceflag")
-	defer f.TearDown()
 	f.SetRestrictedCredentials()
 
 	// Specify the namespace in the Tilt Up invocation,

--- a/integration/onedc_test.go
+++ b/integration/onedc_test.go
@@ -13,8 +13,6 @@ func TestOneDockerCompose(t *testing.T) {
 	f := newDCFixture(t, "onedc")
 
 	f.doV1V2(func() {
-		defer f.TearDown()
-
 		f.dockerKillAll("tilt")
 		f.TiltUp()
 

--- a/integration/oneup_custom_test.go
+++ b/integration/oneup_custom_test.go
@@ -11,7 +11,6 @@ import (
 
 func TestOneUpCustom(t *testing.T) {
 	f := newK8sFixture(t, "oneup_custom")
-	defer f.TearDown()
 
 	f.TiltCI("oneup-custom")
 

--- a/integration/oneup_test.go
+++ b/integration/oneup_test.go
@@ -14,7 +14,6 @@ import (
 
 func TestOneUp(t *testing.T) {
 	f := newK8sFixture(t, "oneup")
-	defer f.TearDown()
 	f.SetRestrictedCredentials()
 
 	f.TiltUp("oneup")

--- a/integration/onewatch_exec_test.go
+++ b/integration/onewatch_exec_test.go
@@ -14,7 +14,6 @@ import (
 
 func TestWatchExec(t *testing.T) {
 	f := newK8sFixture(t, "onewatch_exec")
-	defer f.TearDown()
 
 	f.TiltUp("--update-mode=exec")
 

--- a/integration/onewatch_test.go
+++ b/integration/onewatch_test.go
@@ -13,7 +13,6 @@ import (
 
 func TestOneWatch(t *testing.T) {
 	f := newK8sFixture(t, "onewatch")
-	defer f.TearDown()
 	f.SetRestrictedCredentials()
 
 	f.TiltUp()

--- a/integration/restart_process_different_user_test.go
+++ b/integration/restart_process_different_user_test.go
@@ -13,7 +13,6 @@ import (
 
 func TestRestartProcessDifferentUser(t *testing.T) {
 	f := newK8sFixture(t, "restart_process_different_user")
-	defer f.TearDown()
 
 	f.TiltUp()
 

--- a/integration/same_img_multi_container_test.go
+++ b/integration/same_img_multi_container_test.go
@@ -13,7 +13,6 @@ import (
 
 func TestSameImgMultiContainer(t *testing.T) {
 	f := newK8sFixture(t, "same_img_multi_container")
-	defer f.TearDown()
 
 	f.TiltUp()
 

--- a/integration/shortlived_pods_test.go
+++ b/integration/shortlived_pods_test.go
@@ -14,7 +14,6 @@ import (
 
 func TestShortlivedPods(t *testing.T) {
 	f := newK8sFixture(t, "shortlived_pods")
-	defer f.TearDown()
 
 	f.TiltUp()
 

--- a/integration/tilt_args_test.go
+++ b/integration/tilt_args_test.go
@@ -13,7 +13,6 @@ import (
 
 func TestTiltArgs(t *testing.T) {
 	f := newFixture(t, "tilt_args")
-	defer f.TearDown()
 
 	f.TiltUp("foo")
 

--- a/integration/tilt_ci_test.go
+++ b/integration/tilt_ci_test.go
@@ -29,7 +29,6 @@ type localResource struct {
 // this due to the subtlety in various states.
 func TestTiltCI(t *testing.T) {
 	f := newK8sFixture(t, "tilt_ci")
-	defer f.TearDown()
 	f.SetRestrictedCredentials()
 
 	// dynamically generate a bunch of combinations of local_resource args and write out to

--- a/integration/too_many_deployments_test.go
+++ b/integration/too_many_deployments_test.go
@@ -11,7 +11,6 @@ import (
 
 func TestTooManyDeployments(t *testing.T) {
 	f := newK8sFixture(t, "too_many_deployments")
-	defer f.TearDown()
 
 	f.runCommandSilently("kubectl", "apply", "-f", "namespace.yaml")
 	f.runCommandSilently("kubectl", "apply", "-f", "too_many_deployments/deployments.yaml")

--- a/internal/build/container_test.go
+++ b/internal/build/container_test.go
@@ -23,7 +23,6 @@ import (
 
 func TestDockerBuildDockerfile(t *testing.T) {
 	f := newDockerBuildFixture(t)
-	defer f.teardown()
 
 	df := dockerfile.Dockerfile(`
 FROM alpine
@@ -63,7 +62,6 @@ ADD dir/c.txt .
 
 func TestDockerBuildWithBuildArgs(t *testing.T) {
 	f := newDockerBuildFixture(t)
-	defer f.teardown()
 
 	df := dockerfile.Dockerfile(`FROM alpine
 ARG some_variable_name
@@ -93,7 +91,6 @@ ADD $some_variable_name /test.txt`)
 
 func TestDockerBuildWithExtraTags(t *testing.T) {
 	f := newDockerBuildFixture(t)
-	defer f.teardown()
 
 	df := dockerfile.Dockerfile(`
 FROM alpine
@@ -126,7 +123,6 @@ ADD a.txt .`)
 
 func TestDetectBuildkitCorruption(t *testing.T) {
 	f := newDockerBuildFixture(t)
-	defer f.teardown()
 
 	out := bytes.NewBuffer(nil)
 	ctx := logger.WithLogger(context.Background(), logger.NewTestLogger(out))

--- a/internal/build/custom_builder_test.go
+++ b/internal/build/custom_builder_test.go
@@ -31,7 +31,6 @@ var TwoURLRegistry = container.MustNewRegistryWithHostFromCluster("localhost:123
 
 func TestCustomBuildSuccess(t *testing.T) {
 	f := newFakeCustomBuildFixture(t)
-	defer f.TearDown()
 
 	sha := digest.Digest("sha256:11cd0eb38bc3ceb958ffb2f9bd70be3fb317ce7d255c8a4c3f4af30e298aa1aab")
 	f.dCli.Images["gcr.io/foo/bar:tilt-build-1551202573"] = types.ImageInspect{ID: string(sha)}
@@ -45,7 +44,6 @@ func TestCustomBuildSuccess(t *testing.T) {
 
 func TestCustomBuildSuccessClusterRefTaggedWithDigest(t *testing.T) {
 	f := newFakeCustomBuildFixture(t)
-	defer f.TearDown()
 
 	sha := digest.Digest("sha256:11cd0eb38bc3ceb958ffb2f9bd70be3fb317ce7d255c8a4c3f4af30e298aa1aab")
 	f.dCli.Images["localhost:1234/foo_bar:tilt-build-1551202573"] = types.ImageInspect{ID: string(sha)}
@@ -59,7 +57,6 @@ func TestCustomBuildSuccessClusterRefTaggedWithDigest(t *testing.T) {
 
 func TestCustomBuildSuccessClusterRefWithCustomTag(t *testing.T) {
 	f := newFakeCustomBuildFixture(t)
-	defer f.TearDown()
 
 	sha := digest.Digest("sha256:11cd0eb38bc3ceb958ffb2f9bd70be3fb317ce7d255c8a4c3f4af30e298aa1aab")
 	f.dCli.Images["gcr.io/foo/bar:my-tag"] = types.ImageInspect{ID: string(sha)}
@@ -74,7 +71,6 @@ func TestCustomBuildSuccessClusterRefWithCustomTag(t *testing.T) {
 
 func TestCustomBuildSuccessSkipsLocalDocker(t *testing.T) {
 	f := newFakeCustomBuildFixture(t)
-	defer f.TearDown()
 
 	cb := f.customBuild("exit 0")
 	cb.CmdImageSpec.OutputMode = v1alpha1.CmdImageOutputRemote
@@ -87,7 +83,6 @@ func TestCustomBuildSuccessSkipsLocalDocker(t *testing.T) {
 
 func TestCustomBuildSuccessClusterRefTaggedIfSkipsLocalDocker(t *testing.T) {
 	f := newFakeCustomBuildFixture(t)
-	defer f.TearDown()
 
 	cb := f.customBuild("exit 0")
 	cb.CmdImageSpec.OutputMode = v1alpha1.CmdImageOutputRemote
@@ -100,7 +95,6 @@ func TestCustomBuildSuccessClusterRefTaggedIfSkipsLocalDocker(t *testing.T) {
 
 func TestCustomBuildCmdFails(t *testing.T) {
 	f := newFakeCustomBuildFixture(t)
-	defer f.TearDown()
 
 	cb := f.customBuild("exit 1")
 	_, err := f.cb.Build(f.ctx, refSetFromString("gcr.io/foo/bar"), cb.CmdImageSpec, nil)
@@ -110,7 +104,6 @@ func TestCustomBuildCmdFails(t *testing.T) {
 
 func TestCustomBuildImgNotFound(t *testing.T) {
 	f := newFakeCustomBuildFixture(t)
-	defer f.TearDown()
 
 	cb := f.customBuild("exit 0")
 	_, err := f.cb.Build(f.ctx, refSetFromString("gcr.io/foo/bar"), cb.CmdImageSpec, nil)
@@ -119,7 +112,6 @@ func TestCustomBuildImgNotFound(t *testing.T) {
 
 func TestCustomBuildExpectedTag(t *testing.T) {
 	f := newFakeCustomBuildFixture(t)
-	defer f.TearDown()
 
 	sha := digest.Digest("sha256:11cd0eb38bc3ceb958ffb2f9bd70be3fb317ce7d255c8a4c3f4af30e298aa1aab")
 	f.dCli.Images["gcr.io/foo/bar:the-tag"] = types.ImageInspect{ID: string(sha)}
@@ -138,7 +130,6 @@ func TestCustomBuilderExecsRelativeToTiltfile(t *testing.T) {
 		t.Skip("no sh on windows")
 	}
 	f := newFakeCustomBuildFixture(t)
-	defer f.TearDown()
 
 	f.WriteFile("proj/build.sh", "exit 0")
 
@@ -156,7 +147,6 @@ func TestCustomBuilderExecsRelativeToTiltfile(t *testing.T) {
 
 func TestCustomBuildOutputsToImageRefSuccess(t *testing.T) {
 	f := newFakeCustomBuildFixture(t)
-	defer f.TearDown()
 
 	myTag := "gcr.io/foo/bar:dev"
 	sha := digest.Digest("sha256:11cd0eb38bc3ceb958ffb2f9bd70be3fb317ce7d255c8a4c3f4af30e298aa1aab")
@@ -172,7 +162,6 @@ func TestCustomBuildOutputsToImageRefSuccess(t *testing.T) {
 
 func TestCustomBuildOutputsToImageRefMissingImage(t *testing.T) {
 	f := newFakeCustomBuildFixture(t)
-	defer f.TearDown()
 
 	myTag := "gcr.io/foo/bar:dev"
 	cb := f.customBuild(fmt.Sprintf("echo %s > ref.txt", myTag))
@@ -185,7 +174,6 @@ func TestCustomBuildOutputsToImageRefMissingImage(t *testing.T) {
 
 func TestCustomBuildOutputsToImageRefMalformedImage(t *testing.T) {
 	f := newFakeCustomBuildFixture(t)
-	defer f.TearDown()
 
 	cb := f.customBuild("echo 999 > ref.txt")
 	cb.CmdImageSpec.OutputsImageRefTo = f.JoinPath("ref.txt")
@@ -198,7 +186,6 @@ func TestCustomBuildOutputsToImageRefMalformedImage(t *testing.T) {
 
 func TestCustomBuildOutputsToImageRefSkipsLocalDocker(t *testing.T) {
 	f := newFakeCustomBuildFixture(t)
-	defer f.TearDown()
 
 	myTag := "gcr.io/foo/bar:dev"
 	cb := f.customBuild(fmt.Sprintf("echo %s > ref.txt", myTag))
@@ -216,7 +203,6 @@ func TestCustomBuildImageDep(t *testing.T) {
 	}
 
 	f := newFakeCustomBuildFixture(t)
-	defer f.TearDown()
 
 	sha := digest.Digest("sha256:11cd0eb38bc3ceb958ffb2f9bd70be3fb317ce7d255c8a4c3f4af30e298aa1aab")
 	f.dCli.Images["gcr.io/foo/bar:tilt-build-1551202573"] = types.ImageInspect{ID: string(sha)}

--- a/internal/build/docker_builder_test.go
+++ b/internal/build/docker_builder_test.go
@@ -62,7 +62,6 @@ func TestDigestAsTagToShort(t *testing.T) {
 
 func TestDigestFromSingleStepOutput(t *testing.T) {
 	f := newFakeDockerBuildFixture(t)
-	defer f.teardown()
 
 	input := docker.ExampleBuildOutput1
 	expected := digest.Digest("sha256:11cd0b38bc3ceb958ffb2f9bd70be3fb317ce7d255c8a4c3f4af30e298aa1aab")
@@ -77,7 +76,6 @@ func TestDigestFromSingleStepOutput(t *testing.T) {
 
 func TestDigestFromOutputV1_23(t *testing.T) {
 	f := newFakeDockerBuildFixture(t)
-	defer f.teardown()
 
 	input := docker.ExampleBuildOutputV1_23
 	expected := digest.Digest("sha256:11cd0eb38bc3ceb958ffb2f9bd70be3fb317ce7d255c8a4c3f4af30e298aa1aab")
@@ -93,7 +91,6 @@ func TestDigestFromOutputV1_23(t *testing.T) {
 
 func TestDumpImageDeployRef(t *testing.T) {
 	f := newFakeDockerBuildFixture(t)
-	defer f.teardown()
 
 	digest := digest.Digest("sha256:11cd0eb38bc3ceb958ffb2f9bd70be3fb317ce7d255c8a4c3f4af30e298aa1aab")
 	f.fakeDocker.Images["example-image:dev"] = types.ImageInspect{ID: string(digest)}
@@ -167,7 +164,6 @@ func TestCleanUpBuildKitErrors(t *testing.T) {
 	} {
 		t.Run(tc.expectedTiltError, func(t *testing.T) {
 			f := newFakeDockerBuildFixture(t)
-			defer f.teardown()
 
 			ctx, _, _ := testutils.CtxAndAnalyticsForTest()
 			s := makeDockerBuildErrorOutput(tc.buildKitError)

--- a/internal/build/path_mapping_test.go
+++ b/internal/build/path_mapping_test.go
@@ -12,7 +12,6 @@ import (
 
 func TestFilesToPathMappings(t *testing.T) {
 	f := tempdir.NewTempDirFixture(t)
-	defer f.TearDown()
 
 	paths := []string{
 		filepath.Join("sync1", "fileA"),
@@ -69,7 +68,6 @@ func TestFilesToPathMappings(t *testing.T) {
 
 func TestFileToDirectoryPathMapping(t *testing.T) {
 	f := tempdir.NewTempDirFixture(t)
-	defer f.TearDown()
 
 	paths := []string{
 		filepath.Join("sync1", "fileA"),
@@ -106,7 +104,6 @@ func TestFileToDirectoryPathMapping(t *testing.T) {
 
 func TestFileNotInSyncYieldsNoMapping(t *testing.T) {
 	f := tempdir.NewTempDirFixture(t)
-	defer f.TearDown()
 
 	files := []string{f.JoinPath("not/synced/fileA")}
 

--- a/internal/build/tar_benchmark_test.go
+++ b/internal/build/tar_benchmark_test.go
@@ -15,7 +15,6 @@ import (
 
 func BenchmarkArchivePaths(b *testing.B) {
 	f := tempdir.NewTempDirFixture(b)
-	defer f.TearDown()
 
 	fileCount := 10000
 	for i := 0; i < fileCount; i++ {

--- a/internal/build/tar_test.go
+++ b/internal/build/tar_test.go
@@ -28,7 +28,6 @@ func TestArchiveDf(t *testing.T) {
 	buf := new(bytes.Buffer)
 	ab := NewArchiveBuilder(buf, model.EmptyMatcher)
 	defer ab.Close()
-	defer f.tearDown()
 
 	df := dockerfile.Dockerfile(dfText)
 	err := ab.archiveDf(f.ctx, df)
@@ -52,7 +51,6 @@ func TestArchivePathsIfExists(t *testing.T) {
 	go func() {
 		ab := NewArchiveBuilder(pw, model.EmptyMatcher)
 		defer ab.Close()
-		defer f.tearDown()
 
 		f.WriteFile("a", "a")
 
@@ -81,7 +79,6 @@ func TestArchivePathsIfExists(t *testing.T) {
 
 func TestDontArchiveTiltfile(t *testing.T) {
 	f := newFixture(t)
-	defer f.tearDown()
 
 	filter, err := dockerignore.NewDockerPatternMatcher(f.Path(), []string{"Tiltfile"})
 	if err != nil {
@@ -138,7 +135,6 @@ func TestArchiveOverlapping(t *testing.T) {
 	buf := new(bytes.Buffer)
 	ab := NewArchiveBuilder(buf, model.EmptyMatcher)
 	defer ab.Close()
-	defer f.tearDown()
 
 	f.WriteFile("a/a.txt", "a.txt contents")
 	f.WriteFile("b/b.txt", "b.txt contents")
@@ -177,7 +173,6 @@ func TestArchiveSymlink(t *testing.T) {
 	buf := new(bytes.Buffer)
 	ab := NewArchiveBuilder(buf, model.EmptyMatcher)
 	defer ab.Close()
-	defer f.tearDown()
 
 	f.WriteFile("src/a.txt", "hello world")
 	f.WriteSymlink("a.txt", "src/b.txt")
@@ -210,7 +205,6 @@ func TestArchiveSocket(t *testing.T) {
 	buf := new(bytes.Buffer)
 	ab := NewArchiveBuilder(buf, model.EmptyMatcher)
 	defer ab.Close()
-	defer f.tearDown()
 
 	f.WriteFile("src/a.txt", "hello world")
 	c, err := net.Listen("unix", f.JoinPath("src/my.sock"))
@@ -240,7 +234,6 @@ func TestArchiveSocket(t *testing.T) {
 
 func TestArchiveException(t *testing.T) {
 	f := newFixture(t)
-	defer f.tearDown()
 
 	filter, err := dockerignore.NewDockerPatternMatcher(f.Path(), []string{"*", "!target"})
 	if err != nil {
@@ -267,7 +260,6 @@ func TestArchiveException(t *testing.T) {
 // Write a file continuously, and make sure we don't get tar errors.
 func TestRapidWrite(t *testing.T) {
 	f := newFixture(t)
-	defer f.tearDown()
 
 	f.WriteFile("log.txt", "a")
 
@@ -344,8 +336,4 @@ func (f *fixture) assertFileInTar(tr *tar.Reader, expected expectedFile) {
 
 func (f *fixture) assertFilesInTar(tr *tar.Reader, expected []expectedFile) {
 	testutils.AssertFilesInTar(f.t, tr, expected)
-}
-
-func (f *fixture) tearDown() {
-	f.TempDirFixture.TearDown()
 }

--- a/internal/build/test_utils.go
+++ b/internal/build/test_utils.go
@@ -61,7 +61,7 @@ func newDockerBuildFixture(t testing.TB) *dockerBuildFixture {
 	labels := dockerfile.Labels(map[dockerfile.Label]dockerfile.LabelValue{
 		TestImage: "1",
 	})
-	return &dockerBuildFixture{
+	ret := &dockerBuildFixture{
 		TempDirFixture: tempdir.NewTempDirFixture(t),
 		t:              t,
 		ctx:            ctx,
@@ -70,6 +70,9 @@ func newDockerBuildFixture(t testing.TB) *dockerBuildFixture {
 		reaper:         NewImageReaper(dCli),
 		ps:             ps,
 	}
+
+	t.Cleanup(ret.teardown)
+	return ret
 }
 
 func newFakeDockerBuildFixture(t testing.TB) *dockerBuildFixture {
@@ -81,7 +84,7 @@ func newFakeDockerBuildFixture(t testing.TB) *dockerBuildFixture {
 
 	ps := NewPipelineState(ctx, 3, realClock{})
 
-	return &dockerBuildFixture{
+	ret := &dockerBuildFixture{
 		TempDirFixture: tempdir.NewTempDirFixture(t),
 		t:              t,
 		ctx:            ctx,
@@ -90,6 +93,9 @@ func newFakeDockerBuildFixture(t testing.TB) *dockerBuildFixture {
 		reaper:         NewImageReaper(dCli),
 		ps:             ps,
 	}
+
+	t.Cleanup(ret.teardown)
+	return ret
 }
 
 func (f *dockerBuildFixture) teardown() {
@@ -117,7 +123,6 @@ func (f *dockerBuildFixture) teardown() {
 		_ = exec.Command("docker", "kill", "tilt-registry").Run()
 		_ = exec.Command("docker", "rm", "tilt-registry").Run()
 	}
-	f.TempDirFixture.TearDown()
 }
 
 func (f *dockerBuildFixture) getNameFromTest() wmcontainer.RefSet {

--- a/internal/cli/apiresources_test.go
+++ b/internal/cli/apiresources_test.go
@@ -11,7 +11,6 @@ import (
 
 func TestAPIResources(t *testing.T) {
 	f := newServerFixture(t)
-	defer f.TearDown()
 
 	out := bytes.NewBuffer(nil)
 	cmd := newApiresourcesCmd()

--- a/internal/cli/apply_test.go
+++ b/internal/cli/apply_test.go
@@ -13,7 +13,6 @@ import (
 
 func TestApply(t *testing.T) {
 	f := newServerFixture(t)
-	defer f.TearDown()
 
 	f.WriteFile("sleep.yaml", `
 apiVersion: tilt.dev/v1alpha1

--- a/internal/cli/args_test.go
+++ b/internal/cli/args_test.go
@@ -20,7 +20,6 @@ import (
 
 func TestArgsClear(t *testing.T) {
 	f := newServerFixture(t)
-	defer f.TearDown()
 
 	createTiltfile(f, []string{"foo", "bar"})
 
@@ -39,7 +38,6 @@ func TestArgsClear(t *testing.T) {
 
 func TestArgsNewValue(t *testing.T) {
 	f := newServerFixture(t)
-	defer f.TearDown()
 
 	createTiltfile(f, []string{"foo", "bar"})
 
@@ -59,7 +57,6 @@ func TestArgsNewValue(t *testing.T) {
 
 func TestArgsClearAndNewValue(t *testing.T) {
 	f := newServerFixture(t)
-	defer f.TearDown()
 
 	createTiltfile(f, []string{"foo", "bar"})
 
@@ -74,7 +71,6 @@ func TestArgsClearAndNewValue(t *testing.T) {
 
 func TestArgsNoChange(t *testing.T) {
 	f := newServerFixture(t)
-	defer f.TearDown()
 
 	createTiltfile(f, []string{"foo", "bar"})
 
@@ -140,7 +136,6 @@ func TestArgsEdit(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			f := newServerFixture(t)
-			defer f.TearDown()
 
 			origEditor := os.Getenv("EDITOR")
 			contents := tc.contents

--- a/internal/cli/create_cmd_test.go
+++ b/internal/cli/create_cmd_test.go
@@ -14,7 +14,6 @@ import (
 
 func TestCreateCmd(t *testing.T) {
 	f := newServerFixture(t)
-	defer f.TearDown()
 
 	out := bytes.NewBuffer(nil)
 

--- a/internal/cli/create_ext_test.go
+++ b/internal/cli/create_ext_test.go
@@ -13,7 +13,6 @@ import (
 
 func TestCreateExt(t *testing.T) {
 	f := newServerFixture(t)
-	defer f.TearDown()
 
 	out := bytes.NewBuffer(nil)
 

--- a/internal/cli/create_filewatch_test.go
+++ b/internal/cli/create_filewatch_test.go
@@ -15,7 +15,6 @@ import (
 
 func TestCreateFileWatch(t *testing.T) {
 	f := newServerFixture(t)
-	defer f.TearDown()
 
 	out := bytes.NewBuffer(nil)
 
@@ -47,7 +46,6 @@ func TestCreateFileWatch(t *testing.T) {
 
 func TestCreateFileWatchNoIgnore(t *testing.T) {
 	f := newServerFixture(t)
-	defer f.TearDown()
 
 	out := bytes.NewBuffer(nil)
 

--- a/internal/cli/create_repo_test.go
+++ b/internal/cli/create_repo_test.go
@@ -13,7 +13,6 @@ import (
 
 func TestCreateRepo(t *testing.T) {
 	f := newServerFixture(t)
-	defer f.TearDown()
 
 	out := bytes.NewBuffer(nil)
 

--- a/internal/cli/create_test.go
+++ b/internal/cli/create_test.go
@@ -13,7 +13,6 @@ import (
 
 func TestCreate(t *testing.T) {
 	f := newServerFixture(t)
-	defer f.TearDown()
 
 	f.WriteFile("sleep.yaml", `
 apiVersion: tilt.dev/v1alpha1

--- a/internal/cli/delete_test.go
+++ b/internal/cli/delete_test.go
@@ -15,7 +15,6 @@ import (
 
 func TestDelete(t *testing.T) {
 	f := newServerFixture(t)
-	defer f.TearDown()
 
 	err := f.client.Create(f.ctx, &v1alpha1.Cmd{
 		ObjectMeta: metav1.ObjectMeta{Name: "my-sleep"},

--- a/internal/cli/describe_test.go
+++ b/internal/cli/describe_test.go
@@ -13,7 +13,6 @@ import (
 
 func TestDescribe(t *testing.T) {
 	f := newServerFixture(t)
-	defer f.TearDown()
 
 	err := f.client.Create(f.ctx, &v1alpha1.Cmd{
 		ObjectMeta: metav1.ObjectMeta{Name: "my-sleep"},

--- a/internal/cli/disable_test.go
+++ b/internal/cli/disable_test.go
@@ -52,7 +52,6 @@ func TestDisable(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			f := newEnableFixture(t)
-			defer f.TearDown()
 
 			f.createResources()
 

--- a/internal/cli/edit_test.go
+++ b/internal/cli/edit_test.go
@@ -19,7 +19,6 @@ func TestEdit(t *testing.T) {
 	}
 
 	f := newServerFixture(t)
-	defer f.TearDown()
 
 	err := f.client.Create(f.ctx, &v1alpha1.Cmd{
 		ObjectMeta: metav1.ObjectMeta{Name: "my-sleep"},

--- a/internal/cli/enable_test.go
+++ b/internal/cli/enable_test.go
@@ -67,7 +67,6 @@ func TestEnable(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			f := newEnableFixture(t)
-			defer f.TearDown()
 
 			f.createResources()
 

--- a/internal/cli/explain_test.go
+++ b/internal/cli/explain_test.go
@@ -13,7 +13,6 @@ import (
 
 func TestExplain(t *testing.T) {
 	f := newServerFixture(t)
-	defer f.TearDown()
 
 	err := f.client.Create(f.ctx, &v1alpha1.Cmd{
 		ObjectMeta: metav1.ObjectMeta{Name: "my-sleep"},

--- a/internal/cli/get_test.go
+++ b/internal/cli/get_test.go
@@ -27,7 +27,6 @@ import (
 
 func TestGet(t *testing.T) {
 	f := newServerFixture(t)
-	defer f.TearDown()
 
 	err := f.client.Create(f.ctx, &v1alpha1.Cmd{
 		ObjectMeta: metav1.ObjectMeta{Name: "my-sleep"},
@@ -96,7 +95,7 @@ func newServerFixture(t *testing.T) *serverFixture {
 	origPort := defaultWebPort
 	defaultWebPort = webPort
 
-	return &serverFixture{
+	ret := &serverFixture{
 		TempDirFixture: f,
 		ctx:            ctx,
 		cancel:         cancel,
@@ -105,6 +104,9 @@ func newServerFixture(t *testing.T) *serverFixture {
 		origPort:       origPort,
 		analytics:      a,
 	}
+
+	t.Cleanup(ret.TearDown)
+	return ret
 }
 
 func (f *serverFixture) TearDown() {

--- a/internal/cli/patch_test.go
+++ b/internal/cli/patch_test.go
@@ -14,7 +14,6 @@ import (
 
 func TestPatch(t *testing.T) {
 	f := newServerFixture(t)
-	defer f.TearDown()
 
 	err := f.client.Create(f.ctx, &v1alpha1.Cmd{
 		ObjectMeta: metav1.ObjectMeta{Name: "my-sleep"},

--- a/internal/cli/tiltfile_result_test.go
+++ b/internal/cli/tiltfile_result_test.go
@@ -13,7 +13,6 @@ import (
 
 func TestTiltfileResult(t *testing.T) {
 	f := tempdir.NewTempDirFixture(t)
-	defer f.TearDown()
 	f.Chdir()
 
 	f.WriteFile("Tiltfile", `

--- a/internal/cli/wait_test.go
+++ b/internal/cli/wait_test.go
@@ -14,7 +14,6 @@ import (
 
 func TestWait(t *testing.T) {
 	f := newServerFixture(t)
-	defer f.TearDown()
 
 	err := f.client.Create(f.ctx, &v1alpha1.UIResource{
 		ObjectMeta: metav1.ObjectMeta{Name: "my-sleep"},

--- a/internal/controllers/core/cmd/execer_unix_test.go
+++ b/internal/controllers/core/cmd/execer_unix_test.go
@@ -21,7 +21,6 @@ func TestStopsBackgroundGrandchildren(t *testing.T) {
 		t.Skip("no bash on windows")
 	}
 	f := newProcessExecFixture(t)
-	defer f.tearDown()
 
 	f.start(`bash -c 'sleep 100 &
 echo BACKGROUND $!

--- a/internal/controllers/core/extension/reconciler_test.go
+++ b/internal/controllers/core/extension/reconciler_test.go
@@ -175,7 +175,6 @@ type fixture struct {
 func newFixture(t *testing.T) *fixture {
 	cfb := fake.NewControllerFixtureBuilder(t)
 	tf := tempdir.NewTempDirFixture(t)
-	t.Cleanup(tf.TearDown)
 
 	o := tiltanalytics.NewFakeOpter(analytics.OptIn)
 	ma, ta := tiltanalytics.NewMemoryTiltAnalyticsForTest(o)

--- a/internal/controllers/core/filewatch/controller_test.go
+++ b/internal/controllers/core/filewatch/controller_test.go
@@ -64,7 +64,6 @@ type fixture struct {
 
 func newFixture(t *testing.T) *fixture {
 	tmpdir := tempdir.NewTempDirFixture(t)
-	t.Cleanup(tmpdir.TearDown)
 	tmpdir.Chdir()
 
 	timerMaker := fsevent.MakeFakeTimerMaker(t)

--- a/internal/controllers/core/kubernetesdiscovery/reconciler_test.go
+++ b/internal/controllers/core/kubernetesdiscovery/reconciler_test.go
@@ -489,7 +489,6 @@ func TestClusterChange(t *testing.T) {
 
 	// create a NEW client for A
 	kCliClusterA2 := k8s.NewFakeK8sClient(t)
-	t.Cleanup(kCliClusterA2.TearDown)
 	connectedAtA2 := f.clients.SetK8sClient(clusterNN(*kd1ClusterA), kCliClusterA2)
 
 	// create copies of the old pods with slightly different names so we can
@@ -740,7 +739,6 @@ func (f *fixture) k8sClient(kd v1alpha1.KubernetesDiscovery) (*k8s.FakeK8sClient
 	kCli, rev, err := f.clients.GetK8sClient(clusterNN)
 	if errors.Is(err, cluster.NotFoundError) {
 		fakeCli := k8s.NewFakeK8sClient(f.t)
-		f.t.Cleanup(fakeCli.TearDown)
 		f.clients.AddK8sClient(clusterNN, fakeCli)
 		kCli, rev, err = f.clients.GetK8sClient(clusterNN)
 	}

--- a/internal/controllers/core/podlogstream/podlogstreamcontroller_test.go
+++ b/internal/controllers/core/podlogstream/podlogstreamcontroller_test.go
@@ -488,7 +488,6 @@ type plmFixture struct {
 
 func newPLMFixture(t testing.TB) *plmFixture {
 	kClient := k8s.NewFakeK8sClient(t)
-	t.Cleanup(kClient.TearDown)
 
 	out := bufsync.NewThreadSafeBuffer()
 	ctx, cancel := context.WithCancel(context.Background())

--- a/internal/controllers/core/portforward/reconciler_test.go
+++ b/internal/controllers/core/portforward/reconciler_test.go
@@ -289,7 +289,6 @@ type pfrFixture struct {
 
 func newPFRFixture(t *testing.T) *pfrFixture {
 	kCli := k8s.NewFakeK8sClient(t)
-	t.Cleanup(kCli.TearDown)
 
 	cfb := fake.NewControllerFixtureBuilder(t)
 	r := NewReconciler(cfb.Client, cfb.Store, kCli)

--- a/internal/controllers/core/tiltfile/api_test.go
+++ b/internal/controllers/core/tiltfile/api_test.go
@@ -358,7 +358,6 @@ type apiFixture struct {
 
 func newAPIFixture(t testing.TB) *apiFixture {
 	f := tempdir.NewTempDirFixture(t)
-	t.Cleanup(func() { f.TearDown() })
 
 	ctx := context.Background()
 	c := fake.NewFakeTiltClient()

--- a/internal/controllers/core/tiltfile/filewatch_test.go
+++ b/internal/controllers/core/tiltfile/filewatch_test.go
@@ -29,7 +29,6 @@ import (
 
 func TestFileWatch_basic(t *testing.T) {
 	f := newFWFixture(t)
-	defer f.TearDown()
 
 	target := model.LocalTarget{
 		Name: "foo",
@@ -42,7 +41,6 @@ func TestFileWatch_basic(t *testing.T) {
 
 func TestFileWatch_localRepo(t *testing.T) {
 	f := newFWFixture(t)
-	defer f.TearDown()
 
 	target := model.LocalTarget{
 		Name: "foo",
@@ -60,7 +58,6 @@ func TestFileWatch_localRepo(t *testing.T) {
 
 func TestFileWatch_disabledOnCIMode(t *testing.T) {
 	f := newFWFixture(t)
-	defer f.TearDown()
 
 	f.inputs.EngineMode = store.EngineModeCI
 
@@ -78,7 +75,6 @@ func TestFileWatch_disabledOnCIMode(t *testing.T) {
 
 func TestFileWatch_Dockerignore(t *testing.T) {
 	f := newFWFixture(t)
-	defer f.TearDown()
 
 	target := model.LocalTarget{
 		Name: "foo",
@@ -96,7 +92,6 @@ func TestFileWatch_Dockerignore(t *testing.T) {
 
 func TestFileWatch_IgnoreOutputsImageRefs(t *testing.T) {
 	f := newFWFixture(t)
-	defer f.TearDown()
 
 	target := model.MustNewImageTarget(container.MustParseSelector("img")).
 		WithBuildDetails(model.CustomBuild{
@@ -120,7 +115,6 @@ func TestFileWatch_IgnoreOutputsImageRefs(t *testing.T) {
 
 func TestFileWatch_ConfigFiles(t *testing.T) {
 	f := newFWFixture(t)
-	defer f.TearDown()
 
 	f.SetTiltIgnoreContents("**/foo")
 	f.inputs.ConfigFiles = append(f.inputs.ConfigFiles, "path_to_watch", "stop")
@@ -136,7 +130,6 @@ func TestFileWatch_ConfigFiles(t *testing.T) {
 
 func TestFileWatch_IgnoreTiltIgnore(t *testing.T) {
 	f := newFWFixture(t)
-	defer f.TearDown()
 
 	target := model.LocalTarget{
 		Name: "foo",
@@ -154,7 +147,6 @@ func TestFileWatch_IgnoreTiltIgnore(t *testing.T) {
 
 func TestFileWatch_IgnoreWatchSettings(t *testing.T) {
 	f := newFWFixture(t)
-	defer f.TearDown()
 
 	target := model.LocalTarget{
 		Name: "foo",
@@ -177,7 +169,6 @@ func TestFileWatch_IgnoreWatchSettings(t *testing.T) {
 
 func TestFileWatch_PickUpTiltIgnoreChanges(t *testing.T) {
 	f := newFWFixture(t)
-	defer f.TearDown()
 
 	target := model.LocalTarget{
 		Name: "foo",
@@ -227,7 +218,6 @@ func newFWFixture(t *testing.T) *fwFixture {
 	}
 
 	t.Cleanup(func() {
-		tmpdir.TearDown()
 		cancel()
 	})
 

--- a/internal/controllers/core/tiltfile/reconciler_test.go
+++ b/internal/controllers/core/tiltfile/reconciler_test.go
@@ -493,7 +493,6 @@ type fixture struct {
 func newFixture(t *testing.T) *fixture {
 	cfb := fake.NewControllerFixtureBuilder(t)
 	tf := tempdir.NewTempDirFixture(t)
-	t.Cleanup(tf.TearDown)
 
 	st := NewTestingStore()
 	tfl := tiltfile.NewFakeTiltfileLoader()

--- a/internal/dockercompose/client_test.go
+++ b/internal/dockercompose/client_test.go
@@ -147,7 +147,6 @@ func newDCFixture(t testing.TB) *dcFixture {
 	ctx, _, _ := testutils.CtxAndAnalyticsForTest()
 
 	tmpdir := tempdir.NewTempDirFixture(t)
-	t.Cleanup(tmpdir.TearDown)
 
 	return &dcFixture{
 		t:      t,

--- a/internal/dockerignore/ignore_test.go
+++ b/internal/dockerignore/ignore_test.go
@@ -13,7 +13,6 @@ import (
 
 func TestMatches(t *testing.T) {
 	tf := newTestFixture(t, "node_modules")
-	defer tf.TearDown()
 	tf.AssertResult(tf.JoinPath("node_modules", "foo"), true)
 	tf.AssertResult(tf.JoinPath("node_modules", "foo", "bar", "baz"), true)
 	tf.AssertResultEntireDir(tf.JoinPath("node_modules"), true)
@@ -23,21 +22,18 @@ func TestMatches(t *testing.T) {
 
 func TestComment(t *testing.T) {
 	tf := newTestFixture(t, "# generated code")
-	defer tf.TearDown()
 	tf.AssertResult(tf.JoinPath("node_modules", "foo"), false)
 	tf.AssertResult(tf.JoinPath("foo", "bar"), false)
 }
 
 func TestGlob(t *testing.T) {
 	tf := newTestFixture(t, "*/temp*")
-	defer tf.TearDown()
 	tf.AssertResult(tf.JoinPath("somedir", "temporary.txt"), true)
 	tf.AssertResult(tf.JoinPath("somedir", "temp"), true)
 }
 
 func TestCurrentDirDoubleGlob(t *testing.T) {
 	tf := newTestFixture(t, "**/temp*")
-	defer tf.TearDown()
 	tf.AssertResult(tf.JoinPath("a", "temporary.txt"), true)
 	tf.AssertResult(tf.JoinPath("a", "b", "temporary.txt"), true)
 	tf.AssertResult(tf.JoinPath("a", "b", "c", "temporary.txt"), true)
@@ -47,7 +43,6 @@ func TestCurrentDirDoubleGlob(t *testing.T) {
 
 func TestInnerDirDoubleGlob(t *testing.T) {
 	tf := newTestFixture(t, "a/**/temp*")
-	defer tf.TearDown()
 	tf.AssertResult(tf.JoinPath("a", "temporary.txt"), true)
 	tf.AssertResult(tf.JoinPath("a", "b", "temporary.txt"), true)
 	tf.AssertResult(tf.JoinPath("a", "b", "c", "temporary.txt"), true)
@@ -57,21 +52,18 @@ func TestInnerDirDoubleGlob(t *testing.T) {
 
 func TestUplevel(t *testing.T) {
 	tf := newTestFixture(t, "../a/b.txt")
-	defer tf.TearDown()
 	tf.AssertResult(tf.JoinPath("..", "a", "b.txt"), true)
 	tf.AssertResult(tf.JoinPath("a", "b.txt"), false)
 }
 
 func TestUplevelDoubleGlob(t *testing.T) {
 	tf := newTestFixture(t, "../**/b.txt")
-	defer tf.TearDown()
 	tf.AssertResult(tf.JoinPath("..", "a", "b.txt"), true)
 	tf.AssertResult(tf.JoinPath("a", "b.txt"), true)
 }
 
 func TestUplevelMatchDirDoubleGlob(t *testing.T) {
 	tf := newTestFixture(t, "../**/b")
-	defer tf.TearDown()
 	tf.AssertResult(tf.JoinPath("a", "temporary.txt"), false)
 	tf.AssertResult(tf.JoinPath("a", "b"), true)
 	tf.AssertResult(tf.JoinPath("a", "b", "temporary.txt"), true)
@@ -82,7 +74,6 @@ func TestUplevelMatchDirDoubleGlob(t *testing.T) {
 
 func TestOneCharacterExtension(t *testing.T) {
 	tf := newTestFixture(t, "temp?")
-	defer tf.TearDown()
 	tf.AssertResult(tf.JoinPath("tempa"), true)
 	tf.AssertResult(tf.JoinPath("tempeh"), false)
 	tf.AssertResult(tf.JoinPath("temp"), false)
@@ -90,7 +81,6 @@ func TestOneCharacterExtension(t *testing.T) {
 
 func TestException(t *testing.T) {
 	tf := newTestFixture(t, "docs", "!docs/README.md")
-	defer tf.TearDown()
 	tf.AssertResult(tf.JoinPath("docs", "stuff.md"), true)
 	tf.AssertResult(tf.JoinPath("docs", "README.md"), false)
 	tf.AssertResultEntireDir(tf.JoinPath("docs"), false)
@@ -98,7 +88,6 @@ func TestException(t *testing.T) {
 
 func TestNestedException(t *testing.T) {
 	tf := newTestFixture(t, "a", "!a/b", "a/b/c")
-	defer tf.TearDown()
 	tf.AssertResultEntireDir(tf.JoinPath("a"), false)
 	tf.AssertResultEntireDir(tf.JoinPath("a", "b"), false)
 	tf.AssertResultEntireDir(tf.JoinPath("a", "b", "c"), true)
@@ -106,14 +95,12 @@ func TestNestedException(t *testing.T) {
 
 func TestOrthogonalException(t *testing.T) {
 	tf := newTestFixture(t, "a", "b", "!b/README.md")
-	defer tf.TearDown()
 	tf.AssertResultEntireDir(tf.JoinPath("a"), true)
 	tf.AssertResultEntireDir(tf.JoinPath("b"), false)
 }
 
 func TestNoDockerignoreFile(t *testing.T) {
 	tf := newTestFixture(t)
-	defer tf.TearDown()
 	tf.AssertResult(tf.JoinPath("hi"), false)
 	tf.AssertResult(tf.JoinPath("hi", "hello"), false)
 	tf.AssertResultEntireDir(tf.JoinPath("hi"), false)
@@ -168,8 +155,4 @@ func (tf *testFixture) AssertResultEntireDir(path string, expectedMatches bool) 
 	} else if assert.NoError(tf.t, err) {
 		assert.Equalf(tf.t, expectedMatches, isIgnored, "Expected isIgnored to be %t for file %s, got %t", expectedMatches, path, isIgnored)
 	}
-}
-
-func (tf *testFixture) TearDown() {
-	tf.repoRoot.TearDown()
 }

--- a/internal/engine/build_and_deployer_live_update_test.go
+++ b/internal/engine/build_and_deployer_live_update_test.go
@@ -179,7 +179,6 @@ func runTestCase(t *testing.T, f *bdFixture, tCase testCase) {
 
 func TestLiveUpdateDockerBuildLocalContainer(t *testing.T) {
 	f := newBDFixture(t, k8s.EnvDockerDesktop, container.RuntimeDocker)
-	defer f.TearDown()
 
 	m := manifestbuilder.New(f, "sancho").
 		WithK8sYAML(SanchoYAML).
@@ -200,7 +199,6 @@ func TestLiveUpdateDockerBuildLocalContainer(t *testing.T) {
 
 func TestLiveUpdateDockerBuildLocalContainerSameImgMultipleContainers(t *testing.T) {
 	f := newBDFixture(t, k8s.EnvDockerDesktop, container.RuntimeDocker)
-	defer f.TearDown()
 
 	m := manifestbuilder.New(f, "sancho").
 		WithK8sYAML(SanchoYAML).
@@ -225,7 +223,6 @@ func TestLiveUpdateDockerBuildLocalContainerSameImgMultipleContainers(t *testing
 
 func TestLiveUpdateDockerBuildExecSameImgMultipleContainers(t *testing.T) {
 	f := newBDFixture(t, k8s.EnvGKE, container.RuntimeCrio)
-	defer f.TearDown()
 
 	iTarg := NewSanchoDockerBuildImageTarget(f)
 	lu := assembleLiveUpdate(SanchoSyncSteps(f), nil, false, []string{"i/match/nothing"}, f)
@@ -250,7 +247,6 @@ func TestLiveUpdateDockerBuildExecSameImgMultipleContainers(t *testing.T) {
 
 func TestLiveUpdateDockerBuildLocalContainerDiffImgMultipleContainers(t *testing.T) {
 	f := newBDFixture(t, k8s.EnvDockerDesktop, container.RuntimeDocker)
-	defer f.TearDown()
 
 	sanchoTarg := NewSanchoLiveUpdateImageTarget(f)
 	sidecarTarg := NewSanchoSidecarLiveUpdateImageTarget(f)
@@ -278,7 +274,6 @@ func TestLiveUpdateDockerBuildLocalContainerDiffImgMultipleContainers(t *testing
 
 func TestLiveUpdateDockerBuildExecDiffImgMultipleContainers(t *testing.T) {
 	f := newBDFixture(t, k8s.EnvGKE, container.RuntimeCrio)
-	defer f.TearDown()
 
 	sanchoLU := assembleLiveUpdate(SanchoSyncSteps(f), SanchoRunSteps, false, nil, f)
 	sidecarLU := assembleLiveUpdate(SyncStepsForApp("sidecar", f), RunStepsForApp("sidecar"),
@@ -309,7 +304,6 @@ func TestLiveUpdateDockerBuildExecDiffImgMultipleContainers(t *testing.T) {
 
 func TestLiveUpdateDiffImgMultipleContainersOnlySomeSyncsMatch(t *testing.T) {
 	f := newBDFixture(t, k8s.EnvGKE, container.RuntimeCrio)
-	defer f.TearDown()
 
 	sanchoPath := f.JoinPath("sancho")
 	sanchoSyncs := SanchoSyncSteps(f)
@@ -359,7 +353,6 @@ func TestLiveUpdateDiffImgMultipleContainersOnlySomeSyncsMatch(t *testing.T) {
 
 func TestLiveUpdateDiffImgMultipleContainersSameContextOnlyOneLiveUpdate(t *testing.T) {
 	f := newBDFixture(t, k8s.EnvGKE, container.RuntimeCrio)
-	defer f.TearDown()
 
 	buildContext := f.Path()
 	sanchoSyncs := SanchoSyncSteps(f)
@@ -398,7 +391,6 @@ func TestLiveUpdateDiffImgMultipleContainersSameContextOnlyOneLiveUpdate(t *test
 
 func TestLiveUpdateDiffImgMultipleContainersFallBackIfFilesDoesntMatchAnySyncs(t *testing.T) {
 	f := newBDFixture(t, k8s.EnvGKE, container.RuntimeCrio)
-	defer f.TearDown()
 
 	sanchoSyncs := SanchoSyncSteps(f)
 	sanchoSyncs[0].LocalPath = f.JoinPath("sancho")
@@ -442,7 +434,6 @@ func TestLiveUpdateDiffImgMultipleContainersFallBackIfFilesDoesntMatchAnySyncs(t
 
 func TestLiveUpdateDockerContainerUserRunFailureDoesntFallBack(t *testing.T) {
 	f := newBDFixture(t, k8s.EnvDockerDesktop, container.RuntimeDocker)
-	defer f.TearDown()
 
 	m := manifestbuilder.New(f, "sancho").
 		WithK8sYAML(SanchoYAML).
@@ -473,7 +464,6 @@ func TestLiveUpdateDockerContainerUserRunFailureDoesntFallBack(t *testing.T) {
 
 func TestLiveUpdateExecUserRunFailureDoesntFallBack(t *testing.T) {
 	f := newBDFixture(t, k8s.EnvDockerDesktop, container.RuntimeCrio)
-	defer f.TearDown()
 
 	f.k8s.ExecErrors = []error{nil, userFailureErrExec}
 
@@ -504,7 +494,6 @@ func TestLiveUpdateExecUserRunFailureDoesntFallBack(t *testing.T) {
 // If any container updates fail with a non-UserRunFailure, fall back to image build.
 func TestLiveUpdateMultipleContainersFallsBackForFailure(t *testing.T) {
 	f := newBDFixture(t, k8s.EnvDockerDesktop, container.RuntimeDocker)
-	defer f.TearDown()
 
 	f.docker.SetExecError(fmt.Errorf("egads"))
 
@@ -534,7 +523,6 @@ func TestLiveUpdateMultipleContainersFallsBackForFailure(t *testing.T) {
 // fail with a non-UserRunFailure, fall back to image build.
 func TestLiveUpdateMultipleContainersFallsBackForFailureAfterSuccess(t *testing.T) {
 	f := newBDFixture(t, k8s.EnvDockerDesktop, container.RuntimeDocker)
-	defer f.TearDown()
 
 	// First call = no error, second call = error
 	f.docker.ExecErrorsToThrow = []error{nil, fmt.Errorf("egads")}
@@ -567,7 +555,6 @@ func TestLiveUpdateMultipleContainersFallsBackForFailureAfterSuccess(t *testing.
 // all containers. If ALL the updates fail with a UserRunFailure, don't fall back.
 func TestLiveUpdateMultipleContainersUpdatesAllForUserRunFailuresAndDoesntFallBack(t *testing.T) {
 	f := newBDFixture(t, k8s.EnvDockerDesktop, container.RuntimeDocker)
-	defer f.TearDown()
 
 	// Same UserRunFailure on all three exec calls
 	f.docker.ExecErrorsToThrow = []error{userFailureErrDocker, userFailureErrDocker, userFailureErrDocker}
@@ -605,7 +592,6 @@ func TestLiveUpdateMultipleContainersUpdatesAllForUserRunFailuresAndDoesntFallBa
 // with a non-UserRunFailure), fall back to an image build.
 func TestLiveUpdateMultipleContainersFallsBackForSomeUserRunFailuresSomeSuccess(t *testing.T) {
 	f := newBDFixture(t, k8s.EnvDockerDesktop, container.RuntimeDocker)
-	defer f.TearDown()
 
 	f.docker.ExecErrorsToThrow = []error{userFailureErrDocker, nil, userFailureErrDocker}
 
@@ -636,7 +622,6 @@ func TestLiveUpdateMultipleContainersFallsBackForSomeUserRunFailuresSomeSuccess(
 
 func TestLiveUpdateMultipleContainersFallsBackForSomeUserRunFailuresSomeNonUserFailures(t *testing.T) {
 	f := newBDFixture(t, k8s.EnvDockerDesktop, container.RuntimeDocker)
-	defer f.TearDown()
 
 	f.docker.ExecErrorsToThrow = []error{
 		userFailureErrDocker,
@@ -670,7 +655,6 @@ func TestLiveUpdateMultipleContainersFallsBackForSomeUserRunFailuresSomeNonUserF
 
 func TestLiveUpdateCustomBuildLocalContainer(t *testing.T) {
 	f := newBDFixture(t, k8s.EnvDockerDesktop, container.RuntimeDocker)
-	defer f.TearDown()
 
 	lu := assembleLiveUpdate(SanchoSyncSteps(f), SanchoRunSteps, true, []string{"i/match/nothing"}, f)
 	tCase := testCase{
@@ -692,7 +676,6 @@ func TestLiveUpdateCustomBuildLocalContainer(t *testing.T) {
 
 func TestLiveUpdateHotReloadLocalContainer(t *testing.T) {
 	f := newBDFixture(t, k8s.EnvDockerDesktop, container.RuntimeDocker)
-	defer f.TearDown()
 
 	lu := assembleLiveUpdate(SanchoSyncSteps(f), SanchoRunSteps, false, nil, f)
 	tCase := testCase{
@@ -714,7 +697,6 @@ func TestLiveUpdateHotReloadLocalContainer(t *testing.T) {
 
 func TestLiveUpdateRunTriggerLocalContainer(t *testing.T) {
 	f := newBDFixture(t, k8s.EnvDockerDesktop, container.RuntimeDocker)
-	defer f.TearDown()
 
 	runs := []v1alpha1.LiveUpdateExec{
 		{Args: model.ToUnixCmd("echo hello").Argv},
@@ -741,7 +723,6 @@ func TestLiveUpdateRunTriggerLocalContainer(t *testing.T) {
 
 func TestLiveUpdateRunTriggerExec(t *testing.T) {
 	f := newBDFixture(t, k8s.EnvGKE, container.RuntimeDocker)
-	defer f.TearDown()
 
 	runs := []v1alpha1.LiveUpdateExec{
 		{Args: model.ToUnixCmd("echo hello").Argv},
@@ -769,7 +750,6 @@ func TestLiveUpdateRunTriggerExec(t *testing.T) {
 
 func TestLiveUpdateCustomBuildExec(t *testing.T) {
 	f := newBDFixture(t, k8s.EnvGKE, container.RuntimeDocker)
-	defer f.TearDown()
 
 	lu := assembleLiveUpdate(SanchoSyncSteps(f), SanchoRunSteps, false, nil, f)
 	tCase := testCase{
@@ -792,7 +772,6 @@ func TestLiveUpdateCustomBuildExec(t *testing.T) {
 
 func TestLiveUpdateExecDoesNotSupportRestart(t *testing.T) {
 	f := newBDFixture(t, k8s.EnvGKE, container.RuntimeContainerd)
-	defer f.TearDown()
 
 	lu := assembleLiveUpdate(SanchoSyncSteps(f), SanchoRunSteps, true, []string{"i/match/nothing"}, f)
 	tCase := testCase{
@@ -816,7 +795,6 @@ func TestLiveUpdateExecDoesNotSupportRestart(t *testing.T) {
 
 func TestLiveUpdateDockerBuildExec(t *testing.T) {
 	f := newBDFixture(t, k8s.EnvGKE, container.RuntimeContainerd)
-	defer f.TearDown()
 
 	lu := assembleLiveUpdate(SanchoSyncSteps(f), SanchoRunSteps, false, nil, f)
 	tCase := testCase{
@@ -836,7 +814,6 @@ func TestLiveUpdateDockerBuildExec(t *testing.T) {
 
 func TestLiveUpdateLocalContainerFallBackOn(t *testing.T) {
 	f := newBDFixture(t, k8s.EnvDockerDesktop, container.RuntimeDocker)
-	defer f.TearDown()
 
 	lu := assembleLiveUpdate(SanchoSyncSteps(f), SanchoRunSteps, true, []string{"a.txt"}, f)
 	tCase := testCase{
@@ -860,7 +837,6 @@ func TestLiveUpdateLocalContainerFallBackOn(t *testing.T) {
 
 func TestLiveUpdateExecFallBackOn(t *testing.T) {
 	f := newBDFixture(t, k8s.EnvGKE, container.RuntimeDocker)
-	defer f.TearDown()
 
 	lu := assembleLiveUpdate(SanchoSyncSteps(f), SanchoRunSteps, false, []string{"a.txt"}, f)
 	tCase := testCase{
@@ -884,7 +860,6 @@ func TestLiveUpdateExecFallBackOn(t *testing.T) {
 
 func TestLiveUpdateLocalContainerChangedFileNotMatchingSyncFallsBack(t *testing.T) {
 	f := newBDFixture(t, k8s.EnvDockerDesktop, container.RuntimeDocker)
-	defer f.TearDown()
 
 	steps := []v1alpha1.LiveUpdateSync{{
 		LocalPath:     filepath.Join("specific", "directory"),
@@ -916,7 +891,6 @@ func TestLiveUpdateLocalContainerChangedFileNotMatchingSyncFallsBack(t *testing.
 
 func TestLiveUpdateExecChangedFileNotMatchingSyncFallsBack(t *testing.T) {
 	f := newBDFixture(t, k8s.EnvGKE, container.RuntimeDocker)
-	defer f.TearDown()
 
 	steps := []v1alpha1.LiveUpdateSync{{
 		LocalPath:     filepath.Join("specific", "directory"),
@@ -948,7 +922,6 @@ func TestLiveUpdateExecChangedFileNotMatchingSyncFallsBack(t *testing.T) {
 
 func TestLiveUpdateManyFilesNotMatching(t *testing.T) {
 	f := newBDFixture(t, k8s.EnvGKE, container.RuntimeDocker)
-	defer f.TearDown()
 
 	steps := []v1alpha1.LiveUpdateSync{{
 		LocalPath:     filepath.Join("specific", "directory"),
@@ -992,7 +965,6 @@ func TestLiveUpdateManyFilesNotMatching(t *testing.T) {
 
 func TestLiveUpdateSomeFilesMatchSyncSomeDontFallsBack(t *testing.T) {
 	f := newBDFixture(t, k8s.EnvDockerDesktop, container.RuntimeDocker)
-	defer f.TearDown()
 
 	steps := []v1alpha1.LiveUpdateSync{{
 		LocalPath:     filepath.Join("specific", "directory"),
@@ -1025,7 +997,6 @@ func TestLiveUpdateSomeFilesMatchSyncSomeDontFallsBack(t *testing.T) {
 
 func TestLiveUpdateInFirstImageOfImageDependency(t *testing.T) {
 	f := newBDFixture(t, k8s.EnvDockerDesktop, container.RuntimeDocker)
-	defer f.TearDown()
 
 	steps := []v1alpha1.LiveUpdateSync{{
 		LocalPath:     "sancho-base",
@@ -1052,7 +1023,6 @@ func TestLiveUpdateInFirstImageOfImageDependency(t *testing.T) {
 
 func TestLiveUpdateInFirstImageOfImageDependencyWithoutSync(t *testing.T) {
 	f := newBDFixture(t, k8s.EnvDockerDesktop, container.RuntimeDocker)
-	defer f.TearDown()
 
 	steps := []v1alpha1.LiveUpdateSync{{
 		LocalPath:     "sancho",
@@ -1078,7 +1048,6 @@ func TestLiveUpdateInFirstImageOfImageDependencyWithoutSync(t *testing.T) {
 
 func TestLiveUpdateInSecondImageOfImageDependency(t *testing.T) {
 	f := newBDFixture(t, k8s.EnvDockerDesktop, container.RuntimeDocker)
-	defer f.TearDown()
 
 	steps := []v1alpha1.LiveUpdateSync{{
 		LocalPath:     "sancho",

--- a/internal/engine/build_and_deployer_test.go
+++ b/internal/engine/build_and_deployer_test.go
@@ -67,7 +67,6 @@ var testContainerInfo = liveupdates.Container{
 
 func TestGKEDeploy(t *testing.T) {
 	f := newBDFixture(t, k8s.EnvGKE, container.RuntimeDocker)
-	defer f.TearDown()
 
 	manifest := NewSanchoLiveUpdateManifest(f)
 	targets := buildcontrol.BuildTargets(manifest)
@@ -92,7 +91,6 @@ func TestGKEDeploy(t *testing.T) {
 
 func TestDockerForMacDeploy(t *testing.T) {
 	f := newBDFixture(t, k8s.EnvDockerDesktop, container.RuntimeDocker)
-	defer f.TearDown()
 
 	manifest := NewSanchoDockerBuildManifest(f)
 	targets := buildcontrol.BuildTargets(manifest)
@@ -117,7 +115,6 @@ func TestDockerForMacDeploy(t *testing.T) {
 
 func TestYamlManifestDeploy(t *testing.T) {
 	f := newBDFixture(t, k8s.EnvGKE, container.RuntimeDocker)
-	defer f.TearDown()
 
 	manifest := manifestbuilder.New(f, "some_yaml").
 		WithK8sYAML(testyaml.TracerYAML).Build()
@@ -134,7 +131,6 @@ func TestYamlManifestDeploy(t *testing.T) {
 
 func TestLiveUpdateTaskKilled(t *testing.T) {
 	f := newBDFixture(t, k8s.EnvDockerDesktop, container.RuntimeDocker)
-	defer f.TearDown()
 
 	changed := f.WriteFile("a.txt", "a")
 
@@ -161,7 +157,6 @@ func TestLiveUpdateTaskKilled(t *testing.T) {
 
 func TestFallBackToImageDeploy(t *testing.T) {
 	f := newBDFixture(t, k8s.EnvDockerDesktop, container.RuntimeDocker)
-	defer f.TearDown()
 
 	f.docker.SetExecError(errors.New("some random error"))
 
@@ -183,7 +178,6 @@ func TestFallBackToImageDeploy(t *testing.T) {
 
 func TestLiveUpdateFallbackMessagingRedirect(t *testing.T) {
 	f := newBDFixture(t, k8s.EnvDockerDesktop, container.RuntimeDocker)
-	defer f.TearDown()
 
 	syncs := []v1alpha1.LiveUpdateSync{
 		{LocalPath: ".", ContainerPath: "/blah"},
@@ -217,7 +211,6 @@ func TestLiveUpdateFallbackMessagingRedirect(t *testing.T) {
 
 func TestLiveUpdateFallbackMessagingUnexpectedError(t *testing.T) {
 	f := newBDFixture(t, k8s.EnvDockerDesktop, container.RuntimeDocker)
-	defer f.TearDown()
 
 	f.docker.SetExecError(errors.New("some random error"))
 
@@ -246,7 +239,6 @@ func TestLiveUpdateFallbackMessagingUnexpectedError(t *testing.T) {
 
 func TestLiveUpdateTwice(t *testing.T) {
 	f := newBDFixture(t, k8s.EnvDockerDesktop, container.RuntimeDocker)
-	defer f.TearDown()
 
 	manifest := manifestbuilder.New(f, "sancho").
 		WithK8sYAML(SanchoYAML).
@@ -288,7 +280,6 @@ func TestLiveUpdateTwice(t *testing.T) {
 // and make sure the next image build gets the right file updates.
 func TestLiveUpdateTwiceDeadPod(t *testing.T) {
 	f := newBDFixture(t, k8s.EnvDockerDesktop, container.RuntimeDocker)
-	defer f.TearDown()
 
 	manifest := manifestbuilder.New(f, "sancho").
 		WithK8sYAML(SanchoYAML).
@@ -331,7 +322,6 @@ func TestLiveUpdateTwiceDeadPod(t *testing.T) {
 
 func TestIgnoredFiles(t *testing.T) {
 	f := newBDFixture(t, k8s.EnvDockerDesktop, container.RuntimeDocker)
-	defer f.TearDown()
 
 	manifest := NewSanchoDockerBuildManifest(f)
 
@@ -371,7 +361,6 @@ func TestIgnoredFiles(t *testing.T) {
 
 func TestCustomBuild(t *testing.T) {
 	f := newBDFixture(t, k8s.EnvGKE, container.RuntimeDocker)
-	defer f.TearDown()
 	sha := digest.Digest("sha256:11cd0eb38bc3ceb958ffb2f9bd70be3fb317ce7d255c8a4c3f4af30e298aa1aab")
 	f.docker.Images["gcr.io/some-project-162817/sancho:tilt-build-1551202573"] = types.ImageInspect{ID: string(sha)}
 
@@ -394,7 +383,6 @@ func TestCustomBuild(t *testing.T) {
 
 func TestCustomBuildDeterministicTag(t *testing.T) {
 	f := newBDFixture(t, k8s.EnvGKE, container.RuntimeDocker)
-	defer f.TearDown()
 	refStr := "gcr.io/some-project-162817/sancho:deterministic-tag"
 	sha := digest.Digest("sha256:11cd0eb38bc3ceb958ffb2f9bd70be3fb317ce7d255c8a4c3f4af30e298aa1aab")
 	f.docker.Images[refStr] = types.ImageInspect{ID: string(sha)}
@@ -418,7 +406,6 @@ func TestCustomBuildDeterministicTag(t *testing.T) {
 
 func TestContainerBuildMultiStage(t *testing.T) {
 	f := newBDFixture(t, k8s.EnvDockerDesktop, container.RuntimeDocker)
-	defer f.TearDown()
 
 	manifest := NewSanchoLiveUpdateMultiStageManifest(f)
 	targets := buildcontrol.BuildTargets(manifest)
@@ -456,7 +443,6 @@ func TestContainerBuildMultiStage(t *testing.T) {
 
 func TestDockerComposeImageBuild(t *testing.T) {
 	f := newBDFixture(t, k8s.EnvGKE, container.RuntimeDocker)
-	defer f.TearDown()
 
 	manifest := NewSanchoLiveUpdateDCManifest(f)
 	targets := buildcontrol.BuildTargets(manifest)
@@ -474,7 +460,6 @@ func TestDockerComposeImageBuild(t *testing.T) {
 
 func TestDockerComposeLiveUpdate(t *testing.T) {
 	f := newBDFixture(t, k8s.EnvGKE, container.RuntimeContainerd)
-	defer f.TearDown()
 
 	manifest := NewSanchoLiveUpdateDCManifest(f)
 	targets := buildcontrol.BuildTargets(manifest)
@@ -498,7 +483,6 @@ func TestDockerComposeLiveUpdate(t *testing.T) {
 
 func TestReturnLastUnexpectedError(t *testing.T) {
 	f := newBDFixture(t, k8s.EnvDockerDesktop, container.RuntimeDocker)
-	defer f.TearDown()
 
 	// next Docker build will throw an unexpected error -- this is one we want to return,
 	// even if subsequent builders throw expected errors.
@@ -514,7 +498,6 @@ func TestReturnLastUnexpectedError(t *testing.T) {
 // errors get logged by the upper, so make sure our builder isn't logging the error redundantly
 func TestDockerBuildErrorNotLogged(t *testing.T) {
 	f := newBDFixture(t, k8s.EnvGKE, container.RuntimeDocker)
-	defer f.TearDown()
 
 	// next Docker build will throw an unexpected error -- this is one we want to return,
 	// even if subsequent builders throw expected errors.
@@ -532,7 +515,6 @@ func TestDockerBuildErrorNotLogged(t *testing.T) {
 
 func TestLiveUpdateWithRunFailureReturnsContainerIDs(t *testing.T) {
 	f := newBDFixture(t, k8s.EnvDockerDesktop, container.RuntimeDocker)
-	defer f.TearDown()
 
 	// LiveUpdate will failure with a RunStepFailure
 	f.docker.SetExecError(userFailureErrDocker)
@@ -566,7 +548,6 @@ func TestLiveUpdateWithRunFailureReturnsContainerIDs(t *testing.T) {
 
 func TestLiveUpdateMultipleImagesSamePod(t *testing.T) {
 	f := newBDFixture(t, k8s.EnvDockerDesktop, container.RuntimeDocker)
-	defer f.TearDown()
 
 	manifest, bs := multiImageLiveUpdateManifestAndBuildState(f)
 	_, err := f.BuildAndDeploy(buildcontrol.BuildTargets(manifest), bs)
@@ -591,7 +572,6 @@ func TestLiveUpdateMultipleImagesSamePod(t *testing.T) {
 
 func TestOneLiveUpdateOneDockerBuildDoesImageBuild(t *testing.T) {
 	f := newBDFixture(t, k8s.EnvGKE, container.RuntimeDocker)
-	defer f.TearDown()
 
 	sanchoTarg := NewSanchoLiveUpdateImageTarget(f)          // first target = LiveUpdate
 	sidecarTarg := NewSanchoSidecarDockerBuildImageTarget(f) // second target = DockerBuild
@@ -631,7 +611,6 @@ func TestLiveUpdateMultipleImagesOneRunErrorExecutesRestOfLiveUpdatesAndDoesntIm
 		t.Skip("TODO(nick): fix this")
 	}
 	f := newBDFixture(t, k8s.EnvDockerDesktop, container.RuntimeDocker)
-	defer f.TearDown()
 
 	// First LiveUpdate will simulate a failed Run step
 	f.docker.ExecErrorsToThrow = []error{userFailureErrDocker}
@@ -659,7 +638,6 @@ func TestLiveUpdateMultipleImagesOneRunErrorExecutesRestOfLiveUpdatesAndDoesntIm
 
 func TestLiveUpdateMultipleImagesOneUpdateErrorFallsBackToImageBuild(t *testing.T) {
 	f := newBDFixture(t, k8s.EnvDockerDesktop, container.RuntimeDocker)
-	defer f.TearDown()
 
 	// Second LiveUpdate will throw an error
 	f.docker.ExecErrorsToThrow = []error{nil, fmt.Errorf("whelp ¯\\_(ツ)_/¯")}
@@ -682,7 +660,6 @@ func TestLiveUpdateMultipleImagesOneUpdateErrorFallsBackToImageBuild(t *testing.
 
 func TestLiveUpdateMultipleImagesOneWithUnsyncedChangeFileFallsBackToImageBuild(t *testing.T) {
 	f := newBDFixture(t, k8s.EnvGKE, container.RuntimeDocker)
-	defer f.TearDown()
 
 	manifest, bs := multiImageLiveUpdateManifestAndBuildState(f)
 	bs[manifest.ImageTargetAt(1).ID()].FilesChangedSet["/not/synced"] = true // changed file not in a sync --> fall back to image build
@@ -699,7 +676,6 @@ func TestLiveUpdateMultipleImagesOneWithUnsyncedChangeFileFallsBackToImageBuild(
 
 func TestLocalTargetDeploy(t *testing.T) {
 	f := newBDFixture(t, k8s.EnvGKE, container.RuntimeDocker)
-	defer f.TearDown()
 
 	lt := model.NewLocalTarget("hello-world", model.ToHostCmd("echo hello world"), model.Cmd{}, nil)
 	res, err := f.BuildAndDeploy([]model.TargetSpec{lt}, store.BuildStateSet{})
@@ -714,7 +690,6 @@ func TestLocalTargetDeploy(t *testing.T) {
 
 func TestLocalTargetFailure(t *testing.T) {
 	f := newBDFixture(t, k8s.EnvGKE, container.RuntimeDocker)
-	defer f.TearDown()
 
 	lt := model.NewLocalTarget("hello-world", model.ToHostCmd("echo 'oh no' && exit 1"), model.Cmd{}, nil)
 	res, err := f.BuildAndDeploy([]model.TargetSpec{lt}, store.BuildStateSet{})
@@ -830,7 +805,7 @@ func newBDFixtureWithUpdateMode(t *testing.T, env k8s.Env, runtime container.Run
 		fakeClock{now: time.Unix(1551202573, 0)}, kl, ta, ctrlClient, st, execer)
 	require.NoError(t, err)
 
-	return &bdFixture{
+	ret := &bdFixture{
 		TempDirFixture: f,
 		ctx:            ctx,
 		cancel:         cancel,
@@ -842,12 +817,13 @@ func newBDFixtureWithUpdateMode(t *testing.T, env k8s.Env, runtime container.Run
 		logs:           logs,
 		ctrlClient:     ctrlClient,
 	}
+
+	t.Cleanup(ret.TearDown)
+	return ret
 }
 
 func (f *bdFixture) TearDown() {
-	f.k8s.TearDown()
 	f.cancel()
-	f.TempDirFixture.TearDown()
 }
 
 func (f *bdFixture) NewPathSet(paths ...string) model.PathSet {

--- a/internal/engine/buildcontrol/build_control_test.go
+++ b/internal/engine/buildcontrol/build_control_test.go
@@ -27,7 +27,6 @@ import (
 
 func TestNextTargetToBuildDoesntReturnCurrentlyBuildingTarget(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 
 	mt := f.manifestNeedingCrashRebuild()
 	f.st.UpsertManifestTarget(mt)
@@ -42,7 +41,6 @@ func TestNextTargetToBuildDoesntReturnCurrentlyBuildingTarget(t *testing.T) {
 
 func TestCurrentlyBuildingK8sResourceDisablesLocalScheduling(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 
 	k8s1 := f.upsertK8sManifest("k8s1")
 	k8s2 := f.upsertK8sManifest("k8s2")
@@ -60,7 +58,6 @@ func TestCurrentlyBuildingK8sResourceDisablesLocalScheduling(t *testing.T) {
 
 func TestCurrentlyBuildingK8sResourceDoesNotCreateHoldIfResourceNotPending(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 
 	k8s1 := f.upsertK8sManifest("k8s1")
 	k8s2 := f.upsertK8sManifest("k8s2")
@@ -81,7 +78,6 @@ func TestCurrentlyBuildingK8sResourceDoesNotCreateHoldIfResourceNotPending(t *te
 
 func TestCurrentlyBuildingUncategorizedDisablesOtherK8sTargets(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 
 	_ = f.upsertK8sManifest("k8s1")
 	k8sUnresourced := f.upsertK8sManifest(model.UnresourcedYAMLManifestName)
@@ -97,7 +93,6 @@ func TestCurrentlyBuildingUncategorizedDisablesOtherK8sTargets(t *testing.T) {
 
 func TestK8sDependsOnLocal(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 
 	k8s1 := f.upsertK8sManifest("k8s1", withResourceDeps("local1"))
 	k8s2 := f.upsertK8sManifest("k8s2")
@@ -125,7 +120,6 @@ func TestK8sDependsOnLocal(t *testing.T) {
 
 func TestLocalDependsOnNonWorkloadK8s(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 
 	local1 := f.upsertLocalManifest("local1", withResourceDeps("k8s1"))
 	k8s1 := f.upsertK8sManifest("k8s1", withK8sPodReadiness(model.PodReadinessIgnore))
@@ -157,7 +151,6 @@ func TestLocalDependsOnNonWorkloadK8s(t *testing.T) {
 
 func TestK8sDependsOnCluster(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 
 	f.st.Clusters["default"].Status.Error = "connection error"
 
@@ -176,7 +169,6 @@ func TestK8sDependsOnCluster(t *testing.T) {
 
 func TestCurrentlyBuildingLocalResourceDisablesK8sScheduling(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 
 	f.upsertK8sManifest("k8s1")
 	f.upsertK8sManifest("k8s2")
@@ -193,7 +185,6 @@ func TestCurrentlyBuildingLocalResourceDisablesK8sScheduling(t *testing.T) {
 
 func TestCurrentlyBuildingParallelLocalResource(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 
 	f.upsertK8sManifest("k8s1")
 	local1 := f.upsertLocalManifest("local1", func(m manifestbuilder.ManifestBuilder) manifestbuilder.ManifestBuilder {
@@ -214,7 +205,6 @@ func TestCurrentlyBuildingParallelLocalResource(t *testing.T) {
 
 func TestTriggerIneligibleResource(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 
 	// local1 has a build in progress
 	local1 := f.upsertLocalManifest("local1", func(m manifestbuilder.ManifestBuilder) manifestbuilder.ManifestBuilder {
@@ -232,7 +222,6 @@ func TestTriggerIneligibleResource(t *testing.T) {
 
 func TestTwoK8sTargetsWithBaseImage(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 
 	baseImage := newDockerImageTarget("sancho-base")
 	sanchoOneImage := newDockerImageTarget("sancho-one").
@@ -267,7 +256,6 @@ func TestTwoK8sTargetsWithBaseImage(t *testing.T) {
 
 func TestLiveUpdateMainImageHold(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 
 	srcFile := f.JoinPath("src", "a.txt")
 	f.WriteFile(srcFile, "hello")
@@ -330,7 +318,6 @@ func TestLiveUpdateMainImageHold(t *testing.T) {
 // and the image target matching the deployed container.
 func TestLiveUpdateBaseImageHold(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 
 	srcFile := f.JoinPath("base", "a.txt")
 	f.WriteFile(srcFile, "hello")
@@ -391,7 +378,6 @@ func TestLiveUpdateBaseImageHold(t *testing.T) {
 
 func TestTwoK8sTargetsWithBaseImagePrebuilt(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 
 	baseImage := newDockerImageTarget("sancho-base")
 	sanchoOneImage := newDockerImageTarget("sancho-one").
@@ -421,7 +407,6 @@ func TestTwoK8sTargetsWithBaseImagePrebuilt(t *testing.T) {
 
 func TestHoldForDeploy(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 
 	srcFile := f.JoinPath("src", "a.txt")
 	objFile := f.JoinPath("obj", "a.out")
@@ -489,7 +474,6 @@ func TestHoldForDeploy(t *testing.T) {
 
 func TestHoldForManualLiveUpdate(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 
 	srcFile := f.JoinPath("src", "a.txt")
 	f.WriteFile(srcFile, "hello")
@@ -537,7 +521,6 @@ func TestHoldForManualLiveUpdate(t *testing.T) {
 
 func TestHoldDisabled(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 
 	f.upsertLocalManifest("local")
 	f.st.ManifestTargets["local"].State.DisableState = v1alpha1.DisableStateDisabled
@@ -548,7 +531,6 @@ func TestHoldDisabled(t *testing.T) {
 
 func TestHoldIfAnyDisableStatusPending(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 
 	f.upsertLocalManifest("local1")
 	f.upsertLocalManifest("local2")

--- a/internal/engine/buildcontrol/docker_compose_build_and_deployer_test.go
+++ b/internal/engine/buildcontrol/docker_compose_build_and_deployer_test.go
@@ -27,7 +27,6 @@ import (
 
 func TestDockerComposeTargetBuilt(t *testing.T) {
 	f := newDCBDFixture(t)
-	defer f.TearDown()
 
 	expectedContainerID := "fake-container-id"
 	f.dcCli.ContainerIdOutput = container.ID(expectedContainerID)
@@ -53,7 +52,6 @@ func TestDockerComposeTargetBuilt(t *testing.T) {
 
 func TestTiltBuildsImage(t *testing.T) {
 	f := newDCBDFixture(t)
-	defer f.TearDown()
 
 	iTarget := NewSanchoDockerBuildImageTarget(f)
 	manifest := manifestbuilder.New(f, "fe").
@@ -85,7 +83,6 @@ func TestTiltBuildsImage(t *testing.T) {
 
 func TestTiltBuildsImageWithTag(t *testing.T) {
 	f := newDCBDFixture(t)
-	defer f.TearDown()
 
 	refWithTag := "gcr.io/foo:bar"
 	iTarget := model.MustNewImageTarget(container.MustParseSelector(refWithTag)).
@@ -105,7 +102,6 @@ func TestTiltBuildsImageWithTag(t *testing.T) {
 
 func TestDCBADRejectsAllSpecsIfOneUnsupported(t *testing.T) {
 	f := newDCBDFixture(t)
-	defer f.TearDown()
 
 	specs := []model.TargetSpec{model.DockerComposeTarget{}, model.ImageTarget{}, model.K8sTarget{}}
 
@@ -116,7 +112,6 @@ func TestDCBADRejectsAllSpecsIfOneUnsupported(t *testing.T) {
 
 func TestMultiStageDockerCompose(t *testing.T) {
 	f := newDCBDFixture(t)
-	defer f.TearDown()
 
 	manifest := NewSanchoDockerBuildMultiStageManifest(f).
 		WithDeployTarget(defaultDockerComposeTarget(f, "sancho"))
@@ -144,7 +139,6 @@ ENTRYPOINT /go/bin/sancho
 
 func TestMultiStageDockerComposeWithOnlyOneDirtyImage(t *testing.T) {
 	f := newDCBDFixture(t)
-	defer f.TearDown()
 
 	manifest := NewSanchoDockerBuildMultiStageManifest(f).
 		WithDeployTarget(defaultDockerComposeTarget(f, "sancho"))

--- a/internal/engine/buildcontrol/image_build_and_deployer_test.go
+++ b/internal/engine/buildcontrol/image_build_and_deployer_test.go
@@ -41,7 +41,6 @@ import (
 
 func TestDeployTwinImages(t *testing.T) {
 	f := newIBDFixture(t, k8s.EnvGKE)
-	defer f.TearDown()
 
 	sancho := NewSanchoDockerBuildManifest(f)
 	newK8sTarget := k8s.MustTarget("sancho", yaml.ConcatYAML(SanchoYAML, SanchoTwinYAML)).
@@ -62,7 +61,6 @@ func TestDeployTwinImages(t *testing.T) {
 
 func TestForceUpdate(t *testing.T) {
 	f := newIBDFixture(t, k8s.EnvGKE)
-	defer f.TearDown()
 
 	m := NewSanchoDockerBuildManifest(f)
 
@@ -79,7 +77,6 @@ func TestForceUpdate(t *testing.T) {
 
 func TestForceUpdateDoesNotDeleteNamespace(t *testing.T) {
 	f := newIBDFixture(t, k8s.EnvGKE)
-	defer f.TearDown()
 
 	m := manifestbuilder.New(f, "sancho").
 		WithK8sYAML(SanchoYAML + `
@@ -112,7 +109,6 @@ metadata:
 
 func TestDeleteShouldHappenInReverseOrder(t *testing.T) {
 	f := newIBDFixture(t, k8s.EnvGKE)
-	defer f.TearDown()
 
 	m := newK8sMultiEntityManifest("sancho")
 
@@ -124,7 +120,6 @@ func TestDeleteShouldHappenInReverseOrder(t *testing.T) {
 
 func TestDeployPodWithMultipleImages(t *testing.T) {
 	f := newIBDFixture(t, k8s.EnvGKE)
-	defer f.TearDown()
 
 	iTarget1 := NewSanchoDockerBuildImageTarget(f)
 	iTarget2 := NewSanchoSidecarDockerBuildImageTarget(f)
@@ -154,7 +149,6 @@ func TestDeployPodWithMultipleImages(t *testing.T) {
 
 func TestDeployPodWithMultipleLiveUpdateImages(t *testing.T) {
 	f := newIBDFixture(t, k8s.EnvGKE)
-	defer f.TearDown()
 
 	iTarget1 := NewSanchoLiveUpdateImageTarget(f)
 	iTarget2 := NewSanchoSidecarLiveUpdateImageTarget(f)
@@ -185,7 +179,6 @@ func TestDeployPodWithMultipleLiveUpdateImages(t *testing.T) {
 
 func TestNoImageTargets(t *testing.T) {
 	f := newIBDFixture(t, k8s.EnvGKE)
-	defer f.TearDown()
 
 	targName := "some-k8s-manifest"
 	specs := []model.TargetSpec{
@@ -212,7 +205,6 @@ func TestNoImageTargets(t *testing.T) {
 
 func TestStatefulSetPodManagementPolicy(t *testing.T) {
 	f := newIBDFixture(t, k8s.EnvGKE)
-	defer f.TearDown()
 
 	targName := "redis"
 
@@ -246,7 +238,6 @@ func TestStatefulSetPodManagementPolicy(t *testing.T) {
 
 func TestImageIsClean(t *testing.T) {
 	f := newIBDFixture(t, k8s.EnvGKE)
-	defer f.TearDown()
 
 	manifest := NewSanchoDockerBuildManifest(f)
 	iTargetID1 := manifest.ImageTargets[0].ID()
@@ -268,7 +259,6 @@ func TestImageIsClean(t *testing.T) {
 
 func TestImageIsDirtyAfterContainerBuild(t *testing.T) {
 	f := newIBDFixture(t, k8s.EnvGKE)
-	defer f.TearDown()
 
 	manifest := NewSanchoDockerBuildManifest(f)
 	iTargetID1 := manifest.ImageTargets[0].ID()
@@ -292,7 +282,6 @@ func TestImageIsDirtyAfterContainerBuild(t *testing.T) {
 
 func TestMultiStageDockerBuild(t *testing.T) {
 	f := newIBDFixture(t, k8s.EnvGKE)
-	defer f.TearDown()
 
 	manifest := NewSanchoDockerBuildMultiStageManifest(f)
 	_, err := f.BuildAndDeploy(BuildTargets(manifest), store.BuildStateSet{})
@@ -318,7 +307,6 @@ ENTRYPOINT /go/bin/sancho
 
 func TestMultiStageDockerBuildPreservesSyntaxDirective(t *testing.T) {
 	f := newIBDFixture(t, k8s.EnvGKE)
-	defer f.TearDown()
 
 	baseImage := model.MustNewImageTarget(SanchoBaseRef).
 		WithDockerImage(v1alpha1.DockerImageSpec{
@@ -367,7 +355,6 @@ ENTRYPOINT /go/bin/sancho
 
 func TestMultiStageDockerBuildWithFirstImageDirty(t *testing.T) {
 	f := newIBDFixture(t, k8s.EnvGKE)
-	defer f.TearDown()
 
 	manifest := NewSanchoDockerBuildMultiStageManifest(f)
 	iTargetID1 := manifest.ImageTargets[0].ID()
@@ -403,7 +390,6 @@ ENTRYPOINT /go/bin/sancho
 
 func TestMultiStageDockerBuildWithSecondImageDirty(t *testing.T) {
 	f := newIBDFixture(t, k8s.EnvGKE)
-	defer f.TearDown()
 
 	manifest := NewSanchoDockerBuildMultiStageManifest(f)
 	iTargetID1 := manifest.ImageTargets[0].ID()
@@ -438,7 +424,6 @@ ENTRYPOINT /go/bin/sancho
 
 func TestK8sUpsertTimeout(t *testing.T) {
 	f := newIBDFixture(t, k8s.EnvGKE)
-	defer f.TearDown()
 
 	timeout := 123 * time.Second
 
@@ -457,7 +442,6 @@ func TestK8sUpsertTimeout(t *testing.T) {
 
 func TestKINDLoad(t *testing.T) {
 	f := newIBDFixture(t, k8s.EnvKIND6)
-	defer f.TearDown()
 
 	manifest := NewSanchoDockerBuildManifest(f)
 	_, err := f.BuildAndDeploy(BuildTargets(manifest), store.BuildStateSet{})
@@ -472,7 +456,6 @@ func TestKINDLoad(t *testing.T) {
 
 func TestDockerPushIfKINDAndClusterRef(t *testing.T) {
 	f := newIBDFixture(t, k8s.EnvKIND6)
-	defer f.TearDown()
 
 	manifest := NewSanchoDockerBuildManifest(f)
 	iTarg := manifest.ImageTargetAt(0)
@@ -496,7 +479,6 @@ func TestDockerPushIfKINDAndClusterRef(t *testing.T) {
 
 func TestCustomBuildDisablePush(t *testing.T) {
 	f := newIBDFixture(t, k8s.EnvKIND6)
-	defer f.TearDown()
 	sha := digest.Digest("sha256:11cd0eb38bc3ceb958ffb2f9bd70be3fb317ce7d255c8a4c3f4af30e298aa1aab")
 	f.docker.Images["gcr.io/some-project-162817/sancho:tilt-build"] = types.ImageInspect{ID: string(sha)}
 
@@ -513,7 +495,6 @@ func TestCustomBuildDisablePush(t *testing.T) {
 
 func TestCustomBuildSkipsLocalDocker(t *testing.T) {
 	f := newIBDFixture(t, k8s.EnvKIND6)
-	defer f.TearDown()
 	sha := digest.Digest("sha256:11cd0eb38bc3ceb958ffb2f9bd70be3fb317ce7d255c8a4c3f4af30e298aa1aab")
 	f.docker.Images["gcr.io/some-project-162817/sancho:tilt-build"] = types.ImageInspect{ID: string(sha)}
 
@@ -562,7 +543,6 @@ func TestBuildAndDeployUsesCorrectRef(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			f := newIBDFixture(t, k8s.EnvGKE)
-			defer f.TearDown()
 
 			if strings.Contains(test.name, "custom build") {
 				sha := digest.Digest("sha256:11cd0eb38bc3ceb958ffb2f9bd70be3fb317ce7d255c8a4c3f4af30e298aa1aab")
@@ -602,7 +582,6 @@ func TestBuildAndDeployUsesCorrectRef(t *testing.T) {
 
 func TestDeployInjectImageEnvVar(t *testing.T) {
 	f := newIBDFixture(t, k8s.EnvGKE)
-	defer f.TearDown()
 
 	manifest := NewSanchoManifestWithImageInEnvVar(f)
 	_, err := f.BuildAndDeploy(BuildTargets(manifest), store.BuildStateSet{})
@@ -638,7 +617,6 @@ func TestDeployInjectImageEnvVar(t *testing.T) {
 
 func TestDeployInjectsOverrideCommand(t *testing.T) {
 	f := newIBDFixture(t, k8s.EnvGKE)
-	defer f.TearDown()
 
 	cmd := model.ToUnixCmd("./foo.sh bar")
 	manifest := NewSanchoDockerBuildManifest(f)
@@ -691,7 +669,6 @@ func (f *ibdFixture) firstPodTemplateSpecHash() k8s.PodTemplateSpecHash {
 
 func TestDeployInjectsPodTemplateSpecHash(t *testing.T) {
 	f := newIBDFixture(t, k8s.EnvGKE)
-	defer f.TearDown()
 
 	manifest := NewSanchoDockerBuildManifest(f)
 
@@ -707,7 +684,6 @@ func TestDeployInjectsPodTemplateSpecHash(t *testing.T) {
 
 func TestDeployPodTemplateSpecHashChangesWhenImageChanges(t *testing.T) {
 	f := newIBDFixture(t, k8s.EnvGKE)
-	defer f.TearDown()
 
 	manifest := NewSanchoDockerBuildManifest(f)
 
@@ -733,7 +709,6 @@ func TestDeployPodTemplateSpecHashChangesWhenImageChanges(t *testing.T) {
 
 func TestDeployInjectOverrideCommandClearsOldCommandButNotArgs(t *testing.T) {
 	f := newIBDFixture(t, k8s.EnvGKE)
-	defer f.TearDown()
 
 	cmd := model.ToUnixCmd("./foo.sh bar")
 	manifest := NewSanchoDockerBuildManifestWithYaml(f, testyaml.SanchoYAMLWithCommand)
@@ -766,7 +741,6 @@ func TestDeployInjectOverrideCommandClearsOldCommandButNotArgs(t *testing.T) {
 
 func TestDeployInjectOverrideCommandAndArgs(t *testing.T) {
 	f := newIBDFixture(t, k8s.EnvGKE)
-	defer f.TearDown()
 
 	cmd := model.ToUnixCmd("./foo.sh bar")
 	manifest := NewSanchoDockerBuildManifestWithYaml(f, testyaml.SanchoYAMLWithCommand)
@@ -800,7 +774,6 @@ func TestDeployInjectOverrideCommandAndArgs(t *testing.T) {
 
 func TestCantInjectOverrideCommandWithoutContainer(t *testing.T) {
 	f := newIBDFixture(t, k8s.EnvGKE)
-	defer f.TearDown()
 
 	// CRD YAML: we WILL successfully inject the new image ref, but can't inject
 	// an override command for that image because it's not in a "container" block:
@@ -823,7 +796,6 @@ func TestCantInjectOverrideCommandWithoutContainer(t *testing.T) {
 
 func TestInjectOverrideCommandsMultipleImages(t *testing.T) {
 	f := newIBDFixture(t, k8s.EnvGKE)
-	defer f.TearDown()
 
 	cmd1 := model.ToUnixCmd("./command1.sh foo")
 	cmd2 := model.ToUnixCmd("./command2.sh bar baz")
@@ -867,7 +839,6 @@ func TestInjectOverrideCommandsMultipleImages(t *testing.T) {
 
 func TestIBDDeployUIDs(t *testing.T) {
 	f := newIBDFixture(t, k8s.EnvGKE)
-	defer f.TearDown()
 
 	manifest := NewSanchoDockerBuildManifest(f)
 	result, err := f.BuildAndDeploy(BuildTargets(manifest), store.BuildStateSet{})
@@ -882,7 +853,6 @@ func TestIBDDeployUIDs(t *testing.T) {
 
 func TestDockerBuildTargetStage(t *testing.T) {
 	f := newIBDFixture(t, k8s.EnvGKE)
-	defer f.TearDown()
 
 	iTarget := NewSanchoDockerBuildImageTarget(f)
 	db := iTarget.BuildDetails.(model.DockerBuild)
@@ -902,7 +872,6 @@ func TestDockerBuildTargetStage(t *testing.T) {
 
 func TestDockerBuildStatus(t *testing.T) {
 	f := newIBDFixture(t, k8s.EnvGKE)
-	defer f.TearDown()
 
 	iTarget := NewSanchoDockerBuildImageTarget(f)
 	manifest := manifestbuilder.New(f, "sancho").
@@ -929,7 +898,6 @@ func TestDockerBuildStatus(t *testing.T) {
 
 func TestCustomBuildStatus(t *testing.T) {
 	f := newIBDFixture(t, k8s.EnvGKE)
-	defer f.TearDown()
 
 	sha := digest.Digest("sha256:11cd0eb38bc3ceb958ffb2f9bd70be3fb317ce7d255c8a4c3f4af30e298aa1aab")
 	f.docker.Images["gcr.io/some-project-162817/sancho:tilt-build"] = types.ImageInspect{ID: string(sha)}
@@ -963,7 +931,6 @@ func TestCustomBuildStatus(t *testing.T) {
 
 func TestTwoManifestsWithCommonImage(t *testing.T) {
 	f := newIBDFixture(t, k8s.EnvGKE)
-	defer f.TearDown()
 
 	m1, m2 := NewManifestsWithCommonAncestor(f)
 	results1, err := f.BuildAndDeploy(BuildTargets(m1), store.BuildStateSet{})
@@ -984,7 +951,6 @@ func TestTwoManifestsWithCommonImage(t *testing.T) {
 
 func TestTwoManifestsWithCommonImagePrebuilt(t *testing.T) {
 	f := newIBDFixture(t, k8s.EnvGKE)
-	defer f.TearDown()
 
 	m1, _ := NewManifestsWithCommonAncestor(f)
 	iTarget1 := m1.ImageTargets[0]
@@ -1005,7 +971,6 @@ func TestTwoManifestsWithCommonImagePrebuilt(t *testing.T) {
 
 func TestTwoManifestsWithTwoCommonAncestors(t *testing.T) {
 	f := newIBDFixture(t, k8s.EnvGKE)
-	defer f.TearDown()
 
 	m1, m2 := NewManifestsWithTwoCommonAncestors(f)
 	results1, err := f.BuildAndDeploy(BuildTargets(m1), store.BuildStateSet{})
@@ -1026,7 +991,6 @@ func TestTwoManifestsWithTwoCommonAncestors(t *testing.T) {
 
 func TestTwoManifestsWithSameTwoImages(t *testing.T) {
 	f := newIBDFixture(t, k8s.EnvGKE)
-	defer f.TearDown()
 
 	m1, m2 := NewManifestsWithSameTwoImages(f)
 	results1, err := f.BuildAndDeploy(BuildTargets(m1), store.BuildStateSet{})
@@ -1046,7 +1010,6 @@ func TestTwoManifestsWithSameTwoImages(t *testing.T) {
 
 func TestPlatformFromCluster(t *testing.T) {
 	f := newIBDFixture(t, k8s.EnvGKE)
-	defer f.TearDown()
 
 	f.upsert(&v1alpha1.Cluster{
 		ObjectMeta: metav1.ObjectMeta{Name: "default"},
@@ -1112,7 +1075,7 @@ func newIBDFixture(t *testing.T, env k8s.Env) *ibdFixture {
 	if err != nil {
 		t.Fatal(err)
 	}
-	return &ibdFixture{
+	ret := &ibdFixture{
 		TempDirFixture: f,
 		out:            out,
 		ctx:            ctx,
@@ -1123,6 +1086,8 @@ func newIBDFixture(t *testing.T, env k8s.Env) *ibdFixture {
 		kl:             kl,
 		ctrlClient:     ctrlClient,
 	}
+
+	return ret
 }
 
 func (f *ibdFixture) upsert(obj ctrlclient.Object) {
@@ -1167,11 +1132,6 @@ func (f *ibdFixture) BuildAndDeploy(specs []model.TargetSpec, stateSet store.Bui
 		f.upsert(&ka)
 	}
 	return f.ibd.BuildAndDeploy(f.ctx, f.st, specs, stateSet)
-}
-
-func (f *ibdFixture) TearDown() {
-	f.k8s.TearDown()
-	f.TempDirFixture.TearDown()
 }
 
 func (f *ibdFixture) resultsToNextState(results store.BuildResultSet) store.BuildStateSet {

--- a/internal/engine/buildcontrol/live_update_build_and_deployer_test.go
+++ b/internal/engine/buildcontrol/live_update_build_and_deployer_test.go
@@ -42,7 +42,6 @@ var TestContainers = []liveupdates.Container{TestContainer}
 
 func TestBuildAndDeployBoilsSteps(t *testing.T) {
 	f := newFixture(t)
-	defer f.teardown()
 
 	packageJson := build.PathMapping{LocalPath: f.JoinPath("package.json"), ContainerPath: "/src/package.json"}
 	err := f.buildAndDeploy(f.ctx, f.ps, LiveUpdateInput{
@@ -78,7 +77,6 @@ func TestBuildAndDeployBoilsSteps(t *testing.T) {
 
 func TestUpdateInContainerArchivesFilesToCopyAndGetsFilesToRemove(t *testing.T) {
 	f := newFixture(t)
-	defer f.teardown()
 
 	// Write files so we know whether to cp to or rm from container
 	f.WriteFile("hi", "hello")
@@ -118,7 +116,6 @@ func TestUpdateInContainerArchivesFilesToCopyAndGetsFilesToRemove(t *testing.T) 
 
 func TestDontFallBackOnUserError(t *testing.T) {
 	f := newFixture(t)
-	defer f.teardown()
 
 	f.cu.SetUpdateErr(build.RunStepFailure{ExitCode: 12345})
 
@@ -134,7 +131,6 @@ func TestDontFallBackOnUserError(t *testing.T) {
 
 func TestUpdateContainerWithHotReload(t *testing.T) {
 	f := newFixture(t)
-	defer f.teardown()
 
 	expectedHotReloads := []bool{true, true, false, true}
 	for _, hotReload := range expectedHotReloads {
@@ -165,7 +161,6 @@ func TestUpdateContainerWithHotReload(t *testing.T) {
 
 func TestUpdateMultipleRunningContainers(t *testing.T) {
 	f := newFixture(t)
-	defer f.teardown()
 
 	container1 := liveupdates.Container{
 		PodID:         "mypod",
@@ -218,7 +213,6 @@ func TestUpdateMultipleRunningContainers(t *testing.T) {
 
 func TestErrorStopsSubsequentContainerUpdates(t *testing.T) {
 	f := newFixture(t)
-	defer f.teardown()
 
 	container1 := liveupdates.Container{
 		PodID:         "mypod",
@@ -248,7 +242,6 @@ func TestErrorStopsSubsequentContainerUpdates(t *testing.T) {
 
 func TestUpdateMultipleContainersWithSameTarArchive(t *testing.T) {
 	f := newFixture(t)
-	defer f.teardown()
 
 	container1 := liveupdates.Container{
 		PodID:         "mypod",
@@ -298,7 +291,6 @@ func TestUpdateMultipleContainersWithSameTarArchive(t *testing.T) {
 
 func TestUpdateMultipleContainersWithSameTarArchiveOnRunStepFailure(t *testing.T) {
 	f := newFixture(t)
-	defer f.teardown()
 
 	container1 := liveupdates.Container{
 		PodID:         "mypod",
@@ -348,7 +340,6 @@ func TestUpdateMultipleContainersWithSameTarArchiveOnRunStepFailure(t *testing.T
 
 func TestSkipLiveUpdateIfForceUpdate(t *testing.T) {
 	f := newFixture(t)
-	defer f.teardown()
 
 	m := manifestbuilder.New(f, "sancho").
 		WithK8sYAML(SanchoYAML).
@@ -405,10 +396,6 @@ func newFixture(t testing.TB) *lcbadFixture {
 		lubad:          lubad,
 		ctrlClient:     cfb.Client,
 	}
-}
-
-func (f *lcbadFixture) teardown() {
-	f.TempDirFixture.TearDown()
 }
 
 func (f *lcbadFixture) buildAndDeploy(ctx context.Context, ps *build.PipelineState, input LiveUpdateInput) error {

--- a/internal/engine/buildcontrol/local_target_build_and_deployer_test.go
+++ b/internal/engine/buildcontrol/local_target_build_and_deployer_test.go
@@ -28,7 +28,6 @@ import (
 
 func TestNoLocalTargets(t *testing.T) {
 	f := newLTFixture(t)
-	defer f.TearDown()
 
 	specs := []model.TargetSpec{
 		model.ImageTarget{}, model.K8sTarget{}, model.DockerComposeTarget{},
@@ -43,7 +42,6 @@ func TestNoLocalTargets(t *testing.T) {
 
 func TestTooManyLocalTargets(t *testing.T) {
 	f := newLTFixture(t)
-	defer f.TearDown()
 
 	specs := []model.TargetSpec{
 		model.LocalTarget{}, model.ImageTarget{}, model.K8sTarget{}, model.LocalTarget{},
@@ -58,7 +56,6 @@ func TestTooManyLocalTargets(t *testing.T) {
 
 func TestSuccessfulCommand(t *testing.T) {
 	f := newLTFixture(t)
-	defer f.TearDown()
 
 	targ := f.localTarget("echo hello world")
 
@@ -72,7 +69,6 @@ func TestSuccessfulCommand(t *testing.T) {
 
 func TestWorkdir(t *testing.T) {
 	f := newLTFixture(t)
-	defer f.TearDown()
 
 	f.MkdirAll(filepath.Join("some", "internal", "dir"))
 	workdir := f.JoinPath("some", "internal", "dir")
@@ -93,7 +89,6 @@ func TestWorkdir(t *testing.T) {
 
 func TestExtractOneLocalTarget(t *testing.T) {
 	f := newLTFixture(t)
-	defer f.TearDown()
 
 	targ := f.localTarget("echo hello world")
 
@@ -112,7 +107,6 @@ func TestExtractOneLocalTarget(t *testing.T) {
 
 func TestFailedCommand(t *testing.T) {
 	f := newLTFixture(t)
-	defer f.TearDown()
 
 	targ := f.localTarget("echo oh no && exit 1")
 

--- a/internal/engine/buildcontroller_test.go
+++ b/internal/engine/buildcontroller_test.go
@@ -33,7 +33,6 @@ import (
 
 func TestBuildControllerOnePod(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 
 	manifest := f.newManifest("fe")
 	pb := f.registerForDeployer(manifest)
@@ -58,7 +57,6 @@ func TestBuildControllerOnePod(t *testing.T) {
 
 func TestBuildControllerTooManyPodsForLiveUpdateErrorMessage(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 
 	manifest := manifestbuilder.New(f, "sancho").
 		WithK8sYAML(SanchoYAML).
@@ -106,7 +104,6 @@ func TestBuildControllerTooManyPodsForLiveUpdateErrorMessage(t *testing.T) {
 
 func TestBuildControllerTooManyPodsForDockerBuildNoErrorMessage(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 
 	manifest := NewSanchoDockerBuildManifest(f)
 	// basePB is used for all pods so that they share the same deployment
@@ -151,7 +148,6 @@ func TestBuildControllerTooManyPodsForDockerBuildNoErrorMessage(t *testing.T) {
 
 func TestBuildControllerIgnoresImageTags(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 
 	ref := container.MustParseNamed("gcr.io/blorg-dev/blorg-backend:devel-nick")
 	refSel := container.NewRefSelector(ref)
@@ -192,7 +188,6 @@ func TestBuildControllerIgnoresImageTags(t *testing.T) {
 
 func TestBuildControllerDockerCompose(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 
 	manifest := NewSanchoLiveUpdateDCManifest(f)
 	f.Start([]model.Manifest{manifest})
@@ -217,7 +212,6 @@ func TestBuildControllerDockerCompose(t *testing.T) {
 
 func TestBuildControllerLocalResource(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 
 	dep := f.JoinPath("stuff.json")
 	manifest := manifestbuilder.New(f, "local").
@@ -246,7 +240,6 @@ func TestBuildControllerLocalResource(t *testing.T) {
 
 func TestBuildControllerWontContainerBuildWithTwoPods(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 
 	manifest := f.newManifest("fe")
 	basePB := f.registerForDeployer(manifest)
@@ -288,7 +281,6 @@ func TestBuildControllerWontContainerBuildWithTwoPods(t *testing.T) {
 
 func TestBuildControllerTwoContainers(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 
 	manifest := f.newManifest("fe")
 	basePB := f.registerForDeployer(manifest)
@@ -350,7 +342,6 @@ func TestBuildControllerTwoContainers(t *testing.T) {
 
 func TestBuildControllerWontContainerBuildWithSomeButNotAllReadyContainers(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 
 	manifest := f.newManifest("fe")
 	basePB := f.registerForDeployer(manifest)
@@ -389,7 +380,6 @@ func TestBuildControllerWontContainerBuildWithSomeButNotAllReadyContainers(t *te
 
 func TestBuildControllerCrashRebuild(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 
 	manifest := manifestbuilder.New(f, "fe").
 		WithK8sYAML(SanchoYAML).
@@ -443,7 +433,6 @@ func TestBuildControllerCrashRebuild(t *testing.T) {
 
 func TestCrashRebuildTwoContainersOneImage(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 
 	manifest := manifestbuilder.New(f, "sancho").
 		WithK8sYAML(testyaml.SanchoTwoContainersOneImageYAML).
@@ -495,7 +484,6 @@ func TestCrashRebuildTwoContainersTwoImages(t *testing.T) {
 		t.Skip("TODO(nick): investigate")
 	}
 	f := newTestFixture(t)
-	defer f.TearDown()
 
 	manifest := manifestbuilder.New(f, "sancho").
 		WithK8sYAML(testyaml.SanchoSidecarYAML).
@@ -548,7 +536,6 @@ func TestCrashRebuildTwoContainersTwoImages(t *testing.T) {
 
 func TestRecordLiveUpdatedContainerIDsForFailedLiveUpdate(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 
 	manifest := manifestbuilder.New(f, "sancho").
 		WithK8sYAML(testyaml.SanchoTwoContainersOneImageYAML).
@@ -592,7 +579,6 @@ func TestBuildControllerManualTriggerBuildReasonInit(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			f := newTestFixture(t)
-			defer f.TearDown()
 			mName := model.ManifestName("foobar")
 			manifest := f.newManifest(mName.String()).WithTriggerMode(tc.triggerMode)
 			manifests := []model.Manifest{manifest}
@@ -626,7 +612,6 @@ func TestTriggerModes(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			f := newTestFixture(t)
-			defer f.TearDown()
 
 			manifest := f.simpleManifestWithTriggerMode("foobar", tc.triggerMode)
 			manifests := []model.Manifest{manifest}
@@ -674,7 +659,6 @@ func TestBuildControllerImageBuildTrigger(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			f := newTestFixture(t)
-			defer f.TearDown()
 			mName := model.ManifestName("foobar")
 
 			manifest := f.simpleManifestWithTriggerMode(mName, tc.triggerMode)
@@ -724,7 +708,6 @@ func TestBuildControllerManualTriggerWithFileChangesSinceLastSuccessfulBuildButB
 		t.Skip("TODO(nick): fix this")
 	}
 	f := newTestFixture(t)
-	defer f.TearDown()
 	mName := model.ManifestName("foobar")
 
 	manifest := f.newManifest(mName.String())
@@ -760,7 +743,6 @@ func TestBuildControllerManualTriggerWithFileChangesSinceLastSuccessfulBuildButB
 // https://github.com/tilt-dev/tilt/issues/3915
 func TestFullBuildTriggerClearsLiveUpdate(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 	mName := model.ManifestName("foobar")
 
 	manifest := f.newManifest(mName.String())
@@ -805,7 +787,6 @@ func TestFullBuildTriggerClearsLiveUpdate(t *testing.T) {
 
 func TestBuildQueueOrdering(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 
 	m1 := f.newManifestWithRef("manifest1", container.MustParseNamed("manifest1")).
 		WithTriggerMode(model.TriggerModeManualWithAutoInit)
@@ -860,7 +841,6 @@ func TestBuildQueueOrdering(t *testing.T) {
 
 func TestBuildQueueAndAutobuildOrdering(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 
 	// changes to this dir. will register with our manual manifests
 	dirManual := f.JoinPath("dirManual/")
@@ -923,7 +903,6 @@ func TestBuildQueueAndAutobuildOrdering(t *testing.T) {
 // any manifests without image targets should be deployed before any manifests WITH image targets
 func TestBuildControllerNoBuildManifestsFirst(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 
 	manifests := make([]model.Manifest, 10)
 	for i := 0; i < 10; i++ {
@@ -962,7 +941,6 @@ func TestBuildControllerNoBuildManifestsFirst(t *testing.T) {
 
 func TestBuildControllerUnresourcedYAMLFirst(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 
 	manifests := []model.Manifest{
 		f.newManifest("built1"),
@@ -993,7 +971,6 @@ func TestBuildControllerUnresourcedYAMLFirst(t *testing.T) {
 
 func TestBuildControllerRespectDockerComposeOrder(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 
 	sancho := NewSanchoLiveUpdateDCManifest(f)
 	redis := manifestbuilder.New(f, "redis").WithDockerCompose().Build()
@@ -1022,7 +999,6 @@ func TestBuildControllerRespectDockerComposeOrder(t *testing.T) {
 
 func TestBuildControllerLocalResourcesBeforeClusterResources(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 
 	manifests := []model.Manifest{
 		f.newManifest("clusterBuilt1"),
@@ -1064,7 +1040,6 @@ func TestBuildControllerLocalResourcesBeforeClusterResources(t *testing.T) {
 
 func TestBuildControllerResourceDeps(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 
 	depGraph := map[string][]string{
 		"a": {"e"},
@@ -1122,7 +1097,6 @@ func TestBuildControllerResourceDeps(t *testing.T) {
 // if the local build depends on the k8s build, the k8s build should go first
 func TestBuildControllerResourceDepTrumpsLocalResourcePriority(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 
 	k8sManifest := f.newManifest("foo")
 	pb := f.registerForDeployer(k8sManifest)
@@ -1151,7 +1125,6 @@ func TestBuildControllerResourceDepTrumpsLocalResourcePriority(t *testing.T) {
 // bar depends on foo, we build foo three times before marking it ready, and make sure bar waits
 func TestBuildControllerResourceDepTrumpsInitialBuild(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 
 	foo := manifestbuilder.New(f, "foo").
 		WithLocalResource("foo cmd", []string{f.JoinPath("foo")}).
@@ -1184,7 +1157,6 @@ func TestBuildControllerResourceDepTrumpsInitialBuild(t *testing.T) {
 // bar depends on foo. make sure bar waits on foo even as foo fails
 func TestBuildControllerResourceDepTrumpsPendingBuild(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 
 	foo := manifestbuilder.New(f, "foo").
 		WithLocalResource("foo cmd", []string{f.JoinPath("foo")}).
@@ -1215,7 +1187,6 @@ func TestBuildControllerResourceDepTrumpsPendingBuild(t *testing.T) {
 
 func TestLogsLongResourceName(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 
 	mn := strings.Repeat("foobar", 30)
 
@@ -1242,7 +1213,6 @@ func TestLogsLongResourceName(t *testing.T) {
 
 func TestBuildControllerWontBuildManifestThatsAlreadyBuilding(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 	f.b.completeBuildsManually = true
 
 	// allow multiple builds at once; we care that we can't start multiple builds
@@ -1289,7 +1259,6 @@ func TestBuildControllerWontBuildManifestThatsAlreadyBuilding(t *testing.T) {
 
 func TestBuildControllerWontBuildManifestIfNoSlotsAvailable(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 	f.b.completeBuildsManually = true
 	f.setMaxParallelUpdates(2)
 
@@ -1325,7 +1294,6 @@ func TestBuildControllerWontBuildManifestIfNoSlotsAvailable(t *testing.T) {
 // maxParallelUpdates=3, nothing should explode.)
 func TestCurrentlyBuildingMayExceedMaxParallelUpdates(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 	f.b.completeBuildsManually = true
 	f.setMaxParallelUpdates(3)
 
@@ -1380,7 +1348,6 @@ func TestCurrentlyBuildingMayExceedMaxParallelUpdates(t *testing.T) {
 
 func TestDontStartBuildIfControllerAndEngineUnsynced(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 
 	f.b.completeBuildsManually = true
 	f.setMaxParallelUpdates(3)
@@ -1421,7 +1388,6 @@ func TestErrorHandlingWithMultipleBuilds(t *testing.T) {
 		t.Skip("TODO(nick): fix this")
 	}
 	f := newTestFixture(t)
-	defer f.TearDown()
 	f.b.completeBuildsManually = true
 	f.setMaxParallelUpdates(2)
 
@@ -1468,7 +1434,6 @@ func TestErrorHandlingWithMultipleBuilds(t *testing.T) {
 
 func TestManifestsWithSameTwoImages(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 	m1, m2 := NewManifestsWithSameTwoImages(f)
 	f.Start([]model.Manifest{m1, m2})
 
@@ -1516,7 +1481,6 @@ func TestManifestsWithSameTwoImages(t *testing.T) {
 
 func TestManifestsWithTwoCommonAncestors(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 	m1, m2 := NewManifestsWithTwoCommonAncestors(f)
 	f.Start([]model.Manifest{m1, m2})
 
@@ -1573,7 +1537,6 @@ func TestManifestsWithTwoCommonAncestors(t *testing.T) {
 
 func TestLocalDependsOnNonWorkloadK8s(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 
 	local1 := manifestbuilder.New(f, "local").
 		WithLocalResource("exec-local", nil).
@@ -1600,7 +1563,6 @@ func TestLocalDependsOnNonWorkloadK8s(t *testing.T) {
 
 func TestManifestsWithCommonAncestorAndTrigger(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 	m1, m2 := NewManifestsWithCommonAncestor(f)
 	f.Start([]model.Manifest{m1, m2})
 
@@ -1720,7 +1682,6 @@ local_resource('local', 'sleep 10000')
 
 func TestBuildControllerK8sFileDependencies(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 
 	kt := k8s.MustTarget("fe", testyaml.SanchoYAML).
 		WithPathDependencies(

--- a/internal/engine/k8srollout/podmonitor_test.go
+++ b/internal/engine/k8srollout/podmonitor_test.go
@@ -30,7 +30,6 @@ var PodmonitorWriteGoldenMaster = "0"
 
 func TestMonitorReady(t *testing.T) {
 	f := newPMFixture(t)
-	defer f.TearDown()
 
 	start := time.Now()
 	p := v1alpha1.Pod{
@@ -68,7 +67,6 @@ func TestMonitorReady(t *testing.T) {
 // https://github.com/tilt-dev/tilt/issues/3513
 func TestJobCompleted(t *testing.T) {
 	f := newPMFixture(t)
-	defer f.TearDown()
 
 	start := time.Now()
 	p := v1alpha1.Pod{
@@ -108,7 +106,6 @@ func TestJobCompleted(t *testing.T) {
 
 func TestJobCompletedAfterReady(t *testing.T) {
 	f := newPMFixture(t)
-	defer f.TearDown()
 
 	start := time.Now()
 	p := v1alpha1.Pod{
@@ -173,7 +170,7 @@ func newPMFixture(t *testing.T) *pmFixture {
 	ctx, cancel := context.WithCancel(context.Background())
 	ctx = logger.WithLogger(ctx, logger.NewTestLogger(out))
 
-	return &pmFixture{
+	ret := &pmFixture{
 		TempDirFixture: f,
 		pm:             pm,
 		ctx:            ctx,
@@ -181,11 +178,14 @@ func newPMFixture(t *testing.T) *pmFixture {
 		out:            out,
 		store:          st,
 	}
+
+	t.Cleanup(ret.TearDown)
+
+	return ret
 }
 
 func (f *pmFixture) TearDown() {
 	f.cancel()
-	f.TempDirFixture.TearDown()
 }
 
 type testStore struct {

--- a/internal/engine/k8swatch/event_watch_manager_test.go
+++ b/internal/engine/k8swatch/event_watch_manager_test.go
@@ -33,7 +33,6 @@ import (
 
 func TestEventWatchManager_dispatchesEvent(t *testing.T) {
 	f := newEWMFixture(t)
-	defer f.TearDown()
 
 	mn := model.ManifestName("someK8sManifest")
 
@@ -54,7 +53,6 @@ func TestEventWatchManager_dispatchesEvent(t *testing.T) {
 
 func TestEventWatchManager_dispatchesNamespaceEvent(t *testing.T) {
 	f := newEWMFixture(t)
-	defer f.TearDown()
 
 	mn := model.ManifestName("someK8sManifest")
 
@@ -80,7 +78,6 @@ func TestEventWatchManager_dispatchesNamespaceEvent(t *testing.T) {
 
 func TestEventWatchManager_duplicateDeployIDs(t *testing.T) {
 	f := newEWMFixture(t)
-	defer f.TearDown()
 
 	fe1 := model.ManifestName("fe1")
 	m1 := f.addManifest(fe1)
@@ -120,7 +117,6 @@ func TestEventWatchManagerDifferentEvents(t *testing.T) {
 	for i, c := range cases {
 		t.Run(fmt.Sprintf("Case%d", i), func(t *testing.T) {
 			f := newEWMFixture(t)
-			defer f.TearDown()
 
 			mn := model.ManifestName("someK8sManifest")
 
@@ -149,7 +145,6 @@ func TestEventWatchManagerDifferentEvents(t *testing.T) {
 
 func TestEventWatchManager_listensOnce(t *testing.T) {
 	f := newEWMFixture(t)
-	defer f.TearDown()
 
 	m := f.addManifest("fe")
 	entities := podbuilder.New(t, m).ObjectTreeEntities()
@@ -166,7 +161,6 @@ func TestEventWatchManager_listensOnce(t *testing.T) {
 
 func TestEventWatchManager_watchError(t *testing.T) {
 	f := newEWMFixture(t)
-	defer f.TearDown()
 
 	err := fmt.Errorf("oh noes")
 	f.kClient.EventsWatchErr = err
@@ -186,7 +180,6 @@ func TestEventWatchManager_watchError(t *testing.T) {
 
 func TestEventWatchManager_eventBeforeUID(t *testing.T) {
 	f := newEWMFixture(t)
-	defer f.TearDown()
 
 	mn := model.ManifestName("someK8sManifest")
 
@@ -214,7 +207,6 @@ func TestEventWatchManager_eventBeforeUID(t *testing.T) {
 
 func TestEventWatchManager_ignoresPreStartEvents(t *testing.T) {
 	f := newEWMFixture(t)
-	defer f.TearDown()
 
 	mn := model.ManifestName("someK8sManifest")
 
@@ -307,13 +299,12 @@ func newEWMFixture(t *testing.T) *ewmFixture {
 	}
 	ret.store.UnlockMutableState()
 
+	t.Cleanup(ret.TearDown)
 	return ret
 }
 
 func (f *ewmFixture) TearDown() {
 	f.cancel()
-	f.TempDirFixture.TearDown()
-	f.kClient.TearDown()
 	f.store.AssertNoErrorActions(f.t)
 }
 

--- a/internal/engine/k8swatch/service_watch_test.go
+++ b/internal/engine/k8swatch/service_watch_test.go
@@ -30,7 +30,6 @@ import (
 
 func TestServiceWatch(t *testing.T) {
 	f := newSWFixture(t)
-	defer f.TearDown()
 
 	nodePort := 9998
 	uid := types.UID("fake-uid")
@@ -66,7 +65,6 @@ func TestServiceWatch(t *testing.T) {
 // shows up.
 func TestServiceWatchUIDDelayed(t *testing.T) {
 	f := newSWFixture(t)
-	defer f.TearDown()
 
 	uid := types.UID("fake-uid")
 	manifest := f.addManifest("server")
@@ -103,7 +101,6 @@ func TestServiceWatchUIDDelayed(t *testing.T) {
 
 func TestServiceWatchClusterChange(t *testing.T) {
 	f := newSWFixture(t)
-	defer f.TearDown()
 
 	port := int32(1234)
 	uid := types.UID("fake-uid")
@@ -234,7 +231,7 @@ func newSWFixture(t *testing.T) *swFixture {
 	}
 	st.UnlockMutableState()
 
-	return &swFixture{
+	ret := &swFixture{
 		TempDirFixture: tempdir.NewTempDirFixture(t),
 		clients:        clients,
 		kClient:        kClient,
@@ -245,10 +242,13 @@ func newSWFixture(t *testing.T) *swFixture {
 		t:              t,
 		store:          st,
 	}
+
+	t.Cleanup(ret.TearDown)
+
+	return ret
 }
 
 func (f *swFixture) TearDown() {
-	f.kClient.TearDown()
 	f.cancel()
 	f.store.AssertNoErrorActions(f.t)
 }

--- a/internal/engine/session/controller_test.go
+++ b/internal/engine/session/controller_test.go
@@ -30,7 +30,6 @@ import (
 
 func TestExitControlCI_TiltfileFailure(t *testing.T) {
 	f := newFixture(t, store.EngineModeCI)
-	defer f.TearDown()
 
 	// Tiltfile state is stored independent of resource state within engine
 	f.store.WithState(func(state *store.EngineState) {
@@ -47,7 +46,6 @@ func TestExitControlCI_TiltfileFailure(t *testing.T) {
 
 func TestExitControlIdempotent(t *testing.T) {
 	f := newFixture(t, store.EngineModeCI)
-	defer f.TearDown()
 
 	_ = f.c.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
 	assert.NotNil(t, f.store.LastAction())
@@ -59,7 +57,6 @@ func TestExitControlIdempotent(t *testing.T) {
 
 func TestExitControlCI_FirstBuildFailure(t *testing.T) {
 	f := newFixture(t, store.EngineModeCI)
-	defer f.TearDown()
 
 	m := manifestbuilder.New(f, "fe").WithK8sYAML(testyaml.SanchoYAML).Build()
 	f.upsertManifest(m)
@@ -83,7 +80,6 @@ func TestExitControlCI_FirstBuildFailure(t *testing.T) {
 
 func TestExitControlCI_FirstRuntimeFailure(t *testing.T) {
 	f := newFixture(t, store.EngineModeCI)
-	defer f.TearDown()
 
 	m := manifestbuilder.New(f, "fe").WithK8sYAML(testyaml.SanchoYAML).Build()
 	f.upsertManifest(m)
@@ -130,7 +126,6 @@ func TestExitControlCI_FirstRuntimeFailure(t *testing.T) {
 
 func TestExitControlCI_PodRunningContainerError(t *testing.T) {
 	f := newFixture(t, store.EngineModeCI)
-	defer f.TearDown()
 
 	m := manifestbuilder.New(f, "fe").WithK8sYAML(testyaml.SanchoYAML).Build()
 	f.upsertManifest(m)
@@ -197,7 +192,6 @@ func TestExitControlCI_PodRunningContainerError(t *testing.T) {
 
 func TestExitControlCI_Success(t *testing.T) {
 	f := newFixture(t, store.EngineModeCI)
-	defer f.TearDown()
 
 	m := manifestbuilder.New(f, "fe").
 		WithK8sYAML(testyaml.SanchoYAML).
@@ -239,7 +233,6 @@ func TestExitControlCI_Success(t *testing.T) {
 
 func TestExitControlCI_PodReadinessMode_Wait(t *testing.T) {
 	f := newFixture(t, store.EngineModeCI)
-	defer f.TearDown()
 
 	m := manifestbuilder.New(f, "fe").
 		WithK8sYAML(testyaml.SanchoYAML).
@@ -273,7 +266,6 @@ func TestExitControlCI_PodReadinessMode_Wait(t *testing.T) {
 // TestExitControlCI_PodReadinessMode_Ignore_Pods covers the case where you don't care about a Pod's readiness state
 func TestExitControlCI_PodReadinessMode_Ignore_Pods(t *testing.T) {
 	f := newFixture(t, store.EngineModeCI)
-	defer f.TearDown()
 
 	m := manifestbuilder.New(f, "fe").
 		WithK8sYAML(testyaml.SecretYaml).
@@ -307,7 +299,6 @@ func TestExitControlCI_PodReadinessMode_Ignore_Pods(t *testing.T) {
 // runtime component (i.e. no pods) - this most commonly happens with "uncategorized"
 func TestExitControlCI_PodReadinessMode_Ignore_NoPods(t *testing.T) {
 	f := newFixture(t, store.EngineModeCI)
-	defer f.TearDown()
 
 	m := manifestbuilder.New(f, "fe").
 		WithK8sYAML(testyaml.SecretYaml).
@@ -340,7 +331,6 @@ func TestExitControlCI_PodReadinessMode_Ignore_NoPods(t *testing.T) {
 
 func TestExitControlCI_JobSuccess(t *testing.T) {
 	f := newFixture(t, store.EngineModeCI)
-	defer f.TearDown()
 
 	m := manifestbuilder.New(f, "fe").
 		WithK8sYAML(testyaml.JobYAML).
@@ -391,7 +381,6 @@ func TestExitControlCI_TriggerMode_Local(t *testing.T) {
 		}
 		t.Run(name, func(t *testing.T) {
 			f := newFixture(t, store.EngineModeCI)
-			defer f.TearDown()
 
 			mb := manifestbuilder.New(f, "fe").
 				WithLocalResource("echo hi", nil).
@@ -453,7 +442,6 @@ func TestExitControlCI_TriggerMode_K8s(t *testing.T) {
 	for triggerMode := range model.TriggerModes {
 		t.Run(triggerModeString(triggerMode), func(t *testing.T) {
 			f := newFixture(t, store.EngineModeCI)
-			defer f.TearDown()
 
 			manifest := manifestbuilder.New(f, "fe").
 				WithK8sYAML(testyaml.JobYAML).
@@ -486,7 +474,6 @@ func TestExitControlCI_TriggerMode_K8s(t *testing.T) {
 
 func TestExitControlCI_Disabled(t *testing.T) {
 	f := newFixture(t, store.EngineModeCI)
-	defer f.TearDown()
 
 	f.store.WithState(func(state *store.EngineState) {
 		m1 := manifestbuilder.New(f, "m1").WithLocalServeCmd("m1").Build()
@@ -511,7 +498,6 @@ func TestExitControlCI_Disabled(t *testing.T) {
 
 func TestStatusDisabled(t *testing.T) {
 	f := newFixture(t, store.EngineModeCI)
-	defer f.TearDown()
 
 	f.store.WithState(func(state *store.EngineState) {
 		m1 := manifestbuilder.New(f, "local_update").WithLocalResource("a", nil).Build()

--- a/internal/engine/telemetry/controller_test.go
+++ b/internal/engine/telemetry/controller_test.go
@@ -23,7 +23,6 @@ import (
 
 func TestTelNoScriptTimeIsUpNoInvocation(t *testing.T) {
 	f := newTCFixture(t)
-	defer f.teardown()
 
 	f.run()
 
@@ -32,7 +31,6 @@ func TestTelNoScriptTimeIsUpNoInvocation(t *testing.T) {
 
 func TestTelNoScriptTimeIsNotUpNoInvocation(t *testing.T) {
 	f := newTCFixture(t)
-	defer f.teardown()
 	t1 := time.Now()
 	f.clock.now = t1
 
@@ -44,7 +42,6 @@ func TestTelNoScriptTimeIsNotUpNoInvocation(t *testing.T) {
 
 func TestTelScriptTimeIsNotUpNoInvocation(t *testing.T) {
 	f := newTCFixture(t)
-	defer f.teardown()
 	t1 := time.Now()
 	f.clock.now = t1
 
@@ -57,7 +54,6 @@ func TestTelScriptTimeIsNotUpNoInvocation(t *testing.T) {
 
 func TestTelScriptTimeIsUpNoSpansNoInvocation(t *testing.T) {
 	f := newTCFixture(t)
-	defer f.teardown()
 	t1 := time.Now()
 	f.clock.now = t1
 
@@ -71,7 +67,6 @@ func TestTelScriptTimeIsUpNoSpansNoInvocation(t *testing.T) {
 
 func TestTelScriptTimeIsUpShouldClearSpansAndSetTime(t *testing.T) {
 	f := newTCFixture(t)
-	defer f.teardown()
 	t1 := time.Now()
 	f.clock.now = t1
 
@@ -88,7 +83,6 @@ func TestTelScriptTimeIsUpShouldClearSpansAndSetTime(t *testing.T) {
 
 func TestTelScriptFailsTimeIsUpShouldDeleteFileAndSetTime(t *testing.T) {
 	f := newTCFixture(t)
-	defer f.teardown()
 	t1 := time.Now()
 	f.clock.now = t1
 
@@ -251,10 +245,6 @@ func (tcf *tcFixture) assertNoSpans() {
 	if err != io.EOF {
 		tcf.t.Fatalf("Didn't get EOF for spans: %v %v", r, err)
 	}
-}
-
-func (tcf *tcFixture) teardown() {
-	defer tcf.temp.TearDown()
 }
 
 type fakeClock struct {

--- a/internal/engine/uiresource/subscriber_test.go
+++ b/internal/engine/uiresource/subscriber_test.go
@@ -21,7 +21,6 @@ import (
 
 func TestUpdateTiltfile(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	r := &v1alpha1.UIResource{ObjectMeta: metav1.ObjectMeta{Name: "(Tiltfile)"}}
 	err := f.tc.Create(f.ctx, r)

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -527,7 +527,6 @@ func (b *fakeBuildAndDeployer) completeBuild(key string) {
 
 func TestUpper_Up(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 	manifest := f.newManifest("foobar")
 
 	f.setManifests([]model.Manifest{manifest})
@@ -561,7 +560,6 @@ func TestUpper_Up(t *testing.T) {
 
 func TestUpper_UpK8sEntityOrdering(t *testing.T) {
 	f := newTestFixture(t, fixtureOptions{engineMode: &store.EngineModeCI})
-	defer f.TearDown()
 	f.useRealTiltfileLoader()
 
 	postgresEntities, err := k8s.ParseYAMLFromString(testyaml.PostgresYAML)
@@ -596,7 +594,6 @@ func TestUpper_UpK8sEntityOrdering(t *testing.T) {
 
 func TestUpper_CI(t *testing.T) {
 	f := newTestFixture(t, fixtureOptions{engineMode: &store.EngineModeCI})
-	defer f.TearDown()
 
 	manifest := f.newManifest("foobar")
 	pb := f.registerForDeployer(manifest)
@@ -621,7 +618,6 @@ func TestUpper_CI(t *testing.T) {
 
 func TestUpper_UpWatchFileChange(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 	manifest := f.newManifest("foobar")
 	pb := f.registerForDeployer(manifest)
 	f.Start([]model.Manifest{manifest})
@@ -656,7 +652,6 @@ func TestUpper_UpWatchFileChange(t *testing.T) {
 
 func TestFirstBuildFails_Up(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 	manifest := f.newManifest("foobar")
 	f.SetNextBuildError(errors.New("Build failed"))
 
@@ -678,7 +673,6 @@ func TestFirstBuildFails_Up(t *testing.T) {
 
 func TestFirstBuildCancels_Up(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 	manifest := f.newManifest("foobar")
 	f.SetNextBuildError(context.Canceled)
 
@@ -694,7 +688,6 @@ func TestFirstBuildCancels_Up(t *testing.T) {
 
 func TestFirstBuildFails_CI(t *testing.T) {
 	f := newTestFixture(t, fixtureOptions{engineMode: &store.EngineModeCI})
-	defer f.TearDown()
 	manifest := f.newManifest("foobar")
 	buildFailedToken := errors.New("doesn't compile")
 	f.SetNextBuildError(buildFailedToken)
@@ -725,7 +718,6 @@ func TestFirstBuildFails_CI(t *testing.T) {
 
 func TestCIIgnoresDisabledResources(t *testing.T) {
 	f := newTestFixture(t, fixtureOptions{engineMode: &store.EngineModeCI})
-	defer f.TearDown()
 
 	m1 := f.newManifest("m1")
 	pb := f.registerForDeployer(m1)
@@ -751,7 +743,6 @@ func TestCIIgnoresDisabledResources(t *testing.T) {
 
 func TestRebuildWithChangedFiles(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 	manifest := f.newManifest("foobar")
 	pb := f.registerForDeployer(manifest)
 	f.Start([]model.Manifest{manifest})
@@ -785,7 +776,6 @@ func TestRebuildWithChangedFiles(t *testing.T) {
 
 func TestThreeBuilds(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 	manifest := f.newManifest("fe")
 	pb := f.registerForDeployer(manifest)
 	f.Start([]model.Manifest{manifest})
@@ -819,7 +809,6 @@ func TestThreeBuilds(t *testing.T) {
 
 func TestRebuildWithSpuriousChangedFiles(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 	manifest := f.newManifest("foobar")
 	pb := f.registerForDeployer(manifest)
 	f.Start([]model.Manifest{manifest})
@@ -850,7 +839,6 @@ func TestRebuildWithSpuriousChangedFiles(t *testing.T) {
 
 func TestConfigFileChangeClearsBuildStateToForceImageBuild(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 	f.useRealTiltfileLoader()
 
 	f.WriteFile("Tiltfile", `
@@ -903,7 +891,6 @@ k8s_yaml('snack.yaml')
 
 func TestMultipleChangesOnlyDeployOneManifest(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 	f.useRealTiltfileLoader()
 
 	f.WriteFile("Tiltfile", `
@@ -967,7 +954,6 @@ k8s_resource('doggos', new_name='quux')
 
 func TestSecondResourceIsBuilt(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 	f.useRealTiltfileLoader()
 
 	f.WriteFile("Tiltfile", `
@@ -1012,7 +998,6 @@ k8s_resource('doggos', new_name='quux')  # rename "doggos" --> "quux"
 
 func TestConfigChange_NoOpChange(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 	f.useRealTiltfileLoader()
 
 	f.WriteFile("Tiltfile", `
@@ -1054,7 +1039,6 @@ k8s_yaml('snack.yaml')`)
 
 func TestConfigChange_TiltfileErrorAndFixWithNoChanges(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 	f.useRealTiltfileLoader()
 
 	origTiltfile := `
@@ -1089,7 +1073,6 @@ k8s_yaml('snack.yaml')`
 
 func TestConfigChange_TiltfileErrorAndFixWithFileChange(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 	f.useRealTiltfileLoader()
 
 	tiltfileWithCmd := func(cmd string) string {
@@ -1147,7 +1130,6 @@ k8s_yaml('snack.yaml')
 
 func TestConfigChange_TriggerModeChangePropagatesButDoesntInvalidateBuild(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 	f.useRealTiltfileLoader()
 
 	origTiltfile := `
@@ -1182,7 +1164,6 @@ trigger_mode(TRIGGER_MODE_MANUAL)`, origTiltfile)
 
 func TestConfigChange_ManifestWithPendingChangesBuildsIfTriggerModeChangedToAuto(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 	f.useRealTiltfileLoader()
 
 	baseTiltfile := `trigger_mode(%s)
@@ -1230,7 +1211,6 @@ k8s_yaml('snack.yaml')`
 
 func TestConfigChange_ManifestIncludingInitialBuildsIfTriggerModeChangedToManualAfterInitial(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 
 	foo := f.newManifest("foo").WithTriggerMode(model.TriggerModeManual)
 	bar := f.newManifest("bar")
@@ -1268,7 +1248,6 @@ func TestConfigChange_ManifestIncludingInitialBuildsIfTriggerModeChangedToManual
 
 func TestConfigChange_FilenamesLoggedInManifestBuild(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 	f.useRealTiltfileLoader()
 
 	f.WriteFile("Tiltfile", `
@@ -1304,7 +1283,6 @@ docker_build('gcr.io/windmill-public-containers/servantes/snack', './src', ignor
 
 func TestConfigChange_LocalResourceChange(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 	f.useRealTiltfileLoader()
 
 	f.WriteFile("Tiltfile", `print('tiltfile 1')
@@ -1330,7 +1308,6 @@ local_resource('local', 'echo red fish blue fish', deps='foo.bar')`)
 
 func TestDockerRebuildWithChangedFiles(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 	df := `FROM golang
 ADD ./ ./
 go build ./...
@@ -1364,7 +1341,6 @@ go build ./...
 
 func TestHudUpdated(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 
 	manifest := f.newManifest("foobar")
 
@@ -1391,7 +1367,6 @@ func TestDisabledHudUpdated(t *testing.T) {
 		t.Skip("TODO(nick): Investigate")
 	}
 	f := newTestFixture(t)
-	defer f.TearDown()
 
 	manifest := f.newManifest("foobar")
 	opt := func(ia InitAction) InitAction {
@@ -1430,7 +1405,6 @@ func TestDisabledHudUpdated(t *testing.T) {
 
 func TestPodEvent(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 	manifest := f.newManifest("foobar")
 	pb := f.registerForDeployer(manifest)
 	f.Start([]model.Manifest{manifest})
@@ -1455,7 +1429,6 @@ func TestPodEvent(t *testing.T) {
 
 func TestPodEventContainerStatus(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 	manifest := f.newManifest("foobar")
 	pb := f.registerForDeployer(manifest)
 	f.Start([]model.Manifest{manifest})
@@ -1490,7 +1463,6 @@ func TestPodEventContainerStatus(t *testing.T) {
 
 func TestPodEventContainerStatusWithoutImage(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 	manifest := model.Manifest{
 		Name: model.ManifestName("foobar"),
 	}.WithDeployTarget(k8s.MustTarget("foobar", SanchoYAML))
@@ -1546,7 +1518,6 @@ func TestPodEventContainerStatusWithoutImage(t *testing.T) {
 
 func TestPodUnexpectedContainerStartsImageBuild(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 	f.bc.DisableForTesting()
 
 	name := model.ManifestName("foobar")
@@ -1599,7 +1570,6 @@ func TestPodUnexpectedContainerStartsImageBuild(t *testing.T) {
 
 func TestPodUnexpectedContainerStartsImageBuildOutOfOrderEvents(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 	f.bc.DisableForTesting()
 
 	name := model.ManifestName("foobar")
@@ -1648,7 +1618,6 @@ func TestPodUnexpectedContainerStartsImageBuildOutOfOrderEvents(t *testing.T) {
 
 func TestPodUnexpectedContainerAfterSuccessfulUpdate(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 	f.bc.DisableForTesting()
 
 	name := model.ManifestName("foobar")
@@ -1723,7 +1692,6 @@ func TestPodUnexpectedContainerAfterSuccessfulUpdate(t *testing.T) {
 
 func TestPodEventUpdateByTimestamp(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 	manifest := f.newManifest("foobar")
 	pb := f.registerForDeployer(manifest)
 	f.Start([]model.Manifest{manifest})
@@ -1760,7 +1728,6 @@ func TestPodEventUpdateByTimestamp(t *testing.T) {
 
 func TestPodDeleted(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 	mn := model.ManifestName("foobar")
 	manifest := f.newManifest(mn.String())
 	pb := f.registerForDeployer(manifest)
@@ -1805,7 +1772,6 @@ func TestPodDeleted(t *testing.T) {
 
 func TestPodEventUpdateByPodName(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 	manifest := f.newManifest("foobar")
 	pb := f.registerForDeployer(manifest)
 	f.Start([]model.Manifest{manifest})
@@ -1843,7 +1809,6 @@ func TestPodEventUpdateByPodName(t *testing.T) {
 
 func TestPodEventIgnoreOlderPod(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 	manifest := f.newManifest("foobar")
 	pb := f.registerForDeployer(manifest)
 	f.Start([]model.Manifest{manifest})
@@ -1877,7 +1842,6 @@ func TestPodEventIgnoreOlderPod(t *testing.T) {
 
 func TestPodContainerStatus(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 	manifest := f.newManifest("fe")
 	pb := f.registerForDeployer(manifest)
 	f.Start([]model.Manifest{manifest})
@@ -1917,7 +1881,6 @@ func TestPodContainerStatus(t *testing.T) {
 
 func TestUpper_WatchDockerIgnoredFiles(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 	manifest := f.newManifest("foobar")
 	manifest = manifest.WithImageTarget(manifest.ImageTargetAt(0).
 		WithDockerignores([]model.Dockerignore{
@@ -1942,7 +1905,6 @@ func TestUpper_WatchDockerIgnoredFiles(t *testing.T) {
 
 func TestUpper_ShowErrorPodLog(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 
 	name := model.ManifestName("foobar")
 	manifest := f.newManifest(name.String())
@@ -1972,7 +1934,6 @@ func TestUpper_ShowErrorPodLog(t *testing.T) {
 
 func TestUpperPodLogInCrashLoopThirdInstanceStillUp(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 
 	name := model.ManifestName("foobar")
 	manifest := f.newManifest(name.String())
@@ -2006,7 +1967,6 @@ func TestUpperPodLogInCrashLoopThirdInstanceStillUp(t *testing.T) {
 
 func TestUpperPodLogInCrashLoopPodCurrentlyDown(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 
 	name := model.ManifestName("foobar")
 	manifest := f.newManifest(name.String())
@@ -2039,7 +1999,6 @@ func TestUpperPodLogInCrashLoopPodCurrentlyDown(t *testing.T) {
 
 func TestUpperRecordPodWithMultipleContainers(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 
 	name := model.ManifestName("foobar")
 	manifest := f.newManifest(name.String())
@@ -2081,7 +2040,6 @@ func TestUpperRecordPodWithMultipleContainers(t *testing.T) {
 
 func TestUpperProcessOtherContainersIfOneErrors(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 
 	name := model.ManifestName("foobar")
 	manifest := f.newManifest(name.String())
@@ -2123,7 +2081,6 @@ func TestUpperProcessOtherContainersIfOneErrors(t *testing.T) {
 
 func TestUpper_ServiceEvent(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 
 	manifest := f.newManifest("foobar")
 
@@ -2156,7 +2113,6 @@ func TestUpper_ServiceEvent(t *testing.T) {
 
 func TestUpper_ServiceEventRemovesURL(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 
 	manifest := f.newManifest("foobar")
 
@@ -2193,7 +2149,6 @@ func TestUpper_ServiceEventRemovesURL(t *testing.T) {
 
 func TestUpper_PodLogs(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 
 	name := model.ManifestName("fe")
 	manifest := f.newManifest(string(name))
@@ -2212,7 +2167,6 @@ func TestUpper_PodLogs(t *testing.T) {
 
 func TestK8sEventGlobalLogAndManifestLog(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 
 	name := model.ManifestName("fe")
 	manifest := f.newManifest(string(name))
@@ -2246,7 +2200,6 @@ func TestK8sEventGlobalLogAndManifestLog(t *testing.T) {
 
 func TestK8sEventNotLoggedIfNoManifestForUID(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 
 	name := model.ManifestName("fe")
 	manifest := f.newManifest(string(name))
@@ -2273,7 +2226,6 @@ func TestK8sEventNotLoggedIfNoManifestForUID(t *testing.T) {
 
 func TestHudExitNoError(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 	f.Start([]model.Manifest{})
 	f.store.Dispatch(hud.NewExitAction(nil))
 	err := f.WaitForExit()
@@ -2282,7 +2234,6 @@ func TestHudExitNoError(t *testing.T) {
 
 func TestHudExitWithError(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 	f.Start([]model.Manifest{})
 	e := errors.New("helllllo")
 	f.store.Dispatch(hud.NewExitAction(e))
@@ -2291,7 +2242,6 @@ func TestHudExitWithError(t *testing.T) {
 
 func TestNewConfigsAreWatchedAfterFailure(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 	f.useRealTiltfileLoader()
 	f.loadAndStart()
 
@@ -2308,7 +2258,6 @@ func TestNewConfigsAreWatchedAfterFailure(t *testing.T) {
 
 func TestDockerComposeUp(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 	redis, server := f.setupDCFixture()
 
 	f.Start([]model.Manifest{redis, server})
@@ -2324,7 +2273,6 @@ func TestDockerComposeUp(t *testing.T) {
 
 func TestDockerComposeRedeployFromFileChange(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 	_, m := f.setupDCFixture()
 
 	f.Start([]model.Manifest{m})
@@ -2343,7 +2291,6 @@ func TestDockerComposeRedeployFromFileChange(t *testing.T) {
 
 func TestDockerComposeEventSetsStatus(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 	_, m := f.setupDCFixture()
 
 	f.Start([]model.Manifest{m})
@@ -2381,7 +2328,6 @@ func TestDockerComposeEventSetsStatus(t *testing.T) {
 
 func TestDockerComposeStartsEventWatcher(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 	_, m := f.setupDCFixture()
 
 	// Actual behavior is that we init with zero manifests, and add in manifests
@@ -2415,7 +2361,6 @@ func TestDockerComposeStartsEventWatcher(t *testing.T) {
 
 func TestDockerComposeRecordsBuildLogs(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 	f.useRealTiltfileLoader()
 
 	m, _ := f.setupDCFixture()
@@ -2437,7 +2382,6 @@ func TestDockerComposeRecordsBuildLogs(t *testing.T) {
 
 func TestDockerComposeRecordsRunLogs(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 	f.useRealTiltfileLoader()
 
 	m, _ := f.setupDCFixture()
@@ -2470,7 +2414,6 @@ func TestDockerComposeRecordsRunLogs(t *testing.T) {
 
 func TestDockerComposeFiltersRunLogs(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 	f.useRealTiltfileLoader()
 
 	// since this is a negative test case, we need to ensure our mock behaves properly first
@@ -2518,7 +2461,6 @@ fake-service exited with code 0
 // we inferred crash from ContainerState rather than sequences of events.
 func TestDockerComposeDetectsCrashes(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 	f.useRealTiltfileLoader()
 
 	m1, m2 := f.setupDCFixture()
@@ -2578,7 +2520,6 @@ func TestDockerComposeDetectsCrashes(t *testing.T) {
 
 func TestDockerComposeBuildCompletedSetsStatusToUpIfSuccessful(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 	f.useRealTiltfileLoader()
 
 	m1, _ := f.setupDCFixture()
@@ -2605,7 +2546,6 @@ func TestDockerComposeBuildCompletedSetsStatusToUpIfSuccessful(t *testing.T) {
 
 func TestDockerComposeStopOnDisable(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 	f.useRealTiltfileLoader()
 
 	m, _ := f.setupDCFixture()
@@ -2634,7 +2574,6 @@ func TestDockerComposeStopOnDisable(t *testing.T) {
 
 func TestDockerComposeStartOnReenable(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 	f.useRealTiltfileLoader()
 
 	m, _ := f.setupDCFixture()
@@ -2662,7 +2601,6 @@ func TestDockerComposeStartOnReenable(t *testing.T) {
 
 func TestEmptyTiltfile(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 	f.useRealTiltfileLoader()
 	f.WriteFile("Tiltfile", "")
 
@@ -2694,7 +2632,6 @@ func TestEmptyTiltfile(t *testing.T) {
 
 func TestUpperStart(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 	f.useRealTiltfileLoader()
 
 	tok := token.Token("unit test token")
@@ -2729,7 +2666,6 @@ func TestUpperStart(t *testing.T) {
 
 func TestWatchManifestsWithCommonAncestor(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 	m1, m2 := NewManifestsWithCommonAncestor(f)
 	f.Start([]model.Manifest{m1, m2})
 
@@ -2785,7 +2721,6 @@ func TestConfigChangeThatChangesManifestIsIncludedInManifestsChangedFile(t *test
 	t.Skip("TODO(nick): fix this")
 
 	f := newTestFixture(t)
-	defer f.TearDown()
 	f.useRealTiltfileLoader()
 
 	tiltfile := `
@@ -2820,7 +2755,6 @@ k8s_yaml('snack.yaml')`
 
 func TestSetAnalyticsOpt(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 
 	opt := func(ia InitAction) InitAction {
 		ia.AnalyticsUserOpt = analytics.OptIn
@@ -2853,7 +2787,6 @@ func TestSetAnalyticsOpt(t *testing.T) {
 
 func TestFeatureFlagsStoredOnState(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 
 	f.Start([]model.Manifest{})
 	f.ensureCluster()
@@ -2881,7 +2814,6 @@ func TestFeatureFlagsStoredOnState(t *testing.T) {
 
 func TestTeamIDStoredOnState(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 
 	f.Start([]model.Manifest{})
 	f.ensureCluster()
@@ -2909,7 +2841,6 @@ func TestTeamIDStoredOnState(t *testing.T) {
 
 func TestBuildLogAction(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 	f.bc.DisableForTesting()
 
 	manifest := f.newManifest("alert-injester")
@@ -2945,7 +2876,6 @@ alert-injest… │ ghij`)
 
 func TestBuildErrorLoggedOnceByUpper(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 
 	manifest := f.newManifest("alert-injester")
 	err := errors.New("cats and dogs, living together")
@@ -2963,7 +2893,6 @@ func TestBuildErrorLoggedOnceByUpper(t *testing.T) {
 
 func TestTiltfileChangedFilesOnlyLoggedAfterFirstBuild(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 	f.useRealTiltfileLoader()
 
 	f.WriteFile("Tiltfile", `
@@ -3001,7 +2930,6 @@ k8s_yaml('snack.yaml')`)
 
 func TestDeployUIDsInEngineState(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 
 	uid := types.UID("fake-uid")
 	f.b.nextDeployedUID = uid
@@ -3021,7 +2949,6 @@ func TestDeployUIDsInEngineState(t *testing.T) {
 
 func TestEnableFeatureOnFail(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 	f.useRealTiltfileLoader()
 
 	f.WriteFile("Tiltfile", `
@@ -3041,7 +2968,6 @@ fail('goodnight moon')
 
 func TestSecretScrubbed(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 	f.useRealTiltfileLoader()
 
 	tiltfile := `
@@ -3072,7 +2998,6 @@ data:
 
 func TestShortSecretNotScrubbed(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 	f.useRealTiltfileLoader()
 
 	tiltfile := `
@@ -3101,7 +3026,6 @@ stringData:
 
 func TestDisableDockerPrune(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 	f.useRealTiltfileLoader()
 
 	f.WriteFile("Dockerfile", `FROM iron/go:prod`)
@@ -3123,7 +3047,6 @@ docker_prune_settings(disable=True)
 
 func TestDockerPruneEnabledByDefault(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 	f.useRealTiltfileLoader()
 
 	f.WriteFile("Tiltfile", simpleTiltfile)
@@ -3144,7 +3067,6 @@ func TestDockerPruneEnabledByDefault(t *testing.T) {
 
 func TestHasEverBeenReadyK8s(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 
 	m := f.newManifest("foobar")
 	pb := f.registerForDeployer(m)
@@ -3163,7 +3085,6 @@ func TestHasEverBeenReadyK8s(t *testing.T) {
 
 func TestHasEverBeenCompleteK8s(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 
 	m := f.newManifest("foobar")
 	pb := f.registerForDeployer(m)
@@ -3182,7 +3103,6 @@ func TestHasEverBeenCompleteK8s(t *testing.T) {
 
 func TestHasEverBeenReadyLocal(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 
 	m := manifestbuilder.New(f, "foobar").WithLocalResource("foo", []string{f.Path()}).Build()
 	f.SetNextBuildError(errors.New("failure!"))
@@ -3203,7 +3123,6 @@ func TestHasEverBeenReadyLocal(t *testing.T) {
 
 func TestHasEverBeenReadyDC(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 
 	m, _ := f.setupDCFixture()
 	f.Start([]model.Manifest{m})
@@ -3224,7 +3143,6 @@ func TestHasEverBeenReadyDC(t *testing.T) {
 
 func TestVersionSettingsStoredOnState(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 
 	f.Start([]model.Manifest{})
 	f.ensureCluster()
@@ -3245,7 +3163,6 @@ func TestVersionSettingsStoredOnState(t *testing.T) {
 
 func TestAnalyticsTiltfileOpt(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 
 	f.Start([]model.Manifest{})
 	f.ensureCluster()
@@ -3271,7 +3188,6 @@ func TestAnalyticsTiltfileOpt(t *testing.T) {
 
 func TestConfigArgsChangeCausesTiltfileRerun(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 	f.useRealTiltfileLoader()
 
 	f.WriteFile("Tiltfile", `
@@ -3310,7 +3226,6 @@ print('foo=', cfg['foo'])`)
 
 func TestTelemetryLogAction(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 
 	f.Start([]model.Manifest{})
 
@@ -3340,7 +3255,6 @@ func TestLocalResourceServeWithNoUpdate(t *testing.T) {
 
 		t.Run(name, func(t *testing.T) {
 			f := newTestFixture(t)
-			defer f.TearDown()
 
 			m := manifestbuilder.New(f, "foo").
 				WithLocalServeCmd("true").
@@ -3386,7 +3300,6 @@ func TestLocalResourceServeWithNoUpdate(t *testing.T) {
 
 func TestLocalResourceServeChangeCmd(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 	f.useRealTiltfileLoader()
 
 	f.WriteFile("Tiltfile", "local_resource('foo', serve_cmd='true')")
@@ -3412,7 +3325,6 @@ func TestLocalResourceServeChangeCmd(t *testing.T) {
 
 func TestDefaultUpdateSettings(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 	f.useRealTiltfileLoader()
 
 	f.WriteFile("Dockerfile", `FROM iron/go:prod`)
@@ -3432,7 +3344,6 @@ func TestDefaultUpdateSettings(t *testing.T) {
 
 func TestSetK8sUpsertTimeout(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 	f.useRealTiltfileLoader()
 
 	f.WriteFile("Dockerfile", `FROM iron/go:prod`)
@@ -3453,7 +3364,6 @@ update_settings(k8s_upsert_timeout_secs=123)
 
 func TestSetMaxBuildSlots(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 	f.useRealTiltfileLoader()
 
 	f.WriteFile("Dockerfile", `FROM iron/go:prod`)
@@ -3475,7 +3385,6 @@ update_settings(max_parallel_updates=123)
 // https://github.com/tilt-dev/tilt/issues/3514
 func TestTiltignoreRespectedOnError(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 	f.useRealTiltfileLoader()
 
 	f.WriteFile("Tiltfile", `local("echo hi > a.txt")
@@ -3516,7 +3425,6 @@ fail('x')`)
 
 func TestHandleTiltfileTriggerQueue(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 	f.useRealTiltfileLoader()
 
 	f.WriteFile("Tiltfile", `print("hello world")`)
@@ -3559,7 +3467,6 @@ func TestHandleTiltfileTriggerQueue(t *testing.T) {
 
 func TestOverrideTriggerModeEvent(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 
 	manifest := f.newManifest("foo")
 	f.Start([]model.Manifest{manifest})
@@ -3587,7 +3494,6 @@ func TestOverrideTriggerModeBadManifestLogsError(t *testing.T) {
 	}
 
 	f := newTestFixture(t)
-	defer f.TearDown()
 
 	manifest := f.newManifest("foo")
 	f.Start([]model.Manifest{manifest})
@@ -3610,7 +3516,6 @@ func TestOverrideTriggerModeBadManifestLogsError(t *testing.T) {
 
 func TestOverrideTriggerModeBadTriggerModeLogsError(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 
 	manifest := f.newManifest("foo")
 	f.Start([]model.Manifest{manifest})
@@ -3633,7 +3538,6 @@ func TestOverrideTriggerModeBadTriggerModeLogsError(t *testing.T) {
 
 func TestDisablingResourcePreventsBuild(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 
 	m := manifestbuilder.New(f, "foo").WithLocalResource("foo", []string{f.Path()}).Build()
 
@@ -3652,7 +3556,6 @@ func TestDisablingResourcePreventsBuild(t *testing.T) {
 
 func TestDisableButtonIsCreated(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 	f.useRealTiltfileLoader()
 
 	f.WriteFile("Tiltfile", `
@@ -3681,7 +3584,6 @@ local_resource('foo', 'echo hi')
 
 func TestCmdServerDoesntStartWhenDisabled(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 	f.useRealTiltfileLoader()
 
 	f.WriteFile("Tiltfile", `print('dummy tiltfile with no resources')`)
@@ -3707,7 +3609,6 @@ config.set_enabled_resources(['bar'])
 
 func TestDisabledResourceRemovedFromTriggerQueue(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 
 	m := manifestbuilder.New(f, "foo").WithLocalResource("foo", []string{f.Path()}).Build()
 
@@ -3732,7 +3633,6 @@ func TestDisabledResourceRemovedFromTriggerQueue(t *testing.T) {
 
 func TestLocalResourceNoServeCmdDeps(t *testing.T) {
 	f := newTestFixture(t)
-	defer f.TearDown()
 	f.useRealTiltfileLoader()
 
 	// create a Tiltfile with 2 resources:
@@ -3992,6 +3892,7 @@ func newTestFixture(t *testing.T, options ...fixtureOptions) *testFixture {
 		testutils.FailOnNonCanceledErr(t, err, "hud.Run failed")
 	}()
 
+	t.Cleanup(ret.TearDown)
 	return ret
 }
 
@@ -4414,8 +4315,6 @@ func (f *testFixture) TearDown() {
 			fmt.Println(es.LogStore.String())
 		})
 	}
-	f.TempDirFixture.TearDown()
-	f.kClient.TearDown()
 	close(f.fsWatcher.Events)
 	close(f.fsWatcher.Errors)
 	f.cancel()

--- a/internal/git/gitignore_test.go
+++ b/internal/git/gitignore_test.go
@@ -12,7 +12,6 @@ import (
 
 func TestGitIgnoreTester_GitDirMatches(t *testing.T) {
 	tf := newTestFixture(t)
-	defer tf.TearDown()
 
 	tests := []struct {
 		description string
@@ -81,10 +80,4 @@ func (tf *testFixture) AssertResult(description, path string, expectedMatches bo
 			assert.Equal(t, expectedMatches, isIgnored)
 		}
 	})
-}
-
-func (tf *testFixture) TearDown() {
-	for _, tempDir := range tf.repoRoots {
-		tempDir.TearDown()
-	}
 }

--- a/internal/git/remote_test.go
+++ b/internal/git/remote_test.go
@@ -27,7 +27,6 @@ func TestNormalizedGitRemoteUsername(t *testing.T) {
 
 func TestGitOrigin(t *testing.T) {
 	tf := tempdir.NewTempDirFixture(t)
-	defer tf.TearDown()
 
 	err := exec.Command("git", "init", tf.Path()).Run()
 	if err != nil {

--- a/internal/hud/prompt/prompt_test.go
+++ b/internal/hud/prompt/prompt_test.go
@@ -20,8 +20,7 @@ import (
 const FakeURL = "http://localhost:10350/"
 
 func TestOpenBrowser(t *testing.T) {
-	f := newFixture()
-	defer f.TearDown()
+	f := newFixture(t)
 
 	_ = f.prompt.OnChange(f.ctx, f.st, store.LegacyChangeSummary())
 
@@ -32,8 +31,7 @@ func TestOpenBrowser(t *testing.T) {
 }
 
 func TestOpenStream(t *testing.T) {
-	f := newFixture()
-	defer f.TearDown()
+	f := newFixture(t)
 
 	_ = f.prompt.OnChange(f.ctx, f.st, store.LegacyChangeSummary())
 
@@ -46,8 +44,7 @@ func TestOpenStream(t *testing.T) {
 }
 
 func TestOpenHUD(t *testing.T) {
-	f := newFixture()
-	defer f.TearDown()
+	f := newFixture(t)
 
 	_ = f.prompt.OnChange(f.ctx, f.st, store.LegacyChangeSummary())
 
@@ -60,8 +57,7 @@ func TestOpenHUD(t *testing.T) {
 }
 
 func TestInitOutput(t *testing.T) {
-	f := newFixture()
-	defer f.TearDown()
+	f := newFixture(t)
 
 	f.prompt.SetInitOutput(bytes.NewBuffer([]byte("this is a warning\n")))
 	_ = f.prompt.OnChange(f.ctx, f.st, store.LegacyChangeSummary())
@@ -81,7 +77,7 @@ type fixture struct {
 	prompt *TerminalPrompt
 }
 
-func newFixture() *fixture {
+func newFixture(t *testing.T) *fixture {
 	ctx, _, ta := testutils.CtxAndAnalyticsForTest()
 	ctx, cancel := context.WithCancel(ctx)
 	out := bufsync.NewThreadSafeBuffer()
@@ -96,7 +92,7 @@ func newFixture() *fixture {
 	url, _ := url.Parse(FakeURL)
 
 	prompt := NewTerminalPrompt(ta, openInput, b.OpenURL, out, "localhost", model.WebURL(*url))
-	return &fixture{
+	ret := &fixture{
 		ctx:    ctx,
 		cancel: cancel,
 		out:    out,
@@ -105,6 +101,10 @@ func newFixture() *fixture {
 		b:      b,
 		prompt: prompt,
 	}
+
+	t.Cleanup(ret.TearDown)
+
+	return ret
 }
 
 func (f *fixture) TearDown() {

--- a/internal/hud/server/apiserver_test.go
+++ b/internal/hud/server/apiserver_test.go
@@ -180,7 +180,6 @@ func newAPIServerFixture(t testing.TB) *apiserverFixture {
 	t.Helper()
 
 	tmpdir := tempdir.NewTempDirFixture(t)
-	t.Cleanup(tmpdir.TearDown)
 
 	dir := dirs.NewTiltDevDirAt(tmpdir.Path())
 	ctx, _, _ := testutils.CtxAndAnalyticsForTest()

--- a/internal/hud/server/websocket_reader_test.go
+++ b/internal/hud/server/websocket_reader_test.go
@@ -28,8 +28,6 @@ func TestViewsHandled(t *testing.T) {
 	f.sendView(v)
 	f.assertHandlerCallCount(2)
 	assert.Equal(t, "goodbye world", f.handler.lastViewLog)
-
-	f.tearDown()
 }
 
 func TestHandlerErrorDoesntStopLoop(t *testing.T) {
@@ -47,8 +45,6 @@ func TestHandlerErrorDoesntStopLoop(t *testing.T) {
 	f.sendView(v)
 	f.assertHandlerCallCount(2)
 	assert.Equal(t, "goodbye world", f.handler.lastViewLog)
-
-	f.tearDown()
 }
 
 func TestNonPersistentReaderExistsAfterHandling(t *testing.T) {
@@ -60,8 +56,6 @@ func TestNonPersistentReaderExistsAfterHandling(t *testing.T) {
 	f.assertHandlerCallCount(1)
 	assert.Equal(t, "hello world", f.handler.lastViewLog)
 	f.assertDone()
-
-	f.tearDown()
 }
 
 func TestWebsocketCloseOnNextReaderError(t *testing.T) {
@@ -92,7 +86,7 @@ func newWebsocketReaderFixture(t *testing.T) *websocketReaderFixture {
 	conn := newFakeConn()
 	handler := &fakeViewHandler{}
 
-	return &websocketReaderFixture{
+	ret := &websocketReaderFixture{
 		t:       t,
 		ctx:     ctx,
 		cancel:  cancel,
@@ -102,6 +96,9 @@ func newWebsocketReaderFixture(t *testing.T) *websocketReaderFixture {
 		wsr:     newWebsocketReader(conn, true, handler),
 		done:    make(chan error),
 	}
+
+	t.Cleanup(ret.tearDown)
+	return ret
 }
 
 func (f *websocketReaderFixture) withPersistent(persistent bool) *websocketReaderFixture {

--- a/internal/hud/webview/convert_test.go
+++ b/internal/hud/webview/convert_test.go
@@ -47,7 +47,6 @@ func completeProtoView(t *testing.T, s store.EngineState) *proto_webview.View {
 
 func TestStateToWebViewRelativeEditPaths(t *testing.T) {
 	f := tempdir.NewTempDirFixture(t)
-	defer f.TearDown()
 
 	m := model.Manifest{
 		Name: "foo",

--- a/internal/ignore/path_matcher_test.go
+++ b/internal/ignore/path_matcher_test.go
@@ -48,7 +48,6 @@ type ignoreTestCase struct {
 
 func TestIgnores(t *testing.T) {
 	f := tempdir.NewTempDirFixture(t)
-	defer f.TearDown()
 
 	target := FakeTarget{
 		path: f.Path(),

--- a/internal/k8s/fake_client.go
+++ b/internal/k8s/fake_client.go
@@ -351,11 +351,12 @@ func NewFakeK8sClient(t testing.TB) *FakeK8sClient {
 	}
 	ctx, cancel := context.WithCancel(logger.WithLogger(context.Background(), logger.NewTestLogger(os.Stdout)))
 	t.Cleanup(cancel)
+	t.Cleanup(cli.tearDown)
 	cli.ownerFetcher = NewOwnerFetcher(ctx, cli)
 	return cli
 }
 
-func (c *FakeK8sClient) TearDown() {
+func (c *FakeK8sClient) tearDown() {
 	c.mu.Lock()
 	podWatches := append([]fakePodWatch{}, c.podWatches...)
 	serviceWatches := append([]fakeServiceWatch{}, c.serviceWatches...)

--- a/internal/k8s/watch_test.go
+++ b/internal/k8s/watch_test.go
@@ -33,7 +33,6 @@ import (
 
 func TestK8sClient_WatchPods(t *testing.T) {
 	tf := newWatchTestFixture(t)
-	defer tf.TearDown()
 
 	pod1 := fakePod(PodID("abcd"), "efgh")
 	pod2 := fakePod(PodID("1234"), "hieruyge")
@@ -44,7 +43,6 @@ func TestK8sClient_WatchPods(t *testing.T) {
 
 func TestPodFromInformerCacheAfterWatch(t *testing.T) {
 	tf := newWatchTestFixture(t)
-	defer tf.TearDown()
 
 	pod1 := fakePod(PodID("abcd"), "efgh")
 	pods := []runtime.Object{pod1}
@@ -64,7 +62,6 @@ func TestPodFromInformerCacheAfterWatch(t *testing.T) {
 
 func TestPodFromInformerCacheBeforeWatch(t *testing.T) {
 	tf := newWatchTestFixture(t)
-	defer tf.TearDown()
 
 	pod1 := fakePod(PodID("abcd"), "efgh")
 	pods := []runtime.Object{pod1}
@@ -86,7 +83,6 @@ func TestPodFromInformerCacheBeforeWatch(t *testing.T) {
 
 func TestK8sClient_WatchPodsNamespaces(t *testing.T) {
 	tf := newWatchTestFixture(t)
-	defer tf.TearDown()
 
 	pod1 := fakePod(PodID("pod1"), "pod1")
 	pod2 := fakePod(PodID("pod2-system"), "pod2-system")
@@ -100,7 +96,6 @@ func TestK8sClient_WatchPodsNamespaces(t *testing.T) {
 
 func TestK8sClient_WatchPodDeletion(t *testing.T) {
 	tf := newWatchTestFixture(t)
-	defer tf.TearDown()
 
 	podID := PodID("pod1")
 	pod := fakePod(podID, "image1")
@@ -130,7 +125,6 @@ func TestK8sClient_WatchPodDeletion(t *testing.T) {
 
 func TestK8sClient_WatchPodsFilterNonPods(t *testing.T) {
 	tf := newWatchTestFixture(t)
-	defer tf.TearDown()
 
 	pod := fakePod(PodID("abcd"), "efgh")
 	pods := []runtime.Object{pod}
@@ -145,7 +139,6 @@ func TestK8sClient_WatchServices(t *testing.T) {
 		t.Skip("TODO(nick): investigate")
 	}
 	tf := newWatchTestFixture(t)
-	defer tf.TearDown()
 
 	svc1 := fakeService("svc1")
 	svc2 := fakeService("svc2")
@@ -156,7 +149,6 @@ func TestK8sClient_WatchServices(t *testing.T) {
 
 func TestK8sClient_WatchServicesFilterNonServices(t *testing.T) {
 	tf := newWatchTestFixture(t)
-	defer tf.TearDown()
 
 	svc := fakeService("svc1")
 	svcs := []runtime.Object{svc}
@@ -168,7 +160,6 @@ func TestK8sClient_WatchServicesFilterNonServices(t *testing.T) {
 
 func TestK8sClient_WatchPodsError(t *testing.T) {
 	tf := newWatchTestFixture(t)
-	defer tf.TearDown()
 
 	tf.watchErr = newForbiddenError()
 	_, err := tf.kCli.WatchPods(tf.ctx, "default")
@@ -179,7 +170,6 @@ func TestK8sClient_WatchPodsError(t *testing.T) {
 
 func TestK8sClient_WatchPodsWithNamespaceRestriction(t *testing.T) {
 	tf := newWatchTestFixture(t)
-	defer tf.TearDown()
 
 	tf.nsRestriction = "sandbox"
 	tf.kCli.configNamespace = "sandbox"
@@ -194,7 +184,6 @@ func TestK8sClient_WatchPodsWithNamespaceRestriction(t *testing.T) {
 
 func TestK8sClient_WatchPodsBlockedByNamespaceRestriction(t *testing.T) {
 	tf := newWatchTestFixture(t)
-	defer tf.TearDown()
 
 	tf.nsRestriction = "sandbox"
 	tf.kCli.configNamespace = ""
@@ -207,7 +196,6 @@ func TestK8sClient_WatchPodsBlockedByNamespaceRestriction(t *testing.T) {
 
 func TestK8sClient_WatchServicesWithNamespaceRestriction(t *testing.T) {
 	tf := newWatchTestFixture(t)
-	defer tf.TearDown()
 
 	tf.nsRestriction = "sandbox"
 	tf.kCli.configNamespace = "sandbox"
@@ -222,7 +210,6 @@ func TestK8sClient_WatchServicesWithNamespaceRestriction(t *testing.T) {
 
 func TestK8sClient_WatchServicesBlockedByNamespaceRestriction(t *testing.T) {
 	tf := newWatchTestFixture(t)
-	defer tf.TearDown()
 
 	tf.nsRestriction = "sandbox"
 	tf.kCli.configNamespace = ""
@@ -235,7 +222,6 @@ func TestK8sClient_WatchServicesBlockedByNamespaceRestriction(t *testing.T) {
 
 func TestK8sClient_WatchEvents(t *testing.T) {
 	tf := newWatchTestFixture(t)
-	defer tf.TearDown()
 
 	event1 := fakeEvent("event1", "hello1", 1)
 	event2 := fakeEvent("event2", "hello2", 2)
@@ -246,7 +232,6 @@ func TestK8sClient_WatchEvents(t *testing.T) {
 
 func TestK8sClient_WatchEventsNamespaced(t *testing.T) {
 	tf := newWatchTestFixture(t)
-	defer tf.TearDown()
 
 	tf.kCli.configNamespace = "sandbox"
 
@@ -259,7 +244,6 @@ func TestK8sClient_WatchEventsNamespaced(t *testing.T) {
 
 func TestK8sClient_WatchEventsUpdate(t *testing.T) {
 	tf := newWatchTestFixture(t)
-	defer tf.TearDown()
 
 	event1 := fakeEvent("event1", "hello1", 1)
 	event2 := fakeEvent("event2", "hello2", 1)
@@ -286,7 +270,6 @@ func TestK8sClient_WatchEventsUpdate(t *testing.T) {
 
 func TestWatchPodsAfterAdding(t *testing.T) {
 	tf := newWatchTestFixture(t)
-	defer tf.TearDown()
 
 	pod1 := fakePod(PodID("abcd"), "efgh")
 	tf.addObjects(pod1)
@@ -296,7 +279,6 @@ func TestWatchPodsAfterAdding(t *testing.T) {
 
 func TestWatchServicesAfterAdding(t *testing.T) {
 	tf := newWatchTestFixture(t)
-	defer tf.TearDown()
 
 	svc := fakeService("svc1")
 	tf.addObjects(svc)
@@ -306,7 +288,6 @@ func TestWatchServicesAfterAdding(t *testing.T) {
 
 func TestWatchEventsAfterAdding(t *testing.T) {
 	tf := newWatchTestFixture(t)
-	defer tf.TearDown()
 
 	event := fakeEvent("event1", "hello1", 1)
 	tf.addObjects(event)
@@ -316,7 +297,6 @@ func TestWatchEventsAfterAdding(t *testing.T) {
 
 func TestK8sClient_WatchMeta(t *testing.T) {
 	tf := newWatchTestFixture(t)
-	defer tf.TearDown()
 
 	pod1 := fakePod(PodID("abcd"), "efgh")
 	pod2 := fakePod(PodID("1234"), "hieruyge")
@@ -335,7 +315,6 @@ func TestK8sClient_WatchMeta(t *testing.T) {
 
 func TestK8sClient_WatchMetaBackfillK8s14(t *testing.T) {
 	tf := newWatchTestFixture(t)
-	defer tf.TearDown()
 
 	tf.version.GitVersion = "v1.14.1"
 
@@ -404,6 +383,7 @@ type watchTestFixture struct {
 
 func newWatchTestFixture(t *testing.T) *watchTestFixture {
 	ret := &watchTestFixture{t: t}
+	t.Cleanup(ret.TearDown)
 
 	ctx, _, _ := testutils.CtxAndAnalyticsForTest()
 	ret.ctx, ret.cancel = context.WithCancel(ctx)

--- a/internal/ospath/ospath_test.go
+++ b/internal/ospath/ospath_test.go
@@ -11,7 +11,6 @@ import (
 
 func TestChild(t *testing.T) {
 	f := NewOspathFixture(t)
-	defer f.TearDown()
 
 	paths := []string{
 		filepath.Join("parent", "fileA"),
@@ -34,7 +33,6 @@ func TestChild(t *testing.T) {
 
 func TestCaseInsensitiveFileSystem(t *testing.T) {
 	f := NewOspathFixture(t)
-	defer f.TearDown()
 
 	fileA := filepath.Join("parent", "fileA")
 	f.TouchFiles([]string{fileA})
@@ -54,7 +52,6 @@ func TestIsBrokenSymlink(t *testing.T) {
 		t.Skip("windows does not support user-land symlinks")
 	}
 	f := NewOspathFixture(t)
-	defer f.TearDown()
 
 	f.TouchFiles([]string{
 		"fileA",
@@ -75,7 +72,6 @@ func TestIsBrokenSymlink(t *testing.T) {
 
 func TestInvalidDir(t *testing.T) {
 	f := NewOspathFixture(t)
-	defer f.TearDown()
 
 	// Passing "" as dir used to make Child hang forever. Let's make sure it doesn't do that.
 	_, isChild := Child("", "random")
@@ -86,7 +82,6 @@ func TestInvalidDir(t *testing.T) {
 
 func TestDirTrailingSlash(t *testing.T) {
 	f := NewOspathFixture(t)
-	defer f.TearDown()
 
 	f.TouchFiles([]string{filepath.Join("some", "dir", "file")})
 
@@ -99,7 +94,6 @@ func TestDirTrailingSlash(t *testing.T) {
 
 func TestTryAsCwdChildren(t *testing.T) {
 	f := NewOspathFixture(t)
-	defer f.TearDown()
 	f.Chdir()
 
 	results := TryAsCwdChildren([]string{f.Path()})
@@ -121,10 +115,11 @@ type OspathFixture struct {
 }
 
 func NewOspathFixture(t *testing.T) *OspathFixture {
-	return &OspathFixture{
+	ret := &OspathFixture{
 		TempDirFixture: tempdir.NewTempDirFixture(t),
 		t:              t,
 	}
+	return ret
 }
 
 // pass `expectedRelative` = "" to indicate that `file` is NOT a child of `dir`

--- a/internal/store/engine_state_test.go
+++ b/internal/store/engine_state_test.go
@@ -55,7 +55,6 @@ func (c endpointsCase) validate() {
 
 func TestStateToViewRelativeEditPaths(t *testing.T) {
 	f := tempdir.NewTempDirFixture(t)
-	defer f.TearDown()
 	m := model.Manifest{
 		Name: "foo",
 	}.WithDeployTarget(model.K8sTarget{}).WithImageTarget(model.ImageTarget{}.
@@ -153,7 +152,6 @@ func TestStateToViewLocalResourceLinks(t *testing.T) {
 
 func TestRuntimeStateNonWorkload(t *testing.T) {
 	f := tempdir.NewTempDirFixture(t)
-	defer f.TearDown()
 
 	m := manifestbuilder.New(f, model.UnresourcedYAMLManifestName).
 		WithK8sYAML(testyaml.SecretYaml).
@@ -178,7 +176,6 @@ func TestRuntimeStateJob(t *testing.T) {
 	} {
 		t.Run(string(tc.phase), func(t *testing.T) {
 			f := tempdir.NewTempDirFixture(t)
-			defer f.TearDown()
 
 			m := manifestbuilder.New(f, "foo").
 				WithK8sYAML(testyaml.JobYAML).

--- a/internal/store/json_test.go
+++ b/internal/store/json_test.go
@@ -16,7 +16,6 @@ import (
 
 func TestToJSON(t *testing.T) {
 	f := tempdir.NewTempDirFixture(t)
-	defer f.TearDown()
 
 	m := manifestbuilder.New(f, "fe").
 		WithK8sYAML(testyaml.SanchoYAML).

--- a/internal/store/liveupdates/reducers_test.go
+++ b/internal/store/liveupdates/reducers_test.go
@@ -19,7 +19,6 @@ var SanchoRef = container.MustParseSelector(testyaml.SanchoImage)
 
 func TestNeedsCrashRebuildLiveUpdateV1(t *testing.T) {
 	f := tempdir.NewTempDirFixture(t)
-	defer f.TearDown()
 
 	iTarget := imageTarget()
 	m := manifestbuilder.New(f, model.ManifestName("sancho")).
@@ -40,7 +39,6 @@ func TestNeedsCrashRebuildLiveUpdateV1(t *testing.T) {
 
 func TestNeedsCrashRebuildLiveUpdateV2(t *testing.T) {
 	f := tempdir.NewTempDirFixture(t)
-	defer f.TearDown()
 
 	iTarget := imageTarget()
 	iTarget.LiveUpdateReconciler = true

--- a/internal/testutils/tempdir/temp_dir_fixture.go
+++ b/internal/testutils/tempdir/temp_dir_fixture.go
@@ -31,10 +31,14 @@ func NewTempDirFixture(t testing.TB) *TempDirFixture {
 		t.Fatalf("Error making temp dir: %v", err)
 	}
 
-	return &TempDirFixture{
+	ret := &TempDirFixture{
 		t:   t,
 		dir: dir,
 	}
+
+	t.Cleanup(ret.tearDown)
+
+	return ret
 }
 
 func (f *TempDirFixture) T() testing.TB {
@@ -162,7 +166,7 @@ func (f *TempDirFixture) TempDir(prefix string) string {
 	return name
 }
 
-func (f *TempDirFixture) TearDown() {
+func (f *TempDirFixture) tearDown() {
 	if f.oldDir != "" {
 		err := os.Chdir(f.oldDir)
 		if err != nil {

--- a/internal/testutils/tempdir/temp_dir_fixture_test.go
+++ b/internal/testutils/tempdir/temp_dir_fixture_test.go
@@ -12,7 +12,6 @@ import (
 func TestNestedDirs(t *testing.T) {
 	t.Run("inner", func(t *testing.T) {
 		f := NewTempDirFixture(t)
-		defer f.TearDown()
 
 		assert.Contains(t, f.Path(), "inner")
 		assert.Contains(t, f.Path(), "NestedDirs")

--- a/internal/tiltfile/config/config_test.go
+++ b/internal/tiltfile/config/config_test.go
@@ -35,7 +35,6 @@ func TestSetResources(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			f := NewFixture(t, tc.args, "")
-			defer f.TearDown()
 
 			setResources := ""
 			if len(tc.tiltfileResources) > 0 {
@@ -73,7 +72,6 @@ func TestClearEnabledResources(t *testing.T) {
 	args := strings.Split("united states canada mexico panama haiti jamaica peru", " ")
 
 	f := NewFixture(t, args, "")
-	defer f.TearDown()
 
 	f.File("Tiltfile", "config.clear_enabled_resources()")
 
@@ -91,7 +89,6 @@ func TestClearEnabledResourcesWithArgs(t *testing.T) {
 	args := strings.Split("united states canada mexico panama haiti jamaica peru", " ")
 
 	f := NewFixture(t, args, "")
-	defer f.TearDown()
 
 	f.File("Tiltfile", "config.clear_enabled_resources('foo')")
 
@@ -105,7 +102,6 @@ func TestParsePositional(t *testing.T) {
 	args := strings.Split("united states canada mexico panama haiti jamaica peru", " ")
 
 	f := NewFixture(t, args, "")
-	defer f.TearDown()
 
 	f.File("Tiltfile", `
 config.define_string_list('foo', args=True)
@@ -127,7 +123,6 @@ func TestParseKeyword(t *testing.T) {
 	}
 
 	f := NewFixture(t, args, "")
-	defer f.TearDown()
 
 	f.File("Tiltfile", `
 config.define_string_list('foo')
@@ -144,7 +139,6 @@ print(cfg['foo'])
 func TestParsePositionalAndMultipleInterspersedKeyword(t *testing.T) {
 	args := []string{"--bar", "puerto rico", "--baz", "colombia", "--bar", "venezuela", "--baz", "honduras", "--baz", "guyana", "and", "still"}
 	f := NewFixture(t, args, "")
-	defer f.TearDown()
 
 	f.File("Tiltfile", `
 config.define_string_list('foo', args=True)
@@ -167,7 +161,6 @@ print("baz:", cfg['baz'])
 func TestParseKeywordAfterPositional(t *testing.T) {
 	args := []string{"--bar", "puerto rico", "colombia"}
 	f := NewFixture(t, args, "")
-	defer f.TearDown()
 
 	f.File("Tiltfile", `
 config.define_string_list('foo', args=True)
@@ -186,7 +179,6 @@ print("bar:", cfg['bar'])
 
 func TestMultiplePositionalDefs(t *testing.T) {
 	f := NewFixture(t, nil, "")
-	defer f.TearDown()
 
 	f.File("Tiltfile", `
 config.define_string_list('foo', args=True)
@@ -200,7 +192,6 @@ config.define_string_list('bar', args=True)
 
 func TestMultipleArgsSameName(t *testing.T) {
 	f := NewFixture(t, nil, "")
-	defer f.TearDown()
 
 	f.File("Tiltfile", `
 config.define_string_list('foo')
@@ -214,7 +205,6 @@ config.define_string_list('foo')
 
 func TestUndefinedArg(t *testing.T) {
 	f := NewFixture(t, []string{"--bar", "hello"}, "")
-	defer f.TearDown()
 
 	f.File("Tiltfile", `
 config.define_string_list('foo')
@@ -233,7 +223,6 @@ Usage:
 
 func TestUnprovidedArg(t *testing.T) {
 	f := NewFixture(t, nil, "")
-	defer f.TearDown()
 
 	f.File("Tiltfile", `
 config.define_string_list('foo')
@@ -261,7 +250,6 @@ print("foo:",cfg['foo'])
 
 func TestProvidedButUnexpectedPositionalArgs(t *testing.T) {
 	f := NewFixture(t, []string{"do", "re", "mi"}, "")
-	defer f.TearDown()
 
 	f.File("Tiltfile", `
 cfg = config.parse()
@@ -277,7 +265,6 @@ cfg = config.parse()
 
 func TestUsage(t *testing.T) {
 	f := NewFixture(t, []string{"--bar", "hello"}, "")
-	defer f.TearDown()
 
 	f.File("Tiltfile", `
 config.define_string_list('foo', usage='what can I foo for you today?')
@@ -297,7 +284,6 @@ Usage:
 // i.e., tilt up foo bar gets you resources foo and bar
 func TestDefaultTiltBehavior(t *testing.T) {
 	f := NewFixture(t, []string{"foo", "bar"}, "")
-	defer f.TearDown()
 
 	f.File("Tiltfile", `
 config.define_string_list('resources', usage='which resources to load in Tilt', args=True)
@@ -358,7 +344,6 @@ func TestSettingsFromConfigAndArgs(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			f := NewFixture(t, tc.args, "")
-			defer f.TearDown()
 
 			f.File("Tiltfile", `
 config.define_string_list('a')
@@ -396,7 +381,6 @@ print("c=", cfg.get('c', 'missing'))
 
 func TestUndefinedArgInConfigFile(t *testing.T) {
 	f := NewFixture(t, nil, "")
-	defer f.TearDown()
 
 	f.File("Tiltfile", `
 config.define_string_list('foo')
@@ -413,7 +397,6 @@ print("foo:",cfg.get('foo', []))
 
 func TestWrongTypeArgInConfigFile(t *testing.T) {
 	f := NewFixture(t, nil, "")
-	defer f.TearDown()
 
 	f.File("Tiltfile", `
 config.define_string_list('foo')
@@ -430,7 +413,6 @@ print("foo:",cfg.get('foo', []))
 
 func TestConfigParseFromMultipleDirs(t *testing.T) {
 	f := NewFixture(t, nil, "")
-	defer f.TearDown()
 
 	f.File("Tiltfile", `
 config.define_string_list('foo')
@@ -451,7 +433,6 @@ cfg = config.parse()
 
 func TestDefineSettingAfterParse(t *testing.T) {
 	f := NewFixture(t, nil, "")
-	defer f.TearDown()
 
 	f.File("Tiltfile", `
 cfg = config.parse()
@@ -465,7 +446,6 @@ config.define_string_list('foo')
 
 func TestConfigFileRecordedRead(t *testing.T) {
 	f := NewFixture(t, nil, "")
-	defer f.TearDown()
 
 	f.File("Tiltfile", `
 cfg = config.parse()`)
@@ -480,7 +460,6 @@ cfg = config.parse()`)
 
 func TestSubCommand(t *testing.T) {
 	f := NewFixture(t, nil, "foo")
-	defer f.TearDown()
 
 	f.File("Tiltfile", `
 print(config.tilt_subcommand)
@@ -494,7 +473,6 @@ print(config.tilt_subcommand)
 
 func TestTiltfilePath(t *testing.T) {
 	f := NewFixture(t, nil, "foo")
-	defer f.TearDown()
 
 	f.File("foo/Tiltfile", `
 print(config.main_path)
@@ -513,7 +491,6 @@ print(config.main_path)
 
 func TestTiltfileDir(t *testing.T) {
 	f := NewFixture(t, nil, "foo")
-	defer f.TearDown()
 
 	f.File("foo/Tiltfile", `
 print(config.main_dir)
@@ -608,7 +585,6 @@ func TestTypes(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			f := NewFixture(t, tc.args, "")
-			defer f.TearDown()
 
 			tf := fmt.Sprintf(`
 %s

--- a/internal/tiltfile/custom_build_test.go
+++ b/internal/tiltfile/custom_build_test.go
@@ -8,7 +8,6 @@ import (
 
 func TestCustomBuildImageDeps(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.file("Tiltfile", `
 custom_build(
@@ -37,7 +36,6 @@ k8s_yaml('fe.yaml')
 
 func TestCustomBuildMissingImageDeps(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.file("Tiltfile", `
 custom_build(

--- a/internal/tiltfile/docker_test.go
+++ b/internal/tiltfile/docker_test.go
@@ -14,7 +14,6 @@ import (
 
 func TestDockerignoreInSyncDir(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.yaml("fe.yaml", deployment("fe", image("gcr.io/fe")))
 	f.file("Dockerfile", `
@@ -47,7 +46,6 @@ docker_build('gcr.io/fe', '.', live_update=[
 
 func TestNonDefaultDockerignoreInSyncDir(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.yaml("fe.yaml", deployment("fe", image("gcr.io/fe")))
 	f.file("Dockerfile.custom", `
@@ -103,7 +101,6 @@ func TestCustomPlatform(t *testing.T) {
 				}
 
 				f := newFixture(t)
-				defer f.TearDown()
 
 				f.yaml("fe.yaml", deployment("fe", image("gcr.io/fe")))
 				f.file("Dockerfile", `FROM alpine`)
@@ -126,7 +123,6 @@ func TestCustomPlatform(t *testing.T) {
 
 func TestCustomBuildDepsAreLocalRepos(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.yaml("fe.yaml", deployment("fe", image("gcr.io/fe")))
 	f.file("Dockerfile", `
@@ -156,7 +152,6 @@ custom_build('gcr.io/fe', 'docker build -t $EXPECTED_REF .', ['src'])
 
 func TestCustomBuildDepsZeroArgs(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.yaml("fe.yaml", deployment("fe", image("gcr.io/fe")))
 	f.file("Tiltfile", `
@@ -169,7 +164,6 @@ custom_build('gcr.io/fe', 'docker build -t $EXPECTED_REF .', [])
 
 func TestCustomBuildOutputsImageRefsTo(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.yaml("fe.yaml", deployment("fe", image("gcr.io/fe")))
 	f.file("Dockerfile", `
@@ -192,7 +186,6 @@ custom_build('gcr.io/fe', 'export MY_REF="gcr.io/fe:dev" && docker build -t $MY_
 
 func TestCustomBuildOutputsImageRefsToIncompatibleWithTag(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.file("Tiltfile", `
 custom_build('gcr.io/fe', 'export MY_REF="gcr.io/fe:dev" && docker build -t $MY_REF . && echo $MY_REF > ref.txt',

--- a/internal/tiltfile/encoding/json_test.go
+++ b/internal/tiltfile/encoding/json_test.go
@@ -12,7 +12,6 @@ import (
 
 func TestReadJSON(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.UseRealFS()
 
@@ -60,7 +59,6 @@ test()
 
 func TestJSONDoesNotExist(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.File("Tiltfile", `result = read_json("dne.json")`)
 	result, err := f.ExecFile("Tiltfile")
@@ -75,7 +73,6 @@ func TestJSONDoesNotExist(t *testing.T) {
 
 func TestMalformedJSON(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.UseRealFS()
 
@@ -93,7 +90,6 @@ func TestMalformedJSON(t *testing.T) {
 
 func TestDecodeJSON(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	for _, blob := range []bool{false, true} {
 		t.Run(fmt.Sprintf("blob: %v", blob), func(t *testing.T) {
@@ -132,7 +128,6 @@ test()
 
 func TestEncodeJSON(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.File("Tiltfile", `
 expected = '''[
@@ -173,7 +168,6 @@ test()
 
 func TestEncodeJSONNonStringMapKey(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.File("Tiltfile", `encode_json({1: 'hello'})`)
 
@@ -184,7 +178,6 @@ func TestEncodeJSONNonStringMapKey(t *testing.T) {
 
 func TestEncodeJSONNonJSONable(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.File("Tiltfile", `
 encode_json(blob('hello'))

--- a/internal/tiltfile/encoding/yaml_test.go
+++ b/internal/tiltfile/encoding/yaml_test.go
@@ -12,7 +12,6 @@ import (
 
 func TestReadYAML(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	var document = `
 key1: foo
@@ -51,7 +50,6 @@ assert.equals(expected, observed)
 
 func TestReadYAMLDefaultValue(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.File("Tiltfile", `
 result = read_yaml("dne.yaml", "hello")
@@ -69,7 +67,6 @@ assert.equals('hello', result)
 
 func TestReadYAMLStreamDefaultValue(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.File("Tiltfile", `
 result = read_yaml_stream("dne.yaml", ["hello", "goodbye"])
@@ -87,7 +84,6 @@ assert.equals(['hello', 'goodbye'], result)
 
 func TestYAMLDoesNotExist(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.File("Tiltfile", `result = read_yaml("dne.yaml")`)
 	result, err := f.ExecFile("Tiltfile")
@@ -102,7 +98,6 @@ func TestYAMLDoesNotExist(t *testing.T) {
 
 func TestMalformedYAML(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.UseRealFS()
 
@@ -130,7 +125,6 @@ func TestDecodeYAMLDocument(t *testing.T) {
 	for _, blob := range []bool{false, true} {
 		t.Run(fmt.Sprintf("blob: %v", blob), func(t *testing.T) {
 			f := newFixture(t)
-			defer f.TearDown()
 
 			d := `'- "foo"\n- baz:\n  - "bar"\n  - ""\n  - 1\n  - 2'`
 			if blob {
@@ -161,7 +155,6 @@ assert.equals(expected, observed)
 
 func TestDecodeYAMLEmptyString(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	tf := `
 observed = decode_yaml('')
@@ -211,7 +204,6 @@ const yamlStreamAsStarlark = `[
 
 func TestReadYAMLStream(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.UseRealFS()
 
@@ -240,7 +232,6 @@ test()
 // call read_yaml on a stream, get an error
 func TestReadYAMLUnexpectedStream(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.UseRealFS()
 
@@ -258,7 +249,6 @@ func TestReadYAMLUnexpectedStream(t *testing.T) {
 
 func TestDecodeYAMLStream(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	d := yamlStream
 	d = fmt.Sprintf("observed = decode_yaml_stream('''%s''')\n", d)
@@ -279,7 +269,6 @@ assert.equals(expected, observed)
 
 func TestDecodeYAMLStreamEmptyEntries(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	yaml := `name: hello
 ---
@@ -306,7 +295,6 @@ assert.equals(['hello', 'goodbye'], [r['name'] for r in observed])
 
 func TestDecodeYAMLUnexpectedStream(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	tf := fmt.Sprintf("observed = decode_yaml('''%s''')\n", yamlStream)
 	f.File("Tiltfile", tf)
@@ -321,7 +309,6 @@ func TestDecodeYAMLUnexpectedStream(t *testing.T) {
 
 func TestEncodeYAML(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.File("Tiltfile", `
 expected = '''key1: foo
@@ -361,7 +348,6 @@ assert.equals(expected, str(observed))
 
 func TestEncodeYAMLStream(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	tf := fmt.Sprintf("expected = '''%s'''\n", yamlStream)
 	tf += fmt.Sprintf("observed = encode_yaml_stream(%s)\n", yamlStreamAsStarlark)
@@ -381,7 +367,6 @@ assert.equals(expected, str(observed))
 
 func TestEncodeYAMLNonStringMapKey(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.File("Tiltfile", `encode_yaml({1: 'hello'})`)
 
@@ -392,7 +377,6 @@ func TestEncodeYAMLNonStringMapKey(t *testing.T) {
 
 func TestEncodeYAMLNonYAMLable(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.File("Tiltfile", `
 encode_yaml(blob('hello'))

--- a/internal/tiltfile/git/git_test.go
+++ b/internal/tiltfile/git/git_test.go
@@ -11,7 +11,6 @@ import (
 
 func TestGitRepoPath(t *testing.T) {
 	f := NewFixture(t)
-	defer f.TearDown()
 
 	f.UseRealFS()
 	f.File("Tiltfile", `
@@ -26,7 +25,6 @@ print(local_git_repo('.').paths('.git/index'))
 
 func TestGitRepoBadMethodCall(t *testing.T) {
 	f := NewFixture(t)
-	defer f.TearDown()
 
 	f.UseRealFS()
 	f.File("Tiltfile", `

--- a/internal/tiltfile/hasher/hasher_test.go
+++ b/internal/tiltfile/hasher/hasher_test.go
@@ -26,7 +26,6 @@ func hexSha256(x string) string {
 
 func TestHashesTiltfile(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	contents := `print("Hello")`
 	f.File("Tiltfile", contents)
@@ -44,7 +43,6 @@ func TestHashesTiltfile(t *testing.T) {
 
 func TestHashesMultipleFiles(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	contents := `load('assert.tilt', 'assert')
 message = "Hello"

--- a/internal/tiltfile/helm_test.go
+++ b/internal/tiltfile/helm_test.go
@@ -20,7 +20,6 @@ import (
 
 func TestHelm(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupHelm()
 
@@ -41,7 +40,6 @@ k8s_yaml(yml)
 
 func TestHelmArgs(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupHelm()
 
@@ -71,7 +69,6 @@ k8s_yaml(yml)
 
 func TestHelmNamespaceFlagDoesNotInsertNSEntityIfNSInChart(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupHelm()
 
@@ -103,7 +100,6 @@ k8s_yaml(yml)
 
 func TestHelmNamespaceFlagInsertsNSEntityIfDifferentNSInChart(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupHelm()
 
@@ -125,7 +121,6 @@ k8s_yaml(yml)
 
 func TestHelmInvalidDirectory(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.file("Tiltfile", `
 yml = helm('helm')
@@ -137,7 +132,6 @@ k8s_yaml(yml)
 
 func TestHelmFromRepoPath(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.gitInit(".")
 	f.setupHelm()
@@ -160,7 +154,6 @@ k8s_yaml(yml)
 
 func TestHelmMalformedChart(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.WriteFile("./helm/Chart.yaml", "brrrrr")
 
@@ -179,7 +172,6 @@ k8s_yaml(yml)
 
 func TestHelmNamespace(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupHelm()
 	f.file("helm/templates/public-config.yaml", `apiVersion: v1
@@ -209,7 +201,6 @@ k8s_yaml(yml)
 
 func TestHelmSetArgs(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupHelm()
 
@@ -241,7 +232,6 @@ k8s_yaml(yml)
 
 func TestHelmSetArgsMap(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupHelm()
 
@@ -330,7 +320,6 @@ func TestSubchartRemoteDependencies(t *testing.T) {
 
 func TestHelmReleaseName(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.file("helm/Chart.yaml", `apiVersion: v1
 description: grafana chart
@@ -358,7 +347,6 @@ k8s_yaml(helm('./helm'))
 
 func TestHelm3CRD(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.file("helm/Chart.yaml", `apiVersion: v1
 description: crd chart
@@ -408,7 +396,6 @@ func assertHelmVersion(t *testing.T, versionOutput string, expectedV helmVersion
 
 func TestYamlErrorFromHelm(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 	f.setupHelm()
 	f.file("helm/templates/foo.yaml", "hi")
 	f.file("Tiltfile", `
@@ -430,7 +417,6 @@ k8s_yaml(helm('helm'))
 
 func TestHelmSkipsTests(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupHelmWithTest()
 	f.file("Tiltfile", `
@@ -466,7 +452,6 @@ func TestHelmIncludesRequirements(t *testing.T) {
 	}
 
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupHelmWithRequirements()
 	f.file("Tiltfile", `

--- a/internal/tiltfile/include_test.go
+++ b/internal/tiltfile/include_test.go
@@ -12,7 +12,6 @@ import (
 
 func TestIncludeThreeTiltfiles(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupFooAndBar()
 	f.file("foo/Tiltfile", `
@@ -42,7 +41,6 @@ k8s_yaml(['foo.yaml', 'bar.yaml'])
 
 func TestIncludeCircular(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.file("foo/Tiltfile", `
 include('../Tiltfile')
@@ -56,7 +54,6 @@ include('./foo/Tiltfile')
 
 func TestIncludeTriangular(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.file("foo/Tiltfile", `
 print('foo')
@@ -84,7 +81,6 @@ include('./bar/Tiltfile')
 
 func TestIncludeMissing(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.file("Tiltfile", `
 include('./foo/Tiltfile')
@@ -97,7 +93,6 @@ include('./foo/Tiltfile')
 
 func TestIncludeError(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.file("Tiltfile", `
 include('./foo/Tiltfile')
@@ -114,7 +109,6 @@ local('exit 1')
 
 func TestLoadFunction(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.file("boo/Tiltfile", `
 def shout():
@@ -139,7 +133,6 @@ shout()
 
 func TestLoadError(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.file("Tiltfile", `
 load('./foo/Tiltfile', "x")
@@ -157,7 +150,6 @@ local('exit 1')
 
 func TestLoadDynamic(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.file("foo/Tiltfile", `
 x = 1

--- a/internal/tiltfile/io/io_test.go
+++ b/internal/tiltfile/io/io_test.go
@@ -12,7 +12,6 @@ import (
 
 func TestReadFile(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.File("foo.txt", "foo")
 	f.File("Tiltfile", `
@@ -29,7 +28,6 @@ assert.equals('foo', str(s))
 
 func TestReadFileDefault(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.File("Tiltfile", `
 s = read_file('dne.txt', 'foo')
@@ -45,7 +43,6 @@ assert.equals('foo', str(s))
 
 func TestReadFileDefaultEmptyString(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.File("Tiltfile", `
 s = read_file('dne.txt', '')
@@ -62,7 +59,6 @@ assert.equals('', str(s))
 // make sure we generate an error on invalid type for default even if the file exists
 func TestReadFileInvalidDefaultFileExists(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.File("foo.txt", "foo")
 	f.File("Tiltfile", `
@@ -76,7 +72,6 @@ s = read_file('foo.txt', 5)
 
 func TestReadFileMissing(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.File("Tiltfile", `
 s = read_file('dne.txt')

--- a/internal/tiltfile/k8s_custom_deploy_test.go
+++ b/internal/tiltfile/k8s_custom_deploy_test.go
@@ -12,7 +12,6 @@ import (
 
 func TestK8sCustomDeployLiveUpdateImageSelector(t *testing.T) {
 	f := newLiveUpdateFixture(t)
-	defer f.TearDown()
 
 	f.skipYAML = true
 	f.tiltfileCode = `
@@ -38,7 +37,6 @@ k8s_custom_deploy('foo', 'apply', 'delete', deps=['foo'], image_selector='foo-im
 
 func TestK8sCustomDeployLiveUpdateContainerNameSelector(t *testing.T) {
 	f := newLiveUpdateFixture(t)
-	defer f.TearDown()
 
 	f.skipYAML = true
 	f.tiltfileCode = `
@@ -66,7 +64,6 @@ k8s_custom_deploy('foo', 'apply', 'delete', deps=['foo'], container_selector='ba
 
 func TestK8sCustomDeployNoLiveUpdate(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.file("Tiltfile", `
 k8s_custom_deploy('foo',
@@ -95,7 +92,6 @@ k8s_custom_deploy('foo',
 
 func TestK8sCustomDeployImageDepsMissing(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.file("Tiltfile", `
 k8s_custom_deploy('foo',
@@ -110,7 +106,6 @@ k8s_custom_deploy('foo',
 
 func TestK8sCustomDeployImageDepsMalformed(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.file("Tiltfile", `
 k8s_custom_deploy('foo',
@@ -125,7 +120,6 @@ k8s_custom_deploy('foo',
 
 func TestK8sCustomDeployImageDepExists(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.file("Dockerfile", "FROM golang:1.10")
 	f.file("Tiltfile", `
@@ -148,7 +142,6 @@ docker_build('image-a', '.')
 
 func TestK8sCustomDeployConflict(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.file("Tiltfile", `
 k8s_custom_deploy('foo',
@@ -166,7 +159,6 @@ k8s_custom_deploy('foo',
 
 func TestK8sCustomDeployLocalResourceConflict(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.file("Tiltfile", `
 k8s_custom_deploy('foo',

--- a/internal/tiltfile/links/links_test.go
+++ b/internal/tiltfile/links/links_test.go
@@ -48,7 +48,6 @@ func TestMaybeAddScheme(t *testing.T) {
 
 func TestLinkProps(t *testing.T) {
 	f := starkit.NewFixture(t, NewPlugin())
-	defer f.TearDown()
 
 	f.File("Tiltfile", `
 l = link("localhost:4000", "web")
@@ -62,7 +61,6 @@ print(l.name)
 }
 func TestLinkPropsImmutable(t *testing.T) {
 	f := starkit.NewFixture(t, NewPlugin())
-	defer f.TearDown()
 
 	f.File("Tiltfile", `
 l = link("localhost:4000", "web")

--- a/internal/tiltfile/live_update_test.go
+++ b/internal/tiltfile/live_update_test.go
@@ -15,7 +15,6 @@ import (
 
 func TestLiveUpdateStepNotUsed(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.WriteFile("Tiltfile", "restart_container()")
 
@@ -24,7 +23,6 @@ func TestLiveUpdateStepNotUsed(t *testing.T) {
 
 func TestLiveUpdateRestartContainerNotLast(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupFoo()
 
@@ -41,7 +39,6 @@ docker_build('gcr.io/foo', 'foo',
 
 func TestLiveUpdateSyncRelDest(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupFoo()
 
@@ -57,7 +54,6 @@ docker_build('gcr.io/foo', 'foo',
 
 func TestLiveUpdateRunBeforeSync(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupFoo()
 
@@ -74,7 +70,6 @@ docker_build('gcr.io/foo', 'foo',
 
 func TestLiveUpdateNonStepInSteps(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupFoo()
 
@@ -91,7 +86,6 @@ docker_build('gcr.io/foo', 'foo',
 
 func TestLiveUpdateNonStringInFullBuildTriggers(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupFoo()
 
@@ -109,7 +103,6 @@ docker_build('gcr.io/foo', 'foo',
 
 func TestLiveUpdateNonStringInRunTriggers(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupFoo()
 
@@ -125,7 +118,6 @@ docker_build('gcr.io/foo', 'foo',
 
 func TestLiveUpdateDockerBuildUnqualifiedImageName(t *testing.T) {
 	f := newLiveUpdateFixture(t)
-	defer f.TearDown()
 
 	f.tiltfileCode = "docker_build('foo', 'foo', live_update=%s)"
 	f.init()
@@ -137,7 +129,6 @@ func TestLiveUpdateDockerBuildUnqualifiedImageName(t *testing.T) {
 
 func TestLiveUpdateDockerBuildQualifiedImageName(t *testing.T) {
 	f := newLiveUpdateFixture(t)
-	defer f.TearDown()
 
 	f.expectedImage = "gcr.io/foo"
 	f.tiltfileCode = "docker_build('gcr.io/foo', 'foo', live_update=%s)"
@@ -150,7 +141,6 @@ func TestLiveUpdateDockerBuildQualifiedImageName(t *testing.T) {
 
 func TestLiveUpdateDockerBuildDefaultRegistry(t *testing.T) {
 	f := newLiveUpdateFixture(t)
-	defer f.TearDown()
 
 	f.tiltfileCode = `
 default_registry('gcr.io')
@@ -166,7 +156,6 @@ docker_build('foo', 'foo', live_update=%s)`
 
 func TestLiveUpdateCustomBuild(t *testing.T) {
 	f := newLiveUpdateFixture(t)
-	defer f.TearDown()
 
 	f.tiltfileCode = "custom_build('foo', 'docker build -t $TAG foo', ['foo'], live_update=%s)"
 	f.init()
@@ -178,7 +167,6 @@ func TestLiveUpdateCustomBuild(t *testing.T) {
 
 func TestLiveUpdateOnlyCustomBuild(t *testing.T) {
 	f := newLiveUpdateFixture(t)
-	defer f.TearDown()
 
 	f.tiltfileCode = `
 default_registry('gcr.io/myrepo')
@@ -203,7 +191,6 @@ custom_build('foo', ':', ['foo'], live_update=%s)
 
 func TestLiveUpdateSyncFilesOutsideOfDockerBuildContext(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupFoo()
 
@@ -219,7 +206,6 @@ docker_build('gcr.io/foo', 'foo',
 
 func TestLiveUpdateSyncFilesImageDep(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.gitInit("")
 	f.file("a/message.txt", "message")
@@ -264,7 +250,6 @@ func TestLiveUpdateRun(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			f := newFixture(t)
-			defer f.TearDown()
 
 			f.gitInit("")
 			f.yaml("foo.yaml", deployment("foo", image("gcr.io/image-a")))
@@ -294,7 +279,6 @@ k8s_yaml('foo.yaml')
 
 func TestLiveUpdateFallBackTriggersOutsideOfDockerBuildContext(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupFoo()
 
@@ -311,7 +295,6 @@ docker_build('gcr.io/foo', 'foo',
 
 func TestLiveUpdateSyncFilesOutsideOfCustomBuildDeps(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupFoo()
 
@@ -327,7 +310,6 @@ custom_build('gcr.io/foo', 'docker build -t $TAG foo', ['./foo'],
 
 func TestLiveUpdateFallBackTriggersOutsideOfCustomBuildDeps(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupFoo()
 
@@ -344,7 +326,6 @@ custom_build('gcr.io/foo', 'docker build -t $TAG foo', ['./foo'],
 
 func TestLiveUpdateRestartContainerDeprecationErrorK8s(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupFoo()
 
@@ -361,7 +342,6 @@ docker_build('gcr.io/foo', './foo',
 
 func TestLiveUpdateRestartContainerDeprecationErrorK8sCustomBuild(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupFoo()
 
@@ -379,7 +359,6 @@ custom_build('gcr.io/foo', 'docker build -t $TAG foo', ['./foo'],
 
 func TestLiveUpdateRestartContainerDeprecationErrorMultiple(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupExpand()
 
@@ -407,7 +386,6 @@ docker_build('gcr.io/d', './d',
 
 func TestLiveUpdateNoRestartContainerDeprecationErrorK8sDockerCompose(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 	f.setupFoo()
 	f.file("docker-compose.yml", `version: '3'
 services:

--- a/internal/tiltfile/local_resource_test.go
+++ b/internal/tiltfile/local_resource_test.go
@@ -4,7 +4,6 @@ import "testing"
 
 func TestTestFnDeprecated(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.file("Tiltfile", `
 test("test", "echo hi")

--- a/internal/tiltfile/metrics/metrics_test.go
+++ b/internal/tiltfile/metrics/metrics_test.go
@@ -10,7 +10,6 @@ import (
 
 func TestMetricsEnabled(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 	f.File("Tiltfile", "experimental_metrics_settings(enabled=True)")
 	_, err := f.ExecFile("Tiltfile")
 	assert.NoError(t, err)

--- a/internal/tiltfile/print/print_test.go
+++ b/internal/tiltfile/print/print_test.go
@@ -15,7 +15,6 @@ import (
 
 func TestWarn(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.File("Tiltfile", "warn('problem 1')")
 	_, err := f.ExecFile("Tiltfile")
@@ -25,7 +24,6 @@ func TestWarn(t *testing.T) {
 
 func TestFail(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 	f.File("Tiltfile", "fail('problem 1')")
 	_, err := f.ExecFile("Tiltfile")
 	if assert.Error(t, err) {
@@ -52,7 +50,6 @@ func TestExitArgTypes(t *testing.T) {
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
 			f := newFixture(t)
-			defer f.TearDown()
 
 			f.File(
 				"Tiltfile", fmt.Sprintf(`
@@ -75,7 +72,6 @@ fail("this can't happen!")
 
 func TestExitLoadedTiltfile(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.File("exit.tiltfile", `exit("later alligator")`)
 

--- a/internal/tiltfile/probe/probe_test.go
+++ b/internal/tiltfile/probe/probe_test.go
@@ -11,7 +11,6 @@ import (
 
 func TestProbeMetaOptions(t *testing.T) {
 	f := starkit.NewFixture(t, NewPlugin())
-	defer f.TearDown()
 
 	f.File("Tiltfile", `
 p = probe(initial_delay_secs=123,
@@ -51,7 +50,6 @@ tcp_socket: None
 
 func TestProbeActions_None(t *testing.T) {
 	f := starkit.NewFixture(t, NewPlugin())
-	defer f.TearDown()
 
 	f.File("Tiltfile", `p = probe()`)
 
@@ -61,7 +59,6 @@ func TestProbeActions_None(t *testing.T) {
 
 func TestProbeActions_Multiple(t *testing.T) {
 	f := starkit.NewFixture(t, NewPlugin())
-	defer f.TearDown()
 
 	f.File("Tiltfile", `
 p = probe(exec=exec_action([]), http_get=http_get_action(8000), tcp_socket=None)
@@ -73,7 +70,6 @@ p = probe(exec=exec_action([]), http_get=http_get_action(8000), tcp_socket=None)
 
 func TestProbeActions_Exec(t *testing.T) {
 	f := starkit.NewFixture(t, NewPlugin())
-	defer f.TearDown()
 
 	f.File("Tiltfile", `
 p = probe(exec=exec_action(command=["sleep", "60"]))
@@ -89,7 +85,6 @@ print(p.exec.command)
 
 func TestProbeActions_HTTPGet(t *testing.T) {
 	f := starkit.NewFixture(t, NewPlugin())
-	defer f.TearDown()
 
 	f.File("Tiltfile", `
 p = probe(http_get=http_get_action(host="example.com", port=8888, scheme='https', path='/status'))
@@ -115,7 +110,6 @@ https
 
 func TestProbeActions_HTTPGet_NoHost(t *testing.T) {
 	f := starkit.NewFixture(t, NewPlugin())
-	defer f.TearDown()
 
 	f.File("Tiltfile", `
 p = probe(http_get=http_get_action(8888, scheme='https', path='/status'))
@@ -140,7 +134,6 @@ https
 
 func TestProbeActions_TCPSocket(t *testing.T) {
 	f := starkit.NewFixture(t, NewPlugin())
-	defer f.TearDown()
 
 	f.File("Tiltfile", `
 p = probe(tcp_socket=tcp_socket_action(1234, "localhost"))

--- a/internal/tiltfile/starkit/fixture.go
+++ b/internal/tiltfile/starkit/fixture.go
@@ -39,7 +39,7 @@ func NewFixture(tb testing.TB, plugins ...Plugin) *Fixture {
 	temp := tempdir.NewTempDirFixture(tb)
 	temp.Chdir()
 
-	return &Fixture{
+	ret := &Fixture{
 		tb:      tb,
 		plugins: plugins,
 		path:    temp.Path(),
@@ -53,6 +53,8 @@ func NewFixture(tb testing.TB, plugins ...Plugin) *Fixture {
 			},
 		},
 	}
+
+	return ret
 }
 
 func (f *Fixture) SetContext(ctx context.Context) {
@@ -137,8 +139,4 @@ func (f *Fixture) UseRealFS() {
 	f.path = path
 	f.useRealFS = true
 	f.tf.Spec.Path = path
-}
-
-func (f *Fixture) TearDown() {
-	f.temp.TearDown()
 }

--- a/internal/tiltfile/telemetry/telemetry_test.go
+++ b/internal/tiltfile/telemetry/telemetry_test.go
@@ -13,7 +13,6 @@ import (
 
 func TestTelemetryCmdString(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 	f.File("Tiltfile", "experimental_telemetry_cmd('foo.sh')")
 	result, err := f.ExecFile("Tiltfile")
 
@@ -24,7 +23,6 @@ func TestTelemetryCmdString(t *testing.T) {
 
 func TestTelemetryPeriod(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 	f.File("Tiltfile", "experimental_telemetry_cmd('foo.sh', period='5s')")
 
 	result, err := f.ExecFile("Tiltfile")
@@ -34,7 +32,6 @@ func TestTelemetryPeriod(t *testing.T) {
 
 func TestTelemetryCmdArray(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 	f.File("Tiltfile", "experimental_telemetry_cmd(['foo.sh'])")
 	result, err := f.ExecFile("Tiltfile")
 
@@ -44,7 +41,6 @@ func TestTelemetryCmdArray(t *testing.T) {
 
 func TestTelemetryCmdEmpty(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 	f.File("Tiltfile", "experimental_telemetry_cmd('')")
 	_, err := f.ExecFile("Tiltfile")
 
@@ -53,7 +49,6 @@ func TestTelemetryCmdEmpty(t *testing.T) {
 
 func TestTelemetryCmdMultiple(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 	f.File("Tiltfile", `
 experimental_telemetry_cmd('foo.sh')
 experimental_telemetry_cmd('bar.sh')

--- a/internal/tiltfile/tiltextension/plugin_test.go
+++ b/internal/tiltfile/tiltextension/plugin_test.go
@@ -17,7 +17,6 @@ import (
 
 func TestFetchableAlreadyPresentWorks(t *testing.T) {
 	f := newExtensionFixture(t)
-	defer f.tearDown()
 
 	f.tiltfile(`
 load("ext://fetchable", "printFoo")
@@ -31,7 +30,6 @@ printFoo()
 
 func TestAlreadyPresentWorks(t *testing.T) {
 	f := newExtensionFixture(t)
-	defer f.tearDown()
 
 	f.tiltfile(`
 load("ext://unfetchable", "printFoo")
@@ -45,7 +43,6 @@ printFoo()
 
 func TestExtensionRepoApplyFails(t *testing.T) {
 	f := newExtensionFixture(t)
-	defer f.tearDown()
 
 	f.tiltfile(`
 load("ext://module", "printFoo")
@@ -59,7 +56,6 @@ printFoo()
 
 func TestExtensionApplyFails(t *testing.T) {
 	f := newExtensionFixture(t)
-	defer f.tearDown()
 
 	f.tiltfile(`
 load("ext://module", "printFoo")
@@ -73,7 +69,6 @@ printFoo()
 
 func TestIncludedFileMayIncludeExtension(t *testing.T) {
 	f := newExtensionFixture(t)
-	defer f.tearDown()
 
 	f.tiltfile(`include('Tiltfile.prime')`)
 
@@ -90,7 +85,6 @@ printFoo()
 
 func TestExtensionMayLoadExtension(t *testing.T) {
 	f := newExtensionFixture(t)
-	defer f.tearDown()
 
 	f.tiltfile(`
 load("ext://fooExt", "printFoo")
@@ -105,7 +99,6 @@ printFoo()
 
 func TestLoadedFilesResolveExtensionsFromRootTiltfile(t *testing.T) {
 	f := newExtensionFixture(t)
-	defer f.tearDown()
 
 	f.tiltfile(`include('./nested/Tiltfile')`)
 
@@ -133,7 +126,6 @@ func TestRepoAndExtOverride(t *testing.T) {
 	}
 
 	f := newExtensionFixture(t)
-	defer f.tearDown()
 
 	f.tiltfile(fmt.Sprintf(`
 v1alpha1.extension_repo(name='default', url='file://%s/my-custom-repo')
@@ -157,7 +149,6 @@ func TestRepoOverride(t *testing.T) {
 	}
 
 	f := newExtensionFixture(t)
-	defer f.tearDown()
 
 	f.tiltfile(fmt.Sprintf(`
 v1alpha1.extension_repo(name='default', url='file://%s/my-custom-repo')
@@ -199,11 +190,6 @@ func newExtensionFixture(t *testing.T) *extensionFixture {
 		extr:  extr,
 		extrr: extrr,
 	}
-}
-
-func (f *extensionFixture) tearDown() {
-	defer f.tmp.TearDown()
-	defer f.skf.TearDown()
 }
 
 func (f *extensionFixture) tiltfile(contents string) {

--- a/internal/tiltfile/tiltfile_docker_compose_test.go
+++ b/internal/tiltfile/tiltfile_docker_compose_test.go
@@ -86,7 +86,6 @@ ports:
 
 func TestDockerComposeNothingError(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.file("Tiltfile", "docker_compose(None)")
 
@@ -95,7 +94,6 @@ func TestDockerComposeNothingError(t *testing.T) {
 
 func TestDockerComposeBadTypeError(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.file("Tiltfile", "docker_compose(True)")
 
@@ -104,7 +102,6 @@ func TestDockerComposeBadTypeError(t *testing.T) {
 
 func TestDockerComposeManifest(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.dockerfile(filepath.Join("foo", "Dockerfile"))
 	f.file("docker-compose.yml", simpleConfig)
@@ -128,7 +125,6 @@ func TestDockerComposeManifest(t *testing.T) {
 
 func TestDockerComposeEnvFile(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.file("docker-compose.yml", `services:
   bar:
@@ -153,7 +149,6 @@ func TestDockerComposeEnvFile(t *testing.T) {
 
 func TestDockerComposeConflict(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.dockerfile(filepath.Join("foo", "Dockerfile"))
 	f.file("docker-compose.yml", simpleConfig)
@@ -167,7 +162,6 @@ docker_compose('docker-compose.yml')
 
 func TestDockerComposeYAMLBlob(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.dockerfile(filepath.Join("foo", "Dockerfile"))
 	f.file("docker-compose.yml", simpleConfig)
@@ -191,7 +185,6 @@ func TestDockerComposeYAMLBlob(t *testing.T) {
 
 func TestDockerComposeTwoInlineBlobs(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.dockerfile(filepath.Join("foo", "Dockerfile"))
 	f.file("Tiltfile", fmt.Sprintf(`docker_compose([blob("""\n%s\n"""), blob("""\n%s\n""")])`, simpleConfig, barServiceConfig))
@@ -203,7 +196,6 @@ func TestDockerComposeTwoInlineBlobs(t *testing.T) {
 
 func TestDockerComposeBlobAndFileUsesFileDirForProjectPath(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.dockerfile(filepath.Join("foo", "Dockerfile"))
 	f.file("docker-compose.yml", simpleConfig)
@@ -221,7 +213,6 @@ func TestDockerComposeBlobAndFileUsesFileDirForProjectPath(t *testing.T) {
 
 func TestDockerComposeManifestNoDockerfile(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.file("docker-compose.yml", `version: '3'
 services:
@@ -246,7 +237,6 @@ networks:
 
 func TestDockerComposeManifestAlternateDockerfile(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.dockerfile("baz/alternate-Dockerfile")
 	f.file("docker-compose.yml", fmt.Sprintf(`
@@ -278,7 +268,6 @@ networks:
 
 func TestDockerComposeManifestAbsoluteDockerfile(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	dockerfilePath := f.JoinPath("baz", "Dockerfile")
 	f.dockerfile(dockerfilePath)
@@ -312,7 +301,6 @@ networks:
 
 func TestDockerComposeManifestAlternateDockerfileAndDockerIgnore(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.dockerfile("baz/alternate-Dockerfile")
 	f.dockerignore("baz/alternate-Dockerfile.dockerignore")
@@ -350,7 +338,6 @@ networks:
 
 func TestMultipleDockerComposeDifferentDirsNotSupported(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.dockerfile(filepath.Join("foo", "Dockerfile"))
 	f.file("docker-compose1.yml", simpleConfig)
@@ -369,7 +356,6 @@ docker_compose('docker-compose1.yml')`
 
 func TestMultipleDockerComposeSameDir(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.dockerfile(filepath.Join("foo", "Dockerfile"))
 	f.file("docker-compose1.yml", simpleConfig)
@@ -387,7 +373,6 @@ docker_compose('docker-compose2.yml')`
 
 func TestDockerComposeAndK8sNotSupported(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupFooAndBar()
 	f.file("docker-compose.yml", simpleConfig)
@@ -401,7 +386,6 @@ k8s_yaml('bar.yaml')`
 
 func TestDockerComposeResourceCreationFromAbsPath(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	configPath := f.TempDirFixture.JoinPath("docker-compose.yml")
 	f.dockerfile(filepath.Join("foo", "Dockerfile"))
@@ -421,7 +405,6 @@ services:
 
 func TestDockerComposeMultiStageBuild(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	df := `FROM alpine as builder
 ADD ./src /app
@@ -458,7 +441,6 @@ services:
 
 func TestDockerComposeHonorsDockerIgnore(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	df := `FROM alpine
 
@@ -487,7 +469,6 @@ RUN echo hi`
 
 func TestDockerComposeIgnoresFileChangesOnMountedVolumes(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	df := `FROM alpine
 
@@ -511,7 +492,6 @@ RUN echo hi`
 
 func TestDockerComposeWithDockerBuild(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.dockerfile(filepath.Join("foo", "Dockerfile"))
 	f.file("docker-compose.yml", simpleConfig)
@@ -535,7 +515,6 @@ dc_resource('foo', 'gcr.io/foo')
 
 func TestDockerComposeWithDockerBuildAutoAssociate(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.dockerfile(filepath.Join("foo", "Dockerfile"))
 	f.file("docker-compose.yml", `version: '3'
@@ -568,7 +547,6 @@ docker_compose('docker-compose.yml')
 // I.e. make sure that we handle de/normalization between `fooimage` <--> `docker.io/library/fooimage`
 func TestDockerComposeWithDockerBuildLocalRef(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.dockerfile(filepath.Join("foo", "Dockerfile"))
 	f.file("docker-compose.yml", simpleConfig)
@@ -589,7 +567,6 @@ dc_resource('foo', 'fooimage')
 
 func TestMultipleDockerComposeWithDockerBuild(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.dockerfile(filepath.Join("foo", "Dockerfile"))
 	f.dockerfile(filepath.Join("bar", "Dockerfile"))
@@ -616,7 +593,6 @@ dc_resource('bar', 'gcr.io/bar')
 
 func TestMultipleDockerComposeWithDockerBuildImageNames(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.dockerfile(filepath.Join("foo", "Dockerfile"))
 	f.dockerfile(filepath.Join("bar", "Dockerfile"))
@@ -650,7 +626,6 @@ docker_compose('docker-compose.yml')
 
 func TestDCImageRefSuggestion(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupFoo()
 	f.file("docker-compose.yml", `version: '3'
@@ -672,7 +647,6 @@ If this is deliberate, suppress this warning with: update_settings(suppress_unus
 
 func TestDockerComposeOnlySomeWithDockerBuild(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.dockerfile(filepath.Join("foo", "Dockerfile"))
 	f.file("docker-compose.yml", twoServiceConfig)
@@ -697,7 +671,6 @@ dc_resource('foo', img_name)
 
 func TestDockerComposeResourceNoImageMatch(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.dockerfile(filepath.Join("foo", "Dockerfile"))
 	f.file("docker-compose.yml", simpleConfig)
@@ -710,7 +683,6 @@ dc_resource('no-svc-with-this-name-eek', 'gcr.io/foo')
 
 func TestDockerComposeLoadConfigFilesOnFailure(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.dockerfile(filepath.Join("foo", "Dockerfile"))
 	f.file("docker-compose.yml", simpleConfig)
@@ -727,7 +699,6 @@ fail("deliberate exit")
 
 func TestDockerComposeDoesntSupportEntrypointOverride(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.dockerfile(filepath.Join("foo", "Dockerfile"))
 	f.file("docker-compose.yml", simpleConfig)
@@ -741,7 +712,6 @@ dc_resource('foo', 'gcr.io/foo')
 
 func TestDefaultRegistryWithDockerCompose(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.dockerfile(filepath.Join("foo", "Dockerfile"))
 	f.file("docker-compose.yml", simpleConfig)
@@ -755,7 +725,6 @@ default_registry('bar.com')
 
 func TestDockerComposeLabels(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.dockerfile(filepath.Join("foo", "Dockerfile"))
 	f.file("docker-compose.yml", simpleConfig)
@@ -791,7 +760,6 @@ func TestTriggerModeDC(t *testing.T) {
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
 			f := newFixture(t)
-			defer f.TearDown()
 
 			f.dockerfile(filepath.Join("foo", "Dockerfile"))
 			f.file("docker-compose.yml", simpleConfig)
@@ -837,7 +805,6 @@ docker_compose('docker-compose.yml')
 
 func TestDCResourceNoImage(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupFoo()
 	f.file("docker-compose.yml", simpleConfig)
@@ -851,7 +818,6 @@ dc_resource('foo', trigger_mode=TRIGGER_MODE_AUTO)
 
 func TestDCDependsOn(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.dockerfile(filepath.Join("foo", "Dockerfile"))
 	f.file("docker-compose.yml", twoServiceConfig)
@@ -884,7 +850,6 @@ func TestDockerComposeVersionWarnings(t *testing.T) {
 	for _, tc := range tcs {
 		t.Run(tc.version, func(t *testing.T) {
 			f := newFixture(t)
-			defer f.TearDown()
 
 			f.dockerfile(filepath.Join("foo", "Dockerfile"))
 			f.file("docker-compose.yml", simpleConfig)

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -60,7 +60,6 @@ const simpleDockerignore = "build/"
 
 func TestNoTiltfile(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.loadErrString("No Tiltfile found at")
 	f.assertConfigFiles("Tiltfile")
@@ -68,7 +67,6 @@ func TestNoTiltfile(t *testing.T) {
 
 func TestEmpty(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.file("Tiltfile", "")
 	f.load()
@@ -76,7 +74,6 @@ func TestEmpty(t *testing.T) {
 
 func TestMissingDockerfile(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.file("Tiltfile", `
 docker_build('gcr.io/foo', 'foo')
@@ -88,7 +85,6 @@ k8s_resource('foo', 'foo.yaml')
 
 func TestCustomBuildBadMethodCall(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 	f.setupFoo()
 	f.file("Tiltfile", `
 hfb = custom_build(
@@ -103,7 +99,6 @@ hfb = custom_build(
 
 func TestSimple(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupFoo()
 
@@ -129,7 +124,6 @@ k8s_yaml('foo.yaml')
 // I.e. make sure that we handle de/normalization between `fooimage` <--> `docker.io/library/fooimage`
 func TestLocalImageRef(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.dockerfile("foo/Dockerfile")
 	f.yaml("foo.yaml", deployment("foo", image("fooimage")))
@@ -150,7 +144,6 @@ k8s_yaml('foo.yaml')
 
 func TestExplicitDockerfileIsConfigFile(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 	f.setupFoo()
 	f.dockerfile("other/Dockerfile")
 	f.file("Tiltfile", `
@@ -163,7 +156,6 @@ k8s_yaml('foo.yaml')
 
 func TestExplicitDockerfileAsLocalPath(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 	f.setupFoo()
 	f.dockerfile("other/Dockerfile")
 	f.file("Tiltfile", `
@@ -177,7 +169,6 @@ k8s_yaml('foo.yaml')
 
 func TestExplicitDockerfileContents(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 	f.setupFoo()
 	f.file("Tiltfile", `
 docker_build('gcr.io/foo', 'foo', dockerfile_contents='FROM alpine')
@@ -190,7 +181,6 @@ k8s_yaml('foo.yaml')
 
 func TestExplicitDockerfileContentsAsBlob(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 	f.setupFoo()
 	f.dockerfile("other/Dockerfile")
 	f.file("Tiltfile", `
@@ -205,7 +195,6 @@ k8s_yaml('foo.yaml')
 
 func TestCantSpecifyDFPathAndContents(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 	f.setupFoo()
 	f.dockerfile("other/Dockerfile")
 	f.file("Tiltfile", `
@@ -218,14 +207,12 @@ k8s_yaml('foo.yaml')
 
 func TestVerifiesGitRepo(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 	f.file("Tiltfile", "local_git_repo('.')")
 	f.loadErrString("isn't a valid git repo")
 }
 
 func TestLocal(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupFoo()
 
@@ -254,7 +241,6 @@ k8s_yaml(yaml)
 
 func TestLocalBat(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupFoo()
 
@@ -280,7 +266,6 @@ k8s_yaml(yaml)
 
 func TestLocalEnv(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	// contrived example to ensure that the environment is correctly passed to local -- an env var is echoed back out
 	// which then gets passed as an ignore so that it's visible in the load result for assertion
@@ -296,7 +281,6 @@ watch_settings(ignore=ignore)
 
 func TestLocalEmptyArray(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.file("Tiltfile", `
 local([])
@@ -307,7 +291,6 @@ local([])
 
 func TestLocalEmptyString(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.file("Tiltfile", `
 local('')
@@ -318,7 +301,6 @@ local('')
 
 func TestCustomBuildBat(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupFoo()
 
@@ -343,7 +325,6 @@ k8s_yaml('foo.yaml')
 
 func TestLocalQuiet(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupFoo()
 
@@ -359,7 +340,6 @@ local('echo foobar', quiet=True)
 
 func TestLocalEchoOff(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupFoo()
 
@@ -400,7 +380,6 @@ func TestLocalNoOutput(t *testing.T) {
 		name := fmt.Sprintf("EchoOff%s_Quiet%s", goBoolToStarlark(tc.echoOff), goBoolToStarlark(tc.quiet))
 		t.Run(name, func(t *testing.T) {
 			f := newFixture(t)
-			defer f.TearDown()
 
 			f.setupFoo()
 
@@ -432,7 +411,6 @@ func TestLocalArgvCmd(t *testing.T) {
 		t.Skip("windows doesn't support argv commands. Go converts it to a single string")
 	}
 	f := newFixture(t)
-	defer f.TearDown()
 
 	// this would generate a syntax error if evaluated by a shell
 	f.file("Tiltfile", `local(['echo', 'a"b'])`)
@@ -443,7 +421,6 @@ func TestLocalArgvCmd(t *testing.T) {
 
 func TestLocalTiltEnvPropagation(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	resetEnv := func() {
 		tiltVars := []string{"TILT_HOST", "TILT_PORT"}
@@ -497,7 +474,6 @@ local(command='echo Tilt port is $TILT_PORT', command_bat='echo Tilt port is %TI
 
 func TestReadFile(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupFoo()
 
@@ -517,7 +493,6 @@ k8s_yaml(yaml)
 
 func TestKustomize(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupFoo()
 	f.file("kustomization.yaml", kustomizeFileText)
@@ -537,7 +512,6 @@ k8s_resource("the-deployment", "foo")
 
 func TestKustomizeBin(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 	f.file("kustomization.yaml", kustomizeFileText)
 	f.file("configMap.yaml", kustomizeConfigMapText)
 	f.file("deployment.yaml", kustomizeDeploymentText)
@@ -571,7 +545,6 @@ k8s_resource("the-deployment", "foo")
 
 func TestKustomizeError(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.file("Tiltfile", "kustomize('.')")
 	f.loadErrString("unable to find one of 'kustomization.yaml', 'kustomization.yml' or 'Kustomization'")
@@ -579,7 +552,6 @@ func TestKustomizeError(t *testing.T) {
 
 func TestKustomization(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupFoo()
 	f.file("Kustomization", kustomizeFileText)
@@ -599,7 +571,6 @@ k8s_resource("the-deployment", "foo")
 
 func TestDockerBuildTarget(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupFoo()
 	f.file("Tiltfile", `
@@ -613,7 +584,6 @@ docker_build("gcr.io/foo", "foo", target='stage')
 
 func TestDockerBuildSSH(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupFoo()
 	f.file("Tiltfile", `
@@ -627,7 +597,6 @@ docker_build("gcr.io/foo", "foo", ssh='default')
 
 func TestDockerBuildSecret(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupFoo()
 	f.file("Tiltfile", `
@@ -641,7 +610,6 @@ docker_build("gcr.io/foo", "foo", secret='id=shibboleth')
 
 func TestDockerBuildNetwork(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupFoo()
 	f.file("Tiltfile", `
@@ -655,7 +623,6 @@ docker_build("gcr.io/foo", "foo", network='default')
 
 func TestDockerBuildPull(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupFoo()
 	f.file("Tiltfile", `
@@ -669,7 +636,6 @@ docker_build("gcr.io/foo", "foo", pull=True)
 
 func TestDockerBuildCacheFrom(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupFoo()
 	f.file("Tiltfile", `
@@ -683,7 +649,6 @@ docker_build("gcr.io/foo", "foo", cache_from='gcr.io/foo')
 
 func TestDockerBuildExtraTagString(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupFoo()
 	f.file("Tiltfile", `
@@ -698,7 +663,6 @@ docker_build("gcr.io/foo", "foo", extra_tag='foo:latest')
 
 func TestDockerBuildExtraTagList(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupFoo()
 	f.file("Tiltfile", `
@@ -713,7 +677,6 @@ docker_build("gcr.io/foo", "foo", extra_tag=['foo:latest', 'foo:jenkins-1234'])
 
 func TestDockerBuildExtraTagListInvalid(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupFoo()
 	f.file("Tiltfile", `
@@ -725,7 +688,6 @@ docker_build("gcr.io/foo", "foo", extra_tag='cherry bomb')
 
 func TestDockerBuildCache(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupFoo()
 	f.file("Tiltfile", `
@@ -737,7 +699,6 @@ docker_build("gcr.io/foo", "foo", cache='/paths/to/cache')
 
 func TestK8sResourceAdditiveLinks(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupExpand()
 	f.file("Tiltfile", `
@@ -760,7 +721,6 @@ k8s_resource('b', links=['http://demo-b.localhost/api'])
 
 func TestDuplicateImageNames(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupExpand()
 	f.file("Tiltfile", `
@@ -774,7 +734,6 @@ docker_build('gcr.io/a', 'a')
 
 func TestInvalidImageNameInDockerBuild(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupExpand()
 	f.file("Tiltfile", `
@@ -787,7 +746,6 @@ docker_build("ceci n'est pas une valid image ref", 'a')
 
 func TestInvalidImageNameInK8SYAML(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.file("Tiltfile", `
 yaml_str = """
@@ -886,7 +844,6 @@ func TestPortForward(t *testing.T) {
 	for _, c := range portForwardCases {
 		t.Run(c.name, func(t *testing.T) {
 			f := newFixture(t)
-			defer f.TearDown()
 
 			f.webHost = c.webHost
 			f.setupFoo()
@@ -955,7 +912,6 @@ func TestResourceLinks(t *testing.T) {
 	for _, c := range cases {
 		t.Run("LocalResource-"+c.name, func(t *testing.T) {
 			f := newFixture(t)
-			defer f.TearDown()
 
 			tiltfile := fmt.Sprintf(`
 local_resource('foo', 'echo hi', links=%s)
@@ -976,7 +932,6 @@ local_resource('foo', 'echo hi', links=%s)
 
 		t.Run("K8s-"+c.name, func(t *testing.T) {
 			f := newFixture(t)
-			defer f.TearDown()
 
 			f.setupFoo()
 			s := `
@@ -1003,7 +958,6 @@ k8s_resource('foo') # test that subsequent calls don't clear the links
 
 		t.Run("dc-"+c.name, func(t *testing.T) {
 			f := newFixture(t)
-			defer f.TearDown()
 
 			f.file("docker-compose.yml", `version: '3.0'
 services:
@@ -1034,7 +988,6 @@ dc_resource('foo') # test that subsequent calls don't clear the links
 
 func TestK8sResourceWithLinksAndPortForwards(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupFoo()
 	f.file("Tiltfile", `
@@ -1053,7 +1006,6 @@ k8s_resource('foo', port_forwards=[8000, 8001], links=link("www.zombo.com", name
 
 func TestExpand(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 	f.setupExpand()
 	f.file("Tiltfile", `
 k8s_yaml('all.yaml')
@@ -1073,7 +1025,6 @@ docker_build('gcr.io/d', 'd')
 
 func TestExpandUnresourced(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 	f.dockerfile("a/Dockerfile")
 
 	f.yaml("all.yaml",
@@ -1094,7 +1045,6 @@ docker_build('gcr.io/a', 'a')
 
 func TestUnresourcedPodCreatorYamlAsManifest(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.yaml("pod_creator.yaml", deployment("pod-creator"), secret("not-pod-creator"))
 
@@ -1109,7 +1059,6 @@ k8s_yaml('pod_creator.yaml')
 
 func TestUnresourcedYamlGroupingV1(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	labelsA := map[string]string{"keyA": "valueA"}
 	labelsB := map[string]string{"keyB": "valueB"}
@@ -1138,7 +1087,6 @@ func TestUnresourcedYamlGroupingV1(t *testing.T) {
 
 func TestUnresourcedYamlGroupingV2(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	labelsA := map[string]string{"keyA": "valueA"}
 	labelsB := map[string]string{"keyB": "valueB"}
@@ -1168,7 +1116,6 @@ k8s_yaml('all.yaml')`)
 
 func TestK8sGroupedWhenAddedToResource(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 	f.setupExpand()
 
 	labelsA := map[string]string{"keyA": "valueA"}
@@ -1201,7 +1148,6 @@ docker_build('gcr.io/c', 'c')
 
 func TestImplicitK8sResourceWithoutDockerBuild(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 	f.setupFoo()
 	f.file("Tiltfile", `
 
@@ -1214,7 +1160,6 @@ k8s_resource('foo', port_forwards=8000)
 
 func TestExpandTwoDeploymentsWithSameImage(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 	f.setupExpand()
 	f.yaml("all.yaml",
 		deployment("a", image("gcr.io/a")),
@@ -1241,7 +1186,6 @@ docker_build('gcr.io/d', 'd')
 
 func TestMultipleYamlFiles(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupExpand()
 	f.yaml("a.yaml", deployment("a", image("gcr.io/a")))
@@ -1264,7 +1208,6 @@ docker_build('gcr.io/d', 'd')
 
 func TestLoadOneManifest(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupFooAndBar()
 	f.file("Tiltfile", `
@@ -1283,7 +1226,6 @@ k8s_yaml('bar.yaml')
 
 func TestUncategorizedEnabledEvenIfNotSpecified(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupFooAndBar()
 	f.yaml("service.yaml", service("some-service"))
@@ -1304,7 +1246,6 @@ k8s_yaml('service.yaml')
 
 func TestLoadTypoManifest(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupFooAndBar()
 	f.file("Tiltfile", `
@@ -1325,7 +1266,6 @@ Is this a typo? Existing resources in Tiltfile: "foo", "bar"`, err.Error())
 
 func TestBasicGitPathFilter(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.gitInit("")
 	f.file("Dockerfile", "FROM golang:1.10")
@@ -1348,7 +1288,6 @@ k8s_yaml('foo.yaml')
 
 func TestCustomBuildGitPathFilter(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.gitInit("")
 	f.file("Dockerfile", "FROM golang:1.10")
@@ -1366,7 +1305,6 @@ k8s_yaml('foo.yaml')
 
 func TestDockerignorePathFilter(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.gitInit("")
 	f.file("Dockerfile", "FROM golang:1.10")
@@ -1390,7 +1328,6 @@ k8s_yaml('foo.yaml')
 // up the dockerignore from that directory.
 func TestDockerignoreCustomBuildRelativeDirs(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.file(".dockerignore", "src/sub/a.txt")
 	f.file("src/.dockerignore", "sub/b.txt")
@@ -1417,7 +1354,6 @@ k8s_yaml('foo.yaml')
 // up the dockerignores from both those directories.
 func TestDockerignoreCustomBuildMultipleDeps(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.file(".dockerignore", "src/sub/a.txt")
 	f.file("src/.dockerignore", "sub/b.txt")
@@ -1442,7 +1378,6 @@ k8s_yaml('foo.yaml')
 
 func TestDockerignorePathFilterSubdir(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.gitInit("")
 	f.file("foo/Dockerfile", "FROM golang:1.10")
@@ -1464,7 +1399,6 @@ k8s_yaml('foo.yaml')
 
 func TestK8sYAMLInputBareString(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupFoo()
 	f.WriteFile("bar.yaml", "im not yaml")
@@ -1478,7 +1412,6 @@ docker_build("gcr.io/foo", "foo", cache='/paths/to/cache')
 
 func TestK8sYAMLInputFromReadFile(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupFoo()
 	f.file("Tiltfile", `
@@ -1495,7 +1428,6 @@ docker_build("gcr.io/foo", "foo", cache='/paths/to/cache')
 
 func TestFilterYamlByLabel(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 	f.file("k8s.yaml", yaml.ConcatYAML(
 		testyaml.DoggosDeploymentYaml, testyaml.DoggosServiceYaml,
 		testyaml.SnackYaml, testyaml.SanchoYAML))
@@ -1512,7 +1444,6 @@ k8s_yaml(doggos)
 
 func TestFilterYamlByName(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 	f.file("k8s.yaml", yaml.ConcatYAML(
 		testyaml.DoggosDeploymentYaml, testyaml.DoggosServiceYaml,
 		testyaml.SnackYaml, testyaml.SanchoYAML))
@@ -1528,7 +1459,6 @@ k8s_yaml(doggos)
 
 func TestFilterYamlByNameKind(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 	f.file("k8s.yaml", yaml.ConcatYAML(
 		testyaml.DoggosDeploymentYaml, testyaml.DoggosServiceYaml,
 		testyaml.SnackYaml, testyaml.SanchoYAML))
@@ -1544,7 +1474,6 @@ k8s_yaml(doggos)
 
 func TestFilterYamlByNamespace(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 	f.file("k8s.yaml", yaml.ConcatYAML(
 		testyaml.DoggosDeploymentYaml, testyaml.DoggosServiceYaml,
 		testyaml.SnackYaml, testyaml.SanchoYAML))
@@ -1560,7 +1489,6 @@ k8s_yaml(doggos)
 
 func TestFilterYamlByApiVersion(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 	f.file("k8s.yaml", yaml.ConcatYAML(
 		testyaml.DoggosDeploymentYaml, testyaml.DoggosServiceYaml,
 		testyaml.SnackYaml, testyaml.SanchoYAML))
@@ -1576,7 +1504,6 @@ k8s_yaml(doggos)
 
 func TestFilterYamlNoMatch(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 	f.file("k8s.yaml", yaml.ConcatYAML(testyaml.DoggosDeploymentYaml, testyaml.DoggosServiceYaml))
 	f.file("Tiltfile", `
 doggos, rest = filter_yaml('k8s.yaml', namespace='dne', kind='deployment')
@@ -1587,7 +1514,6 @@ k8s_yaml(doggos)
 
 func TestYamlNone(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupFoo()
 
@@ -1599,7 +1525,6 @@ k8s_yaml(None)
 
 func TestYamlEmptyBlob(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupFoo()
 
@@ -1611,7 +1536,6 @@ k8s_yaml(blob(''))
 
 func TestDuplicateLocalResources(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupFoo()
 
@@ -1627,7 +1551,6 @@ local_resource('foo', 'echo foo')
 // in the init() function
 func TestTopLevelIfStatement(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupFoo()
 
@@ -1647,7 +1570,6 @@ if True:
 
 func TestTopLevelForLoop(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupFoo()
 
@@ -1661,7 +1583,6 @@ for i in range(1, 3):
 
 func TestTopLevelVariableRename(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupFoo()
 
@@ -1675,7 +1596,6 @@ x = 2
 
 func TestEmptyDockerfileDockerBuild(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 	f.setupFoo()
 	f.file("foo/Dockerfile", "")
 	f.file("Tiltfile", `
@@ -1689,7 +1609,6 @@ k8s_yaml('foo.yaml')
 
 func TestSanchoSidecar(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 	f.setupFoo()
 	f.file("Dockerfile", "FROM golang:1.10")
 	f.file("k8s.yaml", testyaml.SanchoSidecarYAML)
@@ -1711,7 +1630,6 @@ docker_build('gcr.io/some-project-162817/sancho-sidecar', '.')
 
 func TestSanchoRedisSidecar(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 	f.setupFoo()
 	f.file("Dockerfile", "FROM golang:1.10")
 	f.file("k8s.yaml", testyaml.SanchoRedisSidecarYAML)
@@ -1730,7 +1648,6 @@ docker_build('gcr.io/some-project-162817/sancho', '.')
 
 func TestExtraPodSelectors(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupExtraPodSelectors("[{'foo': 'bar', 'baz': 'qux'}, {'quux': 'corge'}]")
 	f.load()
@@ -1742,7 +1659,6 @@ func TestExtraPodSelectors(t *testing.T) {
 
 func TestExtraPodSelectorsNotList(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupExtraPodSelectors("'hello'")
 	f.loadErrString("got starlark.String", "dict or a list")
@@ -1750,7 +1666,6 @@ func TestExtraPodSelectorsNotList(t *testing.T) {
 
 func TestExtraPodSelectorsDict(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupExtraPodSelectors("{'foo': 'bar'}")
 	f.load()
@@ -1761,7 +1676,6 @@ func TestExtraPodSelectorsDict(t *testing.T) {
 
 func TestExtraPodSelectorsElementNotDict(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupExtraPodSelectors("['hello']")
 	f.loadErrString("must be dicts", "starlark.String")
@@ -1769,7 +1683,6 @@ func TestExtraPodSelectorsElementNotDict(t *testing.T) {
 
 func TestExtraPodSelectorsKeyNotString(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupExtraPodSelectors("[{54321: 'hello'}]")
 	f.loadErrString("keys must be strings", "54321")
@@ -1777,7 +1690,6 @@ func TestExtraPodSelectorsKeyNotString(t *testing.T) {
 
 func TestExtraPodSelectorsValueNotString(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupExtraPodSelectors("[{'hello': 54321}]")
 	f.loadErrString("values must be strings", "54321")
@@ -1785,7 +1697,6 @@ func TestExtraPodSelectorsValueNotString(t *testing.T) {
 
 func TestPodReadinessDefaultDeployment(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.yaml("foo.yaml", deployment("foo", image("gcr.io/foo:stable")))
 	f.file("Tiltfile", `
@@ -1801,7 +1712,6 @@ k8s_yaml('foo.yaml')
 
 func TestPodReadinessDefaultConfigMap(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.file("config.yaml", `apiVersion: v1
 kind: ConfigMap
@@ -1823,7 +1733,6 @@ k8s_resource(new_name='config', objects=['config'])
 
 func TestPodReadinessDefaultJob(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.file("job.yaml", `apiVersion: batch/v1
 kind: Job
@@ -1842,7 +1751,6 @@ k8s_yaml('job.yaml')
 
 func TestK8sDiscoveryStrategy(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.yaml("foo.yaml", deployment("foo", image("gcr.io/foo:stable")))
 	f.file("Tiltfile", `
@@ -1859,7 +1767,6 @@ k8s_resource('foo', discovery_strategy='selectors-only')
 
 func TestK8sDiscoveryStrategyInvalid(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.yaml("foo.yaml", deployment("foo", image("gcr.io/foo:stable")))
 	f.file("Tiltfile", `
@@ -1872,7 +1779,6 @@ k8s_resource('foo', discovery_strategy='typo')
 
 func TestPodReadinessOverrideDeployment(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.yaml("foo.yaml", deployment("foo", image("gcr.io/foo:stable")))
 	f.file("Tiltfile", `
@@ -1889,7 +1795,6 @@ k8s_resource('foo', pod_readiness='ignore')
 
 func TestPodReadinessOverrideConfigMap(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.file("config.yaml", `apiVersion: v1
 kind: ConfigMap
@@ -1911,7 +1816,6 @@ k8s_resource(new_name='config', objects=['config'], pod_readiness='wait')
 
 func TestPodReadinessInvalid(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.file("config.yaml", `apiVersion: v1
 kind: ConfigMap
@@ -1930,7 +1834,6 @@ k8s_resource(new_name='config', objects=['config'], pod_readiness='w')
 
 func TestDockerBuildMatchingTag(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.gitInit("")
 	f.file("Dockerfile", "FROM golang:1.10")
@@ -1948,7 +1851,6 @@ k8s_yaml('foo.yaml')
 
 func TestDockerBuildButK8sMissing(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.gitInit("")
 	f.file("Dockerfile", "FROM golang:1.10")
@@ -1961,7 +1863,6 @@ docker_build('gcr.io/foo:stable', '.')
 
 func TestDockerBuildButK8sMissingTag(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.gitInit("")
 	f.file("Dockerfile", "FROM golang:1.10")
@@ -1977,7 +1878,6 @@ k8s_yaml('foo.yaml')
 
 func TestDockerBuildUnusedSuppressWarning(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.gitInit("")
 	f.file("Dockerfile", "FROM golang:1.10")
@@ -1993,7 +1893,6 @@ update_settings(suppress_unused_image_warnings=['b'])
 
 func TestDockerBuildButK8sNonMatchingTag(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.gitInit("")
 	f.file("Dockerfile", "FROM golang:1.10")
@@ -2009,7 +1908,6 @@ k8s_yaml('foo.yaml')
 
 func TestFail(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.file("Tiltfile", `
 fail("this is an error")
@@ -2022,7 +1920,6 @@ fail("or this")
 
 func TestBlob(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.file(
 		"Tiltfile",
@@ -2036,7 +1933,6 @@ func TestBlob(t *testing.T) {
 
 func TestBlobErr(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.file(
 		"Tiltfile",
@@ -2048,7 +1944,6 @@ func TestBlobErr(t *testing.T) {
 
 func TestImageDependency(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.gitInit("")
 	f.file("imageA.dockerfile", "FROM golang:1.10")
@@ -2067,7 +1962,6 @@ k8s_yaml('foo.yaml')
 
 func TestImageDependencyLiveUpdate(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.gitInit("")
 	f.file("message.txt", "Hello!")
@@ -2093,7 +1987,6 @@ k8s_yaml('foo.yaml')
 
 func TestImageDependencyCycle(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.gitInit("")
 	f.file("imageA.dockerfile", "FROM gcr.io/image-b")
@@ -2110,7 +2003,6 @@ k8s_yaml('foo.yaml')
 
 func TestImageDependencyDiamond(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.gitInit("")
 	f.file("imageA.dockerfile", "FROM golang:1.10")
@@ -2143,7 +2035,6 @@ k8s_yaml('foo.yaml')
 
 func TestImageDependencyTwice(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.gitInit("")
 	f.file("imageA.dockerfile", "FROM golang:1.10")
@@ -2201,7 +2092,6 @@ k8s_yaml('snack.yaml')
 
 func TestImageDependencyNormalization(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.gitInit("")
 	f.file("common.dockerfile", "FROM golang:1.10")
@@ -2224,7 +2114,6 @@ k8s_yaml('auth.yaml')
 
 func TestImagesWithSameNameAssembly(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.gitInit("")
 	f.file("app.dockerfile", "FROM golang:1.10")
@@ -2247,7 +2136,6 @@ k8s_yaml('app.yaml')
 
 func TestImagesWithSameNameDifferentManifests(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.gitInit("")
 	f.file("app.dockerfile", "FROM golang:1.10")
@@ -2276,7 +2164,6 @@ k8s_yaml('app.yaml')
 
 func TestImageRefSuggestion(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupFoo()
 	f.file("Tiltfile", `
@@ -2290,7 +2177,6 @@ k8s_yaml('foo.yaml')
 
 func TestDir(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.gitInit("")
 	f.yaml("config/foo.yaml", deployment("foo", image("gcr.io/foo")))
@@ -2304,7 +2190,6 @@ func TestDir(t *testing.T) {
 
 func TestDirRecursive(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.gitInit("")
 	f.file("foo/bar", "bar")
@@ -2321,7 +2206,6 @@ for f in files:
 
 func TestCallCounts(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.gitInit("")
 	f.file("Dockerfile", "FROM golang:1.10")
@@ -2351,7 +2235,6 @@ k8s_yaml('foo.yaml')
 
 func TestArgCounts(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.gitInit("")
 	f.file("Dockerfile", "FROM golang:1.10")
@@ -2383,7 +2266,6 @@ k8s_yaml('foo.yaml')
 
 func TestK8sManifestRefInjectCounts(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.gitInit("")
 	f.file("Dockerfile", "FROM golang:1.10")
@@ -2420,7 +2302,6 @@ k8s_yaml(['sancho_twin.yaml', 'sancho_sidecar.yaml', 'blorg.yaml'])
 
 func TestYamlErrorFromLocal(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 	f.file("Tiltfile", `
 yaml = local('echo hi')
 k8s_yaml(yaml)
@@ -2430,7 +2311,6 @@ k8s_yaml(yaml)
 
 func TestYamlErrorFromReadFile(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 	f.file("foo.yaml", "hi")
 	f.file("Tiltfile", `
 k8s_yaml(read_file('foo.yaml'))
@@ -2440,7 +2320,6 @@ k8s_yaml(read_file('foo.yaml'))
 
 func TestYamlErrorFromBlob(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 	f.file("Tiltfile", `
 k8s_yaml(blob('hi'))
 `)
@@ -2449,7 +2328,6 @@ k8s_yaml(blob('hi'))
 
 func TestCustomBuildWithTag(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	tiltfile := `k8s_yaml('foo.yaml')
 custom_build(
@@ -2478,7 +2356,6 @@ custom_build(
 
 func TestCustomBuildDisablePush(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	tiltfile := `k8s_yaml('foo.yaml')
 hfb = custom_build(
@@ -2506,7 +2383,6 @@ hfb = custom_build(
 
 func TestCustomBuildSkipsLocalDocker(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	tiltfile := `
 k8s_yaml('foo.yaml')
@@ -2532,7 +2408,6 @@ custom_build(
 
 func TestImageObjectJSONPath(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 	f.file("um.yaml", `apiVersion: tilt.dev/v1alpha1
 kind: UselessMachine
 metadata:
@@ -2556,7 +2431,6 @@ docker_build('tilt.dev/frontend', '.')
 
 func TestImageObjectJSONPathNoMatch(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 	f.file("um.yaml", `apiVersion: tilt.dev/v1alpha1
 kind: UselessMachine
 metadata:
@@ -2575,7 +2449,6 @@ docker_build('tilt.dev/frontend', '.')
 
 func TestImageObjectJSONPathPodReadinessIgnore(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 	f.file("um.yaml", `apiVersion: tilt.dev/v1alpha1
 kind: UselessMachine
 metadata:
@@ -2600,7 +2473,6 @@ docker_build('tilt.dev/frontend', '.')
 
 func TestExtraImageLocationOneImage(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 	f.setupCRD()
 	f.dockerfile("env/Dockerfile")
 	f.dockerfile("builder/Dockerfile")
@@ -2622,7 +2494,6 @@ docker_build('test/mycrd-env', 'env')
 
 func TestConflictingWorkloadNames(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.dockerfile("foo1/Dockerfile")
 	f.dockerfile("foo2/Dockerfile")
@@ -2665,7 +2536,6 @@ func TestK8sKind(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			f := newFixture(t)
-			defer f.TearDown()
 			f.setupCRD()
 			f.dockerfile("env/Dockerfile")
 			f.dockerfile("builder/Dockerfile")
@@ -2718,7 +2588,6 @@ k8s_kind(%s)
 
 func TestK8sKindImageJSONPathPositional(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 	f.setupCRD()
 	f.dockerfile("env/Dockerfile")
 	f.dockerfile("builder/Dockerfile")
@@ -2732,7 +2601,6 @@ docker_build('test/mycrd-env', 'env')
 
 func TestExtraImageLocationTwoImages(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 	f.setupCRD()
 	f.dockerfile("env/Dockerfile")
 	f.dockerfile("builder/Dockerfile")
@@ -2758,7 +2626,6 @@ docker_build('test/mycrd-env', 'env')
 
 func TestExtraImageLocationDeploymentEnvVarByName(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.dockerfile("foo/Dockerfile")
 	f.dockerfile("foo-fetcher/Dockerfile")
@@ -2792,7 +2659,6 @@ k8s_image_json_path("{.spec.template.spec.containers[*].env[?(@.name=='FETCHER_I
 
 func TestExtraImageLocationDeploymentEnvVarMatch(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.dockerfile("foo/Dockerfile")
 	f.dockerfile("foo-fetcher/Dockerfile")
@@ -2816,7 +2682,6 @@ docker_build('gcr.io/foo-fetcher', 'foo-fetcher', match_in_env_vars=True)
 
 func TestExtraImageLocationDeploymentEnvVarDoesNotMatchIfNotSpecified(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.dockerfile("foo/Dockerfile")
 	f.dockerfile("foo-fetcher/Dockerfile")
@@ -2901,7 +2766,6 @@ k8s_image_json_path("{.spec.template.spec.containers[*].env[?(@.name=='FETCHER_I
 
 func TestExtraImageLocationDeploymentEnvVarByNameAndNamespace(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.dockerfile("foo/Dockerfile")
 	f.dockerfile("foo-fetcher/Dockerfile")
@@ -2926,7 +2790,6 @@ k8s_image_json_path("{.spec.template.spec.containers[*].env[?(@.name=='FETCHER_I
 
 func TestExtraImageLocationNoMatch(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 	f.setupCRD()
 	f.dockerfile("env/Dockerfile")
 	f.dockerfile("builder/Dockerfile")
@@ -2940,7 +2803,6 @@ docker_build('test/mycrd-env', 'env')
 
 func TestExtraImageLocationInvalidJsonPath(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 	f.setupCRD()
 	f.dockerfile("env/Dockerfile")
 	f.dockerfile("builder/Dockerfile")
@@ -2954,35 +2816,30 @@ docker_build('test/mycrd-env', 'env')
 
 func TestExtraImageLocationNoPaths(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 	f.file("Tiltfile", `k8s_image_json_path(kind='MyType')`)
 	f.loadErrString("missing argument for paths")
 }
 
 func TestExtraImageLocationNotListOrString(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 	f.file("Tiltfile", `k8s_image_json_path(kind='MyType', paths=8)`)
 	f.loadErrString("for parameter \"paths\": Expected string, got: 8")
 }
 
 func TestExtraImageLocationListContainsNonString(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 	f.file("Tiltfile", `k8s_image_json_path(kind='MyType', paths=["foo", 8])`)
 	f.loadErrString("for parameter \"paths\": Expected string, got: 8")
 }
 
 func TestExtraImageLocationNoSelectorSpecified(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 	f.file("Tiltfile", `k8s_image_json_path(paths=["foo"])`)
 	f.loadErrString("at least one of kind, name, or namespace must be specified")
 }
 
 func TestDockerBuildEmptyDockerFileArg(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 	f.file("Tiltfile", `
 docker_build('web/api', '', dockerfile='')
 `)
@@ -2991,7 +2848,6 @@ docker_build('web/api', '', dockerfile='')
 
 func TestK8sYamlEmptyArg(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 	f.file("Tiltfile", `
 k8s_yaml('')
 `)
@@ -3000,7 +2856,6 @@ k8s_yaml('')
 
 func TestTwoDefaultRegistries(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.file("Tiltfile", `
 default_registry("gcr.io")
@@ -3011,7 +2866,6 @@ default_registry("docker.io")`)
 
 func TestDefaultRegistryInvalid(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupFoo()
 	f.file("Tiltfile", `
@@ -3024,7 +2878,6 @@ docker_build('gcr.io/foo', 'foo')
 
 func TestDefaultRegistryHostFromCluster(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupFoo()
 	f.file("Tiltfile", `
@@ -3042,7 +2895,6 @@ docker_build('gcr.io/foo', 'foo')
 
 func TestDefaultRegistryAtEndOfTiltfile(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupFoo()
 	// default_registry is the last entry to test that it doesn't only affect subsequently defined images
@@ -3062,7 +2914,6 @@ default_registry('bar.com')
 
 func TestDefaultRegistryTwoImagesOnlyDifferByTag(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.dockerfile("bar/Dockerfile")
 	f.yaml("bar.yaml", deployment("bar", image("gcr.io/foo:bar")))
@@ -3093,7 +2944,6 @@ default_registry('example.com')
 
 func TestDefaultRegistrySingleName(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.dockerfile("fe/Dockerfile")
 	f.yaml("fe.yaml", deployment("fe", image("fe")))
@@ -3134,7 +2984,6 @@ default_registry('123.dkr.ecr.us-east-1.amazonaws.com', single_name='team-a/dev'
 
 func TestDefaultReadFile(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 	f.setupFooAndBar()
 	tiltfile := `
 result = read_file("this_file_does_not_exist", default="foo")
@@ -3155,7 +3004,6 @@ k8s_yaml(str(result) + '.yaml')
 
 func TestWatchFile(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupFoo()
 
@@ -3176,7 +3024,6 @@ k8s_yaml('foo.yaml')
 
 func TestAssemblyBasic(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupFoo()
 
@@ -3196,7 +3043,6 @@ k8s_yaml('foo.yaml')
 
 func TestAssemblyTwoWorkloadsSameImage(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupFoo()
 	f.yaml("bar.yaml", deployment("bar", image("gcr.io/foo")))
@@ -3223,7 +3069,6 @@ k8s_yaml(['foo.yaml', 'bar.yaml'])
 // it with the first workload (https://github.com/tilt-dev/tilt/issues/4233)
 func TestAssemblyServiceWithoutSelectorMatchesNothing(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.yaml("all.yaml",
 		deployment("foo", withLabels(map[string]string{"app": "foo"})),
@@ -3243,7 +3088,6 @@ k8s_yaml('all.yaml')
 
 func TestK8sResourceNoMatch(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupFoo()
 	f.file("Tiltfile", `
@@ -3257,7 +3101,6 @@ k8s_resource('bar', new_name='baz')
 
 func TestK8sResourceNewName(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupFoo()
 	f.file("Tiltfile", `
@@ -3273,7 +3116,6 @@ k8s_resource('foo', new_name='bar')
 
 func TestK8sResourceRenameTwice(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupFoo()
 	f.file("Tiltfile", `
@@ -3289,7 +3131,6 @@ k8s_resource('bar', new_name='baz')
 
 func TestK8sResourceNewNameConflict(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupFooAndBar()
 	f.file("Tiltfile", `
@@ -3303,7 +3144,6 @@ k8s_resource('foo', new_name='bar')
 
 func TestK8sResourceRenameConflictingNames(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.dockerfile("foo1/Dockerfile")
 	f.dockerfile("foo2/Dockerfile")
@@ -3325,7 +3165,6 @@ k8s_resource('foo:deployment:ns2', new_name='foo')
 
 func TestConflictingNewNames(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.yaml("ns1.yaml", namespace("ns1"))
 	f.yaml("ns2.yaml", namespace("ns2"))
@@ -3340,7 +3179,6 @@ k8s_resource(new_name='foo', objects=['ns2:namespace'])
 
 func TestAdditivePortForwards(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupFoo()
 
@@ -3357,7 +3195,6 @@ k8s_resource('foo', port_forwards=8000)
 
 func TestWorkloadToResourceFunction(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupFoo()
 
@@ -3378,7 +3215,6 @@ k8s_resource('hello-foo', port_forwards=8000)
 
 func TestWorkloadToResourceFunctionConflict(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupFooAndBar()
 
@@ -3397,7 +3233,6 @@ workload_to_resource_function(wtrf)
 
 func TestWorkloadToResourceFunctionError(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupFoo()
 
@@ -3416,7 +3251,6 @@ k8s_resource('hello-foo', port_forwards=8000)
 
 func TestWorkloadToResourceFunctionReturnsNonString(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupFoo()
 
@@ -3435,7 +3269,6 @@ k8s_resource('hello-foo', port_forwards=8000)
 
 func TestWorkloadToResourceFunctionTakesNoArgs(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupFoo()
 
@@ -3454,7 +3287,6 @@ k8s_resource('hello-foo', port_forwards=8000)
 
 func TestWorkloadToResourceFunctionTakesTwoArgs(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupFoo()
 
@@ -3473,7 +3305,6 @@ k8s_resource('hello-foo', port_forwards=8000)
 
 func TestMultipleLiveUpdatesOnManifest(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.gitInit("")
 	f.file("sancho/Dockerfile", "FROM golang:1.10")
@@ -3510,7 +3341,6 @@ docker_build('gcr.io/some-project-162817/sancho-sidecar', './sidecar',
 
 func TestImpossibleLiveUpdatesOKNoLiveUpdate(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.gitInit("")
 	f.file("sancho/Dockerfile", "FROM golang:1.10")
@@ -3530,7 +3360,6 @@ docker_build('gcr.io/some-project-162817/sancho-sidecar', './sidecar')
 
 func TestImpossibleLiveUpdatesOKSecondContainerLiveUpdate(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.gitInit("")
 	f.file("sancho/Dockerfile", "FROM golang:1.10")
@@ -3570,7 +3399,6 @@ func TestTriggerModeK8S(t *testing.T) {
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
 			f := newFixture(t)
-			defer f.TearDown()
 
 			f.setupFoo()
 
@@ -3641,7 +3469,6 @@ func TestTriggerModeLocal(t *testing.T) {
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
 			f := newFixture(t)
-			defer f.TearDown()
 
 			var globalTriggerModeDirective string
 			switch testCase.globalSetting {
@@ -3687,7 +3514,6 @@ func TestTriggerModeLocal(t *testing.T) {
 
 func TestTriggerModeInt(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.file("Tiltfile", `
 trigger_mode(1)
@@ -3697,7 +3523,6 @@ trigger_mode(1)
 
 func TestMultipleTriggerMode(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.file("Tiltfile", `
 trigger_mode(TRIGGER_MODE_MANUAL)
@@ -3708,7 +3533,6 @@ trigger_mode(TRIGGER_MODE_MANUAL)
 
 func TestK8sContext(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupFoo()
 
@@ -3729,7 +3553,6 @@ docker_build('gcr.io/foo', 'foo')
 
 func TestDockerbuildIgnoreAsString(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.dockerfile("Dockerfile")
 	f.yaml("foo.yaml", deployment("foo", image("gcr.io/foo")))
@@ -3750,7 +3573,6 @@ k8s_yaml('foo.yaml')
 
 func TestDockerbuildIgnoreAsArray(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.dockerfile("Dockerfile")
 	f.yaml("foo.yaml", deployment("foo", image("gcr.io/foo")))
@@ -3773,7 +3595,6 @@ k8s_yaml('foo.yaml')
 
 func TestDockerbuildInvalidIgnore(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.dockerfile("foo/Dockerfile")
 	f.yaml("foo.yaml", deployment("foo", image("fooimage")))
@@ -3789,7 +3610,6 @@ k8s_yaml('foo.yaml')
 
 func TestDockerbuildOnly(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.dockerfile("Dockerfile")
 	f.yaml("foo.yaml", deployment("foo", image("gcr.io/foo")))
@@ -3809,7 +3629,6 @@ k8s_yaml('foo.yaml')
 
 func TestDockerbuildOnlyAsArray(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.dockerfile("Dockerfile")
 	f.yaml("foo.yaml", deployment("foo", image("gcr.io/foo")))
@@ -3831,7 +3650,6 @@ k8s_yaml('foo.yaml')
 
 func TestDockerbuildInvalidOnly(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.dockerfile("foo/Dockerfile")
 	f.yaml("foo.yaml", deployment("foo", image("fooimage")))
@@ -3847,7 +3665,6 @@ k8s_yaml('foo.yaml')
 
 func TestDockerbuildInvalidOnlyGlob(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.dockerfile("foo/Dockerfile")
 	f.yaml("foo.yaml", deployment("foo", image("fooimage")))
@@ -3863,7 +3680,6 @@ k8s_yaml('foo.yaml')
 
 func TestDockerbuildOnlyAndIgnore(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.dockerfile("Dockerfile")
 	f.yaml("foo.yaml", deployment("foo", image("gcr.io/foo")))
@@ -3888,7 +3704,6 @@ k8s_yaml('foo.yaml')
 // if the same file is ignored and included, the ignore takes precedence
 func TestDockerbuildOnlyAndIgnoreSameFile(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.dockerfile("Dockerfile")
 	f.yaml("foo.yaml", deployment("foo", image("gcr.io/foo")))
@@ -3908,7 +3723,6 @@ k8s_yaml('foo.yaml')
 // We don't do a double negative
 func TestDockerbuildOnlyHasException(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.dockerfile("Dockerfile")
 	f.yaml("foo.yaml", deployment("foo", image("gcr.io/foo")))
@@ -3930,7 +3744,6 @@ k8s_yaml('foo.yaml')
 // That's hard to make work easily, so let's just throw an error
 func TestDockerbuildIgnoreWithNewline(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.dockerfile("Dockerfile")
 	f.yaml("foo.yaml", deployment("foo", image("gcr.io/foo")))
@@ -3943,7 +3756,6 @@ k8s_yaml('foo.yaml')
 }
 func TestDockerbuildOnlyWithNewline(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.dockerfile("Dockerfile")
 	f.yaml("foo.yaml", deployment("foo", image("gcr.io/foo")))
@@ -4073,7 +3885,6 @@ func TestDisableSnapshots(t *testing.T) {
 
 func TestDockerBuildEntrypointString(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.dockerfile("Dockerfile")
 	f.yaml("foo.yaml", deployment("foo", image("gcr.io/foo")))
@@ -4088,7 +3899,6 @@ k8s_yaml('foo.yaml')
 
 func TestDockerBuildContainerArgs(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.dockerfile("Dockerfile")
 	f.yaml("foo.yaml", deployment("foo", image("gcr.io/foo")))
@@ -4107,7 +3917,6 @@ k8s_yaml('foo.yaml')
 
 func TestDockerBuildEntrypointArray(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.dockerfile("Dockerfile")
 	f.yaml("foo.yaml", deployment("foo", image("gcr.io/foo")))
@@ -4122,7 +3931,6 @@ k8s_yaml('foo.yaml')
 
 func TestDockerBuild_buildArgs(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupFoo()
 
@@ -4145,7 +3953,6 @@ k8s_yaml('foo.yaml')
 
 func TestCustomBuildEntrypoint(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.dockerfile("Dockerfile")
 	f.yaml("foo.yaml", deployment("foo", image("gcr.io/foo")))
@@ -4166,7 +3973,6 @@ k8s_yaml('foo.yaml')
 
 func TestCustomBuildContainerArgs(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.dockerfile("Dockerfile")
 	f.yaml("foo.yaml", deployment("foo", image("gcr.io/foo")))
@@ -4185,7 +3991,6 @@ k8s_yaml('foo.yaml')
 // See comments on ImageTarget#MaybeIgnoreRegistry()
 func TestCustomBuildSkipsLocalDockerAndTagPassedIgnoresLocalRegistry(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.dockerfile("Dockerfile")
 	f.yaml("foo.yaml", deployment("foo", image("gcr.io/foo")))
@@ -4202,7 +4007,6 @@ k8s_yaml('foo.yaml')
 
 func TestDuplicateYAMLEntityWithinSingleResource(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.gitInit("")
 	f.yaml("resource.yaml",
@@ -4219,7 +4023,6 @@ k8s_yaml('resource.yaml')
 
 func TestDuplicateYAMLEntityWithinSingleResourceAllowed(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.gitInit("")
 	f.yaml("resource.yaml",
@@ -4233,7 +4036,6 @@ k8s_yaml('resource.yaml', allow_duplicates=True)
 
 func TestDuplicateYAMLEntityAcrossResources(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.dockerfile("foo1/Dockerfile")
 	f.yaml("foo1.yaml", deployment("foo", image("gcr.io/foo1"), namespace("ns1")))
@@ -4252,7 +4054,6 @@ k8s_resource('foo:deployment:ns1', new_name='foo')
 func TestDuplicateYAMLEntityInSingleWorkload(t *testing.T) {
 	//Services corresponding to a deployment get pulled into the same resource.
 	f := newFixture(t)
-	defer f.TearDown()
 
 	labelsFoo := map[string]string{"foo": "bar"}
 	f.yaml("all.yaml",
@@ -4271,7 +4072,6 @@ k8s_yaml('all.yaml')
 
 func TestDuplicateYAMLEntityInUserAssembledNonWorkloadResource(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 	f.gitInit("")
 	f.yaml("all.yaml",
 		service("foo-service"),
@@ -4289,7 +4089,6 @@ k8s_resource(objects=['foo-service:Service:default'], new_name='my-services')
 
 func TestSetTeamID(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.file("Tiltfile", "set_team('sharks')")
 	f.load()
@@ -4299,7 +4098,6 @@ func TestSetTeamID(t *testing.T) {
 
 func TestSetTeamIDEmpty(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.file("Tiltfile", "set_team('')")
 	f.loadErrString("team_id cannot be empty")
@@ -4307,7 +4105,6 @@ func TestSetTeamIDEmpty(t *testing.T) {
 
 func TestSetTeamIDMultiple(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.file("Tiltfile", `
 set_team('sharks')
@@ -4333,7 +4130,6 @@ func TestK8SContextAcceptance(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			f := newFixture(t)
-			defer f.TearDown()
 
 			f.file("Tiltfile", `
 k8s_yaml("foo.yaml")
@@ -4355,7 +4151,6 @@ allow_k8s_contexts("allowed-context")
 // Test for fix to https://github.com/tilt-dev/tilt/issues/4234
 func TestCheckK8SContextWhenOnlyUncategorizedK8s(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	// We'll only have Uncategorized k8s entities, no K8s resources--
 	// make sure we still check K8sContext and throw an error if need be
@@ -4387,7 +4182,6 @@ func TestLocalObeysAllowedK8sContexts(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			f := newFixture(t)
-			defer f.TearDown()
 
 			f.file("Tiltfile", `
 allow_k8s_contexts("allowed-context")
@@ -4408,7 +4202,6 @@ local('echo hi')
 
 func TestLocalResourceOnlyUpdateCmd(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.file("Tiltfile", `
 local_resource("test", "echo hi", deps=["foo/bar", "foo/a.txt"])
@@ -4431,7 +4224,6 @@ local_resource("test", "echo hi", deps=["foo/bar", "foo/a.txt"])
 
 func TestLocalResourceOnlyServeCmd(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.file("Tiltfile", `
 local_resource("test", serve_cmd="sleep 1000")
@@ -4447,7 +4239,6 @@ local_resource("test", serve_cmd="sleep 1000")
 
 func TestLocalResourceUpdateAndServeCmd(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.file("Tiltfile", `
 local_resource("test", cmd="echo hi", serve_cmd="sleep 1000")
@@ -4466,7 +4257,6 @@ local_resource("test", cmd="echo hi", serve_cmd="sleep 1000")
 
 func TestLocalResourceNeitherUpdateOrServeCmd(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.file("Tiltfile", `
 local_resource("test")
@@ -4477,7 +4267,6 @@ local_resource("test")
 
 func TestLocalResourceUpdateCmdArray(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.file("Tiltfile", `
 local_resource("test", ["echo", "hi"])
@@ -4490,7 +4279,6 @@ local_resource("test", ["echo", "hi"])
 
 func TestLocalResourceServeCmdArray(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.file("Tiltfile", `
 local_resource("test", serve_cmd=["echo", "hi"])
@@ -4503,7 +4291,6 @@ local_resource("test", serve_cmd=["echo", "hi"])
 
 func TestLocalResourceWorkdir(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.file("nested/Tiltfile", `
 local_resource("nested-local", "echo nested", deps=["foo/bar", "more_nested/repo"])
@@ -4541,7 +4328,6 @@ local_resource("toplvl-local", "echo hello world", deps=["foo/baz", "foo/a.txt"]
 
 func TestLocalResourceIgnore(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.file(".dockerignore", "**/**.c")
 	f.file("Tiltfile", "include('proj/Tiltfile')")
@@ -4576,7 +4362,6 @@ local_resource("test", "echo hi", deps=["foo"], ignore=["**/*.a", "foo/bar.d"])
 
 func TestLocalResourceUpdateCmdEnv(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.file("Tiltfile", `
 local_resource("test", "echo hi", env={"KEY1": "value1", "KEY2": "value2"}, serve_cmd="sleep 1000")
@@ -4592,7 +4377,6 @@ local_resource("test", "echo hi", env={"KEY1": "value1", "KEY2": "value2"}, serv
 
 func TestLocalResourceServeCmdEnv(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.file("Tiltfile", `
 local_resource("test", "echo hi", serve_cmd="sleep 1000", serve_env={"KEY1": "value1", "KEY2": "value2"})
@@ -4608,7 +4392,6 @@ local_resource("test", "echo hi", serve_cmd="sleep 1000", serve_env={"KEY1": "va
 
 func TestLocalResourceUpdateCmdDir(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.file("nested/inside.txt", "inside the nested directory")
 	f.file("Tiltfile", `
@@ -4624,7 +4407,6 @@ local_resource("test", cmd="cat inside.txt", dir="nested")
 
 func TestLocalResourceUpdateCmdDirNone(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.file("here.txt", "same level")
 	f.file("Tiltfile", `
@@ -4640,7 +4422,6 @@ local_resource("test", cmd="cat here.txt", dir=None)
 
 func TestLocalResourceServeCmdDir(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.file("nested/inside.txt", "inside the nested directory")
 	f.file("Tiltfile", `
@@ -4656,7 +4437,6 @@ local_resource("test", serve_cmd="cat inside.txt", serve_dir="nested")
 
 func TestLocalResourceServeCmdDirNone(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.file("here.txt", "same level")
 	f.file("Tiltfile", `
@@ -4672,7 +4452,6 @@ local_resource("test", serve_cmd="cat here.txt", serve_dir=None)
 
 func TestCustomBuildStoresTiltfilePath(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.file("Tiltfile", `include('proj/Tiltfile')
 k8s_yaml("foo.yaml")`)
@@ -4706,7 +4485,6 @@ func (f *fixture) assertRepos(expectedLocalPaths []string, repos []model.LocalGi
 
 func TestSecretString(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.file("secret.yaml", `
 apiVersion: v1
@@ -4735,7 +4513,6 @@ k8s_yaml('secret.yaml')
 
 func TestSecretBytes(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.file("secret.yaml", `
 apiVersion: v1
@@ -4764,7 +4541,6 @@ k8s_yaml('secret.yaml')
 
 func TestSecretSettingsDisableScrub(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.file("secret.yaml", `
 apiVersion: v1
@@ -4788,7 +4564,6 @@ secret_settings(disable_scrub=True)
 
 func TestDockerPruneSettings(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.file("Tiltfile", `
 docker_prune_settings(max_age_mins=111, num_builds=222)
@@ -4805,7 +4580,6 @@ docker_prune_settings(max_age_mins=111, num_builds=222)
 
 func TestDockerPruneSettingsDefaultsWhenCalled(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.file("Tiltfile", `
 docker_prune_settings(num_builds=123)
@@ -4822,7 +4596,6 @@ docker_prune_settings(num_builds=123)
 
 func TestDockerPruneSettingsDefaultsWhenNotCalled(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.file("Tiltfile", `
 print('nothing to see here')
@@ -4839,7 +4612,6 @@ print('nothing to see here')
 
 func TestK8SDependsOn(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupFooAndBar()
 	f.file("Tiltfile", `
@@ -4858,7 +4630,6 @@ k8s_resource('bar', resource_deps=['foo'])
 
 func TestLocalDependsOn(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.file("Tiltfile", `
 local_resource('foo', 'echo foo')
@@ -4872,7 +4643,6 @@ local_resource('bar', 'echo bar', resource_deps=['foo'])
 
 func TestDependsOnMissingResource(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.file("Tiltfile", `
 local_resource('bar', 'echo bar', resource_deps=['foo'])
@@ -4883,7 +4653,6 @@ local_resource('bar', 'echo bar', resource_deps=['foo'])
 
 func TestDependsOnSelf(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.file("Tiltfile", `
 local_resource('bar', 'echo bar', resource_deps=['bar'])
@@ -4894,7 +4663,6 @@ local_resource('bar', 'echo bar', resource_deps=['bar'])
 
 func TestDependsOnCycle(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.file("Tiltfile", `
 local_resource('foo', 'echo foo', resource_deps=['baz'])
@@ -4934,7 +4702,6 @@ func TestDependsOnPulledInOnPartialLoad(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			f := newFixture(t)
-			defer f.TearDown()
 
 			f.file("Tiltfile", `
 local_resource('a', 'echo a')
@@ -4956,7 +4723,6 @@ local_resource('e', 'echo e')
 
 func TestLocalResourceAllowParallel(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.file("Tiltfile", `
 local_resource("a", ["echo", "hi"], allow_parallel=True)
@@ -4979,7 +4745,6 @@ local_resource("c", serve_cmd=["echo", "hi"])
 
 func TestLocalResourceInvalidName(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.file("Tiltfile", `
 local_resource("a/b", ["echo", "hi"])
@@ -5028,7 +4793,6 @@ func TestMaxParallelUpdates(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			f := newFixture(t)
-			defer f.TearDown()
 
 			f.file("Tiltfile", tc.tiltfile)
 
@@ -5079,7 +4843,6 @@ func TestK8sUpsertTimeout(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			f := newFixture(t)
-			defer f.TearDown()
 
 			f.file("Tiltfile", tc.tiltfile)
 
@@ -5097,7 +4860,6 @@ func TestK8sUpsertTimeout(t *testing.T) {
 
 func TestUpdateSettingsCalledTwice(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.file("Tiltfile", `update_settings(max_parallel_updates=123)
 update_settings(k8s_upsert_timeout_secs=456)`)
@@ -5110,7 +4872,6 @@ update_settings(k8s_upsert_timeout_secs=456)`)
 // recursion is disabled by default in Starlark. Make sure we've enabled it for Tiltfiles.
 func TestRecursionEnabled(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.file("Tiltfile", `
 def fact(n):
@@ -5128,7 +4889,6 @@ print("fact: %d" % (fact(10)))
 
 func TestBuiltinAnalytics(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	// covering:
 	// 1. a positional arg
@@ -5178,7 +4938,6 @@ def printFoo():
 
 func TestCustomTagsReported(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.file("Tiltfile", `
 experimental_analytics_report({'foo': 'bar'})
@@ -5193,7 +4952,6 @@ experimental_analytics_report({'foo': 'bar'})
 
 func TestK8sResourceObjectsAddsNonWorkload(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupFoo()
 	f.yaml("secret.yaml", secret("bar"))
@@ -5216,7 +4974,6 @@ k8s_resource('foo', objects=['bar', 'baz:namespace:default'])
 
 func TestK8sResourceObjectsWithSameName(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupFoo()
 	f.yaml("secret.yaml", secret("bar"))
@@ -5235,7 +4992,6 @@ k8s_resource('foo', objects=['bar', 'bar:namespace:default'])
 
 func TestK8sResourceObjectsCantIncludeSameObjectTwice(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupFoo()
 	f.yaml("secret1.yaml", secret("bar"))
@@ -5255,7 +5011,6 @@ k8s_resource('foo', objects=['bar', 'bar:secret:default'])
 
 func TestK8sResourceObjectsMultipleAmbiguous(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupFoo()
 	f.yaml("secret.yaml", secret("bar"))
@@ -5274,7 +5029,6 @@ k8s_resource('foo', objects=['bar', 'bar'])
 
 func TestK8sResourceObjectEmptySelector(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupFoo()
 	f.yaml("secret.yaml", secret("bar"))
@@ -5293,7 +5047,6 @@ k8s_resource('foo', objects=[''])
 
 func TestK8sResourceObjectInvalidSelector(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupFoo()
 	f.yaml("secret.yaml", secret("bar"))
@@ -5312,7 +5065,6 @@ k8s_resource('foo', objects=['baz:namespace:default:wot'])
 
 func TestK8sResourceObjectSelectorWithEscapedColon(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupFoo()
 	f.yaml("secret.yaml", secret("quu:bar"))
@@ -5335,7 +5087,6 @@ k8s_resource('foo', objects=['quu\\:bar', 'baz:namespace:default'])
 
 func TestK8sResourceObjectSelectorWithEscapedBackslash(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupFoo()
 	f.yaml("secret.yaml", secret("quu\\bar"))
@@ -5358,7 +5109,6 @@ k8s_resource('foo', objects=['quu\\\\bar', 'baz:namespace:default'])
 
 func TestK8sResourceObjectSelectorSuggestedObjectsAreEscaped(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupFoo()
 	f.yaml("secret.yaml", secret("quu:bar"))
@@ -5380,7 +5130,6 @@ k8s_resource('foo', objects=['quu:bar', 'baz:namespace:default'])
 
 func TestK8sResourceObjectSelectorInvalidEscapeSequence(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupFoo()
 	f.yaml("secret.yaml", secret("quu:bar"))
@@ -5401,7 +5150,6 @@ k8s_resource('foo', objects=['qu\\u:bar', 'baz:namespace:default'])
 
 func TestK8sResourceObjectIncludesSelectorThatDoesntExist(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupFoo()
 	f.yaml("secret.yaml", secret("bar"))
@@ -5420,7 +5168,6 @@ k8s_resource('foo', objects=['baz:secret:default'])
 
 func TestK8sResourceObjectsPartialNames(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupFoo()
 	f.yaml("secret.yaml", secret("bar"))
@@ -5441,7 +5188,6 @@ k8s_resource('foo', objects=['bar:secret', 'bar:namespace'])
 
 func TestK8sResourcePrefixesShouldntMatch(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupFoo()
 	f.yaml("secret.yaml", secret("bar"))
@@ -5458,7 +5204,6 @@ k8s_resource('foo', objects=['ba'])
 
 func TestK8sResourceAmbiguousSelector(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupFoo()
 	f.yaml("secret.yaml", secret("bar"))
@@ -5477,7 +5222,6 @@ k8s_resource('foo', objects=['bar'])
 
 func TestK8sResourceObjectDuplicate(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupFoo()
 	f.yaml("secret.yaml", secret("bar"))
@@ -5497,7 +5241,6 @@ k8s_resource('baz', objects=['bar'])
 
 func TestK8sResourceObjectMultipleResources(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupFoo()
 	f.yaml("secret.yaml", secret("bar"))
@@ -5523,7 +5266,6 @@ k8s_resource('baz')
 
 func TestMultipleResourcesMultipleObjects(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupFoo()
 	f.yaml("secret.yaml", secret("bar"))
@@ -5548,7 +5290,6 @@ k8s_resource('baz', objects=['qux'])
 
 func TestK8sResourceAmbiguousWorkloadAmbiguousObject(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupFoo()
 	f.yaml("secret.yaml", secret("foo"))
@@ -5565,7 +5306,6 @@ k8s_resource('foo', objects=['foo'])
 
 func TestK8sResourceObjectsWithWorkloadToResourceFunction(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupFoo()
 	f.yaml("secret.yaml", secret("foo"))
@@ -5588,7 +5328,6 @@ k8s_resource('hello-foo', objects=['foo:secret'])
 
 func TestK8sResourceNewNameWithoutObjects(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.file("Tiltfile", `
 k8s_resource(new_name='foo')
@@ -5599,7 +5338,6 @@ k8s_resource(new_name='foo')
 
 func TestK8sResourceObjectsWithGroup(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupFoo()
 	f.yaml("secret.yaml", secret("bar"))
@@ -5621,7 +5359,6 @@ k8s_resource('foo', objects=['bar', 'baz:namespace:default:core'])
 
 func TestK8sResourceObjectClusterScoped(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupFoo()
 	f.yaml("namespace.yaml", namespace("baz"))
@@ -5644,7 +5381,6 @@ k8s_resource('foo', objects=['baz:namespace'])
 // For now we just leave them as "default"
 func TestK8sResourceObjectClusterScopedWithNamespace(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupFoo()
 	f.yaml("namespace.yaml", namespace("baz"))
@@ -5661,7 +5397,6 @@ k8s_resource('foo', objects=['baz:namespace:qux'])
 
 func TestK8sResourceObjectsNonWorkloadOnly(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.yaml("secret.yaml", secret("bar"))
 	f.yaml("namespace.yaml", namespace("baz"))
@@ -5680,7 +5415,6 @@ k8s_resource(new_name='foo', objects=['bar', 'baz:namespace:default'])
 
 func TestK8sResourceNewNameAdditive(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.yaml("a.yaml", namespace("a"))
 	f.yaml("b.yaml", namespace("b"))
@@ -5698,7 +5432,6 @@ k8s_resource('namespaces', objects=['b'])
 
 func TestK8sExistingResourceAdditive(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.yaml("a.yaml", deployment("a"))
 	f.yaml("b.yaml", namespace("b"))
@@ -5719,7 +5452,6 @@ k8s_resource('a', objects=['c'])
 
 func TestK8sExistingResourceNewNameAdditive(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	// this was working non-deterministically based on hashtable order, so generate a bunch of resources
 	// to reduce the chance of false positives
@@ -5744,7 +5476,6 @@ for i in range(1, 26):
 
 func TestK8sExistingResourceNewNameAlreadyTaken(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.yaml("a.yaml", deployment("a"))
 	f.yaml("b.yaml", namespace("b"))
@@ -5763,7 +5494,6 @@ k8s_resource(new_name='a', objects=['c'])
 
 func TestK8sNonWorkloadOnlyResourceWithAllTheOptions(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupFoo()
 	f.yaml("secret.yaml", secret("bar"))
@@ -5786,7 +5516,6 @@ k8s_resource(new_name='bar', objects=['bar', 'baz:namespace:default'], port_forw
 
 func TestK8sResourceEmptyWorkloadSpecifierAndNoObjects(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupFoo()
 
@@ -5801,7 +5530,6 @@ k8s_resource('', port_forwards=8000)
 
 func TestK8sResourceNonWorkloadRequiresNewName(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.yaml("secret.yaml", secret("bar"))
 	f.yaml("namespace.yaml", namespace("baz"))
@@ -5817,7 +5545,6 @@ k8s_resource(objects=['bar', 'baz:namespace:default'])
 
 func TestK8sResourceNewNameCantOverwriteWorkload(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupFoo()
 	f.yaml("secret.yaml", secret("bar"))
@@ -5838,7 +5565,6 @@ k8s_resource(new_name='bar', objects=['bar:secret'])
 
 func TestK8sResourceObjectsNonAmbiguousDefaultNamespace(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.file("serving-core.yaml", testyaml.KnativeServingCore)
 
@@ -5861,7 +5587,6 @@ k8s_resource(
 
 func TestK8sResourceObjectsAreNotCaseSensitive(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.file("serving-core.yaml", testyaml.KnativeServingCore)
 
@@ -5884,7 +5609,6 @@ k8s_resource(
 
 func TestK8sResourceLabels(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupFoo()
 
@@ -5900,7 +5624,6 @@ k8s_resource('foo', labels="test")
 
 func TestK8sResourceLabelsAppend(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.setupFoo()
 
@@ -5917,7 +5640,6 @@ k8s_resource('foo', labels="test2")
 
 func TestLocalResourceLabels(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.file("Tiltfile", `
 local_resource("test", cmd="echo hi", labels="foo")
@@ -5933,7 +5655,6 @@ local_resource("test2", cmd="echo hi2", labels=["bar", "baz"])
 // https://github.com/tilt-dev/tilt/issues/5467
 func TestLoadErrorWithArgs(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.file("Tiltfile", "asdf")
 	f.loadArgsErrString([]string{"foo"}, "undefined: asdf")
@@ -5941,7 +5662,6 @@ func TestLoadErrorWithArgs(t *testing.T) {
 
 func TestContentsChangedTag(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.file("Tiltfile", "print('Hello')")
 	tiltfile := ctrltiltfile.MainTiltfile(f.JoinPath("Tiltfile"), []string{})

--- a/internal/tiltfile/v1alpha1/plugin_test.go
+++ b/internal/tiltfile/v1alpha1/plugin_test.go
@@ -15,7 +15,6 @@ import (
 
 func TestExtension(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.File("Tiltfile", `
 v1alpha1.extension_repo(name='default', url='https://github.com/tilt-dev/tilt-extensions', ref='HEAD')
@@ -38,7 +37,6 @@ v1alpha1.extension(name='cancel', repo_name='default', repo_path='cancel')
 
 func TestExtensionArgs(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.File("Tiltfile", `
 v1alpha1.extension_repo(name='default', url='https://github.com/tilt-dev/tilt-extensions', ref='HEAD')
@@ -56,7 +54,6 @@ v1alpha1.extension(name='cancel', repo_name='default', repo_path='cancel', args=
 
 func TestExtensionValidation(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.File("Tiltfile", `
 v1alpha1.extension_repo(name='default', url='ftp://github.com/tilt-dev/tilt-extensions')
@@ -68,7 +65,6 @@ v1alpha1.extension_repo(name='default', url='ftp://github.com/tilt-dev/tilt-exte
 
 func TestFileWatchAsDict(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.File("Tiltfile", `
 v1alpha1.file_watch(name='my-fw', watched_paths=['./dir'], ignores=[{'base_path': './dir/ignore', 'patterns': ['**']}])
@@ -93,7 +89,6 @@ v1alpha1.file_watch(name='my-fw', watched_paths=['./dir'], ignores=[{'base_path'
 
 func TestFileWatchDisableOn(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.File("Tiltfile", `
 v1alpha1.file_watch(name='my-fw',
@@ -120,7 +115,6 @@ v1alpha1.file_watch(name='my-fw',
 
 func TestFileWatchWithIgnoreBuiltin(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.File("Tiltfile", `
 v1alpha1.file_watch(
@@ -148,7 +142,6 @@ v1alpha1.file_watch(
 
 func TestCmdDefaultDir(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.File("Tiltfile", `
 v1alpha1.cmd(
@@ -170,7 +163,6 @@ v1alpha1.cmd(
 
 func TestUIButton(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.File("Tiltfile", `
 v1alpha1.ui_button(
@@ -202,7 +194,6 @@ v1alpha1.ui_button(
 
 func TestKubernetesDiscoveryu(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.File("Tiltfile", `
 v1alpha1.kubernetes_discovery(
@@ -230,7 +221,6 @@ v1alpha1.kubernetes_discovery(
 
 func TestConfigMap(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.File("Tiltfile", `
 v1alpha1.config_map(
@@ -256,7 +246,6 @@ v1alpha1.config_map(
 
 func TestKubernetesApply(t *testing.T) {
 	f := newFixture(t)
-	defer f.TearDown()
 
 	f.File("Tiltfile", `
 

--- a/internal/tracer/span_collector_test.go
+++ b/internal/tracer/span_collector_test.go
@@ -16,7 +16,6 @@ import (
 
 func TestExporterSimple(t *testing.T) {
 	f := newFixture(t)
-	defer f.tearDown()
 
 	sd1 := sd(1)
 	f.export(sd1)
@@ -30,7 +29,6 @@ func TestExporterSimple(t *testing.T) {
 
 func TestExporterReject(t *testing.T) {
 	f := newFixture(t)
-	defer f.tearDown()
 
 	sd1 := sd(1)
 	f.export(sd1)
@@ -47,7 +45,6 @@ func TestExporterReject(t *testing.T) {
 // one test that makes sure the final string we're seeing is reasonable
 func TestExporterString(t *testing.T) {
 	f := newFixture(t)
-	defer f.tearDown()
 
 	spanID, _ := trace.SpanIDFromHex("00f067aa0ba902b7")
 	sd := &sdktrace.SpanSnapshot{
@@ -68,7 +65,6 @@ func TestExporterString(t *testing.T) {
 
 func TestExporterTrims(t *testing.T) {
 	f := newFixture(t)
-	defer f.tearDown()
 
 	var sds []*sdktrace.SpanSnapshot
 	for i := 0; i < 2048; i++ {
@@ -82,7 +78,6 @@ func TestExporterTrims(t *testing.T) {
 
 func TestExporterStartsEmpty(t *testing.T) {
 	f := newFixture(t)
-	defer f.tearDown()
 
 	f.assertEmpty()
 	f.assertEmpty()
@@ -105,11 +100,14 @@ type fixture struct {
 func newFixture(t *testing.T) *fixture {
 	ctx := context.Background()
 	sc := NewSpanCollector(ctx)
-	return &fixture{
+	ret := &fixture{
 		t:   t,
 		ctx: ctx,
 		sc:  sc,
 	}
+
+	t.Cleanup(ret.tearDown)
+	return ret
 }
 
 func (f *fixture) tearDown() {

--- a/internal/watch/notify_test.go
+++ b/internal/watch/notify_test.go
@@ -39,13 +39,11 @@ func TestWindowsBufferSize(t *testing.T) {
 
 func TestNoEvents(t *testing.T) {
 	f := newNotifyFixture(t)
-	defer f.tearDown()
 	f.assertEvents()
 }
 
 func TestNoWatches(t *testing.T) {
 	f := newNotifyFixture(t)
-	defer f.tearDown()
 	f.paths = nil
 	f.rebuildWatcher()
 	f.assertEvents()
@@ -58,7 +56,6 @@ func TestEventOrdering(t *testing.T) {
 		return
 	}
 	f := newNotifyFixture(t)
-	defer f.tearDown()
 
 	count := 8
 	dirs := make([]string, count)
@@ -90,7 +87,6 @@ func TestEventOrdering(t *testing.T) {
 // them all quickly. Make sure there are no errors.
 func TestGitBranchSwitch(t *testing.T) {
 	f := newNotifyFixture(t)
-	defer f.tearDown()
 
 	count := 10
 	dirs := make([]string, count)
@@ -144,7 +140,6 @@ func TestGitBranchSwitch(t *testing.T) {
 
 func TestWatchesAreRecursive(t *testing.T) {
 	f := newNotifyFixture(t)
-	defer f.tearDown()
 
 	root := f.TempDir("root")
 
@@ -166,7 +161,6 @@ func TestWatchesAreRecursive(t *testing.T) {
 
 func TestNewDirectoriesAreRecursivelyWatched(t *testing.T) {
 	f := newNotifyFixture(t)
-	defer f.tearDown()
 
 	root := f.TempDir("root")
 
@@ -191,7 +185,6 @@ func TestNewDirectoriesAreRecursivelyWatched(t *testing.T) {
 
 func TestWatchNonExistentPath(t *testing.T) {
 	f := newNotifyFixture(t)
-	defer f.tearDown()
 
 	root := f.TempDir("root")
 	path := filepath.Join(root, "change")
@@ -206,7 +199,6 @@ func TestWatchNonExistentPath(t *testing.T) {
 
 func TestWatchNonExistentPathDoesNotFireSiblingEvent(t *testing.T) {
 	f := newNotifyFixture(t)
-	defer f.tearDown()
 
 	root := f.TempDir("root")
 	watchedFile := filepath.Join(root, "a.txt")
@@ -222,7 +214,6 @@ func TestWatchNonExistentPathDoesNotFireSiblingEvent(t *testing.T) {
 
 func TestRemove(t *testing.T) {
 	f := newNotifyFixture(t)
-	defer f.tearDown()
 
 	root := f.TempDir("root")
 	path := filepath.Join(root, "change")
@@ -242,7 +233,6 @@ func TestRemove(t *testing.T) {
 
 func TestRemoveAndAddBack(t *testing.T) {
 	f := newNotifyFixture(t)
-	defer f.tearDown()
 
 	path := filepath.Join(f.paths[0], "change")
 
@@ -272,7 +262,6 @@ func TestRemoveAndAddBack(t *testing.T) {
 
 func TestSingleFile(t *testing.T) {
 	f := newNotifyFixture(t)
-	defer f.tearDown()
 
 	root := f.TempDir("root")
 	path := filepath.Join(root, "change")
@@ -296,7 +285,6 @@ func TestWriteBrokenLink(t *testing.T) {
 		t.Skip("no user-space symlinks on windows")
 	}
 	f := newNotifyFixture(t)
-	defer f.tearDown()
 
 	link := filepath.Join(f.paths[0], "brokenLink")
 	missingFile := filepath.Join(f.paths[0], "missingFile")
@@ -313,7 +301,6 @@ func TestWriteGoodLink(t *testing.T) {
 		t.Skip("no user-space symlinks on windows")
 	}
 	f := newNotifyFixture(t)
-	defer f.tearDown()
 
 	goodFile := filepath.Join(f.paths[0], "goodFile")
 	err := ioutil.WriteFile(goodFile, []byte("hello"), 0644)
@@ -335,7 +322,6 @@ func TestWatchBrokenLink(t *testing.T) {
 		t.Skip("no user-space symlinks on windows")
 	}
 	f := newNotifyFixture(t)
-	defer f.tearDown()
 
 	newRoot, err := NewDir(t.Name())
 	if err != nil {
@@ -363,7 +349,6 @@ func TestWatchBrokenLink(t *testing.T) {
 
 func TestMoveAndReplace(t *testing.T) {
 	f := newNotifyFixture(t)
-	defer f.tearDown()
 
 	root := f.TempDir("root")
 	file := filepath.Join(root, "myfile")
@@ -383,7 +368,6 @@ func TestMoveAndReplace(t *testing.T) {
 
 func TestWatchBothDirAndFile(t *testing.T) {
 	f := newNotifyFixture(t)
-	defer f.tearDown()
 
 	dir := f.JoinPath("foo")
 	fileA := f.JoinPath("foo", "a")
@@ -402,7 +386,6 @@ func TestWatchBothDirAndFile(t *testing.T) {
 
 func TestWatchNonexistentFileInNonexistentDirectoryCreatedSimultaneously(t *testing.T) {
 	f := newNotifyFixture(t)
-	defer f.tearDown()
 
 	root := f.JoinPath("root")
 	err := os.Mkdir(root, 0777)
@@ -420,7 +403,6 @@ func TestWatchNonexistentFileInNonexistentDirectoryCreatedSimultaneously(t *test
 
 func TestWatchNonexistentDirectory(t *testing.T) {
 	f := newNotifyFixture(t)
-	defer f.tearDown()
 
 	root := f.JoinPath("root")
 	err := os.Mkdir(root, 0777)
@@ -450,7 +432,6 @@ func TestWatchNonexistentDirectory(t *testing.T) {
 
 func TestWatchNonexistentFileInNonexistentDirectory(t *testing.T) {
 	f := newNotifyFixture(t)
-	defer f.tearDown()
 
 	root := f.JoinPath("root")
 	err := os.Mkdir(root, 0777)
@@ -475,7 +456,6 @@ func TestWatchNonexistentFileInNonexistentDirectory(t *testing.T) {
 
 func TestWatchCountInnerFile(t *testing.T) {
 	f := newNotifyFixture(t)
-	defer f.tearDown()
 
 	root := f.paths[0]
 	a := f.JoinPath(root, "a")
@@ -493,7 +473,6 @@ func TestWatchCountInnerFile(t *testing.T) {
 
 func TestWatchCountInnerFileWithIgnore(t *testing.T) {
 	f := newNotifyFixture(t)
-	defer f.tearDown()
 
 	root := f.paths[0]
 	ignore, _ := dockerignore.NewDockerPatternMatcher(root, []string{
@@ -517,7 +496,6 @@ func TestWatchCountInnerFileWithIgnore(t *testing.T) {
 
 func TestIgnoreCreatedDir(t *testing.T) {
 	f := newNotifyFixture(t)
-	defer f.tearDown()
 
 	root := f.paths[0]
 	ignore, _ := dockerignore.NewDockerPatternMatcher(root, []string{"a/b"})
@@ -538,7 +516,6 @@ func TestIgnoreCreatedDir(t *testing.T) {
 
 func TestIgnoreCreatedDirWithExclusions(t *testing.T) {
 	f := newNotifyFixture(t)
-	defer f.tearDown()
 
 	root := f.paths[0]
 	ignore, _ := dockerignore.NewDockerPatternMatcher(root,
@@ -564,7 +541,6 @@ func TestIgnoreCreatedDirWithExclusions(t *testing.T) {
 
 func TestIgnoreInitialDir(t *testing.T) {
 	f := newNotifyFixture(t)
-	defer f.tearDown()
 
 	root := f.TempDir("root")
 	ignore, _ := dockerignore.NewDockerPatternMatcher(root, []string{"a/b"})
@@ -612,6 +588,7 @@ func newNotifyFixture(t *testing.T) *notifyFixture {
 		out:            out,
 	}
 	nf.watch(nf.TempDir("watched"))
+	t.Cleanup(nf.tearDown)
 	return nf
 }
 
@@ -759,6 +736,5 @@ func (f *notifyFixture) closeWatcher() {
 func (f *notifyFixture) tearDown() {
 	f.cancel()
 	f.closeWatcher()
-	f.TempDirFixture.TearDown()
 	numberOfWatches.Set(0)
 }

--- a/internal/watch/paths_test.go
+++ b/internal/watch/paths_test.go
@@ -11,7 +11,6 @@ import (
 
 func TestGreatestExistingAncestor(t *testing.T) {
 	f := tempdir.NewTempDirFixture(t)
-	defer f.TearDown()
 
 	p, err := greatestExistingAncestor(f.Path())
 	assert.NoError(t, err)

--- a/internal/watch/watcher_naive_test.go
+++ b/internal/watch/watcher_naive_test.go
@@ -23,7 +23,6 @@ func TestDontWatchEachFile(t *testing.T) {
 	// this test uses a Linux way to get the number of watches to make sure we're watching
 	// per-directory, not per-file
 	f := newNotifyFixture(t)
-	defer f.tearDown()
 
 	watched := f.TempDir("watched")
 

--- a/pkg/assets/prod_test.go
+++ b/pkg/assets/prod_test.go
@@ -20,7 +20,6 @@ const (
 
 func TestIndexRequest(t *testing.T) {
 	f := newProdServerFixture(t)
-	defer f.TearDown()
 
 	req := httptest.NewRequest("GET", "/", bytes.NewBuffer(nil))
 	res := httptest.NewRecorder()
@@ -34,7 +33,6 @@ func TestIndexRequest(t *testing.T) {
 
 func TestFaviconRequest(t *testing.T) {
 	f := newProdServerFixture(t)
-	defer f.TearDown()
 
 	req := httptest.NewRequest("GET", "/favicon.ico", bytes.NewBuffer(nil))
 	res := httptest.NewRecorder()
@@ -46,7 +44,6 @@ func TestFaviconRequest(t *testing.T) {
 
 func TestFaviconGreenRequest(t *testing.T) {
 	f := newProdServerFixture(t)
-	defer f.TearDown()
 
 	req := httptest.NewRequest("GET", "/static/ico/favicon-green.ico", bytes.NewBuffer(nil))
 	res := httptest.NewRecorder()
@@ -58,7 +55,6 @@ func TestFaviconGreenRequest(t *testing.T) {
 
 func TestChunkRequest(t *testing.T) {
 	f := newProdServerFixture(t)
-	defer f.TearDown()
 
 	req := httptest.NewRequest("GET", "/v1.2.3/static/js/2.f1bd84e9.chunk.js", bytes.NewBuffer(nil))
 	res := httptest.NewRecorder()
@@ -71,7 +67,6 @@ func TestChunkRequest(t *testing.T) {
 
 func TestBuildUrlForReqRedirectsToIndex(t *testing.T) {
 	f := newProdServerFixture(t)
-	defer f.TearDown()
 
 	req := httptest.NewRequest("GET", "/some/random/path", bytes.NewBuffer(nil))
 	res := httptest.NewRecorder()
@@ -84,7 +79,6 @@ func TestBuildUrlForReqRedirectsToIndex(t *testing.T) {
 
 func TestBuildUrlForReqRespectsStatic(t *testing.T) {
 	f := newProdServerFixture(t)
-	defer f.TearDown()
 
 	req := httptest.NewRequest("GET", "/v1.2.3/static/stuff.html", bytes.NewBuffer(nil))
 	res := httptest.NewRecorder()
@@ -97,7 +91,6 @@ func TestBuildUrlForReqRespectsStatic(t *testing.T) {
 
 func TestBuildUrlForReqRespectsVersion(t *testing.T) {
 	f := newProdServerFixture(t)
-	defer f.TearDown()
 
 	req := httptest.NewRequest("GET", "/v111.222.333/stuff.html", bytes.NewBuffer(nil))
 	res := httptest.NewRecorder()
@@ -110,7 +103,6 @@ func TestBuildUrlForReqRespectsVersion(t *testing.T) {
 
 func TestBuildUrlForReqWithVersionParam(t *testing.T) {
 	f := newProdServerFixture(t)
-	defer f.TearDown()
 
 	req := httptest.NewRequest("GET", "/", bytes.NewBuffer(nil))
 	attachQueryVersion(req, string(version666))
@@ -125,7 +117,6 @@ func TestBuildUrlForReqWithVersionParam(t *testing.T) {
 
 func TestBuildUrlForReqWithVersionParamAndStaticPath(t *testing.T) {
 	f := newProdServerFixture(t)
-	defer f.TearDown()
 
 	req := httptest.NewRequest("GET", "/static/stuff.html", bytes.NewBuffer(nil))
 	attachQueryVersion(req, string(version666))
@@ -140,7 +131,6 @@ func TestBuildUrlForReqWithVersionParamAndStaticPath(t *testing.T) {
 
 func TestBuildUrlForReqWithVersionParamAndVersionPrefix(t *testing.T) {
 	f := newProdServerFixture(t)
-	defer f.TearDown()
 
 	req := httptest.NewRequest("GET", "/v111.222.333/stuff.html", bytes.NewBuffer(nil))
 	attachQueryVersion(req, string(version666))
@@ -155,7 +145,6 @@ func TestBuildUrlForReqWithVersionParamAndVersionPrefix(t *testing.T) {
 
 func TestSHARootUrlForReq(t *testing.T) {
 	f := newProdServerFixture(t)
-	defer f.TearDown()
 
 	sha := "8bf2ea29eacff3a407272eb5631edbd1a14a0936"
 	f.SetupServerWithVersion(model.WebVersion(sha))
@@ -170,7 +159,6 @@ func TestSHARootUrlForReq(t *testing.T) {
 
 func TestSHAStaticUrlForReq(t *testing.T) {
 	f := newProdServerFixture(t)
-	defer f.TearDown()
 
 	sha := "8bf2ea29eacff3a407272eb5631edbd1a14a0936"
 	f.SetupServerWithVersion(model.WebVersion(sha))
@@ -185,7 +173,6 @@ func TestSHAStaticUrlForReq(t *testing.T) {
 
 func TestStripPrefixIndexRequest(t *testing.T) {
 	f := newProdServerFixture(t)
-	defer f.TearDown()
 
 	req := httptest.NewRequest("GET", "/tilt-assets", bytes.NewBuffer(nil))
 	res := httptest.NewRecorder()
@@ -206,6 +193,7 @@ type fixture struct {
 
 func newProdServerFixture(t *testing.T) *fixture {
 	f := &fixture{t: t}
+	t.Cleanup(f.TearDown)
 
 	testServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
 		f.recvReq = req

--- a/pkg/model/matcher_test.go
+++ b/pkg/model/matcher_test.go
@@ -11,7 +11,6 @@ import (
 
 func TestNewRelativeFileOrChildMatcher(t *testing.T) {
 	f := tempdir.NewTempDirFixture(t)
-	defer f.TearDown()
 
 	paths := []string{
 		"a",
@@ -30,9 +29,6 @@ func TestNewRelativeFileOrChildMatcher(t *testing.T) {
 }
 
 func TestFileOrChildMatcher(t *testing.T) {
-	f := tempdir.NewTempDirFixture(t)
-	defer f.TearDown()
-
 	matcher := fileOrChildMatcher{map[string]bool{
 		"file.txt":        true,
 		"nested/file.txt": true,


### PR DESCRIPTION
TLDR - eliminate the need for all the `defer f.teardown()`s

This PR is basically the result of searching for `f.teardown()`s, making sure the underlying `f` passes its own `teardown` to `t.Cleanup`, and removing the `f.teardown`.

[here](https://gist.github.com/landism/389f6f8dee14e078d9f2ba18d9625780)'s a gist of the diff with (most of) the "defer f.teardown"s filtered out (generated via `git diff HEAD^ -I'defer t?f.[tT]ear[dD]own'`, if you want to run it locally to get proper colors, though you might have to upgrade `git` to get `-I`)