### PR TITLE
kubernetesapply: when disabling a custom deploy, use the delete cmd, not implicit object cleanup

### DIFF
--- a/internal/controllers/core/kubernetesapply/reconciler.go
+++ b/internal/controllers/core/kubernetesapply/reconciler.go
@@ -135,9 +135,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	r.recordDisableStatus(nn, ka.Spec, *disableStatus)
 
 	// Delete kubernetesapply if it's disabled
+	isDisabling := false
 	gcReason := "garbage collecting Kubernetes objects"
 	if disableStatus.State == v1alpha1.DisableStateDisabled {
 		gcReason = "deleting disabled Kubernetes objects"
+		isDisabling = true
 	} else {
 		// Fetch all the images needed to apply this YAML.
 		imageMaps := make(map[types.NamespacedName]*v1alpha1.ImageMap)
@@ -173,7 +175,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		}
 	}
 
-	toDelete := r.garbageCollect(nn, false)
+	toDelete := r.garbageCollect(nn, isDisabling)
 	r.bestEffortDelete(ctx, nn, toDelete, gcReason)
 
 	newKA, err := r.maybeUpdateStatus(ctx, nn, &ka)


### PR DESCRIPTION
Hello @milas, @landism,

Please review the following commits I made in branch nicks/destroy:

7ee196dd61bdd0b78ddaebff1d87d976e5fed19d (2022-03-09 15:04:52 -0500)
kubernetesapply: when disabling a custom deploy, use the delete cmd, not implicit object cleanup

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics