### PR TITLE
store: separately track builds from different sources

### DIFF
--- a/internal/controllers/core/cmd/controller_test.go
+++ b/internal/controllers/core/cmd/controller_test.go
@@ -79,7 +79,7 @@ func TestUpdateWithCurrentBuild(t *testing.T) {
 		c := model.ToHostCmd("false")
 		localTarget := model.NewLocalTarget(model.TargetName("foo"), c, c, nil)
 		s.ManifestTargets["foo"].Manifest.DeployTarget = localTarget
-		s.ManifestTargets["foo"].State.CurrentBuild = model.BuildRecord{StartTime: f.clock.Now()}
+		s.ManifestTargets["foo"].State.CurrentBuilds["buildcontrol"] = model.BuildRecord{StartTime: f.clock.Now()}
 	})
 
 	f.step()
@@ -89,7 +89,7 @@ func TestUpdateWithCurrentBuild(t *testing.T) {
 	}, 20*time.Millisecond, 5*time.Millisecond)
 
 	f.st.WithState(func(s *store.EngineState) {
-		s.ManifestTargets["foo"].State.CurrentBuild = model.BuildRecord{}
+		delete(s.ManifestTargets["foo"].State.CurrentBuilds, "buildcontrol")
 	})
 
 	f.step()
@@ -1023,9 +1023,8 @@ func (f *fixture) resourceFromTarget(name string, target model.TargetSpec, lastD
 	st := f.st.LockMutableStateForTesting()
 	defer f.st.UnlockMutableState()
 
-	state := &store.ManifestState{
-		LastSuccessfulDeployTime: lastDeploy,
-	}
+	state := store.NewManifestState(m)
+	state.LastSuccessfulDeployTime = lastDeploy
 	state.AddCompletedBuild(model.BuildRecord{
 		StartTime:  lastDeploy,
 		FinishTime: lastDeploy,

--- a/internal/controllers/core/liveupdate/reconciler.go
+++ b/internal/controllers/core/liveupdate/reconciler.go
@@ -43,6 +43,8 @@ import (
 	"github.com/tilt-dev/tilt/pkg/model/logstore"
 )
 
+const LiveUpdateSource = "liveupdate"
+
 var discoveryGVK = v1alpha1.SchemeGroupVersion.WithKind("KubernetesDiscovery")
 var applyGVK = v1alpha1.SchemeGroupVersion.WithKind("KubernetesApply")
 var fwGVK = v1alpha1.SchemeGroupVersion.WithKind("FileWatch")
@@ -532,6 +534,7 @@ func (r *Reconciler) dispatchStartBuildAction(ctx context.Context, lu *v1alpha1.
 		Reason:             model.BuildReasonFlagChangedFiles,
 		SpanID:             logstore.SpanID(spanID),
 		FullBuildTriggered: false,
+		Source:             LiveUpdateSource,
 	})
 
 	buildcontrols.LogBuildEntry(ctx, buildcontrols.BuildEntry{
@@ -560,7 +563,7 @@ func (r *Reconciler) dispatchCompleteBuildAction(lu *v1alpha1.LiveUpdate, newSta
 	}
 	result := store.NewLiveUpdateBuildResult(imageTargetID, containerIDs)
 	resultSet := store.BuildResultSet{imageTargetID: result}
-	r.store.Dispatch(buildcontrols.NewBuildCompleteAction(manifestName, spanID, resultSet, err))
+	r.store.Dispatch(buildcontrols.NewBuildCompleteAction(manifestName, LiveUpdateSource, spanID, resultSet, err))
 }
 
 // Convert the currently tracked state into a set of inputs

--- a/internal/controllers/core/tiltfile/reducers.go
+++ b/internal/controllers/core/tiltfile/reducers.go
@@ -9,6 +9,8 @@ import (
 	"github.com/tilt-dev/tilt/pkg/model"
 )
 
+const TiltfileBuildSource = "tiltfile"
+
 func HandleConfigsReloadStarted(
 	ctx context.Context,
 	state *store.EngineState,
@@ -25,7 +27,7 @@ func HandleConfigsReloadStarted(
 		Edits:     event.FilesChanged,
 		SpanID:    event.SpanID,
 	}
-	ms.CurrentBuild = status
+	ms.CurrentBuilds[TiltfileBuildSource] = status
 	state.RemoveFromTriggerQueue(event.Name)
 	state.StartedTiltfileLoadCount++
 }
@@ -69,7 +71,7 @@ func HandleConfigsReloaded(
 	if !ok {
 		return
 	}
-	b := ms.CurrentBuild
+	b := ms.CurrentBuilds[TiltfileBuildSource]
 
 	// Remove pending file changes that were consumed by this build.
 	for _, status := range ms.BuildStatuses {
@@ -107,7 +109,7 @@ func HandleConfigsReloaded(
 
 		ms.AddCompletedBuild(b)
 	}
-	ms.CurrentBuild = model.BuildRecord{}
+	delete(ms.CurrentBuilds, TiltfileBuildSource)
 	if event.Err != nil {
 		// When the Tiltfile had an error, we want to differentiate between two cases:
 		//

--- a/internal/engine/buildcontroller.go
+++ b/internal/engine/buildcontroller.go
@@ -168,7 +168,7 @@ func (c *BuildController) cleanUpCanceledBuilds(st store.RStore) {
 		canceled := false
 		if cancelButton, ok := state.UIButtons[uibutton.StopBuildButtonName(ms.Name.String())]; ok {
 			lastCancelClick := cancelButton.Status.LastClickedAt
-			canceled = timecmp.AfterOrEqual(lastCancelClick, ms.CurrentBuild().StartTime)
+			canceled = timecmp.AfterOrEqual(lastCancelClick, ms.EarliestCurrentBuild().StartTime)
 		}
 		if disabled || canceled {
 			c.cleanupBuildContext(ms.Name)

--- a/internal/engine/buildcontroller.go
+++ b/internal/engine/buildcontroller.go
@@ -22,6 +22,8 @@ import (
 	"github.com/tilt-dev/tilt/pkg/model/logstore"
 )
 
+const BuildControlSource = "buildcontrol"
+
 type BuildController struct {
 	b                  buildcontrol.BuildAndDeployer
 	buildsStartedCount int // used to synchronize with state
@@ -117,7 +119,7 @@ func (c *BuildController) OnChange(ctx context.Context, st store.RStore, summary
 		Reason:             entry.buildReason,
 		SpanID:             entry.spanID,
 		FullBuildTriggered: entry.buildStateSet.FullBuildTriggered(),
-		IsBuildController:  true,
+		Source:             BuildControlSource,
 	})
 
 	go func() {
@@ -134,7 +136,7 @@ func (c *BuildController) OnChange(ctx context.Context, st store.RStore, summary
 		if ctx.Err() == context.Canceled {
 			err = errors.New("build canceled")
 		}
-		st.Dispatch(buildcontrols.NewBuildCompleteAction(entry.name, entry.spanID, result, err))
+		st.Dispatch(buildcontrols.NewBuildCompleteAction(entry.name, BuildControlSource, entry.spanID, result, err))
 	}()
 
 	return nil
@@ -159,14 +161,14 @@ func (c *BuildController) cleanUpCanceledBuilds(st store.RStore) {
 	defer st.RUnlockState()
 
 	for _, ms := range state.ManifestStates() {
-		if ms.CurrentBuild.Empty() {
+		if !ms.IsBuilding() {
 			continue
 		}
 		disabled := ms.DisableState == v1alpha1.DisableStateDisabled
 		canceled := false
 		if cancelButton, ok := state.UIButtons[uibutton.StopBuildButtonName(ms.Name.String())]; ok {
 			lastCancelClick := cancelButton.Status.LastClickedAt
-			canceled = timecmp.AfterOrEqual(lastCancelClick, ms.CurrentBuild.StartTime)
+			canceled = timecmp.AfterOrEqual(lastCancelClick, ms.CurrentBuild().StartTime)
 		}
 		if disabled || canceled {
 			c.cleanupBuildContext(ms.Name)

--- a/internal/engine/buildcontroller_test.go
+++ b/internal/engine/buildcontroller_test.go
@@ -1688,7 +1688,7 @@ func (f *testFixture) waitUntilManifestBuilding(name model.ManifestName) {
 	})
 
 	f.withState(func(st store.EngineState) {
-		_, ok := st.CurrentlyBuilding[name]
+		ok := st.CurrentBuildSet[name]
 		require.True(f.t, ok, "expected EngineState to reflect that %q is currently building", name)
 	})
 }
@@ -1700,7 +1700,7 @@ func (f *testFixture) waitUntilManifestNotBuilding(name model.ManifestName) {
 	})
 
 	f.withState(func(st store.EngineState) {
-		_, ok := st.CurrentlyBuilding[name]
+		ok := st.CurrentBuildSet[name]
 		require.False(f.t, ok, "expected EngineState to reflect that %q is NOT currently building", name)
 	})
 }

--- a/internal/engine/dockerprune/docker_pruner.go
+++ b/internal/engine/dockerprune/docker_pruner.go
@@ -81,7 +81,7 @@ func (dp *DockerPruner) OnChange(ctx context.Context, st store.RStore, summary s
 	// 	* Engine is currently building something
 	// 	* There are NO `docker_build`s in the Tiltfile
 	// 	* Something is queued for building
-	if !settings.Enabled || len(state.CurrentlyBuilding) > 0 || !state.HasDockerBuild() || buildcontrol.NextManifestNameToBuild(state) != "" {
+	if !settings.Enabled || len(state.CurrentBuildSet) > 0 || !state.HasDockerBuild() || buildcontrol.NextManifestNameToBuild(state) != "" {
 		st.RUnlockState()
 		return nil
 	}

--- a/internal/engine/dockerprune/docker_pruner_test.go
+++ b/internal/engine/dockerprune/docker_pruner_test.go
@@ -465,7 +465,7 @@ func (dpf *dockerPruneFixture) withBuildCount(count int) {
 
 func (dpf *dockerPruneFixture) withCurrentlyBuilding(mn model.ManifestName) {
 	store := dpf.st.LockMutableStateForTesting()
-	store.CurrentlyBuilding[mn] = true
+	store.CurrentBuildSet[mn] = true
 	dpf.st.UnlockMutableState()
 }
 

--- a/internal/engine/runtimelog/docker_compose_log_manager.go
+++ b/internal/engine/runtimelog/docker_compose_log_manager.go
@@ -51,7 +51,7 @@ func (m *DockerComposeLogManager) diff(ctx context.Context, st store.RStore) (se
 		// deleted. This affects tests more than normal builds.
 		// But we should have a better way to associate logs with a particular build.
 		ms := mt.State
-		if ms.CurrentBuild.StartTime.IsZero() && ms.LastBuild().StartTime.IsZero() {
+		if ms.CurrentBuild().StartTime.IsZero() && ms.LastBuild().StartTime.IsZero() {
 			continue
 		}
 		dcState := ms.DCRuntimeState()

--- a/internal/engine/runtimelog/docker_compose_log_manager.go
+++ b/internal/engine/runtimelog/docker_compose_log_manager.go
@@ -51,7 +51,7 @@ func (m *DockerComposeLogManager) diff(ctx context.Context, st store.RStore) (se
 		// deleted. This affects tests more than normal builds.
 		// But we should have a better way to associate logs with a particular build.
 		ms := mt.State
-		if ms.CurrentBuild().StartTime.IsZero() && ms.LastBuild().StartTime.IsZero() {
+		if ms.EarliestCurrentBuild().StartTime.IsZero() && ms.LastBuild().StartTime.IsZero() {
 			continue
 		}
 		dcState := ms.DCRuntimeState()

--- a/internal/engine/session/conv.go
+++ b/internal/engine/session/conv.go
@@ -248,11 +248,12 @@ func buildTarget(mt *store.ManifestTarget, holds buildcontrol.HoldSet) *session.
 	}
 
 	isPending := mt.NextBuildReason() != model.BuildReasonNone
+	currentBuild := mt.State.CurrentBuild()
 	if isPending {
 		res.State.Waiting = waitingFromHolds(mt.Manifest.Name, holds)
-	} else if !mt.State.CurrentBuild.Empty() {
+	} else if !currentBuild.Empty() {
 		res.State.Active = &session.TargetStateActive{
-			StartTime: apis.NewMicroTime(mt.State.CurrentBuild.StartTime),
+			StartTime: apis.NewMicroTime(currentBuild.StartTime),
 		}
 	} else if len(mt.State.BuildHistory) != 0 {
 		lastBuild := mt.State.LastBuild()
@@ -306,9 +307,9 @@ func tiltfileTarget(name model.ManifestName, ms *store.ManifestState) session.Ta
 
 	// Tiltfile is special in engine state and doesn't have a target, just state, so
 	// this logic is largely duplicated from the generic resource build logic
-	if !ms.CurrentBuild.Empty() {
+	if !ms.CurrentBuild().Empty() {
 		target.State.Active = &session.TargetStateActive{
-			StartTime: apis.NewMicroTime(ms.CurrentBuild.StartTime),
+			StartTime: apis.NewMicroTime(ms.CurrentBuild().StartTime),
 		}
 	} else if hasPendingChanges, _ := ms.HasPendingChanges(); hasPendingChanges {
 		target.State.Waiting = &session.TargetStateWaiting{

--- a/internal/engine/session/conv.go
+++ b/internal/engine/session/conv.go
@@ -248,7 +248,7 @@ func buildTarget(mt *store.ManifestTarget, holds buildcontrol.HoldSet) *session.
 	}
 
 	isPending := mt.NextBuildReason() != model.BuildReasonNone
-	currentBuild := mt.State.CurrentBuild()
+	currentBuild := mt.State.EarliestCurrentBuild()
 	if isPending {
 		res.State.Waiting = waitingFromHolds(mt.Manifest.Name, holds)
 	} else if !currentBuild.Empty() {
@@ -307,9 +307,9 @@ func tiltfileTarget(name model.ManifestName, ms *store.ManifestState) session.Ta
 
 	// Tiltfile is special in engine state and doesn't have a target, just state, so
 	// this logic is largely duplicated from the generic resource build logic
-	if !ms.CurrentBuild().Empty() {
+	if ms.IsBuilding() {
 		target.State.Active = &session.TargetStateActive{
-			StartTime: apis.NewMicroTime(ms.CurrentBuild().StartTime),
+			StartTime: apis.NewMicroTime(ms.EarliestCurrentBuild().StartTime),
 		}
 	} else if hasPendingChanges, _ := ms.HasPendingChanges(); hasPendingChanges {
 		target.State.Waiting = &session.TargetStateWaiting{

--- a/internal/engine/uiresource/subscriber_test.go
+++ b/internal/engine/uiresource/subscriber_test.go
@@ -53,7 +53,7 @@ func TestUpdateTiltfile(t *testing.T) {
 
 	f.store.WithState(func(es *store.EngineState) {
 		ms := es.TiltfileStates[model.MainTiltfileManifestName]
-		b := ms.CurrentBuild()
+		b := ms.EarliestCurrentBuild()
 		b.FinishTime = time.Now()
 		ms.AddCompletedBuild(b)
 		delete(ms.CurrentBuilds, "tiltfile")

--- a/internal/engine/uiresource/subscriber_test.go
+++ b/internal/engine/uiresource/subscriber_test.go
@@ -33,7 +33,7 @@ func TestUpdateTiltfile(t *testing.T) {
 	assert.Equal(t, "2", r.ObjectMeta.ResourceVersion)
 
 	f.store.WithState(func(es *store.EngineState) {
-		es.TiltfileStates[model.MainTiltfileManifestName].CurrentBuild.StartTime = time.Now()
+		es.TiltfileStates[model.MainTiltfileManifestName].CurrentBuilds["tiltfile"] = model.BuildRecord{StartTime: time.Now()}
 	})
 
 	_ = f.sub.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
@@ -53,10 +53,10 @@ func TestUpdateTiltfile(t *testing.T) {
 
 	f.store.WithState(func(es *store.EngineState) {
 		ms := es.TiltfileStates[model.MainTiltfileManifestName]
-		b := ms.CurrentBuild
+		b := ms.CurrentBuild()
 		b.FinishTime = time.Now()
 		ms.AddCompletedBuild(b)
-		ms.CurrentBuild = model.BuildRecord{}
+		delete(ms.CurrentBuilds, "tiltfile")
 	})
 
 	_ = f.sub.OnChange(f.ctx, f.store, store.LegacyChangeSummary())

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -2714,7 +2714,7 @@ ghij`)))
 
 	f.WaitUntil("log appears", func(es store.EngineState) bool {
 		ms, _ := es.ManifestState("alert-injester")
-		spanID := ms.CurrentBuild().SpanID
+		spanID := ms.EarliestCurrentBuild().SpanID
 		return spanID != "" && len(es.LogStore.SpanLog(spanID)) > 0
 	})
 

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -2704,6 +2704,7 @@ func TestBuildLogAction(t *testing.T) {
 		ManifestName: manifest.Name,
 		StartTime:    f.Now(),
 		SpanID:       SpanIDForBuildLog(1),
+		Source:       "buildcontrol",
 	})
 
 	f.store.Dispatch(store.NewLogAction(manifest.Name, SpanIDForBuildLog(1), logger.InfoLvl, nil, []byte(`a
@@ -2713,7 +2714,7 @@ ghij`)))
 
 	f.WaitUntil("log appears", func(es store.EngineState) bool {
 		ms, _ := es.ManifestState("alert-injester")
-		spanID := ms.CurrentBuild.SpanID
+		spanID := ms.CurrentBuild().SpanID
 		return spanID != "" && len(es.LogStore.SpanLog(spanID)) > 0
 	})
 

--- a/internal/hud/view.go
+++ b/internal/hud/view.go
@@ -64,7 +64,7 @@ func StateToTerminalView(s store.EngineState, mu *sync.RWMutex) view.View {
 			buildHistory[i] = build
 		}
 
-		currentBuild := ms.CurrentBuild()
+		currentBuild := ms.EarliestCurrentBuild()
 		currentBuild.Edits = ospath.FileListDisplayNames(absWatchDirs, currentBuild.Edits)
 
 		// Sort the strings to make the outputs deterministic.
@@ -102,7 +102,7 @@ func StateToTerminalView(s store.EngineState, mu *sync.RWMutex) view.View {
 const MainTiltfileManifestName = model.MainTiltfileManifestName
 
 func tiltfileResourceView(ms *store.ManifestState) view.Resource {
-	currentBuild := ms.CurrentBuild()
+	currentBuild := ms.EarliestCurrentBuild()
 	tr := view.Resource{
 		Name:         MainTiltfileManifestName,
 		IsTiltfile:   true,

--- a/internal/hud/view.go
+++ b/internal/hud/view.go
@@ -64,8 +64,8 @@ func StateToTerminalView(s store.EngineState, mu *sync.RWMutex) view.View {
 			buildHistory[i] = build
 		}
 
-		currentBuild := ms.CurrentBuild
-		currentBuild.Edits = ospath.FileListDisplayNames(absWatchDirs, ms.CurrentBuild.Edits)
+		currentBuild := ms.CurrentBuild()
+		currentBuild.Edits = ospath.FileListDisplayNames(absWatchDirs, currentBuild.Edits)
 
 		// Sort the strings to make the outputs deterministic.
 		sort.Strings(pendingBuildEdits)
@@ -102,15 +102,16 @@ func StateToTerminalView(s store.EngineState, mu *sync.RWMutex) view.View {
 const MainTiltfileManifestName = model.MainTiltfileManifestName
 
 func tiltfileResourceView(ms *store.ManifestState) view.Resource {
+	currentBuild := ms.CurrentBuild()
 	tr := view.Resource{
 		Name:         MainTiltfileManifestName,
 		IsTiltfile:   true,
-		CurrentBuild: ms.CurrentBuild,
+		CurrentBuild: currentBuild,
 		BuildHistory: ms.BuildHistory,
 		ResourceInfo: view.TiltfileResourceInfo{},
 	}
-	if !ms.CurrentBuild.Empty() {
-		tr.PendingBuildSince = ms.CurrentBuild.StartTime
+	if !currentBuild.Empty() {
+		tr.PendingBuildSince = currentBuild.StartTime
 	} else {
 		tr.LastDeployTime = ms.LastBuild().FinishTime
 	}

--- a/internal/hud/view_test.go
+++ b/internal/hud/view_test.go
@@ -32,9 +32,12 @@ func TestStateToViewRelativeEditPaths(t *testing.T) {
 
 	state := newState([]model.Manifest{m})
 	ms := state.ManifestTargets[m.Name].State
-	ms.CurrentBuild.Edits = []string{
-		f.JoinPath("a", "b", "c", "foo"),
-		f.JoinPath("a", "b", "c", "d", "e")}
+	ms.CurrentBuilds["buildcontrol"] = model.BuildRecord{
+		Edits: []string{
+			f.JoinPath("a", "b", "c", "foo"),
+			f.JoinPath("a", "b", "c", "d", "e"),
+		},
+	}
 	ms.BuildHistory = []model.BuildRecord{
 		{
 			Edits: []string{

--- a/internal/hud/webview/convert.go
+++ b/internal/hud/webview/convert.go
@@ -238,7 +238,8 @@ func toUIResource(mt *store.ManifestTarget, s store.EngineState, disableSources 
 
 	bh := ToBuildsTerminated(ms.BuildHistory, s.LogStore)
 	lastDeploy := metav1.NewMicroTime(ms.LastSuccessfulDeployTime)
-	cb := ToBuildRunning(ms.CurrentBuild)
+	currentBuild := ms.CurrentBuild()
+	cb := ToBuildRunning(currentBuild)
 
 	specs, err := ToAPITargetSpecs(mt.Manifest.TargetSpecs())
 	if err != nil {
@@ -357,7 +358,7 @@ func UIResourceUpToDateCondition(r v1alpha1.UIResourceStatus) v1alpha1.UIResourc
 // not the Tiltfile state in EngineState.
 func TiltfileResource(name model.ManifestName, ms *store.ManifestState, logStore *logstore.LogStore) *v1alpha1.UIResource {
 	ltfb := ms.LastBuild()
-	ctfb := ms.CurrentBuild
+	ctfb := ms.CurrentBuild()
 
 	pctfb := ToBuildRunning(ctfb)
 	history := []v1alpha1.UIBuildTerminated{}

--- a/internal/hud/webview/convert.go
+++ b/internal/hud/webview/convert.go
@@ -238,7 +238,7 @@ func toUIResource(mt *store.ManifestTarget, s store.EngineState, disableSources 
 
 	bh := ToBuildsTerminated(ms.BuildHistory, s.LogStore)
 	lastDeploy := metav1.NewMicroTime(ms.LastSuccessfulDeployTime)
-	currentBuild := ms.CurrentBuild()
+	currentBuild := ms.EarliestCurrentBuild()
 	cb := ToBuildRunning(currentBuild)
 
 	specs, err := ToAPITargetSpecs(mt.Manifest.TargetSpecs())
@@ -358,7 +358,7 @@ func UIResourceUpToDateCondition(r v1alpha1.UIResourceStatus) v1alpha1.UIResourc
 // not the Tiltfile state in EngineState.
 func TiltfileResource(name model.ManifestName, ms *store.ManifestState, logStore *logstore.LogStore) *v1alpha1.UIResource {
 	ltfb := ms.LastBuild()
-	ctfb := ms.CurrentBuild()
+	ctfb := ms.EarliestCurrentBuild()
 
 	pctfb := ToBuildRunning(ctfb)
 	history := []v1alpha1.UIBuildTerminated{}

--- a/internal/store/buildcontrols/actions.go
+++ b/internal/store/buildcontrols/actions.go
@@ -15,12 +15,13 @@ type BuildStartedAction struct {
 	Reason             model.BuildReason
 	SpanID             logstore.SpanID
 	FullBuildTriggered bool
-	IsBuildController  bool
+	Source             string
 }
 
 func (BuildStartedAction) Action() {}
 
 type BuildCompleteAction struct {
+	Source       string
 	ManifestName model.ManifestName
 	SpanID       logstore.SpanID
 	Result       store.BuildResultSet
@@ -30,12 +31,13 @@ type BuildCompleteAction struct {
 
 func (BuildCompleteAction) Action() {}
 
-func NewBuildCompleteAction(mn model.ManifestName, spanID logstore.SpanID, result store.BuildResultSet, err error) BuildCompleteAction {
+func NewBuildCompleteAction(mn model.ManifestName, source string, spanID logstore.SpanID, result store.BuildResultSet, err error) BuildCompleteAction {
 	return BuildCompleteAction{
 		ManifestName: mn,
 		SpanID:       spanID,
 		Result:       result,
 		FinishTime:   time.Now(),
 		Error:        err,
+		Source:       source,
 	}
 }

--- a/internal/store/buildcontrols/reducers.go
+++ b/internal/store/buildcontrols/reducers.go
@@ -18,8 +18,10 @@ import (
 	"github.com/tilt-dev/tilt/pkg/model"
 )
 
+const BuildControlSource = "buildcontrol"
+
 func HandleBuildStarted(ctx context.Context, state *store.EngineState, action BuildStartedAction) {
-	if action.IsBuildController {
+	if action.Source == BuildControlSource {
 		state.BuildControllerStartCount++
 	}
 
@@ -41,7 +43,7 @@ func HandleBuildStarted(ctx context.Context, state *store.EngineState, action Bu
 		SpanID:    action.SpanID,
 	}
 	ms.ConfigFilesThatCausedChange = []string{}
-	ms.CurrentBuild = bs
+	ms.CurrentBuilds[action.Source] = bs
 
 	if ms.IsK8s() {
 		krs := ms.K8sRuntimeState()
@@ -76,8 +78,8 @@ func HandleBuildStarted(ctx context.Context, state *store.EngineState, action Bu
 		ms.LiveUpdatedContainerIDs = container.NewIDSet()
 	}
 
-	state.CurrentlyBuilding[mn] = true
 	state.RemoveFromTriggerQueue(mn)
+	state.CurrentBuildSet[mn] = true
 }
 
 // When a Manifest build finishes, update the BuildStatus for all applicable
@@ -114,7 +116,7 @@ func handleBuildResults(engineState *store.EngineState,
 		// 2) If the current manifest build was kicked off by a trigger, we don't
 		//    want to queue manifests with the same image.
 		if currentMT.NextBuildReason() == model.BuildReasonNone ||
-			engineState.IsCurrentlyBuilding(currentMT.Manifest.Name) {
+			engineState.IsBuilding(currentMT.Manifest.Name) {
 			continue
 		}
 
@@ -177,7 +179,9 @@ func handleBuildResults(engineState *store.EngineState,
 func HandleBuildCompleted(ctx context.Context, engineState *store.EngineState, cb BuildCompleteAction) {
 	mn := cb.ManifestName
 	defer func() {
-		delete(engineState.CurrentlyBuilding, mn)
+		if !engineState.IsBuilding(mn) {
+			delete(engineState.CurrentBuildSet, mn)
+		}
 	}()
 
 	engineState.CompletedBuildCount++
@@ -197,7 +201,7 @@ func HandleBuildCompleted(ctx context.Context, engineState *store.EngineState, c
 	}
 
 	ms := mt.State
-	bs := ms.CurrentBuild
+	bs := ms.CurrentBuilds[cb.Source]
 	bs.Error = err
 	bs.FinishTime = cb.FinishTime
 	bs.BuildTypes = cb.Result.BuildTypes()
@@ -207,7 +211,7 @@ func HandleBuildCompleted(ctx context.Context, engineState *store.EngineState, c
 
 	ms.AddCompletedBuild(bs)
 
-	ms.CurrentBuild = model.BuildRecord{}
+	delete(ms.CurrentBuilds, cb.Source)
 	ms.NeedsRebuildFromCrash = false
 
 	handleBuildResults(engineState, mt, bs, cb.Result)

--- a/internal/store/manifest_target_test.go
+++ b/internal/store/manifest_target_test.go
@@ -17,11 +17,11 @@ func TestLocalTargetUpdateStatus(t *testing.T) {
 	assert.Equal(t, v1alpha1.UpdateStatusPending, mt.UpdateStatus())
 	assert.Equal(t, v1alpha1.RuntimeStatusPending, mt.RuntimeStatus())
 
-	mt.State.CurrentBuild = model.BuildRecord{StartTime: time.Now()}
+	mt.State.CurrentBuilds["buildcontrol"] = model.BuildRecord{StartTime: time.Now()}
 	assert.Equal(t, v1alpha1.UpdateStatusPending, mt.UpdateStatus())
 	assert.Equal(t, v1alpha1.RuntimeStatusPending, mt.RuntimeStatus())
 
-	mt.State.CurrentBuild = model.BuildRecord{}
+	delete(mt.State.CurrentBuilds, "buildcontrol")
 	mt.State.AddCompletedBuild(model.BuildRecord{StartTime: time.Now(), FinishTime: time.Now()})
 	assert.Equal(t, v1alpha1.UpdateStatusNotApplicable, mt.UpdateStatus())
 

--- a/internal/store/tiltfiles/reducers.go
+++ b/internal/store/tiltfiles/reducers.go
@@ -17,6 +17,7 @@ func HandleTiltfileUpsertAction(state *store.EngineState, action TiltfileUpsertA
 			Name:          mn,
 			BuildStatuses: make(map[model.TargetID]*store.BuildStatus),
 			DisableState:  v1alpha1.DisableStateEnabled,
+			CurrentBuilds: make(map[string]model.BuildRecord),
 		}
 	}
 

--- a/pkg/model/target.go
+++ b/pkg/model/target.go
@@ -74,7 +74,6 @@ type TargetSpec interface {
 
 type TargetStatus interface {
 	TargetID() TargetID
-	ActiveBuild() BuildRecord
 	LastBuild() BuildRecord
 }
 


### PR DESCRIPTION
Hello @milas, @landism,

Please review the following commits I made in branch nicks/builds:

3ac775bc56a2fed62878271224eee7effc22693d (2022-03-07 12:50:47 -0500)
store: separately track builds from different sources
This should become more important once we handle independent
image builds that can run in parallel.

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics