### PR TITLE
engine: fix panic in TestPodForgottenOnDisable

### DIFF
--- a/internal/controllers/core/kubernetesapply/disco.go
+++ b/internal/controllers/core/kubernetesapply/disco.go
@@ -32,7 +32,7 @@ func (r *Reconciler) manageOwnedKubernetesDiscovery(ctx context.Context, nn type
 	isNotFound := apierrors.IsNotFound(err)
 	if err != nil && !isNotFound {
 		return fmt.Errorf("failed to fetch managed KubernetesDiscovery objects for KubernetesApply %s: %v",
-			ka.Name, err)
+			nn.Name, err)
 	}
 
 	kd, err := r.toDesiredKubernetesDiscovery(ka)


### PR DESCRIPTION
This test was just merged to master (#5532), and apparently has a chance to panic.

When a KubernetesApply is being deleted, `ka` is `nil`. We don't need `ka` to get the name anyway, since we already have a `NamespacedName`.

Merging w/o review since this is causing master CI to fail and this change seems benign (and mirrors the same change that was made to KubernetesDiscovery in #5532).