### PR TITLE
buildcontrol: remove live update state from build state

### DIFF
--- a/internal/engine/buildcontroller.go
+++ b/internal/engine/buildcontroller.go
@@ -222,30 +222,7 @@ func buildStateSet(ctx context.Context, manifest model.Manifest,
 			depsChanged = append(depsChanged, dep)
 		}
 
-		buildState := store.NewBuildState(status.LastResult, filesChanged, depsChanged)
-
-		// Pass along the container when we can update containers in-place.
-		//
-		// We don't want to pass along the data if the pod is crashing, because
-		// we're not confident that this state is accurate, due to how orchestrators
-		// (like k8s) reschedule containers (i.e., they reset to the original image
-		// rather than persisting the container filesystem.)
-		//
-		// This will probably need to change as the mapping between containers and
-		// manifests becomes many-to-one.
-		iTarget, ok := spec.(model.ImageTarget)
-		if ok {
-			selector := iTarget.LiveUpdateSpec.Selector
-			if manifest.IsK8s() && selector.Kubernetes != nil {
-				buildState.KubernetesSelector = selector.Kubernetes
-				buildState.KubernetesResource = kresource
-			}
-
-			if manifest.IsDC() {
-				buildState.DockerComposeService = dcs
-			}
-		}
-		result[id] = buildState
+		result[id] = store.NewBuildState(status.LastResult, filesChanged, depsChanged)
 	}
 
 	isFullBuildTrigger := reason.HasTrigger() && !buildcontrol.IsLiveUpdateEligibleTrigger(manifest, reason)

--- a/internal/store/build_result.go
+++ b/internal/store/build_result.go
@@ -196,12 +196,6 @@ type BuildState struct {
 	// This field indicates case 1 || case 2 -- i.e. that we should skip
 	// live_update, and force an image build (even if there are no changed files)
 	FullBuildTriggered bool
-
-	KubernetesSelector *v1alpha1.LiveUpdateKubernetesSelector
-
-	KubernetesResource *k8sconv.KubernetesResource
-
-	DockerComposeService *v1alpha1.DockerComposeService
 }
 
 func NewBuildState(result BuildResult, files []string, pendingDeps []model.TargetID) BuildState {

--- a/internal/store/liveupdates/fake.go
+++ b/internal/store/liveupdates/fake.go
@@ -3,25 +3,9 @@ package liveupdates
 import (
 	"sort"
 
-	"github.com/tilt-dev/tilt/internal/store"
 	"github.com/tilt-dev/tilt/internal/store/k8sconv"
 	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
 )
-
-func WithFakeK8sContainers(s store.BuildState, imageName string, containers []Container) store.BuildState {
-	s.KubernetesSelector = &v1alpha1.LiveUpdateKubernetesSelector{Image: imageName}
-	s.KubernetesResource = FakeKubernetesResource(imageName, containers)
-	return s
-}
-
-func WithFakeDCContainer(s store.BuildState, container Container) store.BuildState {
-	s.DockerComposeService = &v1alpha1.DockerComposeService{
-		Status: v1alpha1.DockerComposeServiceStatus{
-			ContainerID: string(container.ContainerID),
-		},
-	}
-	return s
-}
 
 func FakeKubernetesResource(image string, containers []Container) *k8sconv.KubernetesResource {
 	r, err := k8sconv.NewKubernetesResource(FakeKubernetesDiscovery(image, containers), nil)


### PR DESCRIPTION
Hello @landism,

Please review the following commits I made in branch nicks/liveupdate2:

6457079b35132eb660cb4137170ac9466ae7306d (2022-03-29 11:47:47 -0400)
buildcontrol: remove live update state from build state

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics