### PR TITLE
cluster: refactor client initialization

### DIFF
--- a/internal/cli/wire_gen.go
+++ b/internal/cli/wire_gen.go
@@ -336,7 +336,9 @@ func wireCmdUp(ctx context.Context, analytics3 *analytics.TiltAnalytics, cmdTags
 	configmapReconciler := configmap.NewReconciler(deferredClient, storeStore)
 	dockerimageReconciler := dockerimage.NewReconciler(deferredClient)
 	cmdimageReconciler := cmdimage.NewReconciler(deferredClient)
-	clusterReconciler := cluster.NewReconciler(ctx, deferredClient, storeStore, localEnv, connectionManager)
+	dockerClientFactory := _wireDockerClientFuncValue
+	kubernetesClientFactory := _wireKubernetesClientFuncValue
+	clusterReconciler := cluster.NewReconciler(ctx, deferredClient, storeStore, connectionManager, localEnv, dockerClientFactory, kubernetesClientFactory)
 	disableSubscriber := dockercomposeservice.NewDisableSubscriber(ctx, dockerComposeClient, clock)
 	dockercomposeserviceReconciler := dockercomposeservice.NewReconciler(deferredClient, dockerComposeClient, compositeClient, storeStore, scheme, disableSubscriber)
 	v := controllers.ProvideControllers(controller, cmdController, podlogstreamController, reconciler, kubernetesapplyReconciler, uisessionReconciler, uiresourceReconciler, uibuttonReconciler, portforwardReconciler, tiltfileReconciler, togglebuttonReconciler, extensionReconciler, extensionrepoReconciler, liveupdateReconciler, configmapReconciler, dockerimageReconciler, cmdimageReconciler, clusterReconciler, dockercomposeserviceReconciler)
@@ -401,10 +403,12 @@ func wireCmdUp(ctx context.Context, analytics3 *analytics.TiltAnalytics, cmdTags
 }
 
 var (
-	_wireLabelsValue     = dockerfile.Labels{}
-	_wireEngineModeValue = store.EngineModeUp
-	_wireOpenURLValue    = openurl.OpenURL(openurl.BrowserOpen)
-	_wireOpenInputValue  = prompt.OpenInput(prompt.TTYOpen)
+	_wireLabelsValue               = dockerfile.Labels{}
+	_wireEngineModeValue           = store.EngineModeUp
+	_wireDockerClientFuncValue     = cluster.DockerClientFunc(cluster.DockerClientFromEnv)
+	_wireKubernetesClientFuncValue = cluster.KubernetesClientFunc(cluster.KubernetesClientFromEnv)
+	_wireOpenURLValue              = openurl.OpenURL(openurl.BrowserOpen)
+	_wireOpenInputValue            = prompt.OpenInput(prompt.TTYOpen)
 )
 
 func wireCmdCI(ctx context.Context, analytics3 *analytics.TiltAnalytics, subcommand model.TiltSubcommand) (CmdCIDeps, error) {
@@ -545,7 +549,9 @@ func wireCmdCI(ctx context.Context, analytics3 *analytics.TiltAnalytics, subcomm
 	configmapReconciler := configmap.NewReconciler(deferredClient, storeStore)
 	dockerimageReconciler := dockerimage.NewReconciler(deferredClient)
 	cmdimageReconciler := cmdimage.NewReconciler(deferredClient)
-	clusterReconciler := cluster.NewReconciler(ctx, deferredClient, storeStore, localEnv, connectionManager)
+	dockerClientFactory := _wireDockerClientFuncValue
+	kubernetesClientFactory := _wireKubernetesClientFuncValue
+	clusterReconciler := cluster.NewReconciler(ctx, deferredClient, storeStore, connectionManager, localEnv, dockerClientFactory, kubernetesClientFactory)
 	disableSubscriber := dockercomposeservice.NewDisableSubscriber(ctx, dockerComposeClient, clock)
 	dockercomposeserviceReconciler := dockercomposeservice.NewReconciler(deferredClient, dockerComposeClient, compositeClient, storeStore, scheme, disableSubscriber)
 	v := controllers.ProvideControllers(controller, cmdController, podlogstreamController, reconciler, kubernetesapplyReconciler, uisessionReconciler, uiresourceReconciler, uibuttonReconciler, portforwardReconciler, tiltfileReconciler, togglebuttonReconciler, extensionReconciler, extensionrepoReconciler, liveupdateReconciler, configmapReconciler, dockerimageReconciler, cmdimageReconciler, clusterReconciler, dockercomposeserviceReconciler)
@@ -752,7 +758,9 @@ func wireCmdUpdog(ctx context.Context, analytics3 *analytics.TiltAnalytics, cmdT
 	configmapReconciler := configmap.NewReconciler(deferredClient, storeStore)
 	dockerimageReconciler := dockerimage.NewReconciler(deferredClient)
 	cmdimageReconciler := cmdimage.NewReconciler(deferredClient)
-	clusterReconciler := cluster.NewReconciler(ctx, deferredClient, storeStore, localEnv, connectionManager)
+	dockerClientFactory := _wireDockerClientFuncValue
+	kubernetesClientFactory := _wireKubernetesClientFuncValue
+	clusterReconciler := cluster.NewReconciler(ctx, deferredClient, storeStore, connectionManager, localEnv, dockerClientFactory, kubernetesClientFactory)
 	disableSubscriber := dockercomposeservice.NewDisableSubscriber(ctx, dockerComposeClient, clock)
 	dockercomposeserviceReconciler := dockercomposeservice.NewReconciler(deferredClient, dockerComposeClient, compositeClient, storeStore, scheme, disableSubscriber)
 	v := controllers.ProvideControllers(controller, cmdController, podlogstreamController, reconciler, kubernetesapplyReconciler, uisessionReconciler, uiresourceReconciler, uibuttonReconciler, portforwardReconciler, tiltfileReconciler, togglebuttonReconciler, extensionReconciler, extensionrepoReconciler, liveupdateReconciler, configmapReconciler, dockerimageReconciler, cmdimageReconciler, clusterReconciler, dockercomposeserviceReconciler)

--- a/internal/controllers/core/cluster/client.go
+++ b/internal/controllers/core/cluster/client.go
@@ -1,0 +1,69 @@
+package cluster
+
+import (
+	"context"
+
+	"github.com/tilt-dev/tilt/internal/docker"
+	"github.com/tilt-dev/tilt/internal/k8s"
+)
+
+type KubernetesClientFactory interface {
+	New(ctx context.Context, contextOverride k8s.KubeContextOverride, namespaceOverride k8s.NamespaceOverride) (k8s.Client, error)
+}
+
+type KubernetesClientFunc func(ctx context.Context, contextOverride k8s.KubeContextOverride, namespaceOverride k8s.NamespaceOverride) (k8s.Client, error)
+
+func (k KubernetesClientFunc) New(ctx context.Context, contextOverride k8s.KubeContextOverride, namespaceOverride k8s.NamespaceOverride) (k8s.Client, error) {
+	return k(ctx, contextOverride, namespaceOverride)
+}
+
+type DockerClientFactory interface {
+	New(ctx context.Context, env docker.Env) (docker.Client, error)
+}
+
+type DockerClientFunc func(ctx context.Context, env docker.Env) (docker.Client, error)
+
+func (d DockerClientFunc) New(ctx context.Context, env docker.Env) (docker.Client, error) {
+	return d(ctx, env)
+}
+
+func DockerClientFromEnv(ctx context.Context, env docker.Env) (docker.Client, error) {
+	client := docker.NewDockerClient(ctx, env)
+	err := client.CheckConnected()
+	if err != nil {
+		return nil, err
+	}
+	return client, nil
+}
+
+// KubernetesClientFromEnv creates a client based on the machine environment.
+//
+// The Kubernetes Client APIs are really defined for automatic dependency injection.
+// (as opposed to the Kubernetes convention of nested factory structs.)
+//
+// If you have to edit the below, it's easier to let wire generate the
+// factory code for you, then adapt it here.
+func KubernetesClientFromEnv(ctx context.Context, contextOverride k8s.KubeContextOverride, namespaceOverride k8s.NamespaceOverride) (k8s.Client, error) {
+	clientConfig := k8s.ProvideClientConfig(contextOverride, namespaceOverride)
+	apiConfig, err := k8s.ProvideKubeConfig(clientConfig, contextOverride)
+	if err != nil {
+		return nil, err
+	}
+	env := k8s.ProvideEnv(ctx, apiConfig)
+	restConfigOrError := k8s.ProvideRESTConfig(clientConfig)
+
+	clientsetOrError := k8s.ProvideClientset(restConfigOrError)
+	portForwardClient := k8s.ProvidePortForwardClient(restConfigOrError, clientsetOrError)
+	namespace := k8s.ProvideConfigNamespace(clientConfig)
+	kubeContext, err := k8s.ProvideKubeContext(apiConfig)
+	if err != nil {
+		return nil, err
+	}
+	minikubeClient := k8s.ProvideMinikubeClient(kubeContext)
+	client := k8s.ProvideK8sClient(ctx, env, restConfigOrError, clientsetOrError, portForwardClient, namespace, minikubeClient, clientConfig)
+	_, err = client.CheckConnected(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return client, nil
+}

--- a/internal/controllers/core/cluster/client_fake.go
+++ b/internal/controllers/core/cluster/client_fake.go
@@ -1,0 +1,30 @@
+package cluster
+
+import (
+	"context"
+
+	"github.com/tilt-dev/tilt/internal/docker"
+	"github.com/tilt-dev/tilt/internal/k8s"
+)
+
+func FakeKubernetesClientOrError(client k8s.Client, err error) KubernetesClientFactory {
+	return KubernetesClientFunc(func(
+		_ context.Context,
+		_ k8s.KubeContextOverride,
+		_ k8s.NamespaceOverride,
+	) (k8s.Client, error) {
+		if err != nil {
+			return nil, err
+		}
+		return client, nil
+	})
+}
+
+func FakeDockerClientOrError(client docker.Client, err error) DockerClientFactory {
+	return DockerClientFunc(func(_ context.Context, _ docker.Env) (docker.Client, error) {
+		if err != nil {
+			return nil, err
+		}
+		return client, nil
+	})
+}

--- a/internal/controllers/core/cluster/wire.go
+++ b/internal/controllers/core/cluster/wire.go
@@ -9,4 +9,6 @@ import (
 var WireSet = wire.NewSet(
 	NewConnectionManager,
 	wire.Bind(new(cluster.ClientProvider), new(*ConnectionManager)),
+	wire.InterfaceValue(new(KubernetesClientFactory), KubernetesClientFunc(KubernetesClientFromEnv)),
+	wire.InterfaceValue(new(DockerClientFactory), DockerClientFunc(DockerClientFromEnv)),
 )

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -30,6 +30,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/tilt-dev/wmclient/pkg/analytics"
+
 	tiltanalytics "github.com/tilt-dev/tilt/internal/analytics"
 	"github.com/tilt-dev/tilt/internal/cloud"
 	"github.com/tilt-dev/tilt/internal/container"
@@ -108,7 +110,6 @@ import (
 	"github.com/tilt-dev/tilt/pkg/model"
 	"github.com/tilt-dev/tilt/pkg/model/logstore"
 	proto_webview "github.com/tilt-dev/tilt/pkg/webview"
-	"github.com/tilt-dev/wmclient/pkg/analytics"
 )
 
 var originalWD string
@@ -3533,8 +3534,9 @@ func newTestFixture(t *testing.T, options ...fixtureOptions) *testFixture {
 	lur := liveupdate.NewFakeReconciler(st, cu, cdc)
 	dir := dockerimage.NewReconciler(cdc)
 	cir := cmdimage.NewReconciler(cdc)
-	clr := cluster.NewReconciler(ctx, cdc, st, docker.LocalEnv{}, clusterClients)
-	clr.SetFakeClientsForTesting(kClient, dockerClient)
+	clr := cluster.NewReconciler(ctx, cdc, st, clusterClients, docker.LocalEnv{},
+		cluster.FakeDockerClientOrError(dockerClient, nil),
+		cluster.FakeKubernetesClientOrError(kClient, nil))
 
 	cb := controllers.NewControllerBuilder(tscm, controllers.ProvideControllers(
 		fwc,


### PR DESCRIPTION
The motivation here is in preparation for cluster status polling
to make it possible to write more robust unit tests. Currently,
the reconciler behaved very differently when provided with fake
clients for test. (In fact, there was actually a bug as a result
of this! The `ConnectedAt` timestamp handling was different for
tests.)

Now, there's factories for both K8s/Docker clients that get
injected, and tests can override these. Helper methods are
offered to return a static client for all created connections
or an error.

This latter part is critical to simulating errors with fake clients
in a controlled fashion to verify the (forthcoming) retry behavior.