### PR TITLE
kubernetesapply: improvements to custom cmd

### DIFF
--- a/internal/controllers/core/kubernetesapply/reconciler.go
+++ b/internal/controllers/core/kubernetesapply/reconciler.go
@@ -374,6 +374,7 @@ func (r *Reconciler) runCmdDeploy(ctx context.Context, spec v1alpha1.KubernetesA
 		return nil, err
 	}
 
+	logger.Get(ctx).Infof("Running cmd: %s", cmd.String())
 	exitCode, err := r.execer.Run(ctx, cmd, runIO)
 	if err != nil {
 		return nil, fmt.Errorf("apply command failed: %v", err)

--- a/internal/controllers/core/kubernetesapply/reconciler_test.go
+++ b/internal/controllers/core/kubernetesapply/reconciler_test.go
@@ -3,6 +3,7 @@ package kubernetesapply
 import (
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -130,8 +131,9 @@ func TestBasicApplyCmd(t *testing.T) {
 	assert.Equal(t, yamlOut, ka.Status.ResultYAML)
 
 	assert.Contains(t, f.Stdout(),
-		"Objects applied to cluster:\n       → sancho:deployment\n",
+		"Running cmd: custom-apply-cmd\n     Objects applied to cluster:\n       → sancho:deployment\n",
 		"Log output did not include applied objects")
+	assert.Equal(t, 1, strings.Count(f.Stdout(), "Running cmd"))
 
 	// verify that a re-reconcile does NOT re-invoke the command
 	f.execer.RegisterCommandError("custom-apply-cmd", errors.New("this should not get invoked"))

--- a/pkg/model/cmd.go
+++ b/pkg/model/cmd.go
@@ -112,14 +112,21 @@ func ToBatCmd(cmd string) Cmd {
 		return Cmd{}
 	}
 	// from https://docs.docker.com/engine/reference/builder/#run
-	return Cmd{Argv: []string{"cmd", "/S", "/C", cmd}}
+	//
+	// NOTE(nick): cmd /S /C does not handle multi-line strings correctly.
+	// It will execute the first line, then exit. Should we warn or error about this?
+	//
+	// The TrimSpace ensures we at least execute the first non-empty line.
+	return Cmd{Argv: []string{"cmd", "/S", "/C", strings.TrimSpace(cmd)}}
 }
 
 func ToUnixCmd(cmd string) Cmd {
 	if cmd == "" {
 		return Cmd{}
 	}
-	return Cmd{Argv: []string{"sh", "-c", cmd}}
+
+	// trim spurious spaces and execute them in shell.
+	return Cmd{Argv: []string{"sh", "-c", strings.TrimSpace(cmd)}}
 }
 
 func ToUnixCmdInDir(cmd string, dir string) Cmd {


### PR DESCRIPTION
Hello @milas,

Please review the following commits I made in branch nicks/cmd2:

5066673abc8e1ee456fbe771953a5ffb12bc77c9 (2022-03-11 11:33:51 -0500)
kubernetesapply: improvements to custom cmd
print the command before applying
trim spaces
add a note about multi-line batch scripts on windows

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics