### PR TITLE
engine: remove Refs from ImageTarget

### DIFF
--- a/internal/build/image_builder.go
+++ b/internal/build/image_builder.go
@@ -186,7 +186,7 @@ func (ib *ImageBuilder) shouldUseKINDLoad(refs container.TaggedRefs, cluster *v1
 	// if we're using KIND and the image has a separate ref by which it's referred to
 	// in the cluster, that implies that we have a local registry in place, and should
 	// push to that instead of using KIND load.
-	if refs.LocalRef != refs.ClusterRef {
+	if refs.LocalRef.String() != refs.ClusterRef.String() {
 		return false
 	}
 

--- a/internal/build/image_builder.go
+++ b/internal/build/image_builder.go
@@ -41,7 +41,7 @@ func (ib *ImageBuilder) CanReuseRef(ctx context.Context, iTarget model.ImageTarg
 		return true, nil
 	}
 	return false, fmt.Errorf("image %q has no valid buildDetails (neither "+
-		"DockerBuild nor CustomBuild)", iTarget.Refs.ConfigurationRef)
+		"DockerBuild nor CustomBuild)", iTarget.ImageMapSpec.Selector)
 }
 
 // Build the image, and push it if necessary.
@@ -59,7 +59,7 @@ func (ib *ImageBuilder) Build(ctx context.Context,
 		return refs, stages, err
 	}
 
-	pushStage := ib.push(ctx, refs.LocalRef, ps, iTarget, cluster)
+	pushStage := ib.push(ctx, refs, ps, iTarget, cluster)
 	if pushStage != nil {
 		stages = append(stages, *pushStage)
 	}
@@ -76,15 +76,21 @@ func (ib *ImageBuilder) buildOnly(ctx context.Context,
 	iTarget model.ImageTarget,
 	cluster *v1alpha1.Cluster,
 	imageMaps map[types.NamespacedName]*v1alpha1.ImageMap,
-	ps *PipelineState) (container.TaggedRefs, []v1alpha1.DockerImageStageStatus, error) {
-	userFacingRefName := container.FamiliarString(iTarget.Refs.ConfigurationRef)
+	ps *PipelineState,
+) (container.TaggedRefs, []v1alpha1.DockerImageStageStatus, error) {
+	refs, err := iTarget.Refs(cluster)
+	if err != nil {
+		return container.TaggedRefs{}, nil, err
+	}
+
+	userFacingRefName := container.FamiliarString(refs.ConfigurationRef)
 
 	switch bd := iTarget.BuildDetails.(type) {
 	case model.DockerBuild:
 		ps.StartPipelineStep(ctx, "Building Dockerfile: [%s]", userFacingRefName)
 		defer ps.EndPipelineStep(ctx)
 
-		return ib.db.BuildImage(ctx, ps, iTarget.Refs, bd.DockerImageSpec,
+		return ib.db.BuildImage(ctx, ps, refs, bd.DockerImageSpec,
 			cluster,
 			imageMaps,
 			ignore.CreateBuildContextFilter(iTarget))
@@ -92,18 +98,18 @@ func (ib *ImageBuilder) buildOnly(ctx context.Context,
 	case model.CustomBuild:
 		ps.StartPipelineStep(ctx, "Building Custom Build: [%s]", userFacingRefName)
 		defer ps.EndPipelineStep(ctx)
-		refs, err := ib.custb.Build(ctx, iTarget.Refs, bd.CmdImageSpec, imageMaps)
+		refs, err := ib.custb.Build(ctx, refs, bd.CmdImageSpec, imageMaps)
 		return refs, nil, err
 	}
 
 	// Theoretically this should never trip b/c we `validate` the manifest beforehand...?
 	// If we get here, something is very wrong.
 	return container.TaggedRefs{}, nil, fmt.Errorf("image %q has no valid buildDetails (neither "+
-		"DockerBuild nor CustomBuild)", iTarget.Refs.ConfigurationRef)
+		"DockerBuild nor CustomBuild)", refs.ConfigurationRef)
 }
 
-// Push the image if the clsuter requires it.
-func (ib *ImageBuilder) push(ctx context.Context, ref reference.NamedTagged, ps *PipelineState, iTarget model.ImageTarget, cluster *v1alpha1.Cluster) *v1alpha1.DockerImageStageStatus {
+// Push the image if the cluster requires it.
+func (ib *ImageBuilder) push(ctx context.Context, refs container.TaggedRefs, ps *PipelineState, iTarget model.ImageTarget, cluster *v1alpha1.Cluster) *v1alpha1.DockerImageStageStatus {
 	// Skip the push phase entirely if we're on Docker Compose.
 	isDC := cluster != nil &&
 		cluster.Spec.Connection != nil &&
@@ -114,7 +120,7 @@ func (ib *ImageBuilder) push(ctx context.Context, ref reference.NamedTagged, ps 
 
 	// On Kubernetes, we count each push() as a stage, and need to print why
 	// we're skipping if we don't need to push.
-	ps.StartPipelineStep(ctx, "Pushing %s", container.FamiliarString(ref))
+	ps.StartPipelineStep(ctx, "Pushing %s", container.FamiliarString(refs.LocalRef))
 	defer ps.EndPipelineStep(ctx)
 
 	cbSkip := false
@@ -141,9 +147,9 @@ func (ib *ImageBuilder) push(ctx context.Context, ref reference.NamedTagged, ps 
 
 	startTime := apis.NowMicro()
 	var err error
-	if ib.shouldUseKINDLoad(ctx, iTarget, cluster) {
+	if ib.shouldUseKINDLoad(refs, cluster) {
 		ps.Printf(ctx, "Loading image to KIND")
-		err := ib.kl.LoadToKIND(ps.AttachLogger(ctx), cluster, ref)
+		err := ib.kl.LoadToKIND(ps.AttachLogger(ctx), cluster, refs.LocalRef)
 		endTime := apis.NowMicro()
 		stage := &v1alpha1.DockerImageStageStatus{
 			Name:       "kind load",
@@ -157,7 +163,7 @@ func (ib *ImageBuilder) push(ctx context.Context, ref reference.NamedTagged, ps 
 	}
 
 	ps.Printf(ctx, "Pushing with Docker client")
-	err = ib.db.PushImage(ps.AttachLogger(ctx), ref)
+	err = ib.db.PushImage(ps.AttachLogger(ctx), refs.LocalRef)
 
 	endTime := apis.NowMicro()
 	stage := &v1alpha1.DockerImageStageStatus{
@@ -171,7 +177,7 @@ func (ib *ImageBuilder) push(ctx context.Context, ref reference.NamedTagged, ps 
 	return stage
 }
 
-func (ib *ImageBuilder) shouldUseKINDLoad(ctx context.Context, iTarg model.ImageTarget, cluster *v1alpha1.Cluster) bool {
+func (ib *ImageBuilder) shouldUseKINDLoad(refs container.TaggedRefs, cluster *v1alpha1.Cluster) bool {
 	isKIND := k8sConnStatus(cluster).Product == string(clusterid.ProductKIND)
 	if !isKIND {
 		return false
@@ -180,7 +186,7 @@ func (ib *ImageBuilder) shouldUseKINDLoad(ctx context.Context, iTarg model.Image
 	// if we're using KIND and the image has a separate ref by which it's referred to
 	// in the cluster, that implies that we have a local registry in place, and should
 	// push to that instead of using KIND load.
-	if iTarg.HasDistinctClusterRef() {
+	if refs.LocalRef != refs.ClusterRef {
 		return false
 	}
 

--- a/internal/cli/wire_gen.go
+++ b/internal/cli/wire_gen.go
@@ -328,7 +328,7 @@ func wireCmdUp(ctx context.Context, analytics3 *analytics.TiltAnalytics, cmdTags
 	defaults := _wireDefaultsValue
 	tiltfileLoader := tiltfile.ProvideTiltfileLoader(analytics3, plugin, versionPlugin, configPlugin, tiltextensionPlugin, dockerComposeClient, webHost, processExecer, defaults, product)
 	engineMode := _wireEngineModeValue
-	tiltfileReconciler := tiltfile2.NewReconciler(storeStore, tiltfileLoader, client, compositeClient, deferredClient, scheme, engineMode, k8sKubeContextOverride, k8sNamespaceOverride)
+	tiltfileReconciler := tiltfile2.NewReconciler(storeStore, tiltfileLoader, compositeClient, deferredClient, scheme, engineMode, k8sKubeContextOverride, k8sNamespaceOverride)
 	togglebuttonReconciler := togglebutton.NewReconciler(deferredClient, scheme)
 	dockerUpdater := containerupdate.NewDockerUpdater(compositeClient)
 	execUpdater := containerupdate.NewExecUpdater(client)
@@ -541,7 +541,7 @@ func wireCmdCI(ctx context.Context, analytics3 *analytics.TiltAnalytics, subcomm
 	defaults := _wireDefaultsValue
 	tiltfileLoader := tiltfile.ProvideTiltfileLoader(analytics3, plugin, versionPlugin, configPlugin, tiltextensionPlugin, dockerComposeClient, webHost, processExecer, defaults, product)
 	engineMode := _wireStoreEngineModeValue
-	tiltfileReconciler := tiltfile2.NewReconciler(storeStore, tiltfileLoader, client, compositeClient, deferredClient, scheme, engineMode, k8sKubeContextOverride, k8sNamespaceOverride)
+	tiltfileReconciler := tiltfile2.NewReconciler(storeStore, tiltfileLoader, compositeClient, deferredClient, scheme, engineMode, k8sKubeContextOverride, k8sNamespaceOverride)
 	togglebuttonReconciler := togglebutton.NewReconciler(deferredClient, scheme)
 	dockerUpdater := containerupdate.NewDockerUpdater(compositeClient)
 	execUpdater := containerupdate.NewExecUpdater(client)
@@ -750,7 +750,7 @@ func wireCmdUpdog(ctx context.Context, analytics3 *analytics.TiltAnalytics, cmdT
 	defaults := _wireDefaultsValue
 	tiltfileLoader := tiltfile.ProvideTiltfileLoader(analytics3, plugin, versionPlugin, configPlugin, tiltextensionPlugin, dockerComposeClient, webHost, processExecer, defaults, product)
 	engineMode := _wireEngineModeValue2
-	tiltfileReconciler := tiltfile2.NewReconciler(storeStore, tiltfileLoader, k8sClient, compositeClient, deferredClient, scheme, engineMode, k8sKubeContextOverride, k8sNamespaceOverride)
+	tiltfileReconciler := tiltfile2.NewReconciler(storeStore, tiltfileLoader, compositeClient, deferredClient, scheme, engineMode, k8sKubeContextOverride, k8sNamespaceOverride)
 	togglebuttonReconciler := togglebutton.NewReconciler(deferredClient, scheme)
 	dockerUpdater := containerupdate.NewDockerUpdater(compositeClient)
 	execUpdater := containerupdate.NewExecUpdater(k8sClient)

--- a/internal/container/default_registry.go
+++ b/internal/container/default_registry.go
@@ -98,7 +98,11 @@ func MustNewRegistryWithHostFromCluster(host, fromCluster string) Registry {
 // registry rewriting should occur and Tilt should push and pull images to the
 // registry as specified by the configuration ref (e.g. what's passed in to
 // `docker_build` or `custom_build`).
-func RegistryFromCluster(cluster v1alpha1.Cluster) (Registry, error) {
+func RegistryFromCluster(cluster *v1alpha1.Cluster) (Registry, error) {
+	if cluster == nil {
+		return Registry{}, nil
+	}
+
 	if cluster.Status.Error != "" {
 		// if the Cluster has not been initialized, we have not had a chance to
 		// read the local cluster info from it yet
@@ -111,9 +115,11 @@ func RegistryFromCluster(cluster v1alpha1.Cluster) (Registry, error) {
 		regHosting = cluster.Spec.DefaultRegistry
 	}
 
+	return registryFromRegistryHosting(regHosting)
+}
+
+func registryFromRegistryHosting(regHosting *v1alpha1.RegistryHosting) (Registry, error) {
 	if regHosting == nil {
-		// there was also no default registry, so use registries as specified
-		// in the docker_build + custom_build directives in the Tiltfile
 		return Registry{}, nil
 	}
 

--- a/internal/container/default_registry_test.go
+++ b/internal/container/default_registry_test.go
@@ -198,7 +198,7 @@ func TestRegistryFromCluster(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			reg, err := RegistryFromCluster(tt.cluster)
+			reg, err := RegistryFromCluster(&tt.cluster)
 			if tt.expectedErr != "" {
 				require.EqualError(t, err, tt.expectedErr, "Registry error")
 			} else {

--- a/internal/controllers/apis/cluster/registry.go
+++ b/internal/controllers/apis/cluster/registry.go
@@ -1,0 +1,18 @@
+package cluster
+
+import (
+	"github.com/tilt-dev/tilt/internal/container"
+	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
+)
+
+func RegistryHosting(registry *container.Registry) *v1alpha1.RegistryHosting {
+	if registry == nil || registry.Empty() {
+		return nil
+	}
+
+	return &v1alpha1.RegistryHosting{
+		Host:                     registry.Host,
+		HostFromContainerRuntime: registry.HostFromCluster(),
+		SingleName:               registry.SingleName,
+	}
+}

--- a/internal/controllers/core/cluster/reconciler.go
+++ b/internal/controllers/core/cluster/reconciler.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/tilt-dev/tilt/internal/analytics"
 	"github.com/tilt-dev/tilt/internal/controllers/apicmp"
+	"github.com/tilt-dev/tilt/internal/controllers/apis/cluster"
 	"github.com/tilt-dev/tilt/internal/controllers/indexer"
 	"github.com/tilt-dev/tilt/internal/docker"
 	"github.com/tilt-dev/tilt/internal/k8s"
@@ -333,12 +334,7 @@ func (c *connection) toStatus() v1alpha1.ClusterStatus {
 
 	var reg *v1alpha1.RegistryHosting
 	if c.registry != nil {
-		reg = &v1alpha1.RegistryHosting{
-			Host:                     c.registry.Host,
-			HostFromContainerRuntime: c.registry.HostFromCluster(),
-			// TODO(milas+lizz): expose from the Tilt registry object
-			// Help: c.registry.Help,
-		}
+		reg = cluster.RegistryHosting(c.registry)
 	}
 
 	return v1alpha1.ClusterStatus{

--- a/internal/controllers/core/dockerimage/imagemap.go
+++ b/internal/controllers/core/dockerimage/imagemap.go
@@ -27,12 +27,15 @@ func UpdateImageMap(
 	cluster *v1alpha1.Cluster,
 	imageMaps map[types.NamespacedName]*v1alpha1.ImageMap,
 	startTime *metav1.MicroTime,
-	refs container.TaggedRefs) (store.ImageBuildResult, error) {
-
-	result := store.NewImageBuildResult(iTarget.ID(), refs.LocalRef, refs.ClusterRef)
+	taggedRefs container.TaggedRefs,
+) (store.ImageBuildResult, error) {
+	result := store.NewImageBuildResult(iTarget.ID(), taggedRefs.LocalRef, taggedRefs.ClusterRef)
 	if isDockerCompose(cluster) {
-		expectedRef := iTarget.Refs.ConfigurationRef
-		ref, err := tagWithExpected(ctx, docker, refs.LocalRef, expectedRef)
+		imgRefs, err := iTarget.Refs(cluster)
+		if err != nil {
+			return store.ImageBuildResult{}, fmt.Errorf("determining refs: %v", err)
+		}
+		ref, err := tagWithExpected(ctx, docker, taggedRefs.LocalRef, imgRefs.ConfigurationRef)
 		if err != nil {
 			return store.ImageBuildResult{}, err
 		}

--- a/internal/controllers/core/tiltfile/api.go
+++ b/internal/controllers/core/tiltfile/api.go
@@ -16,8 +16,8 @@ import (
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	"github.com/tilt-dev/tilt/internal/container"
 	"github.com/tilt-dev/tilt/internal/controllers/apicmp"
+	"github.com/tilt-dev/tilt/internal/controllers/apis/cluster"
 	"github.com/tilt-dev/tilt/internal/controllers/apis/liveupdate"
 	"github.com/tilt-dev/tilt/internal/controllers/apis/uibutton"
 	"github.com/tilt-dev/tilt/internal/controllers/apiset"
@@ -48,19 +48,22 @@ type disableSourceMap map[model.ManifestName]*v1alpha1.DisableSource
 //
 // In the future, anything that creates objects based on the Tiltfile (e.g., FileWatch specs,
 // LocalServer specs) should go here.
-func updateOwnedObjects(ctx context.Context, client ctrlclient.Client, nn types.NamespacedName,
-	tf *v1alpha1.Tiltfile, tlr *tiltfile.TiltfileLoadResult,
+func updateOwnedObjects(
+	ctx context.Context,
+	client ctrlclient.Client,
+	nn types.NamespacedName,
+	tf *v1alpha1.Tiltfile,
+	tlr *tiltfile.TiltfileLoadResult,
 	changeEnabledResources bool,
 	mode store.EngineMode,
-	registry container.Registry,
-	defaultK8sConnection *v1alpha1.KubernetesClusterConnection) error {
-
+	defaultK8sConnection *v1alpha1.KubernetesClusterConnection,
+) error {
 	disableSources := toDisableSources(tlr)
 
 	if tlr != nil {
 		for i, m := range tlr.Manifests {
 			// Apply the registry to the image refs.
-			err := m.InferImagePropertiesFromCluster(registry)
+			err := m.InferImageProperties()
 			if err != nil {
 				return err
 			}
@@ -601,16 +604,6 @@ func toClusterObjects(nn types.NamespacedName, tlr *tiltfile.TiltfileLoadResult,
 
 	if tlr.HasOrchestrator(model.OrchestratorK8s) {
 		name := v1alpha1.ClusterNameDefault
-
-		var defaultRegistry *v1alpha1.RegistryHosting
-		if !tlr.DefaultRegistry.Empty() {
-			defaultRegistry = &v1alpha1.RegistryHosting{
-				Host:                     tlr.DefaultRegistry.Host,
-				HostFromContainerRuntime: tlr.DefaultRegistry.HostFromCluster(),
-				SingleName:               tlr.DefaultRegistry.SingleName,
-			}
-		}
-
 		result[name] = &v1alpha1.Cluster{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:        name,
@@ -620,7 +613,7 @@ func toClusterObjects(nn types.NamespacedName, tlr *tiltfile.TiltfileLoadResult,
 				Connection: &v1alpha1.ClusterConnection{
 					Kubernetes: defaultK8sConnection.DeepCopy(),
 				},
-				DefaultRegistry: defaultRegistry,
+				DefaultRegistry: cluster.RegistryHosting(&tlr.DefaultRegistry),
 			},
 		}
 	}

--- a/internal/controllers/core/tiltfile/api_test.go
+++ b/internal/controllers/core/tiltfile/api_test.go
@@ -427,7 +427,8 @@ func newAPIFixture(t testing.TB) *apiFixture {
 }
 
 func (f *apiFixture) updateOwnedObjects(nn types.NamespacedName, tf *v1alpha1.Tiltfile, tlr *tiltfile.TiltfileLoadResult) error {
-	return updateOwnedObjects(f.ctx, f.c, nn, tf, tlr, false, store.EngineModeUp, container.Registry{}, &v1alpha1.KubernetesClusterConnection{})
+	return updateOwnedObjects(f.ctx, f.c, nn, tf, tlr, false, store.EngineModeUp,
+		&v1alpha1.KubernetesClusterConnection{})
 }
 
 func (f *apiFixture) Get(nn types.NamespacedName, obj ctrlclient.Object) error {

--- a/internal/controllers/core/tiltfile/reconciler_test.go
+++ b/internal/controllers/core/tiltfile/reconciler_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/tilt-dev/tilt/internal/controllers/apis/uibutton"
 	"github.com/tilt-dev/tilt/internal/controllers/fake"
 	"github.com/tilt-dev/tilt/internal/docker"
-	"github.com/tilt-dev/tilt/internal/k8s"
 	"github.com/tilt-dev/tilt/internal/k8s/testyaml"
 	"github.com/tilt-dev/tilt/internal/store"
 	"github.com/tilt-dev/tilt/internal/testutils/configmap"
@@ -497,8 +496,7 @@ func newFixture(t *testing.T) *fixture {
 	st := NewTestingStore()
 	tfl := tiltfile.NewFakeTiltfileLoader()
 	d := docker.NewFakeClient()
-	kClient := k8s.NewFakeK8sClient(t)
-	r := NewReconciler(st, tfl, kClient, d, cfb.Client, v1alpha1.NewScheme(), store.EngineModeUp, "", "")
+	r := NewReconciler(st, tfl, d, cfb.Client, v1alpha1.NewScheme(), store.EngineModeUp, "", "")
 	q := workqueue.NewRateLimitingQueue(
 		workqueue.NewItemExponentialFailureRateLimiter(time.Millisecond, time.Millisecond))
 	_ = r.requeuer.Start(context.Background(), handler.Funcs{}, q)

--- a/internal/engine/analytics/analytics_reporter.go
+++ b/internal/engine/analytics/analytics_reporter.go
@@ -128,7 +128,7 @@ func (ar *AnalyticsReporter) report(ctx context.Context) {
 					multiImgLU = true
 				}
 				multiContainerLU = multiContainerLU ||
-					refInjectCounts[it.Refs.ConfigurationRef.String()] > 0
+					refInjectCounts[it.ImageMapSpec.Selector] > 0
 			}
 		}
 		if multiContainerLU {

--- a/internal/engine/buildcontrol/docker_compose_build_and_deployer_test.go
+++ b/internal/engine/buildcontrol/docker_compose_build_and_deployer_test.go
@@ -68,7 +68,7 @@ func TestTiltBuildsImage(t *testing.T) {
 
 	assert.Equal(t, 1, f.dCli.BuildCount, "expect one docker build")
 
-	expectedTag := fmt.Sprintf("%s:%s", iTarget.Refs.LocalRef(), docker.TagLatest)
+	expectedTag := fmt.Sprintf("%s:%s", iTarget.ImageMapSpec.Selector, docker.TagLatest)
 	assert.Equal(t, expectedTag, f.dCli.TagTarget)
 
 	upCalls := f.dcCli.UpCalls()

--- a/internal/engine/buildcontrol/target_queue_test.go
+++ b/internal/engine/buildcontrol/target_queue_test.go
@@ -182,7 +182,7 @@ func newFakeBuildHandlerCall(target model.ImageTarget, num int, depResults []sto
 		target: target,
 		result: store.NewImageBuildResultSingleRef(
 			target.ID(),
-			container.MustParseNamedTagged(fmt.Sprintf("%s:%d", target.Refs.ConfigurationRef.String(), num)),
+			container.MustParseNamedTagged(fmt.Sprintf("%s:%d", target.ImageMapSpec.Selector, num)),
 		),
 		depResults: depResults,
 	}
@@ -208,7 +208,7 @@ func newFakeBuildHandler() *fakeBuildHandler {
 func (fbh *fakeBuildHandler) handle(target model.TargetSpec, depResults []store.ImageBuildResult) (store.ImageBuildResult, error) {
 	iTarget := target.(model.ImageTarget)
 	fbh.buildNum++
-	namedTagged := container.MustParseNamedTagged(fmt.Sprintf("%s:%d", iTarget.Refs.ConfigurationRef, fbh.buildNum))
+	namedTagged := container.MustParseNamedTagged(fmt.Sprintf("%s:%d", iTarget.ImageMapSpec.Selector, fbh.buildNum))
 	result := store.NewImageBuildResultSingleRef(target.ID(), namedTagged)
 	fbh.calls[target.ID()] = fakeBuildHandlerCall{target, depResults, result}
 	return result, nil

--- a/internal/engine/buildcontrol/testdata_test.go
+++ b/internal/engine/buildcontrol/testdata_test.go
@@ -159,7 +159,7 @@ func NewSanchoLiveUpdateMultiStageManifest(fixture Fixture) model.Manifest {
 		WithImageMapDeps([]string{baseImage.ImageMapName()})
 
 	return manifestbuilder.New(fixture, "sancho").
-		WithK8sYAML(testyaml.Deployment("sancho", srcImage.Refs.ConfigurationRef.String())).
+		WithK8sYAML(testyaml.Deployment("sancho", srcImage.ImageMapSpec.Selector)).
 		WithImageTargets(baseImage, srcImage).
 		Build()
 }

--- a/internal/engine/dockerprune/docker_pruner.go
+++ b/internal/engine/dockerprune/docker_pruner.go
@@ -109,7 +109,7 @@ func (dp *DockerPruner) OnChange(ctx context.Context, st store.RStore, summary s
 		// N.B. Only determine the ref selectors if we're actually going to prune - OnChange is called for every batch
 		// 	of store events and this is a comparatively expensive operation (lots of regex), but 99% of the time this
 		// 	is called, no pruning is going to happen, so avoid burning CPU cycles unnecessarily
-		imgSelectors := model.LocalRefSelectorsForManifests(state.Manifests())
+		imgSelectors := model.LocalRefSelectorsForManifests(state.Manifests(), state.Clusters)
 		st.RUnlockState()
 		dp.PruneAndRecordState(ctx, settings.MaxAge, settings.KeepRecent, imgSelectors, curBuildCount)
 		return nil

--- a/internal/engine/dockerprune/docker_pruner_test.go
+++ b/internal/engine/dockerprune/docker_pruner_test.go
@@ -432,11 +432,12 @@ func (dpf *dockerPruneFixture) withDockerManifestUnbuilt() {
 }
 
 func (dpf *dockerPruneFixture) withDockerManifest(alreadyBuilt bool) {
-	m := model.Manifest{Name: "some-docker-manifest"}.WithImageTarget(
-		model.ImageTarget{
-			Refs:         container.MustSimpleRefSet(refSel),
-			BuildDetails: model.DockerBuild{},
-		})
+	iTarget := model.MustNewImageTarget(refSel).
+		WithBuildDetails(model.DockerBuild{})
+
+	m := model.Manifest{Name: "some-docker-manifest"}.
+		WithImageTarget(iTarget)
+
 	dpf.withManifestTarget(store.NewManifestTarget(m), alreadyBuilt)
 }
 

--- a/internal/engine/testdata_test.go
+++ b/internal/engine/testdata_test.go
@@ -108,7 +108,8 @@ func NewSanchoLiveUpdate(f Fixture) v1alpha1.LiveUpdateSpec {
 }
 
 func NewSanchoLiveUpdateImageTarget(f Fixture) model.ImageTarget {
-	return NewSanchoDockerBuildImageTarget(f).WithLiveUpdateSpec("sancho:sancho", NewSanchoLiveUpdate(f))
+	return NewSanchoDockerBuildImageTarget(f).
+		WithLiveUpdateSpec("sancho:sancho", NewSanchoLiveUpdate(f))
 }
 
 func NewSanchoSidecarDockerBuildImageTarget(f Fixture) model.ImageTarget {

--- a/internal/tiltfile/k8s_custom_deploy_test.go
+++ b/internal/tiltfile/k8s_custom_deploy_test.go
@@ -24,8 +24,6 @@ k8s_custom_deploy('foo', 'apply', 'delete', deps=['foo'], image_selector='foo-im
 
 	m := f.assertNextManifest("foo", cb(image("foo-img"), f.expectedLU))
 	assert.True(t, m.ImageTargets[0].IsLiveUpdateOnly)
-	// this ref will never actually be used since the image isn't being built but the registry is applied here
-	assert.Equal(t, "gcr.io/myrepo/foo-img", m.ImageTargets[0].Refs.LocalRef().String())
 
 	require.NoError(t, m.InferLiveUpdateSelectors(), "Failed to infer Live Update selectors")
 	luSpec := m.ImageTargets[0].LiveUpdateSpec

--- a/internal/tiltfile/live_update_test.go
+++ b/internal/tiltfile/live_update_test.go
@@ -178,8 +178,6 @@ custom_build('foo', ':', ['foo'], live_update=%s)
 
 	m := f.assertNextManifest("foo", cb(image("foo"), f.expectedLU))
 	assert.True(t, m.ImageTargets[0].IsLiveUpdateOnly)
-	// this ref will never actually be used since the image isn't being built but the registry is applied here
-	assert.Equal(t, "gcr.io/myrepo/foo", m.ImageTargets[0].Refs.LocalRef().String())
 
 	require.NoError(t, m.InferLiveUpdateSelectors(), "Failed to infer Live Update selectors")
 	luSpec := m.ImageTargets[0].LiveUpdateSpec

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -17,15 +17,14 @@ import (
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/tilt-dev/clusterid"
 	tiltanalytics "github.com/tilt-dev/tilt/internal/analytics"
 	"github.com/tilt-dev/tilt/internal/container"
 	"github.com/tilt-dev/tilt/internal/controllers/apis/liveupdate"
 	ctrltiltfile "github.com/tilt-dev/tilt/internal/controllers/apis/tiltfile"
-	"github.com/tilt-dev/tilt/internal/controllers/fake"
 	"github.com/tilt-dev/tilt/internal/docker"
 	"github.com/tilt-dev/tilt/internal/dockercompose"
 	"github.com/tilt-dev/tilt/internal/feature"
@@ -1642,9 +1641,9 @@ docker_build('gcr.io/some-project-162817/sancho-sidecar', '.')
 	m := f.assertNextManifest("sancho")
 	assert.Equal(t, 2, len(m.ImageTargets))
 	assert.Equal(t, "gcr.io/some-project-162817/sancho",
-		m.ImageTargetAt(0).Refs.ConfigurationRef.String())
+		m.ImageTargetAt(0).ImageMapSpec.Selector)
 	assert.Equal(t, "gcr.io/some-project-162817/sancho-sidecar",
-		m.ImageTargetAt(1).Refs.ConfigurationRef.String())
+		m.ImageTargetAt(1).ImageMapSpec.Selector)
 }
 
 func TestSanchoRedisSidecar(t *testing.T) {
@@ -1662,7 +1661,7 @@ docker_build('gcr.io/some-project-162817/sancho', '.')
 	m := f.assertNextManifest("sancho")
 	assert.Equal(t, 1, len(m.ImageTargets))
 	assert.Equal(t, "gcr.io/some-project-162817/sancho",
-		m.ImageTargetAt(0).Refs.ConfigurationRef.String())
+		m.ImageTargetAt(0).ImageMapSpec.Selector)
 }
 
 func TestExtraPodSelectors(t *testing.T) {
@@ -2445,7 +2444,7 @@ docker_build('tilt.dev/frontend', '.')
 	m := f.assertNextManifest("um",
 		podReadiness(model.PodReadinessWait))
 	assert.Equal(t, "tilt.dev/frontend",
-		m.ImageTargets[0].Refs.LocalRef().String())
+		m.ImageTargets[0].ImageMapSpec.Selector)
 }
 
 func TestImageObjectJSONPathNoMatch(t *testing.T) {
@@ -2487,7 +2486,7 @@ docker_build('tilt.dev/frontend', '.')
 	m := f.assertNextManifest("um",
 		podReadiness(model.PodReadinessIgnore))
 	assert.Equal(t, "tilt.dev/frontend",
-		m.ImageTargets[0].Refs.LocalRef().String())
+		m.ImageTargets[0].ImageMapSpec.Selector)
 }
 
 func TestExtraImageLocationOneImage(t *testing.T) {
@@ -2986,7 +2985,9 @@ default_registry('123.dkr.ecr.us-east-1.amazonaws.com', single_name='team-a/dev'
 		db(image("fe").withLocalRef("123.dkr.ecr.us-east-1.amazonaws.com/team-a/dev")),
 		deployment("fe"))
 
-	feTaggedRefs, err := fe.ImageTargets[0].Refs.AddTagSuffix("tilt-build-123")
+	feRefs, err := fe.ImageTargets[0].Refs(f.cluster(fe))
+	assert.NoError(t, err)
+	feTaggedRefs, err := feRefs.AddTagSuffix("tilt-build-123")
 	assert.NoError(t, err)
 	assert.Equal(t, "123.dkr.ecr.us-east-1.amazonaws.com/team-a/dev:fe-tilt-build-123",
 		feTaggedRefs.LocalRef.String())
@@ -2995,7 +2996,9 @@ default_registry('123.dkr.ecr.us-east-1.amazonaws.com', single_name='team-a/dev'
 		db(image("be").withLocalRef("123.dkr.ecr.us-east-1.amazonaws.com/team-a/dev")),
 		deployment("be"))
 
-	beTaggedRefs, err := be.ImageTargets[0].Refs.AddTagSuffix("tilt-build-456")
+	beRefs, err := be.ImageTargets[0].Refs(f.cluster(be))
+	assert.NoError(t, err)
+	beTaggedRefs, err := beRefs.AddTagSuffix("tilt-build-456")
 	assert.NoError(t, err)
 	assert.Equal(t, "123.dkr.ecr.us-east-1.amazonaws.com/team-a/dev:be-tilt-build-456",
 		beTaggedRefs.LocalRef.String())
@@ -4020,7 +4023,9 @@ k8s_yaml('foo.yaml')
 `)
 
 	f.load()
-	refs := f.assertNextManifest("foo").ImageTargets[0].Refs
+	m := f.assertNextManifest("foo")
+	refs, err := m.ImageTargets[0].Refs(f.cluster(m))
+	require.NoError(t, err)
 	assert.Equal(t, "gcr.io/foo", refs.ClusterRef().String())
 }
 
@@ -5718,7 +5723,6 @@ type fixture struct {
 	k8sContext k8s.KubeContext
 	k8sEnv     clusterid.Product
 	webHost    model.WebHost
-	ctrlclient ctrlclient.Client
 
 	ta *tiltanalytics.TiltAnalytics
 	an *analytics.MemoryAnalytics
@@ -5749,8 +5753,6 @@ func newFixture(t *testing.T) *fixture {
 	f := tempdir.NewTempDirFixture(t)
 	f.Chdir()
 
-	ctrlclient := fake.NewFakeTiltClient()
-
 	// copy the features to avoid unintentional mutation by tests
 	features := make(feature.Defaults)
 	for k, v := range feature.MainDefaults {
@@ -5766,7 +5768,6 @@ func newFixture(t *testing.T) *fixture {
 		ta:             ta,
 		k8sContext:     "fake-context",
 		k8sEnv:         clusterid.ProductDockerDesktop,
-		ctrlclient:     ctrlclient,
 		features:       features,
 	}
 
@@ -5911,7 +5912,7 @@ func (f *fixture) loadAllowWarnings(args ...string) {
 	f.loadResult = tlr
 
 	for _, m := range f.loadResult.Manifests {
-		err := m.InferImagePropertiesFromCluster(f.loadResult.DefaultRegistry)
+		err := m.InferImageProperties()
 		require.NoError(f.t, err)
 	}
 }
@@ -5957,7 +5958,7 @@ func (f *fixture) loadArgsErrString(args []string, msgs ...string) {
 	}
 
 	for _, m := range f.loadResult.Manifests {
-		err := m.InferImagePropertiesFromCluster(f.loadResult.DefaultRegistry)
+		err := m.InferImageProperties()
 		require.NoError(f.t, err)
 	}
 }
@@ -6028,7 +6029,9 @@ func (f *fixture) assertNextManifest(name model.ManifestName, opts ...interface{
 		case dbHelper:
 			image := nextImageTarget()
 
-			ref := image.Refs.ConfigurationRef
+			refs, err := image.Refs(f.cluster(m))
+			require.NoError(f.t, err, "Determining image refs")
+			ref := refs.ConfigurationRef
 			if ref.Empty() {
 				f.t.Fatalf("manifest %v has no more image refs; expected %q", m.Name, opt.image.ref)
 			}
@@ -6039,11 +6042,11 @@ func (f *fixture) assertNextManifest(name model.ManifestName, opts ...interface{
 			}
 
 			expectedLocalRef := container.MustParseNamed(opt.image.localRef)
-			require.Equal(f.t, expectedLocalRef.String(), image.Refs.LocalRef().String(), "manifest %v localRef", m.Name)
+			require.Equal(f.t, expectedLocalRef.String(), refs.LocalRef().String(), "manifest %v localRef", m.Name)
 
 			if opt.image.clusterRef != "" {
 				expectedClusterRef := container.MustParseNamed(opt.image.clusterRef)
-				require.Equal(f.t, expectedClusterRef.String(), image.Refs.ClusterRef().String(), "manifest %v clusterRef", m.Name)
+				require.Equal(f.t, expectedClusterRef.String(), refs.ClusterRef().String(), "manifest %v clusterRef", m.Name)
 			}
 
 			assert.Equal(f.t, opt.image.matchInEnvVars, image.MatchInEnvVars)
@@ -6069,7 +6072,11 @@ func (f *fixture) assertNextManifest(name model.ManifestName, opts ...interface{
 			}
 		case cbHelper:
 			image := nextImageTarget()
-			ref := image.Refs.ConfigurationRef
+
+			refs, err := image.Refs(f.cluster(m))
+			require.NoError(f.t, err, "Determining image refs")
+
+			ref := refs.ConfigurationRef
 			expectedRef := container.MustParseNamed(opt.image.ref)
 			if !assert.Equal(f.t, expectedRef.String(), ref.String(), "manifest %v image ref", m.Name) {
 				f.t.FailNow()
@@ -6345,6 +6352,51 @@ func (f *fixture) assertLinks(expected, actual []model.Link) {
 		require.Equalf(f.t, exp.URLString(), actual[i].URLString(), "link at index %d", i)
 		require.Equalf(f.t, exp.Name, actual[i].Name, "link at index %d", i)
 	}
+}
+
+func (f *fixture) cluster(m model.Manifest) *v1alpha1.Cluster {
+	f.t.Helper()
+
+	tlr := f.loadResult
+
+	var defaultRegistry *v1alpha1.RegistryHosting
+	if !tlr.DefaultRegistry.Empty() {
+		defaultRegistry = &v1alpha1.RegistryHosting{
+			Host:                     tlr.DefaultRegistry.Host,
+			HostFromContainerRuntime: tlr.DefaultRegistry.HostFromCluster(),
+			SingleName:               tlr.DefaultRegistry.SingleName,
+		}
+	}
+
+	if m.IsK8s() {
+		return &v1alpha1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: v1alpha1.ClusterNameDefault,
+			},
+			Spec: v1alpha1.ClusterSpec{
+				Connection: &v1alpha1.ClusterConnection{
+					Kubernetes: &v1alpha1.KubernetesClusterConnection{},
+				},
+				DefaultRegistry: defaultRegistry,
+			},
+		}
+	}
+
+	if m.IsDC() {
+		return &v1alpha1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: v1alpha1.ClusterNameDocker,
+			},
+			Spec: v1alpha1.ClusterSpec{
+				Connection: &v1alpha1.ClusterConnection{
+					Docker: &v1alpha1.DockerClusterConnection{},
+				},
+				DefaultRegistry: defaultRegistry,
+			},
+		}
+	}
+
+	return &v1alpha1.Cluster{}
 }
 
 type secretHelper struct {

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -426,10 +426,6 @@ func LocalRefSelectorsForManifests(manifests []Manifest, clusters map[string]*v1
 	var res []container.RefSelector
 	for _, m := range manifests {
 		cluster := clusters[m.ClusterName()]
-		if m.ClusterName() != "" && cluster == nil {
-			continue
-		}
-
 		for _, iTarg := range m.ImageTargets {
 			refs, err := iTarg.Refs(cluster)
 			if err != nil {

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -269,7 +269,7 @@ func (m *Manifest) ClusterName() string {
 }
 
 // Infer image properties for each image.
-func (m *Manifest) InferImagePropertiesFromCluster(reg container.Registry) error {
+func (m *Manifest) InferImageProperties() error {
 	var deployImageIDs []TargetID
 	if m.DeployTarget != nil {
 		deployImageIDs = m.DeployTarget.DependencyIDs()
@@ -286,7 +286,7 @@ func (m *Manifest) InferImagePropertiesFromCluster(reg container.Registry) error
 			clusterNeeds = v1alpha1.ClusterImageNeedsPush
 		}
 
-		iTarget, err := iTarget.InferImagePropertiesFromCluster(reg, clusterNeeds, m.ClusterName())
+		iTarget, err := iTarget.inferImageProperties(clusterNeeds, m.ClusterName())
 		if err != nil {
 			return fmt.Errorf("manifest %s: %v", m.Name, err)
 		}
@@ -422,11 +422,23 @@ func (m Manifest) ManifestName() ManifestName {
 	return m.Name
 }
 
-func LocalRefSelectorsForManifests(manifests []Manifest) []container.RefSelector {
+func LocalRefSelectorsForManifests(manifests []Manifest, clusters map[string]*v1alpha1.Cluster) []container.RefSelector {
 	var res []container.RefSelector
 	for _, m := range manifests {
+		cluster := clusters[m.ClusterName()]
+		if m.ClusterName() != "" && cluster == nil {
+			continue
+		}
+
 		for _, iTarg := range m.ImageTargets {
-			sel := container.NameSelector(iTarg.Refs.LocalRef()).WithNameMatch()
+			refs, err := iTarg.Refs(cluster)
+			if err != nil {
+				// silently ignore any invalid image references because this
+				// logic is only used for Docker pruning, and we can't prune
+				// something invalid anyway
+				continue
+			}
+			sel := container.NameSelector(refs.LocalRef())
 			res = append(res, sel)
 		}
 	}

--- a/pkg/model/manifest_test.go
+++ b/pkg/model/manifest_test.go
@@ -58,15 +58,15 @@ var equalitytests = []struct {
 		false,
 	},
 	{
-		"ImageTarget.ConfigurationRef unequal",
-		Manifest{}.WithImageTarget(ImageTarget{Refs: container.RefSet{ConfigurationRef: img1}}),
-		Manifest{}.WithImageTarget(ImageTarget{Refs: container.RefSet{ConfigurationRef: img2}}),
+		"ImageTarget.ImageMapSpec.Selector unequal",
+		Manifest{}.WithImageTarget(ImageTarget{ImageMapSpec: v1alpha1.ImageMapSpec{Selector: img1.RefFamiliarString()}}),
+		Manifest{}.WithImageTarget(ImageTarget{ImageMapSpec: v1alpha1.ImageMapSpec{Selector: img2.RefFamiliarString()}}),
 		true,
 	},
 	{
 		"ImageTarget.ConfigurationRef equal",
-		Manifest{}.WithImageTarget(ImageTarget{Refs: container.RefSet{ConfigurationRef: img1}}),
-		Manifest{}.WithImageTarget(ImageTarget{Refs: container.RefSet{ConfigurationRef: img1}}),
+		Manifest{}.WithImageTarget(ImageTarget{ImageMapSpec: v1alpha1.ImageMapSpec{Selector: img1.RefFamiliarString()}}),
+		Manifest{}.WithImageTarget(ImageTarget{ImageMapSpec: v1alpha1.ImageMapSpec{Selector: img1.RefFamiliarString()}}),
 		false,
 	},
 	{


### PR DESCRIPTION
This is another place where we need to use the `Cluster` object
to determine the registry to resolve image references on the fly.

The brunt of the fallout here is actually throughout tests; many
of these now rely on the `.ImageMapSpec.Selector` directly, but
some that are testing specific registry-rewriting functionality
have been adapted to work.

Marking this as a draft because it depends upon #5677.