### PR TITLE
buildcontrol: avoid spurious changes to the 'waiting' state on disabled resources

### DIFF
--- a/internal/engine/buildcontrol/build_control_test.go
+++ b/internal/engine/buildcontrol/build_control_test.go
@@ -524,8 +524,6 @@ func TestHoldDisabled(t *testing.T) {
 
 	f.upsertLocalManifest("local")
 	f.st.ManifestTargets["local"].State.DisableState = v1alpha1.DisableStateDisabled
-
-	f.assertHold("local", store.HoldReasonDisabled)
 	f.assertNoTargetNextToBuild()
 }
 

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -3536,24 +3536,6 @@ func TestOverrideTriggerModeBadTriggerModeLogsError(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestDisablingResourcePreventsBuild(t *testing.T) {
-	f := newTestFixture(t)
-
-	m := manifestbuilder.New(f, "foo").WithLocalResource("foo", []string{f.Path()}).Build()
-
-	f.Start([]model.Manifest{m})
-
-	f.setDisableState(m.Name, true)
-
-	action := server.AppendToTriggerQueueAction{Name: "foo", Reason: 123}
-	f.store.Dispatch(action)
-
-	f.WaitUntil("is waiting+disabled", func(state store.EngineState) bool {
-		_, holds := buildcontrol.NextTargetToBuild(state)
-		return holds["foo"].Reason == store.HoldReasonDisabled
-	})
-}
-
 func TestDisableButtonIsCreated(t *testing.T) {
 	f := newTestFixture(t)
 	f.useRealTiltfileLoader()

--- a/internal/hud/webview/convert.go
+++ b/internal/hud/webview/convert.go
@@ -429,7 +429,10 @@ func LogSegmentToEvent(seg *proto_webview.LogSegment, spans map[string]*proto_we
 }
 
 func holdToWaiting(hold store.Hold) *v1alpha1.UIResourceStateWaiting {
-	if hold.Reason == store.HoldReasonNone {
+	if hold.Reason == store.HoldReasonNone ||
+		// "Reconciling" just means the live update is handling the update (rather
+		// than the BuildController) and isn't indicative of a real waiting status.
+		hold.Reason == store.HoldReasonReconciling {
 		return nil
 	}
 	waiting := &v1alpha1.UIResourceStateWaiting{

--- a/internal/store/hold.go
+++ b/internal/store/hold.go
@@ -32,7 +32,6 @@ const (
 	HoldReasonBuildingComponent                HoldReason = "building-component"
 	HoldReasonWaitingForDep                    HoldReason = "waiting-for-dep"
 	HoldReasonWaitingForDeploy                 HoldReason = "waiting-for-deploy"
-	HoldReasonDisabled                         HoldReason = "disabled"
 
 	// We're waiting for a reconciler to respond to the change,
 	// but don't know yet what it's waiting on.


### PR DESCRIPTION
Hello @landism, @milas,

Please review the following commits I made in branch nicks/holds:

38001b7a226093627430dca85294759cb26320ec (2022-02-16 19:57:15 -0500)
buildcontrol: avoid spurious changes to the 'waiting' state on disabled resources
Before this change, the "waiting" state of disabled resources would be
continuously in flux. This is expensive and doesn't even make sense from a data
model perspective - a disabled resource isn't waiting or being held.

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics