### PR TITLE
web: make navigation and table options sticky on Table View, plus minor style fixes

### DIFF
--- a/web/src/OverviewTable.test.tsx
+++ b/web/src/OverviewTable.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { SnackbarProvider } from "notistack"
-import React from "react"
+import React, { ReactElement } from "react"
 import { MemoryRouter } from "react-router"
 import {
   cleanupMockAnalyticsCalls,
@@ -33,10 +33,7 @@ import {
   ResourceListOptions,
   ResourceListOptionsProvider,
 } from "./ResourceListOptionsContext"
-import {
-  matchesResourceName,
-  ResourceNameFilterTextField,
-} from "./ResourceNameFilter"
+import { matchesResourceName } from "./ResourceNameFilter"
 import { ResourceSelectionProvider } from "./ResourceSelectionContext"
 import { ResourceStatusSummaryRoot } from "./ResourceStatusSummary"
 import {
@@ -208,8 +205,15 @@ describe("resource name filter", () => {
     })
 
     it("displays a `no matches` message if there are no matches", () => {
-      let el = container.querySelector(`${ResourceNameFilterTextField} input`)!
-      userEvent.type(el, "eek no matches!")
+      container = renderContainer(
+        tableViewWithSettings({
+          view,
+          resourceListOptions: {
+            ...DEFAULT_OPTIONS,
+            resourceNameFilter: "eek no matches!",
+          },
+        })
+      )
 
       expect(container.querySelector(NoMatchesFound)).toBeDefined()
     })
@@ -446,7 +450,7 @@ describe("overview table with groups", () => {
   })
 
   describe("expand and collapse", () => {
-    let groups: any
+    let groups: NodeListOf<Element>
 
     // Helpers
     const getResourceGroups = () => container.querySelectorAll(OverviewGroup)
@@ -502,7 +506,7 @@ describe("overview table with groups", () => {
       const group = groups[0]
       expect(group.classList.contains("Mui-expanded")).toBe(true)
 
-      userEvent.click(group.querySelector('[role="button"]'))
+      userEvent.click(group.querySelector('[role="button"]') as Element)
 
       // Manually refresh the test component tree
       groups = getResourceGroups()
@@ -517,7 +521,7 @@ describe("overview table with groups", () => {
       const initialGroup = groups[0]
       expect(initialGroup.classList.contains("Mui-expanded")).toBe(true)
 
-      userEvent.click(initialGroup.querySelector('[role="button"]'))
+      userEvent.click(initialGroup.querySelector('[role="button"]') as Element)
 
       const group = getResourceGroups()[0]
       expect(group.classList.contains("Mui-expanded")).toBe(false)
@@ -579,14 +583,21 @@ describe("overview table with groups", () => {
 
   describe("resource name filter", () => {
     it("does not display tables in groups when a resource filter is applied", () => {
-      expect(container.querySelectorAll(OverviewGroupName).length).toBe(7)
-
-      userEvent.type(
-        container.querySelector(`${ResourceNameFilterTextField} input`)!,
-        "filtering!"
+      const nameFilterContainer = renderContainer(
+        tableViewWithSettings({
+          view,
+          labelsEnabled: true,
+          resourceListOptions: {
+            resourceNameFilter: "filtering!",
+            alertsOnTop: false,
+            showDisabledResources: true,
+          },
+        })
       )
 
-      expect(container.querySelectorAll(OverviewGroupName).length).toBe(0)
+      expect(
+        nameFilterContainer.querySelectorAll(OverviewGroupName).length
+      ).toBe(0)
     })
   })
 })
@@ -927,7 +938,7 @@ describe("bulk disable actions", () => {
   })
 })
 
-function renderContainer(x: any) {
+function renderContainer(x: ReactElement) {
   let { container } = render(x)
   return container
 }

--- a/web/src/OverviewTable.tsx
+++ b/web/src/OverviewTable.tsx
@@ -34,14 +34,12 @@ import {
   UNLABELED_LABEL,
 } from "./labels"
 import { LogAlertIndex, useLogAlertIndex } from "./LogStore"
-import { OverviewTableBulkActions } from "./OverviewTableBulkActions"
 import {
   getTableColumns,
   ResourceTableHeaderTip,
   rowIsDisabled,
   RowValues,
 } from "./OverviewTableColumns"
-import { OverviewTableDisplayOptions } from "./OverviewTableDisplayOptions"
 import {
   AccordionDetailsStyleResetMixin,
   AccordionStyleResetMixin,
@@ -55,13 +53,13 @@ import {
   ResourceListOptions,
   useResourceListOptions,
 } from "./ResourceListOptionsContext"
-import { matchesResourceName, ResourceNameFilter } from "./ResourceNameFilter"
+import { matchesResourceName } from "./ResourceNameFilter"
 import { useResourceSelection } from "./ResourceSelectionContext"
 import { resourceIsDisabled, resourceTargetType } from "./ResourceStatus"
 import { TableGroupStatusSummary } from "./ResourceStatusSummary"
 import { ShowMoreButton } from "./ShowMoreButton"
 import { buildStatus, runtimeStatus } from "./status"
-import { Color, Font, FontSize, SizeUnit, Width } from "./style-helpers"
+import { Color, Font, FontSize, SizeUnit } from "./style-helpers"
 import { isZeroTime, timeDiff } from "./time"
 import {
   ResourceName,
@@ -96,11 +94,6 @@ type ResourceTableHeadRowProps = {
 } & TableHeaderProps
 
 // Resource name filter styles
-const OverviewTableResourceNameFilter = styled(ResourceNameFilter)`
-  margin-right: ${SizeUnit(1 / 2)};
-  min-width: ${Width.sidebarDefault}px;
-`
-
 export const ResourceResultCount = styled.p`
   color: ${Color.gray50};
   font-size: ${FontSize.small};
@@ -117,10 +110,12 @@ export const NoMatchesFound = styled.p`
 
 // Table styles
 const OverviewTableRoot = styled.section`
-  margin-bottom: ${SizeUnit(1 / 2)};
+  padding-bottom: ${SizeUnit(1 / 2)};
   margin-left: auto;
   margin-right: auto;
+  /* Max and min width are based on fixed table layout and column widths */
   max-width: 2000px;
+  min-width: 1400px;
 
   @media screen and (max-width: 2200px) {
     margin-left: ${SizeUnit(1 / 2)};
@@ -133,12 +128,6 @@ const TableWithoutGroupsRoot = styled.div`
   border: 1px ${Color.gray40} solid;
   border-radius: 0px 0px 8px 8px;
   background-color: ${Color.gray20};
-`
-
-const OverviewTableMenu = styled.section`
-  display: flex;
-  flex-direction: row;
-  align-items: center;
 `
 
 const ResourceTable = styled.table`
@@ -845,11 +834,6 @@ function OverviewTableContent(props: OverviewTableProps) {
 export default function OverviewTable(props: OverviewTableProps) {
   return (
     <OverviewTableRoot aria-label="Resources overview">
-      <OverviewTableMenu aria-label="Resource menu">
-        <OverviewTableResourceNameFilter />
-        <OverviewTableBulkActions uiButtons={props.view.uiButtons} />
-        <OverviewTableDisplayOptions />
-      </OverviewTableMenu>
       <OverviewTableContent {...props} />
     </OverviewTableRoot>
   )

--- a/web/src/OverviewTableColumns.tsx
+++ b/web/src/OverviewTableColumns.tsx
@@ -128,6 +128,7 @@ const DetailText = styled.div`
 
 const StyledLinkSvg = styled(LinkSvg)`
   fill: ${Color.gray50};
+  flex-shrink: 0;
   margin-right: ${SizeUnit(0.2)};
 `
 

--- a/web/src/OverviewTablePane.tsx
+++ b/web/src/OverviewTablePane.tsx
@@ -3,10 +3,13 @@ import styled from "styled-components"
 import { AnalyticsType } from "./analytics"
 import HeaderBar from "./HeaderBar"
 import OverviewTable from "./OverviewTable"
+import { OverviewTableBulkActions } from "./OverviewTableBulkActions"
+import { OverviewTableDisplayOptions } from "./OverviewTableDisplayOptions"
+import { ResourceNameFilter } from "./ResourceNameFilter"
 import StarredResourceBar, {
   starredResourcePropsFromView,
 } from "./StarredResourceBar"
-import { Color } from "./style-helpers"
+import { Color, SizeUnit, Width } from "./style-helpers"
 
 type OverviewTablePaneProps = {
   view: Proto.webviewView
@@ -20,11 +23,37 @@ let OverviewTablePaneStyle = styled.div`
   background-color: ${Color.gray20};
 `
 
+const OverviewTableStickyNav = styled.div`
+  background-color: ${Color.gray20};
+  position: sticky;
+  top: 0;
+  z-index: 1000;
+`
+
+const OverviewTableMenu = styled.section`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+`
+
+const OverviewTableResourceNameFilter = styled(ResourceNameFilter)`
+  margin-left: ${SizeUnit(1 / 2)};
+  margin-right: ${SizeUnit(1 / 2)};
+  min-width: ${Width.sidebarDefault}px;
+`
+
 export default function OverviewTablePane(props: OverviewTablePaneProps) {
   return (
     <OverviewTablePaneStyle>
-      <HeaderBar view={props.view} currentPage={AnalyticsType.Grid} />
-      <StarredResourceBar {...starredResourcePropsFromView(props.view, "")} />
+      <OverviewTableStickyNav>
+        <HeaderBar view={props.view} currentPage={AnalyticsType.Grid} />
+        <StarredResourceBar {...starredResourcePropsFromView(props.view, "")} />
+        <OverviewTableMenu aria-label="Resource menu">
+          <OverviewTableResourceNameFilter />
+          <OverviewTableBulkActions uiButtons={props.view.uiButtons} />
+          <OverviewTableDisplayOptions />
+        </OverviewTableMenu>
+      </OverviewTableStickyNav>
       <OverviewTable view={props.view} />
     </OverviewTablePaneStyle>
   )

--- a/web/src/OverviewTableStatus.tsx
+++ b/web/src/OverviewTableStatus.tsx
@@ -63,7 +63,6 @@ const StyledOverviewTableStatus = styled(Link)`
   }
   &.is-disabled {
     color: ${Color.gray60};
-    pointer-events: none;
   }
 `
 const StatusIcon = styled.span`


### PR DESCRIPTION
This PR moves the resource name filter, bulk actions, starred bar, and display options into the `OverviewTablePane` component and wraps them in a `sticky` container. They'll be visible as a user scrolls through a long list of resources.

I also included a couple minor adjustments so:
* disabled resource status links are clickable
* tables have a minimum width, since the fixed table layout can make content spill outside of the table container on medium and small screens

![2022-03-10 17 37 11](https://user-images.githubusercontent.com/23283986/157771654-ceb73a1d-de24-4474-bf73-442579fa39f4.gif)

[Closes ch12976](https://app.shortcut.com/windmill/story/12976/nice-to-have-make-header-and-options-bar-sticky-to-top-on-table-view)