### PR TITLE
k8s: fix cluster health & add tests

### DIFF
--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -746,7 +746,7 @@ func (k *K8sClient) apiServerHealthCheck(ctx context.Context, route string, verb
 	}
 	body, err := req.DoRaw(ctx)
 	if err != nil {
-		var statusErr apierrors.StatusError
+		var statusErr *apierrors.StatusError
 		if errors.As(err, &statusErr) {
 			return false, statusErr.ErrStatus.Message, nil
 		}

--- a/internal/k8s/watch_test.go
+++ b/internal/k8s/watch_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/rest"
 
 	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
@@ -362,10 +363,15 @@ func TestSupportsPartialMeta(t *testing.T) {
 
 type fakeDiscovery struct {
 	*difake.FakeDiscovery
+	restClient rest.Interface
 }
 
 func (fakeDiscovery) Fresh() bool { return true }
 func (fakeDiscovery) Invalidate() {}
+
+func (f fakeDiscovery) RESTClient() rest.Interface {
+	return f.restClient
+}
 
 type watchTestFixture struct {
 	t    *testing.T


### PR DESCRIPTION
Pointer receivers strike again! The `errors.As` check would fail
because `*apierrors.StatusError` is what implements `error`, so
need a pointer-to-a-pointer.

Added some tests that I should have included in the first place
now that I figured out how to fake the raw REST client responses
(surprisingly easy!)