### PR TITLE
web: display cluster connection status in global nav

### DIFF
--- a/web/src/GlobalNav.tsx
+++ b/web/src/GlobalNav.tsx
@@ -167,7 +167,7 @@ export function MenuButtonLabeled(
   )
 }
 
-type GlobalNavProps = {
+export type GlobalNavProps = {
   isSnapshot: boolean
   tiltCloudUsername: string
   tiltCloudSchemeHost: string

--- a/web/src/HeaderBar.stories.tsx
+++ b/web/src/HeaderBar.stories.tsx
@@ -1,9 +1,7 @@
 import React from "react"
 import { MemoryRouter } from "react-router"
 import { AnalyticsType } from "./analytics"
-import { GlobalNav } from "./GlobalNav"
 import HeaderBar from "./HeaderBar"
-import { useSnapshotAction } from "./snapshot"
 import {
   clusterConnection,
   nResourceView,
@@ -11,7 +9,6 @@ import {
   twoResourceView,
 } from "./testdata"
 import { UpdateStatus } from "./types"
-import { showUpdate } from "./UpdateDialog"
 
 export default {
   title: "New UI/Shared/HeaderBar",
@@ -79,48 +76,32 @@ export const UpgradeAvailable = () => {
   )
 }
 
-// TODO (lizz): Use HeaderBar component instead of GlobalNav
-// when design & implementation are finalized
-export const NavWithClusterConnectionHealth = () => {
+export const HealthyClusterConnection = () => {
   const view = nResourceView(5)
   const k8sConnection = clusterConnection()
-  const session = view.uiSession?.status
+  view.clusters = [k8sConnection]
 
   return (
-    <GlobalNav
-      isSnapshot={false}
-      runningBuild={session?.runningTiltBuild}
-      snapshot={useSnapshotAction()}
-      showUpdate={showUpdate(view)}
-      suggestedVersion={session?.suggestedTiltVersion}
-      tiltCloudSchemeHost=""
-      tiltCloudTeamID=""
-      tiltCloudTeamName=""
-      tiltCloudUsername=""
-      clusterConnections={[k8sConnection]}
+    <HeaderBar
+      view={view}
+      currentPage={AnalyticsType.Detail}
+      isSocketConnected={true}
     />
   )
 }
 
-export const NavWithClusterConnectionError = () => {
+export const UnhealthyClusterConnection = () => {
   const view = nResourceView(5)
   const k8sConnection = clusterConnection(
     'Get "https://kubernetes.docker.internal:6443/version?timeout=32s": dial tcp 127.0.0.1:6443: connect: connection refused'
   )
-  const session = view.uiSession?.status
+  view.clusters = [k8sConnection]
 
   return (
-    <GlobalNav
-      isSnapshot={false}
-      runningBuild={session?.runningTiltBuild}
-      snapshot={useSnapshotAction()}
-      showUpdate={showUpdate(view)}
-      suggestedVersion={session?.suggestedTiltVersion}
-      tiltCloudSchemeHost=""
-      tiltCloudTeamID=""
-      tiltCloudTeamName=""
-      tiltCloudUsername=""
-      clusterConnections={[k8sConnection]}
+    <HeaderBar
+      view={view}
+      currentPage={AnalyticsType.Detail}
+      isSocketConnected={true}
     />
   )
 }

--- a/web/src/HeaderBar.tsx
+++ b/web/src/HeaderBar.tsx
@@ -6,7 +6,7 @@ import { ReactComponent as DetailViewSvg } from "./assets/svg/detail-view-icon.s
 import { ReactComponent as LogoWordmarkSvg } from "./assets/svg/logo-wordmark.svg"
 import { ReactComponent as TableViewSvg } from "./assets/svg/table-view-icon.svg"
 import { CustomNav } from "./CustomNav"
-import { GlobalNav } from "./GlobalNav"
+import { GlobalNav, GlobalNavProps } from "./GlobalNav"
 import { usePathBuilder } from "./PathBuilder"
 import {
   AllResourceStatusSummary,
@@ -121,7 +121,7 @@ export default function HeaderBar({
   let suggestedVersion = session?.suggestedTiltVersion
   let resources = view?.uiResources || []
 
-  let globalNavProps = {
+  let globalNavProps: GlobalNavProps = {
     isSnapshot,
     snapshot,
     showUpdate: showUpdate(view),
@@ -131,6 +131,7 @@ export default function HeaderBar({
     tiltCloudSchemeHost: session?.tiltCloudSchemeHost ?? "",
     tiltCloudTeamID: session?.tiltCloudTeamID ?? "",
     tiltCloudTeamName: session?.tiltCloudTeamName ?? "",
+    clusterConnections: view.clusters,
   }
 
   const pb = usePathBuilder()


### PR DESCRIPTION
This PR passes the cluster information from the `view` to the `GlobalNav` component, so that cluster status will be visible to users. (Previously the cluster info was only added to storybook components, so we had flexibility to do more API work before showing that information explicitly to users.)

I'll keep this PR in draft state till we're ready to launch. 

Closes [ch13397](https://app.shortcut.com/windmill/story/13397/as-user-i-see-cluster-status-with-dropdown-menu-that-shows-only-k8s-info-no-buttons).