### PR TITLE
Eval plugin for metaprogramming

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,6 @@ require (
 	github.com/mattn/go-colorable v0.1.12
 	github.com/mattn/go-isatty v0.0.14
 	github.com/mattn/go-tty v0.0.3
-	github.com/mitchellh/go-homedir v1.1.0
 	github.com/moby/buildkit v0.8.3
 	github.com/modern-go/reflect2 v1.0.2
 	github.com/opencontainers/go-digest v1.0.0
@@ -166,6 +165,7 @@ require (
 	github.com/mattn/go-shellwords v1.0.12 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
 	github.com/miekg/pkcs11 v1.0.3 // indirect
+	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/go-wordwrap v1.0.0 // indirect
 	github.com/mitchellh/mapstructure v1.4.3 // indirect
 	github.com/moby/locker v1.0.1 // indirect

--- a/internal/tiltfile/eval/eval.go
+++ b/internal/tiltfile/eval/eval.go
@@ -1,0 +1,101 @@
+package eval
+
+import (
+	"fmt"
+
+	"go.starlark.net/starlark"
+
+	"github.com/tilt-dev/tilt/internal/tiltfile/io"
+	"github.com/tilt-dev/tilt/internal/tiltfile/starkit"
+)
+
+type Plugin struct {
+}
+
+func NewPlugin() Plugin {
+	return Plugin{}
+}
+
+type evaluator struct {
+	env *starkit.Environment
+}
+
+func (e Plugin) OnStart(env *starkit.Environment) error {
+	ev := &evaluator{env: env}
+	err := env.AddBuiltin("eval", ev.eval)
+	if err != nil {
+		return err
+	}
+	return env.AddBuiltin("exec", ev.exec)
+}
+
+func (e *evaluator) exec(t *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	src, env, err := e.prepare(t, fn, args, kwargs)
+	if err != nil {
+		return nil, err
+	}
+
+	globals, err := starlark.ExecFile(t, "__exec__", src, env)
+	if err != nil {
+		return nil, err
+	}
+
+	dict := starlark.NewDict(len(globals))
+	for k, v := range globals {
+		err = dict.SetKey(starlark.String(k), v)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return dict, nil
+}
+
+func (e *evaluator) eval(t *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	src, env, err := e.prepare(t, fn, args, kwargs)
+	if err != nil {
+		return nil, err
+	}
+	return starlark.Eval(t, "__eval__", src, env)
+}
+
+func (e *evaluator) prepare(t *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (string, starlark.StringDict, error) {
+	var code starlark.Value
+	err := starkit.UnpackArgs(t, fn.Name(), args, kwargs, "code", &code)
+	if err != nil {
+		return "", nil, err
+	}
+	var src string
+	switch code.(type) {
+	case io.Blob:
+		src = code.String()
+	default:
+		var ok bool
+		src, ok = starlark.AsString(code)
+		if !ok {
+			return "", nil, fmt.Errorf("eval: argument %v is not a string", code)
+		}
+	}
+	env := starlark.StringDict{}
+	depth := t.CallStackDepth()
+	for i := 0; i < depth; i++ {
+		frame := t.DebugFrame(i)
+		callable := frame.Callable()
+		caller, ok := callable.(*starlark.Function)
+		if !ok {
+			continue
+		}
+		for k, v := range caller.Globals() {
+			if !env.Has(k) {
+				env[k] = v
+			}
+		}
+	}
+
+	for k, v := range e.env.Predeclared() {
+		if !env.Has(k) {
+			env[k] = v
+		}
+	}
+
+	return src, env, nil
+}

--- a/internal/tiltfile/eval/eval.go
+++ b/internal/tiltfile/eval/eval.go
@@ -75,27 +75,6 @@ func (e *evaluator) prepare(t *starlark.Thread, fn *starlark.Builtin, args starl
 			return "", nil, fmt.Errorf("eval: argument %v is not a string", code)
 		}
 	}
-	env := starlark.StringDict{}
-	depth := t.CallStackDepth()
-	for i := 0; i < depth; i++ {
-		frame := t.DebugFrame(i)
-		callable := frame.Callable()
-		caller, ok := callable.(*starlark.Function)
-		if !ok {
-			continue
-		}
-		for k, v := range caller.Globals() {
-			if !env.Has(k) {
-				env[k] = v
-			}
-		}
-	}
-
-	for k, v := range e.env.Predeclared() {
-		if !env.Has(k) {
-			env[k] = v
-		}
-	}
-
+	env := e.env.ExtractGlobals(t)
 	return src, env, nil
 }

--- a/internal/tiltfile/starkit/environment.go
+++ b/internal/tiltfile/starkit/environment.go
@@ -76,6 +76,10 @@ func newEnvironment(plugins ...Plugin) *Environment {
 	}
 }
 
+func (e *Environment) Predeclared() starlark.StringDict {
+	return e.predeclared
+}
+
 func (e *Environment) AddLoadInterceptor(i LoadInterceptor) {
 	e.loadInterceptors = append(e.loadInterceptors, i)
 }

--- a/internal/tiltfile/tiltfile_state.go
+++ b/internal/tiltfile/tiltfile_state.go
@@ -37,6 +37,7 @@ import (
 	"github.com/tilt-dev/tilt/internal/tiltfile/config"
 	"github.com/tilt-dev/tilt/internal/tiltfile/dockerprune"
 	"github.com/tilt-dev/tilt/internal/tiltfile/encoding"
+	"github.com/tilt-dev/tilt/internal/tiltfile/eval"
 	"github.com/tilt-dev/tilt/internal/tiltfile/git"
 	"github.com/tilt-dev/tilt/internal/tiltfile/include"
 	"github.com/tilt-dev/tilt/internal/tiltfile/io"
@@ -235,6 +236,7 @@ func (s *tiltfileState) loadManifests(tf *v1alpha1.Tiltfile) ([]model.Manifest, 
 		probe.NewPlugin(),
 		tfv1alpha1.NewPlugin(),
 		hasher.NewPlugin(),
+		eval.NewPlugin(),
 	)
 	if err != nil {
 		return nil, result, starkit.UnpackBacktrace(err)


### PR DESCRIPTION
Toy plugin that implements `eval` and `exec` builtins for metaprogramming fun. Not necessarily intended to be merged.

`eval` takes a starlark expression as a string and returns its result.

`exec` takes any valid starlark code, runs it, and returns a dict of the
resulting symbols that it declared.

Consider the following Tiltfile:

```
def foo():
    print("Hello from %s" % __file__)
    return True

print("1 + 1 = " + repr(eval("1 + 1")))
print("Foo returned: " + repr(eval("foo()")))

bar = exec("""
local_resource("hello", "echo Hi")
def bar():
  print("bar")
""")['bar']

bar()
```

When run, it has the output:

```
Initial Build
Loading Tiltfile at: /private/tmp/Tiltfile
1 + 1 = 2
Hello from /private/tmp/Tiltfile
Foo returned: True
bar
Successfully loaded Tiltfile (751.042µs)
        hello │
        hello │ Initial Build
        hello │ Running cmd: echo Hi
        hello │ Hi
```
