### PR TITLE
ci: use Pulumi context for integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -188,6 +188,8 @@ workflows:
           requires:
             - build-linux
       - test-extensions:
+          context:
+            - Tilt Pulumi Context
           requires:
             - build-linux
       - build-windows:


### PR DESCRIPTION
Mirroring https://github.com/tilt-dev/tilt-extensions/blob/26f6619ab1f99313897a1f068ff862d00bdeb460/.circleci/config.yml#L40-L42