### PR TITLE
test: add tests for live update execs and restarts

### DIFF
--- a/internal/controllers/fake/fixture.go
+++ b/internal/controllers/fake/fixture.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -205,7 +206,9 @@ func (f *ControllerFixture) Upsert(o object) ctrl.Result {
 	f.t.Helper()
 
 	err := f.Client.Create(f.ctx, o)
-	if apierrors.IsAlreadyExists(err) {
+	if err != nil &&
+		(apierrors.IsAlreadyExists(err) ||
+			strings.Contains(err.Error(), "resourceVersion can not be set for Create requests")) {
 		update := o.DeepCopyObject().(object)
 
 		require.NoError(f.t, f.Client.Get(f.ctx, f.KeyForObject(o), o))


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/restartpolicy:

c71e0bc0633efb27e4000f3a84ddc0dea8e6cadd (2022-03-24 16:00:32 -0400)
test: add tests for live update execs and restarts

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics