### PR TITLE
tiltfile: properly model filewatches shared across multiple images

### DIFF
--- a/internal/controllers/core/tiltfile/api_test.go
+++ b/internal/controllers/core/tiltfile/api_test.go
@@ -164,6 +164,39 @@ func TestCmdImageCreate(t *testing.T) {
 	assert.Contains(t, ci.Spec.Ref, SanchoRef.String())
 }
 
+func TestTwoManifestsShareImage(t *testing.T) {
+	f := newAPIFixture(t)
+	target := model.MustNewImageTarget(SanchoRef).
+		WithBuildDetails(model.CustomBuild{
+			CmdImageSpec: v1alpha1.CmdImageSpec{Args: []string{"echo"}},
+			Deps:         []string{f.Path()},
+		})
+	fe1 := manifestbuilder.New(f, "fe1").
+		WithImageTarget(target).
+		WithK8sYAML(testyaml.SanchoYAML).
+		Build()
+	fe2 := manifestbuilder.New(f, "fe2").
+		WithImageTarget(target).
+		WithK8sYAML(testyaml.SanchoYAML).
+		Build()
+	nn := types.NamespacedName{Name: "tiltfile"}
+	tf := &v1alpha1.Tiltfile{ObjectMeta: metav1.ObjectMeta{Name: "tiltfile"}}
+	err := f.updateOwnedObjects(nn, tf,
+		&tiltfile.TiltfileLoadResult{Manifests: []model.Manifest{fe1, fe2}})
+	assert.NoError(t, err)
+
+	name := apis.SanitizeName(fe1.ImageTargets[0].ID().String())
+
+	var fw v1alpha1.FileWatch
+	assert.NoError(t, f.Get(types.NamespacedName{Name: name}, &fw))
+	assert.Equal(t, fw.Spec.DisableSource, &v1alpha1.DisableSource{
+		EveryConfigMap: []v1alpha1.ConfigMapDisableSource{
+			{Name: "fe1-disable", Key: "isDisabled"},
+			{Name: "fe2-disable", Key: "isDisabled"},
+		},
+	})
+}
+
 func TestAPITwoTiltfiles(t *testing.T) {
 	f := newAPIFixture(t)
 	feA := manifestbuilder.New(f, "fe-a").WithK8sYAML(testyaml.SanchoYAML).Build()


### PR DESCRIPTION
Hello @landism, @nicksieger,

Please review the following commits I made in branch nicks/every2:

f289f7a052e3829b2e67ec2258cccf7b4095848a (2022-03-31 17:41:50 -0400)
tiltfile: properly model filewatches shared across multiple images
fixes https://github.com/tilt-dev/tilt/issues/5621

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics