### PR TITLE
feature: mark the live_update_v2 flag as obsolete

### DIFF
--- a/internal/feature/flags.go
+++ b/internal/feature/flags.go
@@ -68,7 +68,7 @@ var MainDefaults = Defaults{
 	},
 	LiveUpdateV2: Value{
 		Enabled: true,
-		Status:  Active,
+		Status:  Obsolete,
 	},
 	DisableResources: Value{
 		Enabled: true,

--- a/internal/tiltfile/docker_compose.go
+++ b/internal/tiltfile/docker_compose.go
@@ -24,7 +24,6 @@ import (
 	"github.com/tilt-dev/tilt/internal/container"
 	"github.com/tilt-dev/tilt/internal/controllers/apis/liveupdate"
 	"github.com/tilt-dev/tilt/internal/dockercompose"
-	"github.com/tilt-dev/tilt/internal/feature"
 	"github.com/tilt-dev/tilt/internal/tiltfile/io"
 	"github.com/tilt-dev/tilt/internal/tiltfile/links"
 	"github.com/tilt-dev/tilt/internal/tiltfile/starkit"
@@ -401,14 +400,12 @@ func (s *tiltfileState) dcServiceToManifest(service *dcService, dcSet dcResource
 		mds = append(mds, model.ManifestName(md))
 	}
 
-	if s.features.Get(feature.LiveUpdateV2) {
-		for i, iTarget := range iTargets {
-			if liveupdate.IsEmptySpec(iTarget.LiveUpdateSpec) {
-				continue
-			}
-			iTarget.LiveUpdateReconciler = true
-			iTargets[i] = iTarget
+	for i, iTarget := range iTargets {
+		if liveupdate.IsEmptySpec(iTarget.LiveUpdateSpec) {
+			continue
 		}
+		iTarget.LiveUpdateReconciler = true
+		iTargets[i] = iTarget
 	}
 
 	m := model.Manifest{

--- a/internal/tiltfile/tiltfile_state.go
+++ b/internal/tiltfile/tiltfile_state.go
@@ -1127,14 +1127,12 @@ func (s *tiltfileState) translateK8s(resources []*k8sResource, updateSettings mo
 			return nil, errors.Wrapf(err, "getting image build info for %s", r.name)
 		}
 
-		if s.features.Get(feature.LiveUpdateV2) {
-			for i, iTarget := range iTargets {
-				if liveupdate.IsEmptySpec(iTarget.LiveUpdateSpec) {
-					continue
-				}
-				iTarget.LiveUpdateReconciler = true
-				iTargets[i] = iTarget
+		for i, iTarget := range iTargets {
+			if liveupdate.IsEmptySpec(iTarget.LiveUpdateSpec) {
+				continue
 			}
+			iTarget.LiveUpdateReconciler = true
+			iTargets[i] = iTarget
 		}
 
 		m = m.WithImageTargets(iTargets)


### PR DESCRIPTION
Hello @landism, @milas,

Please review the following commits I made in branch nicks/liveupdateflag:

628032535b3c57a29b67442e2f43335801bc0bb6 (2022-03-24 15:28:47 -0400)
feature: mark the live_update_v2 flag as obsolete

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics