### PR TITLE
release: add github author names to the release changelog

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -51,8 +51,10 @@ checksum:
   name_template: 'checksums.txt'
 snapshot:
   name_template: "{{ .Tag }}-next"
+  
 changelog:
   sort: asc
+  use: github
   filters:
     exclude:
     - '^docs?:'
@@ -60,6 +62,7 @@ changelog:
     - '^cleanup:'
     - '^circleci:'
     - '^ci:'
+    
 brews:
 - tap:
     owner: tilt-dev


### PR DESCRIPTION
Hello @lianmakesthings,

Please review the following commits I made in branch nicks/contributors:

bfc63385bc94552c1d5acb98d1a8af6777d649f1 (2022-02-22 11:01:44 -0500)
release: add github author names to the release changelog

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics