### PR TITLE
web: re-add shared disabled resources style mixin to fix compilation error

### DIFF
--- a/web/src/OverviewTableColumns.tsx
+++ b/web/src/OverviewTableColumns.tsx
@@ -23,10 +23,10 @@ import OverviewTableStatus from "./OverviewTableStatus"
 import OverviewTableTriggerModeToggle from "./OverviewTableTriggerModeToggle"
 import { useResourceNav } from "./ResourceNav"
 import { useResourceSelection } from "./ResourceSelectionContext"
+import { disabledResourceStyleMixin } from "./ResourceStatus"
 import { useStarredResources } from "./StarredResourcesContext"
 import {
   Color,
-  Font,
   FontSize,
   mixinResetButtonStyle,
   SizeUnit,
@@ -110,9 +110,7 @@ export const Name = styled.button`
   }
 
   &.isDisabled {
-    font-family: ${Font.sansSerif};
-    font-style: italic;
-    font-size: 14px; /* Use non-standard font-size, since sans-serif font looks larger than monospace font */
+    ${disabledResourceStyleMixin}
     color: ${Color.gray60};
   }
 `

--- a/web/src/ResourceStatus.ts
+++ b/web/src/ResourceStatus.ts
@@ -1,9 +1,16 @@
+import { Font } from "./style-helpers"
 import {
   ResourceDisableState,
   ResourceStatus,
   TargetType,
   UIResource,
 } from "./types"
+
+export const disabledResourceStyleMixin = `
+font-family: ${Font.sansSerif};
+font-style: italic;
+font-size: 14px; /* Use non-standard font-size, since sans-serif font looks larger than monospace font */
+`
 
 export function ClassNameFromResourceStatus(rs: ResourceStatus): string {
   switch (rs) {


### PR DESCRIPTION
I added back the `disabledResourceStyleMixin`, since we're using those styles in multiple places. This will fix the compilation error in the main branch.