### PR TITLE
engine: clear known pods when KD is deleted

### DIFF
--- a/internal/controllers/core/kubernetesdiscovery/portforwards.go
+++ b/internal/controllers/core/kubernetesdiscovery/portforwards.go
@@ -23,7 +23,7 @@ func (r *Reconciler) manageOwnedPortForwards(ctx context.Context, nn types.Names
 	err := indexer.ListOwnedBy(ctx, r.ctrlClient, &pfList, nn, apiType)
 	if err != nil {
 		return fmt.Errorf("failed to fetch managed PortForward objects for KubernetesDiscovery %s: %v",
-			kd.Name, err)
+			nn.Name, err)
 	}
 
 	pf, err := r.toDesiredPortForward(kd)


### PR DESCRIPTION
### Problem

When a KuberenetesApply is disabled, we delete its KubernetesDiscovery. When we delete a KubernetesDiscovery, the resource's K8sRuntimeState.FilteredPods remains the same forever. The only known impact of this at the moment is that UIResource.Status will list pods that no longer exist. AFAIK the frontend handles that fine.

### Solution

If a KubernetesApply's KubernetesDiscovery doesn't exist, clear the resource's K8sRuntimeState.FilteredPods.