### PR TITLE
feature: enable stop build buttons

### DIFF
--- a/internal/controllers/core/tiltfile/api.go
+++ b/internal/controllers/core/tiltfile/api.go
@@ -346,10 +346,6 @@ func toToggleButtons(tlr *tiltfile.TiltfileLoadResult, disableSources disableSou
 
 func toCancelButtons(tlr *tiltfile.TiltfileLoadResult) apiset.TypedObjectSet {
 	result := apiset.TypedObjectSet{}
-	if !tlr.FeatureFlags[feature.CancelBuild] {
-		return result
-	}
-
 	for _, m := range tlr.Manifests {
 		button := uibutton.CancelButton(m.Name.String())
 		result[button.Name] = button

--- a/internal/engine/configs/configs_controller.go
+++ b/internal/engine/configs/configs_controller.go
@@ -8,15 +8,13 @@ import (
 
 	"github.com/tilt-dev/tilt/internal/controllers/apis/tiltfile"
 	"github.com/tilt-dev/tilt/internal/controllers/apis/uibutton"
-	"github.com/tilt-dev/tilt/internal/feature"
 	"github.com/tilt-dev/tilt/internal/store"
 	"github.com/tilt-dev/tilt/pkg/model"
 )
 
 type ConfigsController struct {
-	ctrlClient                           ctrlclient.Client
-	isInitialTiltfileCreated             bool
-	isInitialTiltfileCancelButtonCreated bool
+	ctrlClient               ctrlclient.Client
+	isInitialTiltfileCreated bool
 }
 
 func NewConfigsController(ctrlClient ctrlclient.Client) *ConfigsController {
@@ -36,12 +34,7 @@ func (cc *ConfigsController) OnChange(ctx context.Context, st store.RStore, summ
 			return err
 		}
 	}
-	if !cc.isInitialTiltfileCancelButtonCreated {
-		err := cc.maybeCreateInitialTiltfileCancelButton(ctx, st)
-		if err != nil {
-			return err
-		}
-	}
+
 	return nil
 }
 
@@ -56,25 +49,11 @@ func (cc *ConfigsController) maybeCreateInitialTiltfile(ctx context.Context, st 
 	if err != nil && !apierrors.IsAlreadyExists(err) {
 		return err
 	}
-
-	cc.isInitialTiltfileCreated = true
-	return nil
-}
-
-func (cc *ConfigsController) maybeCreateInitialTiltfileCancelButton(ctx context.Context, st store.RStore) error {
-	state := st.RLockState()
-	// TODO(matt) - once we enable the feature and remove the flag, just merge this into maybeCreateInitialTiltfile
-	cancelEnabled := state.Features[feature.CancelBuild]
-	st.RUnlockState()
-	if !cancelEnabled {
-		return nil
-	}
-	err := cc.ctrlClient.Create(ctx, uibutton.CancelButton(model.MainTiltfileManifestName.String()))
+	err = cc.ctrlClient.Create(ctx, uibutton.CancelButton(model.MainTiltfileManifestName.String()))
 	if err != nil && !apierrors.IsAlreadyExists(err) {
 		return err
 	}
 
-	cc.isInitialTiltfileCancelButtonCreated = true
-
+	cc.isInitialTiltfileCreated = true
 	return nil
 }

--- a/internal/engine/configs/configs_controller_test.go
+++ b/internal/engine/configs/configs_controller_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/tilt-dev/tilt/internal/controllers/apis/tiltfile"
 	"github.com/tilt-dev/tilt/internal/controllers/apis/uibutton"
 	"github.com/tilt-dev/tilt/internal/controllers/fake"
-	"github.com/tilt-dev/tilt/internal/feature"
 	"github.com/tilt-dev/tilt/internal/store"
 	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
 	"github.com/tilt-dev/tilt/pkg/model"
@@ -22,33 +21,6 @@ func TestCreateTiltfile(t *testing.T) {
 	st.WithState(func(s *store.EngineState) {
 		s.DesiredTiltfilePath = "./fake-tiltfile-path"
 		s.UserConfigState = model.NewUserConfigState([]string{"arg1", "arg2"})
-	})
-	ctx := context.Background()
-	client := fake.NewFakeTiltClient()
-	cc := NewConfigsController(client)
-	require.NoError(t, cc.OnChange(ctx, st, store.ChangeSummary{}))
-
-	var tf v1alpha1.Tiltfile
-	require.NoError(t, client.Get(ctx, types.NamespacedName{Name: model.MainTiltfileManifestName.String()}, &tf))
-	assert.Equal(t, tf.Spec, v1alpha1.TiltfileSpec{
-		Path: tiltfile.ResolveFilename("fake-tiltfile-path"),
-		Args: []string{"arg1", "arg2"},
-		RestartOn: &v1alpha1.RestartOnSpec{
-			FileWatches: []string{"configs:(Tiltfile)"},
-		},
-		StopOn: &v1alpha1.StopOnSpec{
-			UIButtons: []string{"(Tiltfile)-cancel"},
-		},
-	})
-}
-
-// TODO(matt) - replace TestCreateTiltfile above with this when removing feature.CancelBuild
-func TestCreateTiltfileCancelEnabled(t *testing.T) {
-	st := store.NewTestingStore()
-	st.WithState(func(s *store.EngineState) {
-		s.DesiredTiltfilePath = "./fake-tiltfile-path"
-		s.UserConfigState = model.NewUserConfigState([]string{"arg1", "arg2"})
-		s.Features = map[string]bool{feature.CancelBuild: true}
 	})
 	ctx := context.Background()
 	client := fake.NewFakeTiltClient()

--- a/internal/feature/flags.go
+++ b/internal/feature/flags.go
@@ -27,7 +27,6 @@ const Labels = "labels"
 const LiveUpdateV2 = "live_update_v2"
 const DisableResources = "disable_resources"
 const BulkDisableResources = "bulk_disable_resources"
-const CancelBuild = "cancel_build"
 
 // The Value a flag can have. Status should never be changed.
 type Value struct {
@@ -78,11 +77,6 @@ var MainDefaults = Defaults{
 	BulkDisableResources: Value{
 		Enabled: false,
 		Status:  Obsolete,
-	},
-	// TODO(matt) - remove once the frontend styling is in place
-	CancelBuild: Value{
-		Enabled: false,
-		Status:  Active,
 	},
 }
 


### PR DESCRIPTION
(to be merged after #5514)

This removes the feature flag for stop build buttons, any gates that checked that flag, and enables the feature for all users.

(we don't need to keep it around as "Obsolete" since it was never advertised)