### PR TITLE
integration: wait for resource to become ready before disabling

### DIFF
--- a/integration/disable_test.go
+++ b/integration/disable_test.go
@@ -43,13 +43,20 @@ func TestDisableDC(t *testing.T) {
 	ctx, cancel := context.WithTimeout(f.ctx, time.Minute)
 	defer cancel()
 
+	f.WaitUntil(ctx, "uiresource available", func() (string, error) {
+		out, err := f.tilt.Get(ctx, "uiresource")
+		return string(out), err
+	}, "disabletest")
+
+	f.runOrFail(f.tilt.cmd(ctx, []string{"wait", "--for=condition=Ready", "uiresource/disabletest"}, nil), "wait")
+
 	psArgs := []string{
 		"ps", "-f", "name=disabletest", "--format", "{{.Image}}",
 	}
 
-	f.WaitUntil(ctx, "service up", func() (string, error) {
-		return f.dockerCmdOutput(psArgs)
-	}, "disabletest")
+	out, err := f.dockerCmdOutput(psArgs)
+	require.NoError(t, err)
+	require.Contains(t, out, "disabletest")
 
 	f.WaitUntil(ctx, "disable configmap available", func() (string, error) {
 		out, err := f.tilt.Get(ctx, "configmap")


### PR DESCRIPTION
Hello @nicksieger, @landism,

Please review the following commits I made in branch nicks/flake2:

f589a550f11f7b515c163cf4835d35b0307f6b95 (2022-03-15 12:58:24 -0400)
integration: wait for resource to become ready before disabling

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics