### PR TITLE
k8s: add cluster/apiserver health check method

### DIFF
--- a/internal/k8s/exploding_client.go
+++ b/internal/k8s/exploding_client.go
@@ -98,3 +98,7 @@ func (ec *explodingClient) CheckConnected(ctx context.Context) (*version.Info, e
 func (ec *explodingClient) OwnerFetcher() OwnerFetcher {
 	return NewOwnerFetcher(context.Background(), ec)
 }
+
+func (ec *explodingClient) ClusterHealth(_ context.Context, _ bool) (ClusterHealth, error) {
+	return ClusterHealth{}, errors.Wrap(ec.err, "could not set up kubernetes client")
+}


### PR DESCRIPTION
This will be used to poll for cluster health and update the Tilt
`Cluster` status object in the (Tilt) apiserver accordingly.