### PR TITLE
ci: fix cross-compilation toolchain + bump to Go 1.17.8

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -6,13 +6,16 @@ RUN go get -u github.com/google/wire/cmd/wire
 
 RUN go get -u golang.org/x/tools/cmd/goimports
 
-RUN sudo apt-get install default-jdk
-
 USER root
 
-RUN curl -sL https://deb.nodesource.com/setup_16.x | bash -
-
-RUN apt-get install -y nodejs
+RUN curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
+    echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
+    curl -sL https://deb.nodesource.com/setup_16.x | bash - && \
+    apt install -y -q --no-install-recommends \
+      default-jdk \
+      nodejs \
+      yarn \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN mv /usr/bin/docker-compose /usr/bin/docker-compose-v1
 ARG DOCKER_COMPOSE_V2_VERSION=v2.2.2
@@ -32,7 +35,7 @@ RUN curl --silent --show-error --location --fail --retry 3 --output /tmp/kustomi
   && tar -xz -C /tmp -f /tmp/kustomize.tar.gz \
   && mv /tmp/kustomize /usr/bin/kustomize
 
-RUN curl --silent --show-error --location --fail --retry 3 --output /tmp/helm.tar.gz  https://get.helm.sh/helm-v3.5.0-linux-amd64.tar.gz \
+RUN curl --silent --show-error --location --fail --retry 3 --output /tmp/helm.tar.gz  https://get.helm.sh/helm-v3.8.1-linux-amd64.tar.gz \
   && tar -xz -C /tmp -f /tmp/helm.tar.gz \
   && mv /tmp/linux-amd64/helm /usr/bin/helm3
 
@@ -45,7 +48,4 @@ RUN /tmp/google-cloud-sdk/install.sh
 
 RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.43.0
 
-RUN curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.22.10
-
 ENV PATH="${PATH}:/tmp/google-cloud-sdk/bin"
-ENV PATH="${PATH}:/home/circleci/.yarn/bin"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
   build-linux:
     resource_class: medium+
     docker:
-      - image: gcr.io/windmill-public-containers/tilt-ci@sha256:2f11a26fc7401a7f0bea1c7d1bf8e5d6aaff846c5d344c1c69d2283430f07ad0
+      - image: gcr.io/windmill-public-containers/tilt-ci@sha256:668ac2e555f10d21c7cb8409c03746ae4e1f92848eca873329eac5244f621709
     # apiserver code generation scripts require being in GOPATH
     working_directory: /go/src/github.com/tilt-dev/tilt
 
@@ -50,7 +50,7 @@ jobs:
 
   publish-assets:
     docker:
-      - image: gcr.io/windmill-public-containers/tilt-ci@sha256:2f11a26fc7401a7f0bea1c7d1bf8e5d6aaff846c5d344c1c69d2283430f07ad0
+      - image: gcr.io/windmill-public-containers/tilt-ci@sha256:668ac2e555f10d21c7cb8409c03746ae4e1f92848eca873329eac5244f621709
     steps:
       - checkout
       - run: echo $GCLOUD_SERVICE_KEY > /tmp/gcloud-service-key.json
@@ -65,7 +65,7 @@ jobs:
       size: "large"
     steps:
       - run: choco install make kustomize kubernetes-helm docker-compose mingw
-      - run: choco upgrade -y --allow-downgrade golang --version=1.17.2
+      - run: choco upgrade -y --allow-downgrade golang --version=1.17.8
       - run: go get -u gotest.tools/gotestsum
       - checkout
       - run: iex ./scripts/install-dc2.ps1
@@ -110,7 +110,7 @@ jobs:
     steps:
       - checkout
       - go/install:
-          version: "1.17.2"
+          version: "1.17.8"
       - run: curl -fsSL "https://github.com/gotestyourself/gotestsum/releases/download/v1.7.0/gotestsum_1.7.0_darwin_amd64.tar.gz" | sudo tar -xz -C /usr/local/bin gotestsum
       # We can't run the container tests on macos because nested
       # VMs don't work on circleci.
@@ -146,10 +146,20 @@ jobs:
       - slack/notify-on-failure:
           only_for_branches: master
 
+  release-verify:
+    resource_class: medium+
+    docker:
+      - image: gcr.io/windmill-public-containers/tilt-releaser@sha256:a9ba28831609c2afc4ecd710814b8b465d18443c9ee3b822d5778f031c8f5fce
+    steps:
+      - checkout
+      # `goreleaser build` generates binaries but does not publish
+      - run: goreleaser build --snapshot --rm-dist
+      - run: make build-js
+
   release:
     resource_class: medium+
     docker:
-      - image: gcr.io/windmill-public-containers/tilt-releaser
+      - image: gcr.io/windmill-public-containers/tilt-releaser@sha256:a9ba28831609c2afc4ecd710814b8b465d18443c9ee3b822d5778f031c8f5fce
     steps:
       - setup_remote_docker:
           version: 20.10.6
@@ -166,15 +176,22 @@ jobs:
       - slack/status:
           mentions: "nick"
 
+parameters:
+  verify_release:
+    default: false
+    type: boolean
+
 workflows:
   version: 2
   shellcheck:
+    unless: << pipeline.parameters.verify_release >>
     jobs:
       - shellcheck/check:
           dir: scripts
           exclude: SC2001
 
   build:
+    unless: << pipeline.parameters.verify_release >>
     # The linux job is cheaper than the others, so run that first.
     jobs:
       - build-linux
@@ -208,7 +225,16 @@ workflows:
             branches:
               only: master
 
+  release-verify:
+    when: << pipeline.parameters.verify_release >>
+    jobs:
+      - release-verify:
+          filters:
+            branches:
+              only: master
+
   release:
+    unless: << pipeline.parameters.verify_release >>
     jobs:
       - release:
           context:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -228,10 +228,7 @@ workflows:
   release-verify:
     when: << pipeline.parameters.verify_release >>
     jobs:
-      - release-verify:
-          filters:
-            branches:
-              only: master
+      - release-verify
 
   release:
     unless: << pipeline.parameters.verify_release >>

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,30 +11,61 @@ builds:
   - amd64
   - arm64
   env:
-  # Compiles against the MacOS FSEvents system libraries.
+  # clang is a cross-compiler by default, so the same CC/CXX works
+  # for arm64 (M1) & amd64 (Intel) builds
   - CGO_ENABLED=1
-  - CC=/osxcross/target/bin/x86_64h-apple-darwin20.2-clang
-  - CXX=/osxcross/target/bin/x86_64h-apple-darwin20.2-clang++
+  - CC=o64h-clang
+  - CXX=o64h-clang++
 - main: ./cmd/tilt/main.go
-  id: tilt
+  id: tilt-linux-arm64
+  flags:
+    - -tags=osusergo
+    - -mod=vendor
+  goos:
+    - linux
+  goarch:
+    - arm64
+  env:
+    - CGO_ENABLED=1
+    - CC=aarch64-linux-gnu-gcc
+    - CXX=aarch64-linux-gnu-g++
+- main: ./cmd/tilt/main.go
+  id: tilt-linux-arm
+  flags:
+    - -tags=osusergo
+    - -mod=vendor
+  goos:
+    - linux
+  goarch:
+    - arm
+  env:
+    - CGO_ENABLED=1
+    - CC=arm-linux-gnueabi-gcc
+    - CXX=arm-linux-gnueabi-g++
+- main: ./cmd/tilt/main.go
+  id: tilt-linux-amd64
+  flags:
+    - -tags=osusergo
+    - -mod=vendor
+  goos:
+    - linux
+  goarch:
+    - amd64
+  env:
+    - CGO_ENABLED=1
+- main: ./cmd/tilt/main.go
+  id: tilt-windows-amd64
   flags:
   - -tags=osusergo
   - -mod=vendor
   goos:
-  - linux
   - windows
   goarch:
   - amd64
-  - arm
-  - arm64
-  # https://goreleaser.com/deprecations/#builds-for-windowsarm64
-  ignore:
-  - goos: windows
-    goarch: arm
-  - goos: windows
-    goarch: arm64
   env:
-  - CGO_ENABLED=0
+    - CGO_ENABLED=1
+    - CC=x86_64-w64-mingw32-gcc
+    - CXX=x86_64-w64-mingw32-g++
 archives:
 - name_template: "{{ .ProjectName }}.{{ .Version }}.{{ .Os }}.{{ .Arch }}"
   replacements:

--- a/scripts/release.Dockerfile
+++ b/scripts/release.Dockerfile
@@ -4,15 +4,16 @@
 # 1) Better leverage OS-specific C headers
 # 2) Be able to do releases from a CI job
 
-FROM gcr.io/windmill-public-containers/golang-cross:1.17.2
+FROM gcr.io/windmill-public-containers/golang-cross:1.17.8-1
 
 RUN apt-get update && \
-    apt-get install -y \
-    apt-transport-https \
-    ca-certificates \
-    curl \
-    gnupg-agent \
-    software-properties-common
+    apt-get install -y -q --no-install-recommends \
+        apt-transport-https \
+        ca-certificates \
+        curl \
+        gnupg-agent \
+        software-properties-common \
+    && rm -rf /var/lib/apt/lists/*
 
 # Install docker
 # Adapted from https://github.com/circleci/circleci-images/blob/staging/shared/images/Dockerfile-basic.template
@@ -29,7 +30,7 @@ RUN set -exu \
   && which docker \
   && (docker version || true)
 
-ENV GORELEASER_VERSION=v0.183.0
+ENV GORELEASER_VERSION=v1.6.3
 RUN set -exu \
   && URL="https://github.com/goreleaser/goreleaser/releases/download/${GORELEASER_VERSION}/goreleaser_Linux_x86_64.tar.gz" \
   && echo goreleaser URL: $URL \
@@ -38,12 +39,13 @@ RUN set -exu \
   && mv /tmp/goreleaser /usr/bin/ \
   && goreleaser --version
 
-RUN curl -sL https://deb.nodesource.com/setup_16.x | bash -
-RUN apt install -y nodejs
-
 RUN curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
     echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
-  apt-get update && apt-get install yarn
+    curl -sL https://deb.nodesource.com/setup_16.x | bash - && \
+    apt install -y -q --no-install-recommends \
+      nodejs \
+      yarn \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN git clone https://github.com/Homebrew/brew /home/linuxbrew/.linuxbrew
 ENV PATH=/home/linuxbrew/.linuxbrew/bin:$PATH


### PR DESCRIPTION
This pulls in changes from tilt-dev/golang-cross#2 and makes the
necessary changes on the Tilt side:
 * Use the updated `golang-cross` base image
   * Minor cleanup to `tilt-releaser` image to reduce layer sizes
 * Split `.goreleaser.yml` into more "builds" by OS/arch and pass
   the proper `CC` / `CXX` flags now that we need cgo for every
   target
 * Re-build generic Tilt CI Linux image to pick up Go 1.17.8 to
   match the releaser
   * Minor cleanup to reduce layer sizes + fix build issue due to
     image having cached IP for apt source
 * Update image references for CircleCI jobs
 * Update Go versions for macOS/Windows CircleCI jobs
   * Linux Go version determined by generic Tilt CI image above
 * Add new `release-verify` job that runs a `goreleaser build` +
   `yarn build` but doesn't publish anything
   * Does not run by default! A pipeline can be manually kicked
     off for a branch with the `verify_release` parameter set to
     `true`, which will only run the verify workflow and not the
     standard build/test jobs
   * Can be used to safely verify build changes pre-release on
     feature branches (e.g. after upgrading deps in `go.mod` or
     messing with Webpack configs)