### PR TITLE
store: move HUD view rendering into the HUD package

### DIFF
--- a/internal/hud/fake_hud.go
+++ b/internal/hud/fake_hud.go
@@ -41,7 +41,7 @@ func (h *FakeHud) Run(ctx context.Context, dispatch func(action store.Action), r
 
 func (h *FakeHud) OnChange(ctx context.Context, st store.RStore, _ store.ChangeSummary) error {
 	state := st.RLockState()
-	view := store.StateToView(state, st.StateMutex())
+	view := StateToTerminalView(state, st.StateMutex())
 	st.RUnlockState()
 
 	err := h.update(view, h.viewState)

--- a/internal/hud/hud.go
+++ b/internal/hud/hud.go
@@ -215,7 +215,7 @@ func (h *Hud) handleScreenEvent(ctx context.Context, dispatch func(action store.
 			url := h.webURL
 
 			// If the cursor is in the default position (Tiltfile), open the All log.
-			if r.Name != store.MainTiltfileManifestName {
+			if r.Name != MainTiltfileManifestName {
 				url.Path = fmt.Sprintf("/r/%s/", r.Name)
 			}
 
@@ -276,7 +276,7 @@ func (h *Hud) OnChange(ctx context.Context, st store.RStore, _ store.ChangeSumma
 
 	toPrint := ""
 	state := st.RLockState()
-	view := store.StateToView(state, st.StateMutex())
+	view := StateToTerminalView(state, st.StateMutex())
 
 	// if the hud isn't running, make sure new logs are visible on stdout
 	if !h.isRunning {

--- a/internal/hud/view.go
+++ b/internal/hud/view.go
@@ -1,0 +1,150 @@
+package hud
+
+import (
+	"os"
+	"sort"
+	"sync"
+
+	"github.com/tilt-dev/tilt/internal/dockercompose"
+	"github.com/tilt-dev/tilt/internal/hud/view"
+	"github.com/tilt-dev/tilt/internal/k8s"
+	"github.com/tilt-dev/tilt/internal/ospath"
+	"github.com/tilt-dev/tilt/internal/store"
+	"github.com/tilt-dev/tilt/internal/store/k8sconv"
+	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
+	"github.com/tilt-dev/tilt/pkg/model"
+	"github.com/tilt-dev/tilt/pkg/model/logstore"
+)
+
+func StateToTerminalView(s store.EngineState, mu *sync.RWMutex) view.View {
+	ret := view.View{}
+
+	for _, ms := range s.TiltfileStates {
+		ret.Resources = append(ret.Resources, tiltfileResourceView(ms))
+	}
+
+	for _, name := range s.ManifestDefinitionOrder {
+		mt, ok := s.ManifestTargets[name]
+		if !ok {
+			continue
+		}
+
+		ms := mt.State
+		if ms.DisableState == v1alpha1.DisableStateDisabled {
+			// Don't show disabled resources in the terminal UI.
+			continue
+		}
+
+		var absWatchDirs []string
+		for i, p := range mt.Manifest.LocalPaths() {
+			if i > 50 {
+				// Bail out after 50 to avoid pathological performance issues.
+				break
+			}
+			fi, err := os.Stat(p)
+
+			// Treat this as a directory when there's an error.
+			if err != nil || fi.IsDir() {
+				absWatchDirs = append(absWatchDirs, p)
+			}
+		}
+
+		var pendingBuildEdits []string
+		for _, status := range ms.BuildStatuses {
+			for f := range status.PendingFileChanges {
+				pendingBuildEdits = append(pendingBuildEdits, f)
+			}
+		}
+
+		pendingBuildEdits = ospath.FileListDisplayNames(absWatchDirs, pendingBuildEdits)
+
+		buildHistory := append([]model.BuildRecord{}, ms.BuildHistory...)
+		for i, build := range buildHistory {
+			build.Edits = ospath.FileListDisplayNames(absWatchDirs, build.Edits)
+			buildHistory[i] = build
+		}
+
+		currentBuild := ms.CurrentBuild
+		currentBuild.Edits = ospath.FileListDisplayNames(absWatchDirs, ms.CurrentBuild.Edits)
+
+		// Sort the strings to make the outputs deterministic.
+		sort.Strings(pendingBuildEdits)
+
+		endpoints := store.ManifestTargetEndpoints(mt)
+
+		// NOTE(nick): Right now, the UX is designed to show the output exactly one
+		// pod. A better UI might summarize the pods in other ways (e.g., show the
+		// "most interesting" pod that's crash looping, or show logs from all pods
+		// at once).
+		_, pendingBuildSince := ms.HasPendingChanges()
+		r := view.Resource{
+			Name:               name,
+			LastDeployTime:     ms.LastSuccessfulDeployTime,
+			TriggerMode:        mt.Manifest.TriggerMode,
+			BuildHistory:       buildHistory,
+			PendingBuildEdits:  pendingBuildEdits,
+			PendingBuildSince:  pendingBuildSince,
+			PendingBuildReason: mt.NextBuildReason(),
+			CurrentBuild:       currentBuild,
+			Endpoints:          model.LinksToURLStrings(endpoints), // hud can't handle link names, just send URLs
+			ResourceInfo:       resourceInfoView(mt),
+		}
+
+		ret.Resources = append(ret.Resources, r)
+	}
+
+	ret.LogReader = logstore.NewReader(mu, s.LogStore)
+	ret.FatalError = s.FatalError
+
+	return ret
+}
+
+const MainTiltfileManifestName = model.MainTiltfileManifestName
+
+func tiltfileResourceView(ms *store.ManifestState) view.Resource {
+	tr := view.Resource{
+		Name:         MainTiltfileManifestName,
+		IsTiltfile:   true,
+		CurrentBuild: ms.CurrentBuild,
+		BuildHistory: ms.BuildHistory,
+		ResourceInfo: view.TiltfileResourceInfo{},
+	}
+	if !ms.CurrentBuild.Empty() {
+		tr.PendingBuildSince = ms.CurrentBuild.StartTime
+	} else {
+		tr.LastDeployTime = ms.LastBuild().FinishTime
+	}
+	return tr
+}
+
+func resourceInfoView(mt *store.ManifestTarget) view.ResourceInfoView {
+	runStatus := mt.RuntimeStatus()
+	switch state := mt.State.RuntimeState.(type) {
+	case dockercompose.State:
+		return view.NewDCResourceInfo(
+			state.ContainerState.Status, state.ContainerID, state.SpanID, state.StartTime, runStatus)
+	case store.K8sRuntimeState:
+		if mt.Manifest.PodReadinessMode() == model.PodReadinessIgnore {
+			return view.YAMLResourceInfo{
+				K8sDisplayNames: state.EntityDisplayNames(),
+			}
+		}
+		pod := state.MostRecentPod()
+		podID := k8s.PodID(pod.Name)
+		return view.K8sResourceInfo{
+			PodName:            pod.Name,
+			PodCreationTime:    pod.CreatedAt.Time,
+			PodUpdateStartTime: state.UpdateStartTime[podID],
+			PodStatus:          pod.Status,
+			PodRestarts:        int(state.VisiblePodContainerRestarts(podID)),
+			SpanID:             k8sconv.SpanIDForPod(mt.Manifest.Name, podID),
+			RunStatus:          runStatus,
+			DisplayNames:       state.EntityDisplayNames(),
+		}
+	case store.LocalRuntimeState:
+		return view.NewLocalResourceInfo(runStatus, state.PID, state.SpanID)
+	default:
+		// This is silly but it was the old behavior.
+		return view.K8sResourceInfo{}
+	}
+}

--- a/internal/hud/view_test.go
+++ b/internal/hud/view_test.go
@@ -1,0 +1,244 @@
+package hud
+
+import (
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+
+	"github.com/tilt-dev/tilt/internal/hud/view"
+	"github.com/tilt-dev/tilt/internal/k8s"
+	"github.com/tilt-dev/tilt/internal/k8s/testyaml"
+	"github.com/tilt-dev/tilt/internal/store"
+	"github.com/tilt-dev/tilt/internal/store/k8sconv"
+	"github.com/tilt-dev/tilt/internal/testutils/manifestbuilder"
+	"github.com/tilt-dev/tilt/internal/testutils/tempdir"
+	"github.com/tilt-dev/tilt/pkg/apis"
+	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
+	"github.com/tilt-dev/tilt/pkg/model"
+)
+
+func TestStateToViewRelativeEditPaths(t *testing.T) {
+	f := tempdir.NewTempDirFixture(t)
+	m := model.Manifest{
+		Name: "foo",
+	}.WithDeployTarget(model.K8sTarget{}).WithImageTarget(model.ImageTarget{}.
+		WithDockerImage(v1alpha1.DockerImageSpec{Context: f.JoinPath("a", "b", "c")}))
+
+	state := newState([]model.Manifest{m})
+	ms := state.ManifestTargets[m.Name].State
+	ms.CurrentBuild.Edits = []string{
+		f.JoinPath("a", "b", "c", "foo"),
+		f.JoinPath("a", "b", "c", "d", "e")}
+	ms.BuildHistory = []model.BuildRecord{
+		{
+			Edits: []string{
+				f.JoinPath("a", "b", "c", "foo"),
+				f.JoinPath("a", "b", "c", "d", "e"),
+			},
+		},
+	}
+	ms.MutableBuildStatus(m.ImageTargets[0].ID()).PendingFileChanges =
+		map[string]time.Time{
+			f.JoinPath("a", "b", "c", "foo"):    time.Now(),
+			f.JoinPath("a", "b", "c", "d", "e"): time.Now(),
+		}
+	v := StateToTerminalView(*state, &sync.RWMutex{})
+
+	require.Len(t, v.Resources, 2)
+
+	r, _ := v.Resource(m.Name)
+	assert.Equal(t, []string{"foo", filepath.Join("d", "e")}, r.LastBuild().Edits)
+	assert.Equal(t, []string{"foo", filepath.Join("d", "e")}, r.CurrentBuild.Edits)
+	assert.Equal(t, []string{filepath.Join("d", "e"), "foo"}, r.PendingBuildEdits) // these are sorted for deterministic ordering
+}
+
+func TestStateToTerminalViewPortForwards(t *testing.T) {
+	m := model.Manifest{
+		Name: "foo",
+	}.WithDeployTarget(model.K8sTarget{
+		KubernetesApplySpec: v1alpha1.KubernetesApplySpec{
+			PortForwardTemplateSpec: &v1alpha1.PortForwardTemplateSpec{
+				Forwards: []v1alpha1.Forward{
+					{LocalPort: 8000, ContainerPort: 5000},
+					{LocalPort: 7000, ContainerPort: 5001},
+				},
+			},
+		},
+	})
+	state := newState([]model.Manifest{m})
+	v := StateToTerminalView(*state, &sync.RWMutex{})
+	res, _ := v.Resource(m.Name)
+	assert.Equal(t,
+		[]string{"http://localhost:8000/", "http://localhost:7000/"},
+		res.Endpoints)
+}
+
+func TestStateToWebViewLinksAndPortForwards(t *testing.T) {
+	m := model.Manifest{
+		Name: "foo",
+	}.WithDeployTarget(model.K8sTarget{
+		KubernetesApplySpec: v1alpha1.KubernetesApplySpec{
+			PortForwardTemplateSpec: &v1alpha1.PortForwardTemplateSpec{
+				Forwards: []v1alpha1.Forward{
+					{LocalPort: 8000, ContainerPort: 5000},
+					{LocalPort: 8001, ContainerPort: 5001, Name: "debugger"},
+				},
+			},
+		},
+		Links: []model.Link{
+			model.MustNewLink("www.apple.edu", "apple"),
+			model.MustNewLink("www.zombo.com", "zombo"),
+		},
+	})
+	state := newState([]model.Manifest{m})
+	v := StateToTerminalView(*state, &sync.RWMutex{})
+	res, _ := v.Resource(m.Name)
+	assert.Equal(t,
+		[]string{"www.apple.edu", "www.zombo.com", "http://localhost:8000/", "http://localhost:8001/"},
+		res.Endpoints)
+}
+func TestStateToTerminalViewLocalResourceLinks(t *testing.T) {
+	m := model.Manifest{
+		Name: "foo",
+	}.WithDeployTarget(model.LocalTarget{
+		Links: []model.Link{
+			model.MustNewLink("www.apple.edu", "apple"),
+			model.MustNewLink("www.zombo.com", "zombo"),
+		},
+	})
+	state := newState([]model.Manifest{m})
+	v := StateToTerminalView(*state, &sync.RWMutex{})
+	res, _ := v.Resource(m.Name)
+	assert.Equal(t,
+		[]string{"www.apple.edu", "www.zombo.com"},
+		res.Endpoints)
+}
+
+func TestRuntimeStateNonWorkload(t *testing.T) {
+	f := tempdir.NewTempDirFixture(t)
+
+	m := manifestbuilder.New(f, model.UnresourcedYAMLManifestName).
+		WithK8sYAML(testyaml.SecretYaml).
+		Build()
+	state := newState([]model.Manifest{m})
+	runtimeState := state.ManifestTargets[m.Name].State.K8sRuntimeState()
+	assert.Equal(t, v1alpha1.RuntimeStatusPending, runtimeState.RuntimeStatus())
+
+	runtimeState.HasEverDeployedSuccessfully = true
+
+	assert.Equal(t, v1alpha1.RuntimeStatusOK, runtimeState.RuntimeStatus())
+}
+
+func TestRuntimeStateJob(t *testing.T) {
+	for _, tc := range []struct {
+		phase                 v1.PodPhase
+		expectedRuntimeStatus v1alpha1.RuntimeStatus
+	}{
+		{v1.PodRunning, v1alpha1.RuntimeStatusPending},
+		{v1.PodSucceeded, v1alpha1.RuntimeStatusOK},
+		{v1.PodFailed, v1alpha1.RuntimeStatusError},
+	} {
+		t.Run(string(tc.phase), func(t *testing.T) {
+			f := tempdir.NewTempDirFixture(t)
+
+			m := manifestbuilder.New(f, "foo").
+				WithK8sYAML(testyaml.JobYAML).
+				WithK8sPodReadiness(model.PodReadinessSucceeded).
+				Build()
+			state := newState([]model.Manifest{m})
+			runtimeState := state.ManifestTargets[m.Name].State.K8sRuntimeState()
+			assert.Equal(t, v1alpha1.RuntimeStatusPending, runtimeState.RuntimeStatus())
+
+			runtimeState.HasEverDeployedSuccessfully = true
+
+			pod := v1alpha1.Pod{
+				Name:      "pod",
+				CreatedAt: apis.Now(),
+				Phase:     string(tc.phase),
+			}
+			runtimeState.FilteredPods = []v1alpha1.Pod{pod}
+
+			assert.Equal(t, tc.expectedRuntimeStatus, runtimeState.RuntimeStatus())
+		})
+	}
+}
+
+func TestStateToTerminalViewUnresourcedYAMLManifest(t *testing.T) {
+	m := k8sManifest(t, model.UnresourcedYAMLManifestName, testyaml.SanchoYAML)
+	state := newState([]model.Manifest{m})
+	krs := state.ManifestTargets[m.Name].State.K8sRuntimeState()
+	krs.ApplyFilter = yamlToApplyFilter(t, testyaml.SanchoYAML)
+	state.ManifestTargets[m.Name].State.RuntimeState = krs
+
+	v := StateToTerminalView(*state, &sync.RWMutex{})
+
+	assert.Equal(t, 2, len(v.Resources))
+
+	r, _ := v.Resource(m.Name)
+	assert.Equal(t, nil, r.LastBuild().Error)
+
+	expectedInfo := view.YAMLResourceInfo{
+		K8sDisplayNames: []string{"sancho:deployment"},
+	}
+	assert.Equal(t, expectedInfo, r.ResourceInfo)
+}
+
+func TestStateToTerminalViewNonWorkloadYAMLManifest(t *testing.T) {
+	m := k8sManifest(t, "foo", testyaml.SecretYaml)
+	state := newState([]model.Manifest{m})
+	krs := state.ManifestTargets[m.Name].State.K8sRuntimeState()
+	krs.ApplyFilter = yamlToApplyFilter(t, testyaml.SecretYaml)
+	state.ManifestTargets[m.Name].State.RuntimeState = krs
+
+	v := StateToTerminalView(*state, &sync.RWMutex{})
+
+	assert.Equal(t, 2, len(v.Resources))
+
+	r, _ := v.Resource(m.Name)
+	assert.Equal(t, nil, r.LastBuild().Error)
+
+	expectedInfo := view.YAMLResourceInfo{
+		K8sDisplayNames: []string{"mysecret:secret"},
+	}
+	assert.Equal(t, expectedInfo, r.ResourceInfo)
+}
+
+func newState(manifests []model.Manifest) *store.EngineState {
+	ret := store.NewState()
+	for _, m := range manifests {
+		ret.ManifestTargets[m.Name] = store.NewManifestTarget(m)
+		ret.ManifestDefinitionOrder = append(ret.ManifestDefinitionOrder, m.Name)
+	}
+
+	return ret
+}
+
+func yamlToApplyFilter(t testing.TB, yaml string) *k8sconv.KubernetesApplyFilter {
+	t.Helper()
+	entities, err := k8s.ParseYAMLFromString(yaml)
+	require.NoError(t, err, "Failed to parse YAML")
+	for i := range entities {
+		entities[i].SetUID(uuid.New().String())
+	}
+	yaml, err = k8s.SerializeSpecYAML(entities)
+	require.NoError(t, err, "Failed to re-serialize YAML")
+	applyFilter, err := k8sconv.NewKubernetesApplyFilter(&v1alpha1.KubernetesApplyStatus{
+		ResultYAML: yaml,
+	})
+	require.NoError(t, err, "Failed to create KubernetesApplyFilter")
+	require.NotNil(t, applyFilter, "ApplyFilter was nil")
+	return applyFilter
+}
+
+func k8sManifest(t testing.TB, name model.ManifestName, yaml string) model.Manifest {
+	t.Helper()
+	kt, err := k8s.NewTargetForYAML(name.TargetName(), yaml, nil)
+	require.NoError(t, err, "Failed to create Kubernetes deploy target")
+	return model.Manifest{Name: name}.WithDeployTarget(kt)
+}

--- a/internal/store/engine_state.go
+++ b/internal/store/engine_state.go
@@ -2,10 +2,8 @@ package store
 
 import (
 	"fmt"
-	"os"
 	"sort"
 	"strconv"
-	"sync"
 	"time"
 
 	"github.com/tilt-dev/wmclient/pkg/analytics"
@@ -13,9 +11,7 @@ import (
 	tiltanalytics "github.com/tilt-dev/tilt/internal/analytics"
 	"github.com/tilt-dev/tilt/internal/container"
 	"github.com/tilt-dev/tilt/internal/dockercompose"
-	"github.com/tilt-dev/tilt/internal/hud/view"
 	"github.com/tilt-dev/tilt/internal/k8s"
-	"github.com/tilt-dev/tilt/internal/ospath"
 	"github.com/tilt-dev/tilt/internal/store/dcconv"
 	"github.com/tilt-dev/tilt/internal/store/k8sconv"
 	"github.com/tilt-dev/tilt/internal/timecmp"
@@ -891,134 +887,7 @@ func ManifestTargetEndpoints(mt *ManifestTarget) (endpoints []model.Link) {
 	return endpoints
 }
 
-func StateToView(s EngineState, mu *sync.RWMutex) view.View {
-	ret := view.View{}
-
-	for _, ms := range s.TiltfileStates {
-		ret.Resources = append(ret.Resources, tiltfileResourceView(ms))
-	}
-
-	for _, name := range s.ManifestDefinitionOrder {
-		mt, ok := s.ManifestTargets[name]
-		if !ok {
-			continue
-		}
-
-		ms := mt.State
-
-		var absWatchDirs []string
-		for i, p := range mt.Manifest.LocalPaths() {
-			if i > 50 {
-				// Bail out after 50 to avoid pathological performance issues.
-				break
-			}
-			fi, err := os.Stat(p)
-
-			// Treat this as a directory when there's an error.
-			if err != nil || fi.IsDir() {
-				absWatchDirs = append(absWatchDirs, p)
-			}
-		}
-
-		var pendingBuildEdits []string
-		for _, status := range ms.BuildStatuses {
-			for f := range status.PendingFileChanges {
-				pendingBuildEdits = append(pendingBuildEdits, f)
-			}
-		}
-
-		pendingBuildEdits = ospath.FileListDisplayNames(absWatchDirs, pendingBuildEdits)
-
-		buildHistory := append([]model.BuildRecord{}, ms.BuildHistory...)
-		for i, build := range buildHistory {
-			build.Edits = ospath.FileListDisplayNames(absWatchDirs, build.Edits)
-			buildHistory[i] = build
-		}
-
-		currentBuild := ms.CurrentBuild
-		currentBuild.Edits = ospath.FileListDisplayNames(absWatchDirs, ms.CurrentBuild.Edits)
-
-		// Sort the strings to make the outputs deterministic.
-		sort.Strings(pendingBuildEdits)
-
-		endpoints := ManifestTargetEndpoints(mt)
-
-		// NOTE(nick): Right now, the UX is designed to show the output exactly one
-		// pod. A better UI might summarize the pods in other ways (e.g., show the
-		// "most interesting" pod that's crash looping, or show logs from all pods
-		// at once).
-		_, pendingBuildSince := ms.HasPendingChanges()
-		r := view.Resource{
-			Name:               name,
-			LastDeployTime:     ms.LastSuccessfulDeployTime,
-			TriggerMode:        mt.Manifest.TriggerMode,
-			BuildHistory:       buildHistory,
-			PendingBuildEdits:  pendingBuildEdits,
-			PendingBuildSince:  pendingBuildSince,
-			PendingBuildReason: mt.NextBuildReason(),
-			CurrentBuild:       currentBuild,
-			Endpoints:          model.LinksToURLStrings(endpoints), // hud can't handle link names, just send URLs
-			ResourceInfo:       resourceInfoView(mt),
-		}
-
-		ret.Resources = append(ret.Resources, r)
-	}
-
-	ret.LogReader = logstore.NewReader(mu, s.LogStore)
-	ret.FatalError = s.FatalError
-
-	return ret
-}
-
 const MainTiltfileManifestName = model.MainTiltfileManifestName
-
-func tiltfileResourceView(ms *ManifestState) view.Resource {
-	tr := view.Resource{
-		Name:         MainTiltfileManifestName,
-		IsTiltfile:   true,
-		CurrentBuild: ms.CurrentBuild,
-		BuildHistory: ms.BuildHistory,
-		ResourceInfo: view.TiltfileResourceInfo{},
-	}
-	if !ms.CurrentBuild.Empty() {
-		tr.PendingBuildSince = ms.CurrentBuild.StartTime
-	} else {
-		tr.LastDeployTime = ms.LastBuild().FinishTime
-	}
-	return tr
-}
-
-func resourceInfoView(mt *ManifestTarget) view.ResourceInfoView {
-	runStatus := mt.RuntimeStatus()
-	switch state := mt.State.RuntimeState.(type) {
-	case dockercompose.State:
-		return view.NewDCResourceInfo(
-			state.ContainerState.Status, state.ContainerID, state.SpanID, state.StartTime, runStatus)
-	case K8sRuntimeState:
-		if mt.Manifest.PodReadinessMode() == model.PodReadinessIgnore {
-			return view.YAMLResourceInfo{
-				K8sDisplayNames: state.EntityDisplayNames(),
-			}
-		}
-		pod := state.MostRecentPod()
-		podID := k8s.PodID(pod.Name)
-		return view.K8sResourceInfo{
-			PodName:            pod.Name,
-			PodCreationTime:    pod.CreatedAt.Time,
-			PodUpdateStartTime: state.UpdateStartTime[podID],
-			PodStatus:          pod.Status,
-			PodRestarts:        int(state.VisiblePodContainerRestarts(podID)),
-			SpanID:             k8sconv.SpanIDForPod(mt.Manifest.Name, podID),
-			RunStatus:          runStatus,
-			DisplayNames:       state.EntityDisplayNames(),
-		}
-	case LocalRuntimeState:
-		return view.NewLocalResourceInfo(runStatus, state.PID, state.SpanID)
-	default:
-		// This is silly but it was the old behavior.
-		return view.K8sResourceInfo{}
-	}
-}
 
 // DockerComposeConfigPath returns the path to the docker-compose yaml file of any
 // docker-compose manifests on this EngineState.

--- a/internal/store/engine_state_test.go
+++ b/internal/store/engine_state_test.go
@@ -3,24 +3,16 @@ package store
 import (
 	"fmt"
 	"net/url"
-	"path/filepath"
-	"sync"
 	"testing"
 	"time"
 
 	"github.com/docker/go-connections/nat"
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	v1 "k8s.io/api/core/v1"
 
 	"github.com/tilt-dev/tilt/internal/container"
-	"github.com/tilt-dev/tilt/internal/hud/view"
 	"github.com/tilt-dev/tilt/internal/k8s"
 	"github.com/tilt-dev/tilt/internal/k8s/testyaml"
-	"github.com/tilt-dev/tilt/internal/store/k8sconv"
-	"github.com/tilt-dev/tilt/internal/testutils/manifestbuilder"
-	"github.com/tilt-dev/tilt/internal/testutils/tempdir"
 	"github.com/tilt-dev/tilt/pkg/apis"
 	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
 	"github.com/tilt-dev/tilt/pkg/model"
@@ -51,192 +43,6 @@ func (c endpointsCase) validate() {
 			panic("test case implies impossible resource")
 		}
 	}
-}
-
-func TestStateToViewRelativeEditPaths(t *testing.T) {
-	f := tempdir.NewTempDirFixture(t)
-	m := model.Manifest{
-		Name: "foo",
-	}.WithDeployTarget(model.K8sTarget{}).WithImageTarget(model.ImageTarget{}.
-		WithDockerImage(v1alpha1.DockerImageSpec{Context: f.JoinPath("a", "b", "c")}))
-
-	state := newState([]model.Manifest{m})
-	ms := state.ManifestTargets[m.Name].State
-	ms.CurrentBuild.Edits = []string{
-		f.JoinPath("a", "b", "c", "foo"),
-		f.JoinPath("a", "b", "c", "d", "e")}
-	ms.BuildHistory = []model.BuildRecord{
-		{
-			Edits: []string{
-				f.JoinPath("a", "b", "c", "foo"),
-				f.JoinPath("a", "b", "c", "d", "e"),
-			},
-		},
-	}
-	ms.MutableBuildStatus(m.ImageTargets[0].ID()).PendingFileChanges =
-		map[string]time.Time{
-			f.JoinPath("a", "b", "c", "foo"):    time.Now(),
-			f.JoinPath("a", "b", "c", "d", "e"): time.Now(),
-		}
-	v := StateToView(*state, &sync.RWMutex{})
-
-	require.Len(t, v.Resources, 2)
-
-	r, _ := v.Resource(m.Name)
-	assert.Equal(t, []string{"foo", filepath.Join("d", "e")}, r.LastBuild().Edits)
-	assert.Equal(t, []string{"foo", filepath.Join("d", "e")}, r.CurrentBuild.Edits)
-	assert.Equal(t, []string{filepath.Join("d", "e"), "foo"}, r.PendingBuildEdits) // these are sorted for deterministic ordering
-}
-
-func TestStateToViewPortForwards(t *testing.T) {
-	m := model.Manifest{
-		Name: "foo",
-	}.WithDeployTarget(model.K8sTarget{
-		KubernetesApplySpec: v1alpha1.KubernetesApplySpec{
-			PortForwardTemplateSpec: &v1alpha1.PortForwardTemplateSpec{
-				Forwards: []v1alpha1.Forward{
-					{LocalPort: 8000, ContainerPort: 5000},
-					{LocalPort: 7000, ContainerPort: 5001},
-				},
-			},
-		},
-	})
-	state := newState([]model.Manifest{m})
-	v := StateToView(*state, &sync.RWMutex{})
-	res, _ := v.Resource(m.Name)
-	assert.Equal(t,
-		[]string{"http://localhost:8000/", "http://localhost:7000/"},
-		res.Endpoints)
-}
-
-func TestStateToWebViewLinksAndPortForwards(t *testing.T) {
-	m := model.Manifest{
-		Name: "foo",
-	}.WithDeployTarget(model.K8sTarget{
-		KubernetesApplySpec: v1alpha1.KubernetesApplySpec{
-			PortForwardTemplateSpec: &v1alpha1.PortForwardTemplateSpec{
-				Forwards: []v1alpha1.Forward{
-					{LocalPort: 8000, ContainerPort: 5000},
-					{LocalPort: 8001, ContainerPort: 5001, Name: "debugger"},
-				},
-			},
-		},
-		Links: []model.Link{
-			model.MustNewLink("www.apple.edu", "apple"),
-			model.MustNewLink("www.zombo.com", "zombo"),
-		},
-	})
-	state := newState([]model.Manifest{m})
-	v := StateToView(*state, &sync.RWMutex{})
-	res, _ := v.Resource(m.Name)
-	assert.Equal(t,
-		[]string{"www.apple.edu", "www.zombo.com", "http://localhost:8000/", "http://localhost:8001/"},
-		res.Endpoints)
-}
-func TestStateToViewLocalResourceLinks(t *testing.T) {
-	m := model.Manifest{
-		Name: "foo",
-	}.WithDeployTarget(model.LocalTarget{
-		Links: []model.Link{
-			model.MustNewLink("www.apple.edu", "apple"),
-			model.MustNewLink("www.zombo.com", "zombo"),
-		},
-	})
-	state := newState([]model.Manifest{m})
-	v := StateToView(*state, &sync.RWMutex{})
-	res, _ := v.Resource(m.Name)
-	assert.Equal(t,
-		[]string{"www.apple.edu", "www.zombo.com"},
-		res.Endpoints)
-}
-
-func TestRuntimeStateNonWorkload(t *testing.T) {
-	f := tempdir.NewTempDirFixture(t)
-
-	m := manifestbuilder.New(f, model.UnresourcedYAMLManifestName).
-		WithK8sYAML(testyaml.SecretYaml).
-		Build()
-	state := newState([]model.Manifest{m})
-	runtimeState := state.ManifestTargets[m.Name].State.K8sRuntimeState()
-	assert.Equal(t, v1alpha1.RuntimeStatusPending, runtimeState.RuntimeStatus())
-
-	runtimeState.HasEverDeployedSuccessfully = true
-
-	assert.Equal(t, v1alpha1.RuntimeStatusOK, runtimeState.RuntimeStatus())
-}
-
-func TestRuntimeStateJob(t *testing.T) {
-	for _, tc := range []struct {
-		phase                 v1.PodPhase
-		expectedRuntimeStatus v1alpha1.RuntimeStatus
-	}{
-		{v1.PodRunning, v1alpha1.RuntimeStatusPending},
-		{v1.PodSucceeded, v1alpha1.RuntimeStatusOK},
-		{v1.PodFailed, v1alpha1.RuntimeStatusError},
-	} {
-		t.Run(string(tc.phase), func(t *testing.T) {
-			f := tempdir.NewTempDirFixture(t)
-
-			m := manifestbuilder.New(f, "foo").
-				WithK8sYAML(testyaml.JobYAML).
-				WithK8sPodReadiness(model.PodReadinessSucceeded).
-				Build()
-			state := newState([]model.Manifest{m})
-			runtimeState := state.ManifestTargets[m.Name].State.K8sRuntimeState()
-			assert.Equal(t, v1alpha1.RuntimeStatusPending, runtimeState.RuntimeStatus())
-
-			runtimeState.HasEverDeployedSuccessfully = true
-
-			pod := v1alpha1.Pod{
-				Name:      "pod",
-				CreatedAt: apis.Now(),
-				Phase:     string(tc.phase),
-			}
-			runtimeState.FilteredPods = []v1alpha1.Pod{pod}
-
-			assert.Equal(t, tc.expectedRuntimeStatus, runtimeState.RuntimeStatus())
-		})
-	}
-}
-
-func TestStateToViewUnresourcedYAMLManifest(t *testing.T) {
-	m := k8sManifest(t, model.UnresourcedYAMLManifestName, testyaml.SanchoYAML)
-	state := newState([]model.Manifest{m})
-	krs := state.ManifestTargets[m.Name].State.K8sRuntimeState()
-	krs.ApplyFilter = yamlToApplyFilter(t, testyaml.SanchoYAML)
-	state.ManifestTargets[m.Name].State.RuntimeState = krs
-
-	v := StateToView(*state, &sync.RWMutex{})
-
-	assert.Equal(t, 2, len(v.Resources))
-
-	r, _ := v.Resource(m.Name)
-	assert.Equal(t, nil, r.LastBuild().Error)
-
-	expectedInfo := view.YAMLResourceInfo{
-		K8sDisplayNames: []string{"sancho:deployment"},
-	}
-	assert.Equal(t, expectedInfo, r.ResourceInfo)
-}
-
-func TestStateToViewNonWorkloadYAMLManifest(t *testing.T) {
-	m := k8sManifest(t, "foo", testyaml.SecretYaml)
-	state := newState([]model.Manifest{m})
-	krs := state.ManifestTargets[m.Name].State.K8sRuntimeState()
-	krs.ApplyFilter = yamlToApplyFilter(t, testyaml.SecretYaml)
-	state.ManifestTargets[m.Name].State.RuntimeState = krs
-
-	v := StateToView(*state, &sync.RWMutex{})
-
-	assert.Equal(t, 2, len(v.Resources))
-
-	r, _ := v.Resource(m.Name)
-	assert.Equal(t, nil, r.LastBuild().Error)
-
-	expectedInfo := view.YAMLResourceInfo{
-		K8sDisplayNames: []string{"mysecret:secret"},
-	}
-	assert.Equal(t, expectedInfo, r.ResourceInfo)
 }
 
 func TestMostRecentPod(t *testing.T) {
@@ -502,23 +308,6 @@ func assertLinks(t *testing.T, expected, actual []model.Link) {
 		// and if those match, compare everything else
 		assert.Equal(t, expected, actual)
 	}
-}
-
-func yamlToApplyFilter(t testing.TB, yaml string) *k8sconv.KubernetesApplyFilter {
-	t.Helper()
-	entities, err := k8s.ParseYAMLFromString(yaml)
-	require.NoError(t, err, "Failed to parse YAML")
-	for i := range entities {
-		entities[i].SetUID(uuid.New().String())
-	}
-	yaml, err = k8s.SerializeSpecYAML(entities)
-	require.NoError(t, err, "Failed to re-serialize YAML")
-	applyFilter, err := k8sconv.NewKubernetesApplyFilter(&v1alpha1.KubernetesApplyStatus{
-		ResultYAML: yaml,
-	})
-	require.NoError(t, err, "Failed to create KubernetesApplyFilter")
-	require.NotNil(t, applyFilter, "ApplyFilter was nil")
-	return applyFilter
 }
 
 func k8sManifest(t testing.TB, name model.ManifestName, yaml string) model.Manifest {


### PR DESCRIPTION
Hello @landism,

Please review the following commits I made in branch nicks/issue5543:

c19167de564b3c33f647a3d075527dbee04fe3ff (2022-02-28 14:32:30 -0500)
store: move HUD view rendering into the HUD package
Also: skip disabled resources when rendering the legacy HUD

Fixes https://github.com/tilt-dev/tilt/issues/5543

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics