### PR TITLE
api: add cluster helpers to ControllerFixture

### DIFF
--- a/internal/controllers/apis/cluster/client_test.go
+++ b/internal/controllers/apis/cluster/client_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/tilt-dev/tilt/internal/controllers/fake"
 	"github.com/tilt-dev/tilt/internal/k8s"
 	"github.com/tilt-dev/tilt/internal/timecmp"
 	"github.com/tilt-dev/tilt/pkg/apis"
@@ -132,7 +133,7 @@ type cmFixture struct {
 }
 
 func newCmFixture(t testing.TB) *cmFixture {
-	cp := NewFakeClientProvider(nil)
+	cp := NewFakeClientProvider(t, fake.NewFakeTiltClient())
 	return &cmFixture{
 		t:  t,
 		cp: cp,

--- a/internal/controllers/core/kubernetesdiscovery/reconciler.go
+++ b/internal/controllers/core/kubernetesdiscovery/reconciler.go
@@ -207,7 +207,7 @@ func (w *Reconciler) getCluster(ctx context.Context, kd *v1alpha1.KubernetesDisc
 	var cluster v1alpha1.Cluster
 	err := w.ctrlClient.Get(ctx, clusterNN, &cluster)
 	if err != nil {
-		return nil, fmt.Errorf("could not fetch cluster %s: %v", kd.Spec.Cluster, err)
+		return nil, err
 	}
 	return &cluster, nil
 }

--- a/internal/controllers/fake/fixture.go
+++ b/internal/controllers/fake/fixture.go
@@ -209,11 +209,11 @@ func (f *ControllerFixture) Upsert(o object) ctrl.Result {
 	if err != nil &&
 		(apierrors.IsAlreadyExists(err) ||
 			strings.Contains(err.Error(), "resourceVersion can not be set for Create requests")) {
-		update := o.DeepCopyObject().(object)
+		tmp := o.DeepCopyObject().(object)
 
-		require.NoError(f.t, f.Client.Get(f.ctx, f.KeyForObject(o), o))
-		update.SetResourceVersion(o.GetResourceVersion())
-		return f.Update(update)
+		require.NoError(f.t, f.Client.Get(f.ctx, f.KeyForObject(o), tmp))
+		o.SetResourceVersion(tmp.GetResourceVersion())
+		return f.Update(o)
 	}
 	require.NoError(f.t, err)
 	return f.MustReconcile(f.KeyForObject(o))

--- a/internal/engine/k8swatch/event_watch_manager_test.go
+++ b/internal/engine/k8swatch/event_watch_manager_test.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/tilt-dev/tilt/internal/controllers/apis/cluster"
+	"github.com/tilt-dev/tilt/internal/controllers/fake"
 	"github.com/tilt-dev/tilt/pkg/apis"
 	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
 
@@ -258,15 +259,14 @@ type ewmFixture struct {
 }
 
 func newEWMFixture(t *testing.T) *ewmFixture {
-	kClient := k8s.NewFakeK8sClient(t)
-
 	ctx, _, _ := testutils.CtxAndAnalyticsForTest()
 	ctx, cancel := context.WithCancel(ctx)
 
 	clock := clockwork.NewFakeClock()
 	st := store.NewTestingStore()
 
-	cc := cluster.NewFakeClientProvider(kClient)
+	cc := cluster.NewFakeClientProvider(t, fake.NewFakeTiltClient())
+	kClient := cc.EnsureDefaultK8sCluster(ctx)
 
 	ret := &ewmFixture{
 		TempDirFixture: tempdir.NewTempDirFixture(t),

--- a/internal/engine/k8swatch/service_watch_test.go
+++ b/internal/engine/k8swatch/service_watch_test.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/tilt-dev/tilt/internal/controllers/apis/cluster"
+	"github.com/tilt-dev/tilt/internal/controllers/fake"
 	"github.com/tilt-dev/tilt/internal/k8s/testyaml"
 	"github.com/tilt-dev/tilt/internal/store/k8sconv"
 	"github.com/tilt-dev/tilt/internal/testutils"
@@ -202,13 +203,13 @@ type swFixture struct {
 func newSWFixture(t *testing.T) *swFixture {
 	nip := k8s.NodeIP("fakeip")
 
-	kClient := k8s.NewFakeK8sClient(t)
-	kClient.FakeNodeIP = nip
-
 	ctx, _, _ := testutils.CtxAndAnalyticsForTest()
 	ctx, cancel := context.WithCancel(ctx)
 
-	clients := cluster.NewFakeClientProvider(kClient)
+	clients := cluster.NewFakeClientProvider(t, fake.NewFakeTiltClient())
+	kClient := clients.EnsureDefaultK8sCluster(ctx)
+	kClient.FakeNodeIP = nip
+
 	sw := NewServiceWatcher(clients, k8s.DefaultNamespace)
 	st := store.NewTestingStore()
 


### PR DESCRIPTION
I extracted this from the KubernetesDiscovery Reconciler since it'll
be needed across a bunch of them.