### PR TITLE
buildcontrol: move image build logic into the reconcilers

### DIFF
--- a/internal/build/image_builder.go
+++ b/internal/build/image_builder.go
@@ -1,4 +1,4 @@
-package buildcontrol
+package build
 
 import (
 	"context"
@@ -9,7 +9,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/tilt-dev/clusterid"
-	"github.com/tilt-dev/tilt/internal/build"
 	"github.com/tilt-dev/tilt/internal/container"
 	"github.com/tilt-dev/tilt/internal/ignore"
 	"github.com/tilt-dev/tilt/internal/k8s"
@@ -19,12 +18,12 @@ import (
 )
 
 type ImageBuilder struct {
-	db    *build.DockerBuilder
-	custb *build.CustomBuilder
+	db    *DockerBuilder
+	custb *CustomBuilder
 	kl    KINDLoader
 }
 
-func NewImageBuilder(db *build.DockerBuilder, custb *build.CustomBuilder, kl KINDLoader) *ImageBuilder {
+func NewImageBuilder(db *DockerBuilder, custb *CustomBuilder, kl KINDLoader) *ImageBuilder {
 	return &ImageBuilder{
 		db:    db,
 		custb: custb,
@@ -54,7 +53,7 @@ func (ib *ImageBuilder) Build(ctx context.Context,
 	iTarget model.ImageTarget,
 	cluster *v1alpha1.Cluster,
 	imageMaps map[types.NamespacedName]*v1alpha1.ImageMap,
-	ps *build.PipelineState) (container.TaggedRefs, []v1alpha1.DockerImageStageStatus, error) {
+	ps *PipelineState) (container.TaggedRefs, []v1alpha1.DockerImageStageStatus, error) {
 	refs, stages, err := ib.buildOnly(ctx, iTarget, cluster, imageMaps, ps)
 	if err != nil {
 		return refs, stages, err
@@ -77,7 +76,7 @@ func (ib *ImageBuilder) buildOnly(ctx context.Context,
 	iTarget model.ImageTarget,
 	cluster *v1alpha1.Cluster,
 	imageMaps map[types.NamespacedName]*v1alpha1.ImageMap,
-	ps *build.PipelineState) (container.TaggedRefs, []v1alpha1.DockerImageStageStatus, error) {
+	ps *PipelineState) (container.TaggedRefs, []v1alpha1.DockerImageStageStatus, error) {
 	userFacingRefName := container.FamiliarString(iTarget.Refs.ConfigurationRef)
 
 	switch bd := iTarget.BuildDetails.(type) {
@@ -104,7 +103,7 @@ func (ib *ImageBuilder) buildOnly(ctx context.Context,
 }
 
 // Push the image if the clsuter requires it.
-func (ib *ImageBuilder) push(ctx context.Context, ref reference.NamedTagged, ps *build.PipelineState, iTarget model.ImageTarget, cluster *v1alpha1.Cluster) *v1alpha1.DockerImageStageStatus {
+func (ib *ImageBuilder) push(ctx context.Context, ref reference.NamedTagged, ps *PipelineState, iTarget model.ImageTarget, cluster *v1alpha1.Cluster) *v1alpha1.DockerImageStageStatus {
 	// Skip the push phase entirely if we're on Docker Compose.
 	isDC := cluster != nil &&
 		cluster.Spec.Connection != nil &&

--- a/internal/build/kind.go
+++ b/internal/build/kind.go
@@ -1,4 +1,4 @@
-package buildcontrol
+package build
 
 import (
 	"context"

--- a/internal/cli/wire.go
+++ b/internal/cli/wire.go
@@ -34,7 +34,6 @@ import (
 	"github.com/tilt-dev/tilt/internal/dockercompose"
 	"github.com/tilt-dev/tilt/internal/engine"
 	engineanalytics "github.com/tilt-dev/tilt/internal/engine/analytics"
-	"github.com/tilt-dev/tilt/internal/engine/buildcontrol"
 	"github.com/tilt-dev/tilt/internal/engine/configs"
 	"github.com/tilt-dev/tilt/internal/engine/dockerprune"
 	"github.com/tilt-dev/tilt/internal/engine/k8srollout"
@@ -148,7 +147,7 @@ var BaseWireSet = wire.NewSet(
 	xdg.NewTiltDevBase,
 	token.GetOrCreateToken,
 
-	buildcontrol.NewKINDLoader,
+	build.NewKINDLoader,
 
 	wire.Value(feature.MainDefaults),
 )

--- a/internal/cli/wire_gen.go
+++ b/internal/cli/wire_gen.go
@@ -338,8 +338,12 @@ func wireCmdUp(ctx context.Context, analytics3 *analytics.TiltAnalytics, cmdTags
 	}
 	liveupdateReconciler := liveupdate.NewReconciler(storeStore, dockerUpdater, execUpdater, updateMode, kubeContext, deferredClient, scheme)
 	configmapReconciler := configmap.NewReconciler(deferredClient, storeStore)
-	dockerimageReconciler := dockerimage.NewReconciler(deferredClient)
-	cmdimageReconciler := cmdimage.NewReconciler(deferredClient)
+	buildClock := build.ProvideClock()
+	customBuilder := build.NewCustomBuilder(compositeClient, buildClock)
+	kindLoader := build.NewKINDLoader()
+	imageBuilder := build.NewImageBuilder(dockerBuilder, customBuilder, kindLoader)
+	dockerimageReconciler := dockerimage.NewReconciler(deferredClient, compositeClient, imageBuilder)
+	cmdimageReconciler := cmdimage.NewReconciler(deferredClient, compositeClient, imageBuilder)
 	dockerClientFactory := _wireDockerClientFuncValue
 	kubernetesClientFactory := _wireKubernetesClientFuncValue
 	clusterReconciler := cluster.NewReconciler(ctx, deferredClient, storeStore, clock, connectionManager, localEnv, dockerClientFactory, kubernetesClientFactory)
@@ -357,12 +361,8 @@ func wireCmdUp(ctx context.Context, analytics3 *analytics.TiltAnalytics, cmdTags
 	openInput := _wireOpenInputValue
 	terminalPrompt := prompt.NewTerminalPrompt(analytics3, openInput, openURL, stdout, webHost, webURL)
 	serviceWatcher := k8swatch.NewServiceWatcher(connectionManager, namespace)
-	buildClock := build.ProvideClock()
-	customBuilder := build.NewCustomBuilder(compositeClient, buildClock)
-	kindLoader := buildcontrol.NewKINDLoader()
-	imageBuilder := buildcontrol.NewImageBuilder(dockerBuilder, customBuilder, kindLoader)
-	imageBuildAndDeployer := buildcontrol.NewImageBuildAndDeployer(imageBuilder, analytics3, buildClock, deferredClient, kubernetesapplyReconciler)
-	dockerComposeBuildAndDeployer := buildcontrol.NewDockerComposeBuildAndDeployer(dockercomposeserviceReconciler, compositeClient, imageBuilder, buildClock, deferredClient)
+	imageBuildAndDeployer := buildcontrol.NewImageBuildAndDeployer(dockerimageReconciler, cmdimageReconciler, imageBuilder, analytics3, buildClock, deferredClient, kubernetesapplyReconciler)
+	dockerComposeBuildAndDeployer := buildcontrol.NewDockerComposeBuildAndDeployer(dockerimageReconciler, cmdimageReconciler, imageBuilder, dockercomposeserviceReconciler, buildClock, deferredClient)
 	localTargetBuildAndDeployer := buildcontrol.NewLocalTargetBuildAndDeployer(buildClock, deferredClient, cmdController)
 	buildOrder := engine.DefaultBuildOrder(imageBuildAndDeployer, dockerComposeBuildAndDeployer, localTargetBuildAndDeployer, updateMode)
 	spanCollector := tracer.NewSpanCollector(ctx)
@@ -550,8 +550,12 @@ func wireCmdCI(ctx context.Context, analytics3 *analytics.TiltAnalytics, subcomm
 	}
 	liveupdateReconciler := liveupdate.NewReconciler(storeStore, dockerUpdater, execUpdater, updateMode, kubeContext, deferredClient, scheme)
 	configmapReconciler := configmap.NewReconciler(deferredClient, storeStore)
-	dockerimageReconciler := dockerimage.NewReconciler(deferredClient)
-	cmdimageReconciler := cmdimage.NewReconciler(deferredClient)
+	buildClock := build.ProvideClock()
+	customBuilder := build.NewCustomBuilder(compositeClient, buildClock)
+	kindLoader := build.NewKINDLoader()
+	imageBuilder := build.NewImageBuilder(dockerBuilder, customBuilder, kindLoader)
+	dockerimageReconciler := dockerimage.NewReconciler(deferredClient, compositeClient, imageBuilder)
+	cmdimageReconciler := cmdimage.NewReconciler(deferredClient, compositeClient, imageBuilder)
 	dockerClientFactory := _wireDockerClientFuncValue
 	kubernetesClientFactory := _wireKubernetesClientFuncValue
 	clusterReconciler := cluster.NewReconciler(ctx, deferredClient, storeStore, clock, connectionManager, localEnv, dockerClientFactory, kubernetesClientFactory)
@@ -569,12 +573,8 @@ func wireCmdCI(ctx context.Context, analytics3 *analytics.TiltAnalytics, subcomm
 	openInput := _wireOpenInputValue
 	terminalPrompt := prompt.NewTerminalPrompt(analytics3, openInput, openURL, stdout, webHost, webURL)
 	serviceWatcher := k8swatch.NewServiceWatcher(connectionManager, namespace)
-	buildClock := build.ProvideClock()
-	customBuilder := build.NewCustomBuilder(compositeClient, buildClock)
-	kindLoader := buildcontrol.NewKINDLoader()
-	imageBuilder := buildcontrol.NewImageBuilder(dockerBuilder, customBuilder, kindLoader)
-	imageBuildAndDeployer := buildcontrol.NewImageBuildAndDeployer(imageBuilder, analytics3, buildClock, deferredClient, kubernetesapplyReconciler)
-	dockerComposeBuildAndDeployer := buildcontrol.NewDockerComposeBuildAndDeployer(dockercomposeserviceReconciler, compositeClient, imageBuilder, buildClock, deferredClient)
+	imageBuildAndDeployer := buildcontrol.NewImageBuildAndDeployer(dockerimageReconciler, cmdimageReconciler, imageBuilder, analytics3, buildClock, deferredClient, kubernetesapplyReconciler)
+	dockerComposeBuildAndDeployer := buildcontrol.NewDockerComposeBuildAndDeployer(dockerimageReconciler, cmdimageReconciler, imageBuilder, dockercomposeserviceReconciler, buildClock, deferredClient)
 	localTargetBuildAndDeployer := buildcontrol.NewLocalTargetBuildAndDeployer(buildClock, deferredClient, cmdController)
 	buildOrder := engine.DefaultBuildOrder(imageBuildAndDeployer, dockerComposeBuildAndDeployer, localTargetBuildAndDeployer, updateMode)
 	spanCollector := tracer.NewSpanCollector(ctx)
@@ -758,8 +758,12 @@ func wireCmdUpdog(ctx context.Context, analytics3 *analytics.TiltAnalytics, cmdT
 	}
 	liveupdateReconciler := liveupdate.NewReconciler(storeStore, dockerUpdater, execUpdater, updateMode, kubeContext, deferredClient, scheme)
 	configmapReconciler := configmap.NewReconciler(deferredClient, storeStore)
-	dockerimageReconciler := dockerimage.NewReconciler(deferredClient)
-	cmdimageReconciler := cmdimage.NewReconciler(deferredClient)
+	buildClock := build.ProvideClock()
+	customBuilder := build.NewCustomBuilder(compositeClient, buildClock)
+	kindLoader := build.NewKINDLoader()
+	imageBuilder := build.NewImageBuilder(dockerBuilder, customBuilder, kindLoader)
+	dockerimageReconciler := dockerimage.NewReconciler(deferredClient, compositeClient, imageBuilder)
+	cmdimageReconciler := cmdimage.NewReconciler(deferredClient, compositeClient, imageBuilder)
 	dockerClientFactory := _wireDockerClientFuncValue
 	kubernetesClientFactory := _wireKubernetesClientFuncValue
 	clusterReconciler := cluster.NewReconciler(ctx, deferredClient, storeStore, clock, connectionManager, localEnv, dockerClientFactory, kubernetesClientFactory)
@@ -1139,7 +1143,7 @@ var BaseWireSet = wire.NewSet(
 	provideWebMode,
 	provideWebURL,
 	provideWebPort,
-	provideWebHost, server.WireSet, provideAssetServer, tracer.NewSpanCollector, wire.Bind(new(trace.SpanExporter), new(*tracer.SpanCollector)), wire.Bind(new(tracer.SpanSource), new(*tracer.SpanCollector)), dirs.UseTiltDevDir, xdg.NewTiltDevBase, token.GetOrCreateToken, buildcontrol.NewKINDLoader, wire.Value(feature.MainDefaults),
+	provideWebHost, server.WireSet, provideAssetServer, tracer.NewSpanCollector, wire.Bind(new(trace.SpanExporter), new(*tracer.SpanCollector)), wire.Bind(new(tracer.SpanSource), new(*tracer.SpanCollector)), dirs.UseTiltDevDir, xdg.NewTiltDevBase, token.GetOrCreateToken, build.NewKINDLoader, wire.Value(feature.MainDefaults),
 )
 
 var CLIClientWireSet = wire.NewSet(

--- a/internal/controllers/core/cmdimage/reconciler.go
+++ b/internal/controllers/core/cmdimage/reconciler.go
@@ -6,23 +6,34 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	"github.com/tilt-dev/tilt/internal/build"
+	"github.com/tilt-dev/tilt/internal/controllers/core/dockerimage"
+	"github.com/tilt-dev/tilt/internal/docker"
+	"github.com/tilt-dev/tilt/internal/store"
+	"github.com/tilt-dev/tilt/pkg/apis"
 	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
+	"github.com/tilt-dev/tilt/pkg/model"
 )
 
 // Manages the CmdImage API object.
 type Reconciler struct {
 	client ctrlclient.Client
+	docker docker.Client
+	ib     *build.ImageBuilder
 }
 
 var _ reconcile.Reconciler = &Reconciler{}
 
-func NewReconciler(client ctrlclient.Client) *Reconciler {
+func NewReconciler(client ctrlclient.Client, docker docker.Client, ib *build.ImageBuilder) *Reconciler {
 	return &Reconciler{
 		client: client,
+		docker: docker,
+		ib:     ib,
 	}
 }
 
@@ -38,6 +49,37 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	}
 
 	return ctrl.Result{}, nil
+}
+
+// Build the image, and push it if necessary.
+//
+// The error is simply the "main" build failure reason.
+func (r *Reconciler) ForceApply(
+	ctx context.Context,
+	iTarget model.ImageTarget,
+	cluster *v1alpha1.Cluster,
+	imageMaps map[types.NamespacedName]*v1alpha1.ImageMap,
+	ps *build.PipelineState) (store.ImageBuildResult, error) {
+
+	// TODO(nick): It might make sense to reset the ImageMapStatus here
+	// to an empty image while the image is building. maybe?
+	// I guess it depends on how image reconciliation works, and
+	// if you want the live container to keep receiving updates
+	// while an image build is going on in parallel.
+	startTime := apis.NowMicro()
+	MaybeUpdateStatus(ctx, r.client, iTarget, ToBuildingStatus(iTarget, startTime))
+
+	refs, _, err := r.ib.Build(ctx, iTarget, cluster, imageMaps, ps)
+	if err != nil {
+		MaybeUpdateStatus(ctx, r.client, iTarget, ToCompletedFailStatus(iTarget, startTime, err))
+		return store.ImageBuildResult{}, err
+	}
+
+	MaybeUpdateStatus(ctx, r.client, iTarget, ToCompletedSuccessStatus(iTarget, startTime, refs))
+
+	return dockerimage.UpdateImageMap(
+		ctx, r.client, r.docker,
+		iTarget, cluster, imageMaps, &startTime, refs)
 }
 
 func (r *Reconciler) CreateBuilder(mgr ctrl.Manager) (*builder.Builder, error) {

--- a/internal/controllers/core/dockerimage/imagemap.go
+++ b/internal/controllers/core/dockerimage/imagemap.go
@@ -1,0 +1,89 @@
+package dockerimage
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/docker/distribution/reference"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/tilt-dev/tilt/internal/container"
+	"github.com/tilt-dev/tilt/internal/docker"
+	"github.com/tilt-dev/tilt/internal/store"
+	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
+	"github.com/tilt-dev/tilt/pkg/model"
+)
+
+// A helper function for updating the imagemap
+// from dockerimage.Reconciler and cmdimage.Reconciler.
+// This is mainly for easing the transition to reconcilers.
+func UpdateImageMap(
+	ctx context.Context,
+	client ctrlclient.Client,
+	docker docker.Client,
+	iTarget model.ImageTarget,
+	cluster *v1alpha1.Cluster,
+	imageMaps map[types.NamespacedName]*v1alpha1.ImageMap,
+	startTime *metav1.MicroTime,
+	refs container.TaggedRefs) (store.ImageBuildResult, error) {
+
+	result := store.NewImageBuildResult(iTarget.ID(), refs.LocalRef, refs.ClusterRef)
+	if isDockerCompose(cluster) {
+		expectedRef := iTarget.Refs.ConfigurationRef
+		ref, err := tagWithExpected(ctx, docker, refs.LocalRef, expectedRef)
+		if err != nil {
+			return store.ImageBuildResult{}, err
+		}
+
+		result = store.NewImageBuildResultSingleRef(iTarget.ID(), ref)
+	}
+
+	result.ImageMapStatus.BuildStartTime = startTime
+	nn := types.NamespacedName{Name: iTarget.ImageMapName()}
+	im, ok := imageMaps[nn]
+	if !ok {
+		return store.ImageBuildResult{}, fmt.Errorf("apiserver missing ImageMap: %s", iTarget.ID().Name)
+	}
+	im.Status = result.ImageMapStatus
+	err := client.Status().Update(ctx, im)
+	if err != nil {
+		return store.ImageBuildResult{}, fmt.Errorf("updating ImageMap: %v", err)
+	}
+
+	return result, err
+}
+
+// tagWithExpected tags the given ref as whatever Docker Compose expects, i.e. as
+// the `image` value given in docker-compose.yaml. (If DC yaml specifies an image
+// with a tag, use that name + tag; otherwise, tag as latest.)
+func tagWithExpected(
+	ctx context.Context,
+	dCli docker.Client,
+	ref reference.NamedTagged,
+	expected container.RefSelector) (reference.NamedTagged, error) {
+	dCli = dCli.ForOrchestrator(model.OrchestratorDC)
+
+	var tagAs reference.NamedTagged
+	expectedNt, err := container.ParseNamedTagged(expected.String())
+	if err == nil {
+		// expected ref already includes a tag, so just tag the image as that
+		tagAs = expectedNt
+	} else {
+		// expected ref is just a name, so tag it as `latest` b/c that's what Docker Compose wants
+		tagAs, err = reference.WithTag(ref, docker.TagLatest)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	err = dCli.ImageTag(ctx, ref.String(), tagAs.String())
+	return tagAs, err
+}
+
+func isDockerCompose(cluster *v1alpha1.Cluster) bool {
+	return cluster != nil &&
+		cluster.Spec.Connection != nil &&
+		cluster.Spec.Connection.Docker != nil
+}

--- a/internal/controllers/core/dockerimage/reconciler.go
+++ b/internal/controllers/core/dockerimage/reconciler.go
@@ -6,23 +6,33 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	"github.com/tilt-dev/tilt/internal/build"
+	"github.com/tilt-dev/tilt/internal/docker"
+	"github.com/tilt-dev/tilt/internal/store"
+	"github.com/tilt-dev/tilt/pkg/apis"
 	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
+	"github.com/tilt-dev/tilt/pkg/model"
 )
 
 // Manages the DockerImage API object.
 type Reconciler struct {
 	client ctrlclient.Client
+	docker docker.Client
+	ib     *build.ImageBuilder
 }
 
 var _ reconcile.Reconciler = &Reconciler{}
 
-func NewReconciler(client ctrlclient.Client) *Reconciler {
+func NewReconciler(client ctrlclient.Client, docker docker.Client, ib *build.ImageBuilder) *Reconciler {
 	return &Reconciler{
 		client: client,
+		docker: docker,
+		ib:     ib,
 	}
 }
 
@@ -38,6 +48,37 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	}
 
 	return ctrl.Result{}, nil
+}
+
+// Build the image, and push it if necessary.
+//
+// The error is simply the "main" build failure reason.
+func (r *Reconciler) ForceApply(
+	ctx context.Context,
+	iTarget model.ImageTarget,
+	cluster *v1alpha1.Cluster,
+	imageMaps map[types.NamespacedName]*v1alpha1.ImageMap,
+	ps *build.PipelineState) (store.ImageBuildResult, error) {
+
+	// TODO(nick): It might make sense to reset the ImageMapStatus here
+	// to an empty image while the image is building. maybe?
+	// I guess it depends on how image reconciliation works, and
+	// if you want the live container to keep receiving updates
+	// while an image build is going on in parallel.
+	startTime := apis.NowMicro()
+	MaybeUpdateStatus(ctx, r.client, iTarget, ToBuildingStatus(iTarget, startTime))
+
+	refs, stages, err := r.ib.Build(ctx, iTarget, cluster, imageMaps, ps)
+	if err != nil {
+		MaybeUpdateStatus(ctx, r.client, iTarget, ToCompletedFailStatus(iTarget, startTime, stages, err))
+		return store.ImageBuildResult{}, err
+	}
+
+	MaybeUpdateStatus(ctx, r.client, iTarget, ToCompletedSuccessStatus(iTarget, startTime, stages, refs))
+
+	return UpdateImageMap(
+		ctx, r.client, r.docker,
+		iTarget, cluster, imageMaps, &startTime, refs)
 }
 
 func (r *Reconciler) CreateBuilder(mgr ctrl.Manager) (*builder.Builder, error) {

--- a/internal/engine/buildcontrol/wire.go
+++ b/internal/engine/buildcontrol/wire.go
@@ -18,7 +18,9 @@ import (
 	"github.com/tilt-dev/tilt/internal/analytics"
 	"github.com/tilt-dev/tilt/internal/build"
 	"github.com/tilt-dev/tilt/internal/containerupdate"
+	"github.com/tilt-dev/tilt/internal/controllers/core/cmdimage"
 	"github.com/tilt-dev/tilt/internal/controllers/core/dockercomposeservice"
+	"github.com/tilt-dev/tilt/internal/controllers/core/dockerimage"
 	"github.com/tilt-dev/tilt/internal/controllers/core/kubernetesapply"
 	"github.com/tilt-dev/tilt/internal/docker"
 	"github.com/tilt-dev/tilt/internal/dockercompose"
@@ -47,7 +49,7 @@ var BaseWireSet = wire.NewSet(
 	NewLocalTargetBuildAndDeployer,
 	containerupdate.NewDockerUpdater,
 	containerupdate.NewExecUpdater,
-	NewImageBuilder,
+	build.NewImageBuilder,
 
 	tracer.InitOpenTelemetry,
 
@@ -63,7 +65,7 @@ func ProvideImageBuildAndDeployer(
 	clusterEnv docker.ClusterEnv,
 	dir *dirs.TiltDevDir,
 	clock build.Clock,
-	kp KINDLoader,
+	kp build.KINDLoader,
 	analytics *analytics.TiltAnalytics,
 	ctrlclient ctrlclient.Client,
 	st store.RStore,
@@ -71,6 +73,8 @@ func ProvideImageBuildAndDeployer(
 	wire.Build(
 		BaseWireSet,
 		kubernetesapply.NewReconciler,
+		dockerimage.NewReconciler,
+		cmdimage.NewReconciler,
 	)
 
 	return nil, nil
@@ -88,7 +92,9 @@ func ProvideDockerComposeBuildAndDeployer(
 		BaseWireSet,
 		dockercomposeservice.WireSet,
 		build.ProvideClock,
-		NewKINDLoader,
+		build.NewKINDLoader,
+		dockerimage.NewReconciler,
+		cmdimage.NewReconciler,
 	)
 
 	return nil, nil

--- a/internal/engine/wire.go
+++ b/internal/engine/wire.go
@@ -20,7 +20,9 @@ import (
 	"github.com/tilt-dev/tilt/internal/build"
 	"github.com/tilt-dev/tilt/internal/container"
 	"github.com/tilt-dev/tilt/internal/controllers/core/cmd"
+	"github.com/tilt-dev/tilt/internal/controllers/core/cmdimage"
 	"github.com/tilt-dev/tilt/internal/controllers/core/dockercomposeservice"
+	"github.com/tilt-dev/tilt/internal/controllers/core/dockerimage"
 	"github.com/tilt-dev/tilt/internal/controllers/core/kubernetesapply"
 	"github.com/tilt-dev/tilt/internal/docker"
 	"github.com/tilt-dev/tilt/internal/dockercompose"
@@ -60,7 +62,7 @@ func provideFakeBuildAndDeployer(
 	updateMode liveupdates.UpdateModeFlag,
 	dcc dockercompose.DockerComposeClient,
 	clock build.Clock,
-	kp buildcontrol.KINDLoader,
+	kp build.KINDLoader,
 	analytics *analytics.TiltAnalytics,
 	ctrlClient ctrlclient.Client,
 	st store.RStore,
@@ -71,6 +73,8 @@ func provideFakeBuildAndDeployer(
 		provideFakeKubeContext,
 		provideFakeDockerClusterEnv,
 		kubernetesapply.NewReconciler,
+		dockerimage.NewReconciler,
+		cmdimage.NewReconciler,
 		dockercomposeservice.WireSet,
 		cmd.WireSet,
 		clockwork.NewRealClock,


### PR DESCRIPTION
Hello @milas, @landism,

Please review the following commits I made in branch nicks/cluster9:

4b294b71e83ae0b8a3d1a8d782946b4a72a0f734 (2022-04-05 14:08:18 -0400)
buildcontrol: move image build logic into the reconcilers

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics