### PR TITLE
web: update the document title and favicon when Tilt UI disconnects

### DIFF
--- a/web/src/HUD.tsx
+++ b/web/src/HUD.tsx
@@ -27,7 +27,7 @@ import { ResourceSelectionProvider } from "./ResourceSelectionContext"
 import ShareSnapshotModal from "./ShareSnapshotModal"
 import { TiltSnackbarProvider } from "./Snackbar"
 import { SnapshotActionProvider } from "./snapshot"
-import SocketBar, { isSocketConnected } from "./SocketBar"
+import SocketBar, { isTiltSocketConnected } from "./SocketBar"
 import { StarredResourcesContextProvider } from "./StarredResourcesContext"
 import { ShowErrorModal, ShowFatalErrorModal, SocketState } from "./types"
 
@@ -235,7 +235,7 @@ export default class HUD extends Component<HudProps, HudState> {
   }
 
   renderOverviewSwitch() {
-    const tiltConnected = isSocketConnected(this.state.socketState)
+    const isSocketConnected = isTiltSocketConnected(this.state.socketState)
     return (
       <FeaturesProvider
         featureFlags={this.state.view.uiSession?.status?.featureFlags || null}
@@ -252,7 +252,7 @@ export default class HUD extends Component<HudProps, HudState> {
                         render={(props: RouteComponentProps<any>) => (
                           <OverviewResourcePane
                             view={this.state.view}
-                            tiltConnected={tiltConnected}
+                            isSocketConnected={isSocketConnected}
                           />
                         )}
                       />
@@ -260,7 +260,7 @@ export default class HUD extends Component<HudProps, HudState> {
                         render={() => (
                           <OverviewTablePane
                             view={this.state.view}
-                            tiltConnected={tiltConnected}
+                            isSocketConnected={isSocketConnected}
                           />
                         )}
                       />

--- a/web/src/HUD.tsx
+++ b/web/src/HUD.tsx
@@ -27,7 +27,7 @@ import { ResourceSelectionProvider } from "./ResourceSelectionContext"
 import ShareSnapshotModal from "./ShareSnapshotModal"
 import { TiltSnackbarProvider } from "./Snackbar"
 import { SnapshotActionProvider } from "./snapshot"
-import SocketBar from "./SocketBar"
+import SocketBar, { isSocketConnected } from "./SocketBar"
 import { StarredResourcesContextProvider } from "./StarredResourcesContext"
 import { ShowErrorModal, ShowFatalErrorModal, SocketState } from "./types"
 
@@ -198,10 +198,6 @@ export default class HUD extends Component<HudProps, HudState> {
     }
 
     let tiltfileKey = session?.tiltfileKey
-    let runningBuild = session?.runningTiltBuild
-    let suggestedVersion = session?.suggestedTiltVersion
-    const versionSettings = session?.versionSettings
-    const checkUpdates = versionSettings?.checkUpdates ?? true
     let shareSnapshotModal = this.renderShareSnapshotModal(view)
     let fatalErrorModal = this.renderFatalErrorModal(view)
     let errorModal = this.renderErrorModal()
@@ -239,6 +235,7 @@ export default class HUD extends Component<HudProps, HudState> {
   }
 
   renderOverviewSwitch() {
+    const tiltConnected = isSocketConnected(this.state.socketState)
     return (
       <FeaturesProvider
         featureFlags={this.state.view.uiSession?.status?.featureFlags || null}
@@ -253,12 +250,18 @@ export default class HUD extends Component<HudProps, HudState> {
                       <Route
                         path={this.path("/r/:name/overview")}
                         render={(props: RouteComponentProps<any>) => (
-                          <OverviewResourcePane view={this.state.view} />
+                          <OverviewResourcePane
+                            view={this.state.view}
+                            tiltConnected={tiltConnected}
+                          />
                         )}
                       />
                       <Route
                         render={() => (
-                          <OverviewTablePane view={this.state.view} />
+                          <OverviewTablePane
+                            view={this.state.view}
+                            tiltConnected={tiltConnected}
+                          />
                         )}
                       />
                     </Switch>

--- a/web/src/HeaderBar.stories.tsx
+++ b/web/src/HeaderBar.stories.tsx
@@ -22,7 +22,7 @@ export const TwoResources = () => (
   <HeaderBar
     view={twoResourceView()}
     currentPage={AnalyticsType.Detail}
-    tiltConnected={true}
+    isSocketConnected={true}
   />
 )
 
@@ -30,7 +30,7 @@ export const TenResources = () => (
   <HeaderBar
     view={tenResourceView()}
     currentPage={AnalyticsType.Detail}
-    tiltConnected={true}
+    isSocketConnected={true}
   />
 )
 
@@ -43,7 +43,7 @@ export const TenResourcesErrorsAndWarnings = () => {
     <HeaderBar
       view={view}
       currentPage={AnalyticsType.Grid}
-      tiltConnected={true}
+      isSocketConnected={true}
     />
   )
 }
@@ -52,7 +52,7 @@ export const OneHundredResources = () => (
   <HeaderBar
     view={nResourceView(100)}
     currentPage={AnalyticsType.Grid}
-    tiltConnected={true}
+    isSocketConnected={true}
   />
 )
 
@@ -66,7 +66,7 @@ export const UpgradeAvailable = () => {
     <HeaderBar
       view={view}
       currentPage={AnalyticsType.Detail}
-      tiltConnected={true}
+      isSocketConnected={true}
     />
   )
 }

--- a/web/src/HeaderBar.stories.tsx
+++ b/web/src/HeaderBar.stories.tsx
@@ -19,11 +19,19 @@ export default {
 }
 
 export const TwoResources = () => (
-  <HeaderBar view={twoResourceView()} currentPage={AnalyticsType.Detail} />
+  <HeaderBar
+    view={twoResourceView()}
+    currentPage={AnalyticsType.Detail}
+    tiltConnected={true}
+  />
 )
 
 export const TenResources = () => (
-  <HeaderBar view={tenResourceView()} currentPage={AnalyticsType.Detail} />
+  <HeaderBar
+    view={tenResourceView()}
+    currentPage={AnalyticsType.Detail}
+    tiltConnected={true}
+  />
 )
 
 export const TenResourcesErrorsAndWarnings = () => {
@@ -31,11 +39,21 @@ export const TenResourcesErrorsAndWarnings = () => {
   view.uiResources[0].status.updateStatus = UpdateStatus.Error
   view.uiResources[1].status.buildHistory[0].warnings = ["warning time"]
   view.uiResources[5].status.updateStatus = UpdateStatus.Error
-  return <HeaderBar view={view} currentPage={AnalyticsType.Grid} />
+  return (
+    <HeaderBar
+      view={view}
+      currentPage={AnalyticsType.Grid}
+      tiltConnected={true}
+    />
+  )
 }
 
 export const OneHundredResources = () => (
-  <HeaderBar view={nResourceView(100)} currentPage={AnalyticsType.Grid} />
+  <HeaderBar
+    view={nResourceView(100)}
+    currentPage={AnalyticsType.Grid}
+    tiltConnected={true}
+  />
 )
 
 export const UpgradeAvailable = () => {
@@ -44,5 +62,11 @@ export const UpgradeAvailable = () => {
   status!.suggestedTiltVersion = "0.18.1"
   status!.runningTiltBuild = { version: "0.18.0", dev: false }
   status!.versionSettings = { checkUpdates: true }
-  return <HeaderBar view={view} currentPage={AnalyticsType.Detail} />
+  return (
+    <HeaderBar
+      view={view}
+      currentPage={AnalyticsType.Detail}
+      tiltConnected={true}
+    />
+  )
 }

--- a/web/src/HeaderBar.tsx
+++ b/web/src/HeaderBar.tsx
@@ -105,14 +105,14 @@ const ViewLinkSection = styled.div`
 
 type HeaderBarProps = {
   view: Proto.webviewView
-  tiltConnected: boolean
+  isSocketConnected: boolean
   currentPage?: AnalyticsType.Detail | AnalyticsType.Grid
 }
 
 export default function HeaderBar({
   view,
   currentPage,
-  tiltConnected,
+  isSocketConnected,
 }: HeaderBarProps) {
   let isSnapshot = usePathBuilder().isSnapshot()
   let snapshot = useSnapshotAction()
@@ -169,7 +169,7 @@ export default function HeaderBar({
         displayText="Resources"
         labelText="Status summary for all resources"
         resources={resources}
-        tiltConnected={tiltConnected}
+        isSocketConnected={isSocketConnected}
       />
       <CustomNav view={view} />
       <GlobalNav {...globalNavProps} />

--- a/web/src/HeaderBar.tsx
+++ b/web/src/HeaderBar.tsx
@@ -105,10 +105,15 @@ const ViewLinkSection = styled.div`
 
 type HeaderBarProps = {
   view: Proto.webviewView
+  tiltConnected: boolean
   currentPage?: AnalyticsType.Detail | AnalyticsType.Grid
 }
 
-export default function HeaderBar({ view, currentPage }: HeaderBarProps) {
+export default function HeaderBar({
+  view,
+  currentPage,
+  tiltConnected,
+}: HeaderBarProps) {
   let isSnapshot = usePathBuilder().isSnapshot()
   let snapshot = useSnapshotAction()
   let session = view?.uiSession?.status
@@ -164,6 +169,7 @@ export default function HeaderBar({ view, currentPage }: HeaderBarProps) {
         displayText="Resources"
         labelText="Status summary for all resources"
         resources={resources}
+        tiltConnected={tiltConnected}
       />
       <CustomNav view={view} />
       <GlobalNav {...globalNavProps} />

--- a/web/src/OverviewResourcePane.stories.tsx
+++ b/web/src/OverviewResourcePane.stories.tsx
@@ -68,7 +68,7 @@ function OverviewResourcePaneHarness(props: {
   return (
     <MemoryRouter initialEntries={[entry]}>
       <ResourceNavProvider validateResource={validateResource}>
-        <OverviewResourcePane view={view} tiltConnected={true} />
+        <OverviewResourcePane view={view} isSocketConnected={true} />
       </ResourceNavProvider>
     </MemoryRouter>
   )

--- a/web/src/OverviewResourcePane.stories.tsx
+++ b/web/src/OverviewResourcePane.stories.tsx
@@ -68,7 +68,7 @@ function OverviewResourcePaneHarness(props: {
   return (
     <MemoryRouter initialEntries={[entry]}>
       <ResourceNavProvider validateResource={validateResource}>
-        <OverviewResourcePane view={view} />
+        <OverviewResourcePane view={view} tiltConnected={true} />
       </ResourceNavProvider>
     </MemoryRouter>
   )

--- a/web/src/OverviewResourcePane.test.tsx
+++ b/web/src/OverviewResourcePane.test.tsx
@@ -52,7 +52,7 @@ describe("alert filtering", () => {
       <MemoryRouter initialEntries={["/"]}>
         <LogStoreProvider value={logStore}>
           <ResourceNavProvider validateResource={() => true}>
-            <OverviewResourcePane view={view} />
+            <OverviewResourcePane view={view} isSocketConnected={true} />
           </ResourceNavProvider>
         </LogStoreProvider>
       </MemoryRouter>
@@ -136,7 +136,7 @@ describe("alert filtering", () => {
                 openResource: () => {},
               }}
             >
-              <OverviewResourcePane view={view} />
+              <OverviewResourcePane view={view} isSocketConnected={true} />
             </ResourceNavContextProvider>
           </SnackbarProvider>
         </LogStoreProvider>

--- a/web/src/OverviewResourcePane.tsx
+++ b/web/src/OverviewResourcePane.tsx
@@ -19,7 +19,7 @@ import { ResourceName } from "./types"
 type UIResource = Proto.v1alpha1UIResource
 type OverviewResourcePaneProps = {
   view: Proto.webviewView
-  tiltConnected: boolean
+  isSocketConnected: boolean
 }
 
 let OverviewResourcePaneRoot = styled.div`
@@ -97,7 +97,7 @@ export default function OverviewResourcePane(props: OverviewResourcePaneProps) {
       <HeaderBar
         view={props.view}
         currentPage={AnalyticsType.Detail}
-        tiltConnected={props.tiltConnected}
+        isSocketConnected={props.isSocketConnected}
       />
       <StarredResourceBar
         {...starredResourcePropsFromView(props.view, selectedTab)}

--- a/web/src/OverviewResourcePane.tsx
+++ b/web/src/OverviewResourcePane.tsx
@@ -19,6 +19,7 @@ import { ResourceName } from "./types"
 type UIResource = Proto.v1alpha1UIResource
 type OverviewResourcePaneProps = {
   view: Proto.webviewView
+  tiltConnected: boolean
 }
 
 let OverviewResourcePaneRoot = styled.div`
@@ -93,7 +94,11 @@ export default function OverviewResourcePane(props: OverviewResourcePaneProps) {
 
   return (
     <OverviewResourcePaneRoot>
-      <HeaderBar view={props.view} currentPage={AnalyticsType.Detail} />
+      <HeaderBar
+        view={props.view}
+        currentPage={AnalyticsType.Detail}
+        tiltConnected={props.tiltConnected}
+      />
       <StarredResourceBar
         {...starredResourcePropsFromView(props.view, selectedTab)}
       />

--- a/web/src/OverviewTablePane.stories.tsx
+++ b/web/src/OverviewTablePane.stories.tsx
@@ -59,24 +59,27 @@ export default {
 }
 
 export const TwoResources = () => (
-  <OverviewTablePane view={twoResourceView()} tiltConnected={true} />
+  <OverviewTablePane view={twoResourceView()} isSocketConnected={true} />
 )
 
 export const TenResources = () => (
-  <OverviewTablePane view={tenResourceView()} tiltConnected={true} />
+  <OverviewTablePane view={tenResourceView()} isSocketConnected={true} />
 )
 
 export const TenResourcesWithLabels = () => (
-  <OverviewTablePane view={nResourceWithLabelsView(10)} tiltConnected={true} />
+  <OverviewTablePane
+    view={nResourceWithLabelsView(10)}
+    isSocketConnected={true}
+  />
 )
 
 export const OneHundredResources = () => (
-  <OverviewTablePane view={nResourceView(100)} tiltConnected={true} />
+  <OverviewTablePane view={nResourceView(100)} isSocketConnected={true} />
 )
 
 export const OneHundredResourcesOneStar = () => (
   <StarredResourceMemoryProvider initialValueForTesting={["vigoda_2"]}>
-    <OverviewTablePane view={nResourceView(100)} tiltConnected={true} />
+    <OverviewTablePane view={nResourceView(100)} isSocketConnected={true} />
   </StarredResourceMemoryProvider>
 )
 
@@ -95,7 +98,7 @@ export const OneHundredResourcesTenStars = () => {
   ]
   return (
     <StarredResourceMemoryProvider initialValueForTesting={items}>
-      <OverviewTablePane view={nResourceView(100)} tiltConnected={true} />
+      <OverviewTablePane view={nResourceView(100)} isSocketConnected={true} />
     </StarredResourceMemoryProvider>
   )
 }

--- a/web/src/OverviewTablePane.stories.tsx
+++ b/web/src/OverviewTablePane.stories.tsx
@@ -58,21 +58,25 @@ export default {
   },
 }
 
-export const TwoResources = () => <OverviewTablePane view={twoResourceView()} />
+export const TwoResources = () => (
+  <OverviewTablePane view={twoResourceView()} tiltConnected={true} />
+)
 
-export const TenResources = () => <OverviewTablePane view={tenResourceView()} />
+export const TenResources = () => (
+  <OverviewTablePane view={tenResourceView()} tiltConnected={true} />
+)
 
 export const TenResourcesWithLabels = () => (
-  <OverviewTablePane view={nResourceWithLabelsView(10)} />
+  <OverviewTablePane view={nResourceWithLabelsView(10)} tiltConnected={true} />
 )
 
 export const OneHundredResources = () => (
-  <OverviewTablePane view={nResourceView(100)} />
+  <OverviewTablePane view={nResourceView(100)} tiltConnected={true} />
 )
 
 export const OneHundredResourcesOneStar = () => (
   <StarredResourceMemoryProvider initialValueForTesting={["vigoda_2"]}>
-    <OverviewTablePane view={nResourceView(100)} />
+    <OverviewTablePane view={nResourceView(100)} tiltConnected={true} />
   </StarredResourceMemoryProvider>
 )
 
@@ -91,7 +95,7 @@ export const OneHundredResourcesTenStars = () => {
   ]
   return (
     <StarredResourceMemoryProvider initialValueForTesting={items}>
-      <OverviewTablePane view={nResourceView(100)} />
+      <OverviewTablePane view={nResourceView(100)} tiltConnected={true} />
     </StarredResourceMemoryProvider>
   )
 }

--- a/web/src/OverviewTablePane.tsx
+++ b/web/src/OverviewTablePane.tsx
@@ -13,6 +13,7 @@ import { Color, SizeUnit, Width } from "./style-helpers"
 
 type OverviewTablePaneProps = {
   view: Proto.webviewView
+  tiltConnected: boolean
 }
 
 let OverviewTablePaneStyle = styled.div`
@@ -56,7 +57,11 @@ export default function OverviewTablePane(props: OverviewTablePaneProps) {
   return (
     <OverviewTablePaneStyle>
       <OverviewTableStickyNav>
-        <HeaderBar view={props.view} currentPage={AnalyticsType.Grid} />
+        <HeaderBar
+          view={props.view}
+          currentPage={AnalyticsType.Grid}
+          tiltConnected={props.tiltConnected}
+        />
         <StarredResourceBar {...starredResourcePropsFromView(props.view, "")} />
         <OverviewTableMenu aria-label="Resource menu">
           <OverviewTableResourceNameFilter />

--- a/web/src/OverviewTablePane.tsx
+++ b/web/src/OverviewTablePane.tsx
@@ -13,7 +13,7 @@ import { Color, SizeUnit, Width } from "./style-helpers"
 
 type OverviewTablePaneProps = {
   view: Proto.webviewView
-  tiltConnected: boolean
+  isSocketConnected: boolean
 }
 
 let OverviewTablePaneStyle = styled.div`
@@ -60,7 +60,7 @@ export default function OverviewTablePane(props: OverviewTablePaneProps) {
         <HeaderBar
           view={props.view}
           currentPage={AnalyticsType.Grid}
-          tiltConnected={props.tiltConnected}
+          isSocketConnected={props.isSocketConnected}
         />
         <StarredResourceBar {...starredResourcePropsFromView(props.view, "")} />
         <OverviewTableMenu aria-label="Resource menu">

--- a/web/src/ResourceStatusSummary.tsx
+++ b/web/src/ResourceStatusSummary.tsx
@@ -301,13 +301,13 @@ function statusCounts(statuses: ResourceStatus[]): StatusCounts {
 
 function ResourceMetadata(props: {
   counts: StatusCounts
-  tiltConnected?: boolean
+  isSocketConnected?: boolean
 }) {
   let { totalEnabled, healthy, pending, unhealthy } = props.counts
   useEffect(() => {
     let favicon: any = document.head.querySelector("#favicon")
     let faviconHref = ""
-    if (props.tiltConnected === false) {
+    if (props.isSocketConnected === false) {
       document.title = `… disconnected ┊ Tilt`
       faviconHref = "/static/ico/favicon-gray.ico"
     } else if (unhealthy > 0) {
@@ -323,7 +323,7 @@ function ResourceMetadata(props: {
     if (favicon) {
       favicon.href = faviconHref
     }
-  }, [totalEnabled, healthy, pending, unhealthy, props.tiltConnected])
+  }, [totalEnabled, healthy, pending, unhealthy, props.isSocketConnected])
   return <></>
 }
 
@@ -336,7 +336,7 @@ type ResourceStatusSummaryOptions = {
 
 type ResourceStatusSummaryProps = {
   statuses: ResourceStatus[]
-  tiltConnected?: boolean
+  isSocketConnected?: boolean
 } & ResourceStatusSummaryOptions
 
 function ResourceStatusSummary(props: ResourceStatusSummaryProps) {
@@ -350,7 +350,7 @@ function ResourceStatusSummary(props: ResourceStatusSummaryProps) {
       {updateMetadata && (
         <ResourceMetadata
           counts={statusCounts(props.statuses)}
-          tiltConnected={props.tiltConnected}
+          isSocketConnected={props.isSocketConnected}
         />
       )}
       <ResourceGroupStatus
@@ -372,7 +372,7 @@ function ResourceStatusSummary(props: ResourceStatusSummaryProps) {
 
 type StatusSummaryProps<T> = {
   resources: readonly T[]
-  tiltConnected?: boolean
+  isSocketConnected?: boolean
 } & ResourceStatusSummaryOptions
 
 export function SidebarGroupStatusSummary(

--- a/web/src/ResourceStatusSummary.tsx
+++ b/web/src/ResourceStatusSummary.tsx
@@ -299,12 +299,18 @@ function statusCounts(statuses: ResourceStatus[]): StatusCounts {
   }
 }
 
-function ResourceMetadata(props: { counts: StatusCounts }) {
+function ResourceMetadata(props: {
+  counts: StatusCounts
+  tiltConnected?: boolean
+}) {
   let { totalEnabled, healthy, pending, unhealthy } = props.counts
   useEffect(() => {
     let favicon: any = document.head.querySelector("#favicon")
     let faviconHref = ""
-    if (unhealthy > 0) {
+    if (props.tiltConnected === false) {
+      document.title = `… disconnected ┊ Tilt`
+      faviconHref = "/static/ico/favicon-gray.ico"
+    } else if (unhealthy > 0) {
       document.title = `✖︎ ${unhealthy} ┊ Tilt`
       faviconHref = "/static/ico/favicon-red.ico"
     } else if (pending || totalEnabled === 0) {
@@ -317,7 +323,7 @@ function ResourceMetadata(props: { counts: StatusCounts }) {
     if (favicon) {
       favicon.href = faviconHref
     }
-  }, [totalEnabled, healthy, pending, unhealthy])
+  }, [totalEnabled, healthy, pending, unhealthy, props.tiltConnected])
   return <></>
 }
 
@@ -330,6 +336,7 @@ type ResourceStatusSummaryOptions = {
 
 type ResourceStatusSummaryProps = {
   statuses: ResourceStatus[]
+  tiltConnected?: boolean
 } & ResourceStatusSummaryOptions
 
 function ResourceStatusSummary(props: ResourceStatusSummaryProps) {
@@ -341,7 +348,10 @@ function ResourceStatusSummary(props: ResourceStatusSummaryProps) {
   return (
     <ResourceStatusSummaryRoot aria-label={labelText}>
       {updateMetadata && (
-        <ResourceMetadata counts={statusCounts(props.statuses)} />
+        <ResourceMetadata
+          counts={statusCounts(props.statuses)}
+          tiltConnected={props.tiltConnected}
+        />
       )}
       <ResourceGroupStatus
         counts={statusCounts(props.statuses)}
@@ -362,6 +372,7 @@ function ResourceStatusSummary(props: ResourceStatusSummaryProps) {
 
 type StatusSummaryProps<T> = {
   resources: readonly T[]
+  tiltConnected?: boolean
 } & ResourceStatusSummaryOptions
 
 export function SidebarGroupStatusSummary(

--- a/web/src/ResourceStatusSummary.tsx
+++ b/web/src/ResourceStatusSummary.tsx
@@ -6,6 +6,7 @@ import { ReactComponent as CloseSvg } from "./assets/svg/close.svg"
 import { ReactComponent as DisabledSvg } from "./assets/svg/not-allowed.svg"
 import { ReactComponent as PendingSvg } from "./assets/svg/pending.svg"
 import { ReactComponent as WarningSvg } from "./assets/svg/warning.svg"
+import { linkToTiltAsset } from "./constants"
 import { FilterLevel } from "./logfilters"
 import { useLogStore } from "./LogStore"
 import { RowValues } from "./OverviewTableColumns"
@@ -309,7 +310,9 @@ function ResourceMetadata(props: {
     let faviconHref = ""
     if (props.isSocketConnected === false) {
       document.title = `… disconnected ┊ Tilt`
-      faviconHref = "/static/ico/favicon-gray.ico"
+      // Use a publically-hosted favicon since Tilt is disconnected
+      // and it's not guaranteed that the favicon will be cached
+      faviconHref = linkToTiltAsset("ico", "dashboard-favicon-gray.ico")
     } else if (unhealthy > 0) {
       document.title = `✖︎ ${unhealthy} ┊ Tilt`
       faviconHref = "/static/ico/favicon-red.ico"

--- a/web/src/SocketBar.tsx
+++ b/web/src/SocketBar.tsx
@@ -40,7 +40,7 @@ let Bar = styled.div`
   animation: ${pulse} 3s ease infinite;
 `
 
-export function isSocketConnected(state: SocketState) {
+export function isTiltSocketConnected(state: SocketState) {
   if (
     state === SocketState.Reconnecting ||
     state === SocketState.Closed ||

--- a/web/src/SocketBar.tsx
+++ b/web/src/SocketBar.tsx
@@ -40,6 +40,18 @@ let Bar = styled.div`
   animation: ${pulse} 3s ease infinite;
 `
 
+export function isSocketConnected(state: SocketState) {
+  if (
+    state === SocketState.Reconnecting ||
+    state === SocketState.Closed ||
+    state === SocketState.Loading
+  ) {
+    return false
+  }
+
+  return true
+}
+
 export default function SocketBar(props: SocketBarProps) {
   let state = props.state
   let message = ""

--- a/web/src/constants.ts
+++ b/web/src/constants.ts
@@ -23,8 +23,9 @@ function podStatusIsError(status: string | undefined) {
 
 export { podStatusIsCrash, podStatusIsError }
 
-// Links to Tilt's documentation
+// Links to Tilt sites
 export const TILT_DOCS_LINK = "https://docs.tilt.dev"
+export const TILT_PUBLIC_ASSETS_LINK = "https://tilt.dev/assets"
 
 export enum TiltDocsPage {
   DebugFaq = "debug_faq.html",
@@ -43,6 +44,13 @@ export function linkToTiltDocs(page?: TiltDocsPage, anchor?: string) {
   }
 
   return `${TILT_DOCS_LINK}/${page}${anchor ?? ""}`
+}
+
+export function linkToTiltAsset(
+  assetType: "svg" | "ico" | "js" | "css" | "img",
+  filename: string
+) {
+  return `${TILT_PUBLIC_ASSETS_LINK}/${assetType}/${filename}`
 }
 
 export const DEFAULT_RESOURCE_LIST_LIMIT = 20


### PR DESCRIPTION
This PR updates the document title and page favicon when there's a socket connection issue, so it's clearer to users looking at a browser tab title that Tilt has disconnected.

Closes #5650