### PR TITLE
docker: support Colima for building direct to cluster

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/spf13/cobra v1.3.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.7.0
-	github.com/tilt-dev/clusterid v0.1.2
+	github.com/tilt-dev/clusterid v0.1.3
 	github.com/tilt-dev/dockerignore v0.1.1
 	github.com/tilt-dev/fsevents v0.0.0-20200515134857-2efe37af20de
 	github.com/tilt-dev/fsnotify v1.4.8-0.20210701141043-dd524499d3fe

--- a/go.sum
+++ b/go.sum
@@ -1580,6 +1580,8 @@ github.com/tilt-dev/browser v0.0.1 h1:e+mFToX6A7pkMlGFrXW5VLvS7qS0HVbcXqmR0uPrWU
 github.com/tilt-dev/browser v0.0.1/go.mod h1:2DaMt8P8xEqDFzxaAbraOig5iUmQdd1wtO1Tb6tODHA=
 github.com/tilt-dev/clusterid v0.1.2 h1:ch+qLP6y3n6KvuIyovSa030hJuWJ//G8gXqvouxpRSc=
 github.com/tilt-dev/clusterid v0.1.2/go.mod h1:QeDTv8HzwdCk6P1WzQXA+wpPSYAniAWipqbTLEF9ets=
+github.com/tilt-dev/clusterid v0.1.3 h1:D4Z7wsXjPO805JLYGUUXQ08nFXxavXr5GwHRWL556aA=
+github.com/tilt-dev/clusterid v0.1.3/go.mod h1:MV6q698Z7LEbu9i7p+JwqGsu2EkiiaQViIrL6gd8XiI=
 github.com/tilt-dev/dockerignore v0.1.1 h1:/MPYqcD8qMCMyh3yiHuQdzbMQi9NL4vVopo6/9D/XvE=
 github.com/tilt-dev/dockerignore v0.1.1/go.mod h1:2ooUDj8B9FNWYvHadA4EKG0JDaeAOjiq5P+mvEzS2eY=
 github.com/tilt-dev/fsevents v0.0.0-20200515134857-2efe37af20de h1:tG+nJMUUxV7MJm/MeU1Mw7rvmwN9GWyHMMg+wtf9HS4=

--- a/vendor/github.com/tilt-dev/clusterid/product.go
+++ b/vendor/github.com/tilt-dev/clusterid/product.go
@@ -37,17 +37,19 @@ const (
 	ProductKIND           Product = "kind"
 	ProductK3D            Product = "k3d"
 	ProductRancherDesktop Product = "rancher-desktop"
+	ProductColima         Product = "colima"
 )
 
-func (e Product) IsDevCluster() bool {
-	return e == ProductMinikube ||
-		e == ProductDockerDesktop ||
-		e == ProductMicroK8s ||
-		e == ProductCRC ||
-		e == ProductKIND ||
-		e == ProductK3D ||
-		e == ProductKrucible ||
-		e == ProductRancherDesktop
+func (p Product) IsDevCluster() bool {
+	return p == ProductMinikube ||
+		p == ProductDockerDesktop ||
+		p == ProductMicroK8s ||
+		p == ProductCRC ||
+		p == ProductKIND ||
+		p == ProductK3D ||
+		p == ProductKrucible ||
+		p == ProductRancherDesktop ||
+		p == ProductColima
 }
 
 func ProductFromContext(c *clientcmdapi.Context, cl *clientcmdapi.Cluster) Product {
@@ -76,6 +78,8 @@ func ProductFromContext(c *clientcmdapi.Context, cl *clientcmdapi.Cluster) Produ
 		return ProductK3D
 	} else if strings.HasPrefix(cn, "rancher-desktop") {
 		return ProductRancherDesktop
+	} else if strings.HasPrefix(cn, "colima") {
+		return ProductColima
 	}
 
 	loc := c.LocationOfOrigin

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -645,8 +645,8 @@ github.com/theupdateframework/notary/tuf/data
 github.com/theupdateframework/notary/tuf/signed
 github.com/theupdateframework/notary/tuf/utils
 github.com/theupdateframework/notary/tuf/validation
-# github.com/tilt-dev/clusterid v0.1.2
-## explicit; go 1.17
+# github.com/tilt-dev/clusterid v0.1.3
+## explicit; go 1.18
 github.com/tilt-dev/clusterid
 # github.com/tilt-dev/dockerignore v0.1.1
 ## explicit; go 1.16


### PR DESCRIPTION
Colima is a macOS/Linux local cluster tool built on top of Lima.
It creates lightweight VMs with Docker and (optionally) Kubernetes
with Docker being used as the Kubernetes container runtime and the
socket exposed for building images directly to its context.

Fixes #5625.