### PR TITLE
cluster: improve unrecoverable error message

### DIFF
--- a/internal/controllers/core/cluster/reconciler_test.go
+++ b/internal/controllers/core/cluster/reconciler_test.go
@@ -40,12 +40,14 @@ func TestKubernetesError(t *testing.T) {
 
 	// Create a fake client factory that always returns an error
 	origClientFactory := f.r.k8sClientFactory
-	f.r.k8sClientFactory = FakeKubernetesClientOrError(nil, errors.New("connection error"))
+	f.r.k8sClientFactory = FakeKubernetesClientOrError(nil, errors.New("fake error"))
 	f.Create(cluster)
 
 	assert.Equal(t, "", cluster.Status.Error)
 	f.MustGet(nn, cluster)
-	assert.Equal(t, "connection error", cluster.Status.Error)
+	assert.Equal(t,
+		"Tilt encountered an error connecting to your Kubernetes cluster:\n\tfake error\nYou will need to restart Tilt after resolving the issue.",
+		cluster.Status.Error)
 	assert.Nil(t, cluster.Status.ConnectedAt, "ConnectedAt should be empty")
 
 	// replace the working client factory but ensure that it's not invoked


### PR DESCRIPTION
Until the `cluster_refresh` feature is done, initialization errors
for the cluster are unrecoverable, as not all parts of Tilt know
how to re-initialize the client/themsleves properly on change.

<img width="1247" alt="Tilt web UI showing a cluster error message" src="https://user-images.githubusercontent.com/841263/163249567-5077f154-98b8-4ee3-baee-05b86aba9b78.png">

The error message is now wrapped with some additional context and
a notice that Tilt needs to be restarted after fixing the issue.