### PR TITLE
tiltfile: log post-starlark execution error locations at start of line

### DIFF
--- a/internal/tiltfile/k8s.go
+++ b/internal/tiltfile/k8s.go
@@ -875,7 +875,7 @@ func (s *tiltfileState) calculateResourceNames(workloads []k8s.K8sEntity) ([]str
 	if s.workloadToResourceFunction.fn != nil {
 		names, err := s.workloadToResourceFunctionNames(workloads)
 		if err != nil {
-			return nil, errors.Wrapf(err, "error applying workload_to_resource_function %s", s.workloadToResourceFunction.pos.String())
+			return nil, errors.Wrapf(err, "%s: error applying workload_to_resource_function", s.workloadToResourceFunction.pos.String())
 		}
 		return names, nil
 	} else {

--- a/internal/tiltfile/live_update.go
+++ b/internal/tiltfile/live_update.go
@@ -286,7 +286,7 @@ func (s *tiltfileState) liveUpdateFromSteps(t *starlark.Thread, maybeSteps starl
 			spec.Restart = v1alpha1.LiveUpdateRestartStrategyAlways
 
 		default:
-			return v1alpha1.LiveUpdateSpec{}, fmt.Errorf("internal error - unknown liveUpdateStep '%v' of type '%T', declared at %s", x, x, x.declarationPos())
+			return v1alpha1.LiveUpdateSpec{}, fmt.Errorf("%s: internal error - unknown liveUpdateStep '%v' of type '%T'", x.declarationPos(), x, x)
 		}
 
 		s.consumeLiveUpdateStep(step)
@@ -308,9 +308,9 @@ func (s *tiltfileState) checkForUnconsumedLiveUpdateSteps() error {
 	if len(s.unconsumedLiveUpdateSteps) > 0 {
 		var errorStrings []string
 		for _, step := range s.unconsumedLiveUpdateSteps {
-			errorStrings = append(errorStrings, fmt.Sprintf("value '%s' of type '%s' declared at %s", step.String(), step.Type(), step.declarationPos()))
+			errorStrings = append(errorStrings, fmt.Sprintf("%s: value '%s' of type '%s'", step.declarationPos(), step.String(), step.Type()))
 		}
-		return fmt.Errorf("found %d live_update steps that were created but not used in a live_update: %s",
+		return fmt.Errorf("found %d live_update steps that were created but not used in a live_update:\n%s",
 			len(s.unconsumedLiveUpdateSteps), strings.Join(errorStrings, "\n\t"))
 	}
 

--- a/internal/tiltfile/tiltfile_state.go
+++ b/internal/tiltfile/tiltfile_state.go
@@ -807,7 +807,7 @@ func (s *tiltfileState) assembleK8s() error {
 			if opts.newName != "" && opts.newName != r.name {
 				err := s.checkResourceConflict(opts.newName)
 				if err != nil {
-					return fmt.Errorf("k8s_resource at %s specified to rename %q to %q: %v",
+					return fmt.Errorf("%s: k8s_resource specified to rename %q to %q: %v",
 						opts.tiltfilePosition.String(), r.name, opts.newName, err)
 				}
 				delete(s.k8sByName, r.name)
@@ -858,7 +858,7 @@ func (s *tiltfileState) assembleK8s() error {
 			for name := range s.k8sByName {
 				knownResources = append(knownResources, name)
 			}
-			return fmt.Errorf("k8s_resource at %s specified unknown resource %q. known resources: %s",
+			return fmt.Errorf("%s: k8s_resource specified unknown resource %q. known k8s resources: %s",
 				opts.tiltfilePosition.String(), opts.workload, strings.Join(knownResources, ", "))
 		}
 	}

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -3118,7 +3118,7 @@ k8s_yaml('foo.yaml')
 k8s_resource('bar', new_name='baz')
 `)
 
-	f.loadErrString("specified unknown resource \"bar\". known resources: foo")
+	f.loadErrString("specified unknown resource \"bar\". known k8s resources: foo")
 }
 
 func TestK8sResourceNewName(t *testing.T) {


### PR DESCRIPTION
For any errors that occur during starlark execution, we automatically get a line:row:col at the start of the error.

Some errors, however, occur as part of Tiltfile loading *after* starlark execution has finished. For some of these, we store a starlark `syntax.Position` sourcing the error, and stick it in the error string.

For consistency and ease of parsing, this PR changes those errors so that the locations are at the start of the line.