### PR TITLE
cluster: populate local registry information

### DIFF
--- a/internal/controllers/core/cluster/cache.go
+++ b/internal/controllers/core/cluster/cache.go
@@ -9,6 +9,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
+	"github.com/tilt-dev/tilt/internal/container"
 	"github.com/tilt-dev/tilt/internal/controllers/apis/cluster"
 	"github.com/tilt-dev/tilt/internal/docker"
 	"github.com/tilt-dev/tilt/internal/k8s"
@@ -41,6 +42,7 @@ type connection struct {
 	error        string
 	createdAt    time.Time
 	arch         string
+	registry     *container.Registry
 }
 
 func (k *ConnectionManager) GetK8sClient(clusterKey types.NamespacedName) (k8s.Client, metav1.MicroTime, error) {


### PR DESCRIPTION
This PR populates the local registry info in the cluster API object. (Once #5631 is merged in, I'll point this PR to the main branch.)