### PR TITLE
k8s: improve error messages during Pod exec failures

### DIFF
--- a/internal/build/error.go
+++ b/internal/build/error.go
@@ -15,11 +15,11 @@ import (
 const TaskKillExitCode = 137
 
 func WrapCodeExitError(err error, cID container.ID, cmd model.Cmd) error {
-	exitErr, isExitErr := err.(exec.CodeExitError)
-	if isExitErr {
+	var exitCodeErr exec.CodeExitError
+	if errors.As(err, &exitCodeErr) {
 		return RunStepFailure{
 			Cmd:      cmd,
-			ExitCode: exitErr.ExitStatus(),
+			ExitCode: exitCodeErr.ExitStatus(),
 		}
 	}
 	return errors.Wrapf(err, "executing %v on container %s", cmd, cID.ShortStr())

--- a/internal/k8s/exec.go
+++ b/internal/k8s/exec.go
@@ -30,7 +30,7 @@ func (k *K8sClient) Exec(_ context.Context, podID PodID, cName container.Name, n
 
 	exec, err := remotecommand.NewSPDYExecutor(k.restConfig, "POST", req.URL())
 	if err != nil {
-		return fmt.Errorf("establishing connection: %v", err)
+		return fmt.Errorf("establishing connection: %w", err)
 	}
 
 	err = exec.Stream(remotecommand.StreamOptions{
@@ -48,7 +48,7 @@ func (k *K8sClient) Exec(_ context.Context, podID PodID, cName container.Name, n
 			// can do here
 			err = errors.New("unknown server error")
 		}
-		return fmt.Errorf("executing command: %v", err)
+		return fmt.Errorf("executing command: %w", err)
 	}
 	return nil
 }

--- a/internal/k8s/exec.go
+++ b/internal/k8s/exec.go
@@ -2,6 +2,8 @@ package k8s
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"io"
 
 	corev1 "k8s.io/api/core/v1"
@@ -11,7 +13,7 @@ import (
 	"github.com/tilt-dev/tilt/internal/container"
 )
 
-func (k *K8sClient) Exec(ctx context.Context, podID PodID, cName container.Name, n Namespace, cmd []string, stdin io.Reader, stdout io.Writer, stderr io.Writer) error {
+func (k *K8sClient) Exec(_ context.Context, podID PodID, cName container.Name, n Namespace, cmd []string, stdin io.Reader, stdout io.Writer, stderr io.Writer) error {
 	req := k.core.RESTClient().Post().
 		Resource("pods").
 		Namespace(n.String()).
@@ -28,12 +30,25 @@ func (k *K8sClient) Exec(ctx context.Context, podID PodID, cName container.Name,
 
 	exec, err := remotecommand.NewSPDYExecutor(k.restConfig, "POST", req.URL())
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to establish connection: %v", err)
 	}
 
-	return exec.Stream(remotecommand.StreamOptions{
+	err = exec.Stream(remotecommand.StreamOptions{
 		Stdin:  stdin,
 		Stdout: stdout,
 		Stderr: stderr,
 	})
+	if err != nil {
+		if err.Error() == "" {
+			// Executor::Stream() attempts to decode metav1.Status errors to
+			// handle non-zero exit codes from commands; unfortunately, for
+			// all _other_ failure cases, the error returned is the `Message`
+			// field, which might be empty and there's no way for us to further
+			// introspect at this point, so a generic message is the best we
+			// can do here
+			err = errors.New("unknown server error")
+		}
+		return fmt.Errorf("failed to execute command: %v", err)
+	}
+	return nil
 }

--- a/internal/k8s/exec.go
+++ b/internal/k8s/exec.go
@@ -30,7 +30,7 @@ func (k *K8sClient) Exec(_ context.Context, podID PodID, cName container.Name, n
 
 	exec, err := remotecommand.NewSPDYExecutor(k.restConfig, "POST", req.URL())
 	if err != nil {
-		return fmt.Errorf("failed to establish connection: %v", err)
+		return fmt.Errorf("establishing connection: %v", err)
 	}
 
 	err = exec.Stream(remotecommand.StreamOptions{
@@ -48,7 +48,7 @@ func (k *K8sClient) Exec(_ context.Context, podID PodID, cName container.Name, n
 			// can do here
 			err = errors.New("unknown server error")
 		}
-		return fmt.Errorf("failed to execute command: %v", err)
+		return fmt.Errorf("executing command: %v", err)
 	}
 	return nil
 }


### PR DESCRIPTION
When running a command in a Pod, `client-go` attempts to handle
the failure case of a non-zero exit code by inspecting a
`metav1.Status` object.

For other failure cases, it returns `fmt.Errorf(status.Message)`,
and `Message` might be blank, resulting in cryptic error messages
from Tilt.

There's not a lot we can do without upstream `client-go` changes
on the Tilt side, so some extra context is added around where the
exec failed, and for the stream error case, a generic fallback
error message is used if we get an empty error from `client-go`.

See `remotecommand/v4.go` for the problematic `client-go` code:
https://github.com/kubernetes/client-go/blob/8e46da3fd12b54a2d1726fc9a9438ff8fc38494c/tools/remotecommand/v4.go#L91-L118