### PR TITLE
buildcontrol: use ClusterNeeds to determine whether to push

### DIFF
--- a/internal/engine/buildcontrol/extractors.go
+++ b/internal/engine/buildcontrol/extractors.go
@@ -1,7 +1,6 @@
 package buildcontrol
 
 import (
-	"github.com/tilt-dev/tilt/internal/store"
 	"github.com/tilt-dev/tilt/pkg/model"
 )
 
@@ -18,45 +17,4 @@ func extractImageAndK8sTargets(specs []model.TargetSpec) (iTargets []model.Image
 		}
 	}
 	return iTargets, kTargets
-}
-
-// Returns true if the given image is deployed to one of the given k8s targets.
-// Note that some images are injected into other images, so may never be deployed.
-func IsImageDeployedToK8s(iTarget model.ImageTarget, kTarget model.K8sTarget) bool {
-	id := iTarget.ID()
-	for _, depID := range kTarget.DependencyIDs() {
-		if depID == id {
-			return true
-		}
-	}
-	return false
-}
-
-// Returns true if the given image is deployed to one of the given docker-compose targets.
-// Note that some images are injected into other images, so may never be deployed.
-func IsImageDeployedToDC(iTarget model.ImageTarget, dcTarget model.DockerComposeTarget) bool {
-	id := iTarget.ID()
-	for _, depID := range dcTarget.DependencyIDs() {
-		if depID == id {
-			return true
-		}
-	}
-	return false
-}
-
-// Given a target, return all the target IDs in its tree of dependencies that
-// have changed files.
-func HasFileChangesTree(g model.TargetGraph, target model.TargetSpec, stateSet store.BuildStateSet) ([]model.TargetID, error) {
-	result := []model.TargetID{}
-	err := g.VisitTree(target, func(current model.TargetSpec) error {
-		state := stateSet[current.ID()]
-		if len(state.FilesChangedSet) > 0 {
-			result = append(result, current.ID())
-		}
-		return nil
-	})
-	if err != nil {
-		return nil, err
-	}
-	return result, nil
 }

--- a/internal/engine/buildcontrol/image_build_and_deployer.go
+++ b/internal/engine/buildcontrol/image_build_and_deployer.go
@@ -240,7 +240,7 @@ func (ibd *ImageBuildAndDeployer) push(ctx context.Context, ref reference.NamedT
 	if cbSkip {
 		ps.Printf(ctx, "Skipping push: custom_build() configured to handle push itself")
 		return nil
-	} else if !IsImageDeployedToK8s(iTarget, kTarget) {
+	} else if iTarget.ClusterNeeds() != v1alpha1.ClusterImageNeedsPush {
 		ps.Printf(ctx, "Skipping push: base image does not need deploy")
 		return nil
 	} else if ibd.db.WillBuildToKubeContext(k8s.KubeContext(k8sConnStatus(cluster).Context)) {

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -251,7 +251,7 @@ type fakeBuildAndDeployer struct {
 
 var _ buildcontrol.BuildAndDeployer = &fakeBuildAndDeployer{}
 
-func (b *fakeBuildAndDeployer) nextImageBuildResult(iTarget model.ImageTarget, deployTarget model.TargetSpec) store.ImageBuildResult {
+func (b *fakeBuildAndDeployer) nextImageBuildResult(iTarget model.ImageTarget) store.ImageBuildResult {
 	tag := fmt.Sprintf("tilt-%d", b.buildCount)
 	localRefTagged := container.MustWithTag(iTarget.Refs.LocalRef(), tag)
 	clusterRefTagged := container.MustWithTag(iTarget.Refs.ClusterRef(), tag)
@@ -321,18 +321,7 @@ func (b *fakeBuildAndDeployer) BuildAndDeploy(ctx context.Context, st store.RSto
 
 	err = queue.RunBuilds(func(target model.TargetSpec, depResults []store.ImageBuildResult) (store.ImageBuildResult, error) {
 		iTarget := target.(model.ImageTarget)
-		var deployTarget model.TargetSpec
-		if !call.dc().Empty() {
-			if buildcontrol.IsImageDeployedToDC(iTarget, call.dc()) {
-				deployTarget = call.dc()
-			}
-		} else {
-			if buildcontrol.IsImageDeployedToK8s(iTarget, call.k8s()) {
-				deployTarget = call.k8s()
-			}
-		}
-
-		return b.nextImageBuildResult(iTarget, deployTarget), nil
+		return b.nextImageBuildResult(iTarget), nil
 	})
 	result := queue.NewResults().ToBuildResultSet()
 	if err != nil {


### PR DESCRIPTION
Hello @milas, @landism,

Please review the following commits I made in branch nicks/cluster7:

2326cd8b18a8b50f879517724567f7fc711e4b53 (2022-04-04 13:09:56 -0400)
buildcontrol: use ClusterNeeds to determine whether to push
most importantly, this is the last step to removing the
dependency of image build/push on K8sTarget

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics