### PR TITLE
dc: hide 'going to remove...' message when disabling dc services

### DIFF
--- a/internal/cli/klog_test.go
+++ b/internal/cli/klog_test.go
@@ -2,11 +2,9 @@ package cli
 
 import (
 	"bytes"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"k8s.io/klog/v2"
 )
 
@@ -52,50 +50,4 @@ func PrintWatchEndedV4() {
 }
 func PrintWatchEndedWarning() {
 	klog.Warningf("watch ended")
-}
-
-func TestFilteredWriter(t *testing.T) {
-	for _, tc := range []struct {
-		name           string
-		input          []string
-		expectedOutput string
-	}{
-		{
-			name:           "normal",
-			input:          []string{"abc\n", "foobar\n", "def\n"},
-			expectedOutput: "abc\ndef\n",
-		},
-		{
-			name:           "all one line",
-			input:          []string{"abc\nfoobar\ndef\n"},
-			expectedOutput: "abc\ndef\n",
-		},
-		{
-			name:           "lines split across writes",
-			input:          []string{"ab", "c\n", "foo", "ba", "r\n", "de", "f", "\n"},
-			expectedOutput: "abc\ndef\n",
-		},
-		{
-			name: "actual warning we want to suppress",
-			input: []string{
-				"hello\n",
-				"W1021 14:53:11.799222 68992 reflector.go:299] github.com/tilt-dev/tilt/internal/k8s/watch.go:172: " +
-					"watch of *v1.Pod ended with: too old resource version: 191906663 (191912819)\n",
-				"goodbye\n"},
-			expectedOutput: "hello\ngoodbye\n",
-		},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			out := bytes.NewBuffer(nil)
-			fw := newFilteredWriter(out, func(s string) bool {
-				return strings.Contains(s, "foobar") || isResourceVersionTooOldRegexp.MatchString(s)
-			})
-			for _, s := range tc.input {
-				_, err := fw.Write([]byte(s))
-				require.NoError(t, err)
-			}
-
-			require.Equal(t, tc.expectedOutput, out.String())
-		})
-	}
 }

--- a/internal/dockercompose/fake_client.go
+++ b/internal/dockercompose/fake_client.go
@@ -37,6 +37,7 @@ type FakeDCClient struct {
 	rmCalls   []RmCall
 	DownError error
 	RmError   error
+	RmOutput  string
 	WorkDir   string
 }
 
@@ -98,6 +99,8 @@ func (c *FakeDCClient) Rm(ctx context.Context, specs []model.DockerComposeUpSpec
 		c.RmError = nil
 		return err
 	}
+
+	_, _ = fmt.Fprint(stdout, c.RmOutput)
 	return nil
 }
 

--- a/internal/filteredwriter/filtered_writer.go
+++ b/internal/filteredwriter/filtered_writer.go
@@ -1,0 +1,50 @@
+package filteredwriter
+
+import (
+	"io"
+	"sync"
+)
+
+type filteredWriter struct {
+	underlying io.Writer
+	filterFunc func(s string) bool
+	leftover   []byte
+	mu         sync.Mutex
+}
+
+func (fw *filteredWriter) Write(buf []byte) (int, error) {
+	fw.mu.Lock()
+	defer fw.mu.Unlock()
+	buf = append([]byte{}, append(fw.leftover, buf...)...)
+	start := 0
+	written := 0
+	for i, b := range buf {
+		if b == '\n' {
+			end := i
+			if buf[i-1] == '\r' {
+				end--
+			}
+			s := string(buf[start:end])
+
+			if !fw.filterFunc(s) {
+				n, err := fw.underlying.Write(buf[start : i+1])
+				written += n
+				if err != nil {
+					fw.leftover = append([]byte{}, buf[i+1:]...)
+					return len(buf), err
+				}
+			}
+
+			start = i + 1
+		}
+	}
+
+	fw.leftover = append([]byte{}, buf[start:]...)
+
+	return len(buf), nil
+}
+
+// lines matching `filterFunc` will not be output to the underlying writer
+func New(underlying io.Writer, filterFunc func(s string) bool) io.Writer {
+	return &filteredWriter{underlying: underlying, filterFunc: filterFunc}
+}

--- a/internal/filteredwriter/filtered_writer_test.go
+++ b/internal/filteredwriter/filtered_writer_test.go
@@ -1,0 +1,55 @@
+package filteredwriter
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFilteredWriter(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		input          []string
+		expectedOutput string
+	}{
+		{
+			name:           "normal",
+			input:          []string{"abc\n", "foobar\n", "def\n"},
+			expectedOutput: "abc\ndef\n",
+		},
+		{
+			name:           "all one line",
+			input:          []string{"abc\nfoobar\ndef\n"},
+			expectedOutput: "abc\ndef\n",
+		},
+		{
+			name:           "lines split across writes",
+			input:          []string{"ab", "c\n", "foo", "ba", "r\n", "de", "f", "\n"},
+			expectedOutput: "abc\ndef\n",
+		},
+		{
+			name: "actual warning we want to suppress",
+			input: []string{
+				"hello\n",
+				"W1021 14:53:11.799222 68992 reflector.go:299] github.com/tilt-dev/tilt/internal/k8s/watch.go:172: " +
+					"watch of *v1.Pod ended with: too old resource version: 191906663 (191912819)\n",
+				"goodbye\n"},
+			expectedOutput: "hello\ngoodbye\n",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			out := bytes.NewBuffer(nil)
+			fw := New(out, func(s string) bool {
+				return strings.Contains(s, "foobar") || strings.Contains(s, "too old resource version")
+			})
+			for _, s := range tc.input {
+				_, err := fw.Write([]byte(s))
+				require.NoError(t, err)
+			}
+
+			require.Equal(t, tc.expectedOutput, out.String())
+		})
+	}
+}


### PR DESCRIPTION
### Problem

For some reason, when we filter `docker-compose rm` through a Tilt logger, we get:
```
Stopping servantes_fortune_1 ... 
Stopping servantes_fortune_1 ... done
servantes_fortune_1 exited with code 137
Removing servantes_fortune_1 ... 
Removing servantes_fortune_1 ... done
Going to remove servantes_fortune_1
```

The last line says "Going to...", which leads one to expect it's going to do something else, but nothing ever comes.

When running docker-compose directly, it shows up in a more sensible place:
```
Stopping servantes_vigoda_1 ... done
Going to remove servantes_vigoda_1
Removing servantes_vigoda_1 ... done
```

(you also might note there's only one line each for "stopping" and "removing" - they do tty tricks to go back and update the existing line, which is probably also why it looks weird in Tilt)

### Solution
I couldn't find a clean way to fix this, and the message doesn't add much value anyway, so just filter it out of the DC output:
```
Stopping servantes_fortune_1 ... 
Stopping servantes_fortune_1 ... done
servantes_fortune_1 exited with code 137
Removing servantes_fortune_1 ... 
Removing servantes_fortune_1 ... done
```

Ideally we could find a way to get out of their TTY tricks, which might also save us from their duplicate "stopping" and "removing" messages, but I couldn't find one in 20 minutes, and `docker build` has a bad history of "you either get tty or non-human-readable output", which doesn't give me hope.

(do we already have a less home-rolled filtering io.Writer?)