### PR TITLE
web: fix socket bar z-index so it displays on Table View

### DIFF
--- a/web/src/ApiButton.tsx
+++ b/web/src/ApiButton.tsx
@@ -32,7 +32,7 @@ import {
   InstrumentedTextField,
 } from "./instrumentedComponents"
 import { usePathBuilder } from "./PathBuilder"
-import { Color, FontSize, SizeUnit } from "./style-helpers"
+import { Color, FontSize, SizeUnit, ZIndex } from "./style-helpers"
 import { apiTimeFormat, tiltApiPut } from "./tiltApi"
 import { UIButton, UIInputSpec, UIInputStatus } from "./types"
 
@@ -100,7 +100,7 @@ export const UIBUTTON_STOP_BUILD_TYPE = "StopBuild"
 
 // Styles
 const ApiButtonFormRoot = styled.div`
-  z-index: 20;
+  z-index: ${ZIndex.ApiButton};
 `
 const ApiButtonFormFooter = styled.div`
   margin-top: ${SizeUnit(0.5)};

--- a/web/src/OverviewTablePane.tsx
+++ b/web/src/OverviewTablePane.tsx
@@ -9,7 +9,7 @@ import { ResourceNameFilter } from "./ResourceNameFilter"
 import StarredResourceBar, {
   starredResourcePropsFromView,
 } from "./StarredResourceBar"
-import { Color, SizeUnit, Width } from "./style-helpers"
+import { Color, SizeUnit, Width, ZIndex } from "./style-helpers"
 
 type OverviewTablePaneProps = {
   view: Proto.webviewView
@@ -27,7 +27,7 @@ const OverviewTableStickyNav = styled.div`
   background-color: ${Color.gray20};
   position: sticky;
   top: 0;
-  z-index: 1000;
+  z-index: ${ZIndex.TableStickyHeader};
 `
 
 const OverviewTableMenu = styled.section`

--- a/web/src/SocketBar.tsx
+++ b/web/src/SocketBar.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 import styled, { keyframes } from "styled-components"
-import { Color, ColorAlpha, ColorRGBA } from "./style-helpers"
+import { Color, ColorAlpha, ColorRGBA, ZIndex } from "./style-helpers"
 import { SocketState } from "./types"
 
 type SocketBarProps = {
@@ -21,7 +21,7 @@ let pulse = keyframes`
 
 let SocketBarRoot = styled.div`
   position: fixed;
-  z-index: 1000;
+  z-index: ${ZIndex.SocketBar};
   width: 100vw;
   display: flex;
   top: 0;

--- a/web/src/constants.scss
+++ b/web/src/constants.scss
@@ -57,9 +57,6 @@ $statusbar-height: $spacing-unit * 1.5; // Height.statusbar
 // Z-Index
 $z-modal: 3000;
 $z-analyticsNudge: 2000;
-$z-statusbar: 1000;
-$z-sidebar: 1000; // Sync
-$z-topBar: 500;
 
 // MISC
 $animation-timing: 200ms;

--- a/web/src/style-helpers.ts
+++ b/web/src/style-helpers.ts
@@ -74,11 +74,12 @@ export enum Width {
 
 export const overviewItemBorderRadius = "6px"
 
+// When adding new z-index values, check to see
+// if there are conflicting values in constants.scss
 export enum ZIndex {
-  OverviewItemActions = 2000,
-  SidebarMenu = 2000,
-  Sidebar = 1000,
-  HUDHeader = 500,
+  ApiButton = 5,
+  TableStickyHeader = 999,
+  SocketBar = 1000,
 }
 
 export enum AnimDuration {


### PR DESCRIPTION
Fixing a bug I introduced when I implemented the sticky Table View bar 🤦🏻‍♂️

This PR fixes the conflicting overlap in `z-index` values that caused the socket bar message to be hidden on Table View. I also centralized any `z-index` values greater than `2`, so we can avoid conflicts like this in the future.