### PR TITLE
k8s: send Pods and Jobs down the same update codepath as other resources

### DIFF
--- a/internal/k8s/client_test.go
+++ b/internal/k8s/client_test.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"helm.sh/helm/v3/pkg/kube"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -83,32 +82,6 @@ func TestDeleteMissingKind(t *testing.T) {
 	assert.Equal(t,
 		[]string{"ConfigMap", "PersistentVolume", "PersistentVolumeClaim", "Service"},
 		kinds)
-}
-
-func TestUpsertMutableAndImmutable(t *testing.T) {
-	f := newClientTestFixture(t)
-	eDeploy := MustParseYAMLFromString(t, testyaml.SanchoYAML)[0]
-	eJob := MustParseYAMLFromString(t, testyaml.JobYAML)[0]
-	eNamespace := MustParseYAMLFromString(t, testyaml.MyNamespaceYAML)[0]
-
-	_, err := f.k8sUpsert(f.ctx, []K8sEntity{eDeploy, eJob, eNamespace})
-	if !assert.Nil(t, err) {
-		t.FailNow()
-	}
-
-	require.Len(t, f.resourceClient.updates, 2)
-	require.Len(t, f.resourceClient.creates, 1)
-
-	// compare entities instead of strings because str > entity > string gets weird
-	call0Entity := NewK8sEntity(f.resourceClient.updates[0].Object)
-	call1Entity := NewK8sEntity(f.resourceClient.updates[1].Object)
-
-	// `apply` should preserve input order of entities (we sort them further upstream)
-	require.Equal(t, eDeploy, call0Entity, "expect call 0 to have applied deployment first (preserve input order)")
-	require.Equal(t, eNamespace, call1Entity, "expect call 0 to have applied namespace second (preserve input order)")
-
-	call2Entity := NewK8sEntity(f.resourceClient.creates[0].Object)
-	require.Equal(t, eJob, call2Entity, "expect create job")
 }
 
 func TestUpsertAnnotationTooLong(t *testing.T) {

--- a/internal/k8s/entity.go
+++ b/internal/k8s/entity.go
@@ -159,41 +159,6 @@ func CopyEntities(entities []K8sEntity) []K8sEntity {
 	return res
 }
 
-// MutableAndImmutableEntities returns two lists of k8s entities: mutable ones (that can simply be
-// `kubectl apply`'d), and immutable ones (such as jobs and pods, which will need to be `--force`'d).
-// (We assume input entities are already sorted in a safe order to apply -- see kustomize/ordering.go.)
-func MutableAndImmutableEntities(entities entityList) (mutable, immutable []K8sEntity) {
-	for _, e := range entities {
-		if e.ImmutableOnceCreated() {
-			immutable = append(immutable, e)
-			continue
-		}
-		mutable = append(mutable, e)
-	}
-
-	return mutable, immutable
-}
-
-func ImmutableEntities(entities []K8sEntity) []K8sEntity {
-	result := make([]K8sEntity, 0)
-	for _, e := range entities {
-		if e.ImmutableOnceCreated() {
-			result = append(result, e)
-		}
-	}
-	return result
-}
-
-func MutableEntities(entities []K8sEntity) []K8sEntity {
-	result := make([]K8sEntity, 0)
-	for _, e := range entities {
-		if !e.ImmutableOnceCreated() {
-			result = append(result, e)
-		}
-	}
-	return result
-}
-
 type LoadBalancerSpec struct {
 	Name      string
 	Namespace Namespace


### PR DESCRIPTION
Hello @milas, @landism,

Please review the following commits I made in branch nicks/deadcode:

49e34b218ada023d6c47f5fe8c114be4e12f3627 (2022-03-01 22:26:46 -0500)
k8s: send Pods and Jobs down the same update codepath as other resources
We used to handle Pods and Jobs differently, because
they were immutable. Now, the main codepath should handle
immutability correctly.

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics