### PR TITLE
liveupdate: display exec errors correctly

### DIFF
--- a/internal/controllers/core/liveupdate/reconciler_test.go
+++ b/internal/controllers/core/liveupdate/reconciler_test.go
@@ -2,6 +2,8 @@ package liveupdate
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -13,6 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	"github.com/tilt-dev/tilt/internal/build"
 	"github.com/tilt-dev/tilt/internal/containerupdate"
 	"github.com/tilt-dev/tilt/internal/controllers/apis/configmap"
 	"github.com/tilt-dev/tilt/internal/controllers/apis/liveupdate"
@@ -720,12 +723,94 @@ func TestDockerComposeExecs(t *testing.T) {
 		assert.Equal(t, txtChangeTime, lu.Status.Containers[0].LastFileTimeSynced)
 	}
 
+	// Make sure there were no exec errors.
+	if assert.NotNil(t, f.st.lastCompletedAction) {
+		assert.Nil(t, f.st.lastCompletedAction.Error)
+	}
+
 	// Make sure two cmds were executed, and one was skipped.
 	if assert.Equal(t, 1, len(f.cu.Calls)) {
 		assert.Equal(t, []model.Cmd{
 			model.ToUnixCmd("./foo.sh bar"),
 			model.ToUnixCmd("yarn install"),
 		}, f.cu.Calls[0].Cmds)
+	}
+}
+
+func TestDockerComposeExecInfraFailure(t *testing.T) {
+	f := newFixture(t)
+
+	p, _ := os.Getwd()
+	nowMicro := apis.NowMicro()
+	txtPath := filepath.Join(p, "a.txt")
+	txtChangeTime := metav1.MicroTime{Time: nowMicro.Add(time.Second)}
+
+	f.setupDockerComposeFrontend()
+
+	var lu v1alpha1.LiveUpdate
+	f.MustGet(types.NamespacedName{Name: "frontend-liveupdate"}, &lu)
+
+	execs := []v1alpha1.LiveUpdateExec{
+		{Args: model.ToUnixCmd("echo error && exit 1").Argv},
+	}
+	lu.Spec.Execs = execs
+	f.Upsert(&lu)
+
+	f.cu.SetUpdateErr(fmt.Errorf("cluster connection lost"))
+
+	// Trigger a file event, and make sure that the status reflects the sync.
+	f.addFileEvent("frontend-fw", txtPath, txtChangeTime)
+	f.MustReconcile(types.NamespacedName{Name: "frontend-liveupdate"})
+
+	f.MustGet(types.NamespacedName{Name: "frontend-liveupdate"}, &lu)
+	if assert.NotNil(t, lu.Status.Failed) {
+		assert.Equal(t, "UpdateFailed", lu.Status.Failed.Reason)
+		assert.Equal(t, "Updating container main-id: cluster connection lost",
+			lu.Status.Failed.Message)
+	}
+
+	// Make sure there were  exec errors.
+	if assert.NotNil(t, f.st.lastCompletedAction) {
+		assert.Equal(t, "Updating container main-id: cluster connection lost",
+			f.st.lastCompletedAction.Error.Error())
+	}
+}
+
+func TestDockerComposeExecRunFailure(t *testing.T) {
+	f := newFixture(t)
+
+	p, _ := os.Getwd()
+	nowMicro := apis.NowMicro()
+	txtPath := filepath.Join(p, "a.txt")
+	txtChangeTime := metav1.MicroTime{Time: nowMicro.Add(time.Second)}
+
+	f.setupDockerComposeFrontend()
+
+	var lu v1alpha1.LiveUpdate
+	f.MustGet(types.NamespacedName{Name: "frontend-liveupdate"}, &lu)
+
+	execs := []v1alpha1.LiveUpdateExec{
+		{Args: model.ToUnixCmd("echo error && exit 1").Argv},
+	}
+	lu.Spec.Execs = execs
+	f.Upsert(&lu)
+
+	f.cu.SetUpdateErr(build.NewRunStepFailure(errors.New("compilation failed")))
+
+	// Trigger a file event, and make sure that the status reflects the sync.
+	f.addFileEvent("frontend-fw", txtPath, txtChangeTime)
+	f.MustReconcile(types.NamespacedName{Name: "frontend-liveupdate"})
+
+	f.MustGet(types.NamespacedName{Name: "frontend-liveupdate"}, &lu)
+	assert.Nil(t, lu.Status.Failed)
+	if assert.Equal(t, 1, len(lu.Status.Containers)) {
+		assert.Equal(t, "compilation failed", lu.Status.Containers[0].LastExecError)
+	}
+
+	// Make sure there were  exec errors.
+	if assert.NotNil(t, f.st.lastCompletedAction) {
+		assert.Equal(t, "compilation failed",
+			f.st.lastCompletedAction.Error.Error())
 	}
 }
 


### PR DESCRIPTION
Hello @landism,

Please review the following commits I made in branch nicks/execerror:

4b7eb165ccc34afdc836193fed14321602e700e1 (2022-03-28 16:00:17 -0400)
liveupdate: display exec errors correctly
fixes https://github.com/tilt-dev/tilt/issues/5635

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics