### PR TITLE
liveupdate: fix handling of docker-compose restarts

### DIFF
--- a/internal/controllers/core/liveupdate/reconciler_test.go
+++ b/internal/controllers/core/liveupdate/reconciler_test.go
@@ -182,6 +182,18 @@ func TestConsumeFileEventsDockerCompose(t *testing.T) {
 	if assert.Equal(t, 1, len(f.cu.Calls)) {
 		assert.True(t, f.cu.Calls[0].HotReload)
 	}
+
+	f.assertSteadyState(&lu)
+
+	// Docker Compose containers can be restarted in-place,
+	// preserving their filesystem.
+	dc := &v1alpha1.DockerComposeService{}
+	f.MustGet(types.NamespacedName{Name: "frontend-service"}, dc)
+	dc = dc.DeepCopy()
+	dc.Status.ContainerState.StartedAt = apis.NowMicro()
+	f.UpdateStatus(dc)
+
+	f.assertSteadyState(&lu)
 }
 
 func TestConsumeFileEventsUpdateModeManual(t *testing.T) {

--- a/internal/controllers/core/liveupdate/resource.go
+++ b/internal/controllers/core/liveupdate/resource.go
@@ -4,7 +4,6 @@ import (
 	"time"
 
 	"github.com/docker/distribution/reference"
-	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/tilt-dev/tilt/internal/container"
 	"github.com/tilt-dev/tilt/internal/dockercompose"
@@ -21,9 +20,6 @@ import (
 type luResource interface {
 	// The time to start syncing changes from.
 	bestStartTime() time.Time
-
-	// The names of any pods, for tracking state.
-	podNames() []types.NamespacedName
 
 	// An iterator for visiting each container.
 	visitSelectedContainers(visit func(pod v1alpha1.Pod, c v1alpha1.Container) bool)
@@ -46,14 +42,6 @@ func (r *luK8sResource) bestStartTime() time.Time {
 		}
 	}
 	return startTime
-}
-
-func (r *luK8sResource) podNames() []types.NamespacedName {
-	result := []types.NamespacedName{}
-	for _, pod := range r.res.FilteredPods {
-		result = append(result, types.NamespacedName{Name: pod.Name, Namespace: pod.Namespace})
-	}
-	return result
 }
 
 // Visit all selected containers.
@@ -92,15 +80,6 @@ type luDCResource struct {
 
 func (r *luDCResource) bestStartTime() time.Time {
 	return r.res.Status.LastApplyStartTime.Time
-}
-
-// In DockerCompose, we treat every container as a single-container pod.
-func (r *luDCResource) podNames() []types.NamespacedName {
-	result := []types.NamespacedName{}
-	if r.res.Status.ContainerID != "" {
-		result = append(result, types.NamespacedName{Name: r.res.Status.ContainerID})
-	}
-	return result
 }
 
 // Visit all selected containers.


### PR DESCRIPTION
Hello @milas, @landism,

Please review the following commits I made in branch nicks/liveupdatedc:

0931493713b7a385edd66787730db793a3a3ecc6 (2022-04-06 15:14:25 -0400)
liveupdate: fix handling of docker-compose restarts
Fixes https://github.com/tilt-dev/tilt/issues/5663

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics