### PR TITLE
buildcontrol: put the Cluster in BuildState

### DIFF
--- a/internal/engine/buildcontrol/build_control.go
+++ b/internal/engine/buildcontrol/build_control.go
@@ -230,8 +230,6 @@ func HoldTargetsWithBuildingComponents(state store.EngineState, mts []*store.Man
 }
 
 func targetsByCluster(mts []*store.ManifestTarget) map[string][]*store.ManifestTarget {
-	// TODO(nick): In the future, K8s objects may reference the cluster
-	// they're deploying to.
 	clusters := make(map[string][]*store.ManifestTarget)
 	for _, mt := range mts {
 		if mt.Manifest.IsK8s() {

--- a/internal/engine/buildcontrol/image_build_and_deployer_test.go
+++ b/internal/engine/buildcontrol/image_build_and_deployer_test.go
@@ -989,17 +989,17 @@ func TestTwoManifestsWithSameTwoImages(t *testing.T) {
 func TestPlatformFromCluster(t *testing.T) {
 	f := newIBDFixture(t, clusterid.ProductGKE)
 
-	f.upsert(&v1alpha1.Cluster{
+	cluster := &v1alpha1.Cluster{
 		ObjectMeta: metav1.ObjectMeta{Name: "default"},
 		Status: v1alpha1.ClusterStatus{
 			Arch: "amd64",
 		},
-	})
+	}
 
 	m := NewSanchoDockerBuildManifest(f)
 	iTargetID1 := m.ImageTargets[0].ID()
 	stateSet := store.BuildStateSet{
-		iTargetID1: store.BuildState{FullBuildTriggered: true},
+		iTargetID1: store.BuildState{FullBuildTriggered: true, Cluster: cluster},
 	}
 	_, err := f.BuildAndDeploy(BuildTargets(m), stateSet)
 	require.NoError(t, err)

--- a/internal/store/build_result.go
+++ b/internal/store/build_result.go
@@ -196,6 +196,9 @@ type BuildState struct {
 	// This field indicates case 1 || case 2 -- i.e. that we should skip
 	// live_update, and force an image build (even if there are no changed files)
 	FullBuildTriggered bool
+
+	// The default cluster.
+	Cluster *v1alpha1.Cluster
 }
 
 func NewBuildState(result BuildResult, files []string, pendingDeps []model.TargetID) BuildState {
@@ -212,6 +215,13 @@ func NewBuildState(result BuildResult, files []string, pendingDeps []model.Targe
 		FilesChangedSet: set,
 		DepsChangedSet:  depsSet,
 	}
+}
+
+func (b BuildState) ClusterOrEmpty() *v1alpha1.Cluster {
+	if b.Cluster == nil {
+		return &v1alpha1.Cluster{}
+	}
+	return b.Cluster
 }
 
 func (b BuildState) WithFullBuildTriggered(isImageBuildTrigger bool) BuildState {


### PR DESCRIPTION
Hello @milas, @landism,

Please review the following commits I made in branch nicks/liveupdate3:

2716aeb84ad81354220c369123b248f6d031b04a (2022-03-30 13:21:16 -0400)
buildcontrol: put the Cluster in BuildState

b70a390062a8471baa8009268acd36b795213655 (2022-03-29 11:53:55 -0400)
buildcontrol: remove live update state from build state

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics