### PR TITLE
dockercomposeservice: fix some test race conditions

### DIFF
--- a/internal/controllers/core/dockercomposeservice/disable_watcher_test.go
+++ b/internal/controllers/core/dockercomposeservice/disable_watcher_test.go
@@ -37,7 +37,7 @@ Going to remove servantes_fortune_1
 	f.clock.Advance(20 * disableDebounceDelay)
 	f.startTime = f.clock.Now()
 
-	require.NoError(t, f.log.WaitUntilContains("Stopping servantes", 20*time.Millisecond))
+	require.NoError(t, f.log.WaitUntilContains("Stopping servantes", time.Second))
 	expectedOutput := strings.Replace(f.dcClient.RmOutput, "Going to remove servantes_fortune_1\n", "", -1)
 	require.Equal(t, expectedOutput, f.log.String())
 }
@@ -84,10 +84,11 @@ func TestDockerComposeRetryIfStartTimeChanges(t *testing.T) {
 	f.updateQueue("m1", v1alpha1.DisableStateDisabled)
 	f.updateQueue("m2", v1alpha1.DisableStateEnabled)
 	require.Len(t, f.dcClient.RmCalls(), 0)
+	f.clock.BlockUntil(1)
 
 	f.updateQueue("m2", v1alpha1.DisableStateDisabled)
-
 	f.clock.BlockUntil(2)
+
 	f.clock.Advance(2 * disableDebounceDelay)
 
 	require.Eventually(t, func() bool {
@@ -113,7 +114,7 @@ func TestDockerComposeDontDisableIfReenabledDuringDebounce(t *testing.T) {
 	f.updateQueue("m1", v1alpha1.DisableStateDisabled)
 	f.updateQueue("m2", v1alpha1.DisableStateDisabled)
 
-	f.clock.BlockUntil(1)
+	f.clock.BlockUntil(2)
 
 	// reenable m2 during debounce
 	f.updateQueue("m2", v1alpha1.DisableStateEnabled)


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/flake:

c21469ab04c1ffe1c7208c473d9b279b622db19d (2022-03-22 17:22:07 -0400)
dockercomposeservice: fix some test race conditions
Most of these are caused by https://github.com/jonboulle/clockwork/issues/35

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics