### PR TITLE
web: refactor ApiButton tests to use react-testing-library instead of enzyme

### DIFF
--- a/web/src/ApiButton.test.tsx
+++ b/web/src/ApiButton.test.tsx
@@ -1,9 +1,14 @@
-import { Button, Icon, TextField } from "@material-ui/core"
-import { mount } from "enzyme"
+import {
+  render,
+  RenderOptions,
+  RenderResult,
+  screen,
+  waitFor,
+} from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
 import fetchMock from "fetch-mock"
 import { SnackbarProvider } from "notistack"
 import React, { PropsWithChildren } from "react"
-import { act } from "react-dom/test-utils"
 import { MemoryRouter } from "react-router"
 import { AnalyticsAction } from "./analytics"
 import {
@@ -14,17 +19,13 @@ import {
 } from "./analytics_test_helpers"
 import {
   ApiButton,
-  ApiButtonForm,
-  ApiButtonInputsToggleButton,
-  ApiButtonLabel,
+  ApiButtonType,
   buttonsByComponent,
   ButtonSet,
 } from "./ApiButton"
 import { mockUIButtonUpdates } from "./ApiButton.testhelpers"
 import { accessorsForTesting, tiltfileKeyContext } from "./BrowserStorage"
 import { HudErrorContextProvider } from "./HudErrorContext"
-import { InstrumentedButton } from "./instrumentedComponents"
-import { flushPromises } from "./promise"
 import {
   boolFieldForUIButton,
   disableButton,
@@ -32,7 +33,7 @@ import {
   oneUIButton,
   textFieldForUIButton,
 } from "./testdata"
-import { UIButton, UIButtonStatus } from "./types"
+import { UIButton, UIButtonStatus, UIInputSpec } from "./types"
 
 const buttonInputsAccessor = accessorsForTesting(
   `apibutton-TestButton`,
@@ -40,7 +41,7 @@ const buttonInputsAccessor = accessorsForTesting(
 )
 
 type ApiButtonProviderProps = {
-  setError?: () => void
+  setError?: (error: string) => void
 }
 
 function ApiButtonProviders({
@@ -58,10 +59,18 @@ function ApiButtonProviders({
   )
 }
 
-function mountButton(b: UIButton, providerProps?: {}) {
-  return mount(<ApiButton uiButton={b} />, {
-    wrappingComponent: ApiButtonProviders,
-    wrappingComponentProps: providerProps,
+// Following the custom render example from RTL:
+// https://testing-library.com/docs/react-testing-library/setup/#custom-render
+function customRender(
+  component: JSX.Element,
+  options?: RenderOptions,
+  providerProps?: ApiButtonProviderProps
+) {
+  return render(component, {
+    wrapper: ({ children }) => (
+      <ApiButtonProviders {...providerProps} children={children} />
+    ),
+    ...options,
   })
 }
 
@@ -80,265 +89,38 @@ describe("ApiButton", () => {
   })
 
   it("renders a simple button", () => {
-    const b = oneUIButton({ iconName: "flight_takeoff" })
-    const root = mountButton(b)
-    const button = root.find(ApiButton).find("button")
-    expect(button.length).toEqual(1)
-    expect(button.find(Icon).text()).toEqual(b.spec!.iconName)
-    expect(button.find(ApiButtonLabel).text()).toEqual(b.spec!.text)
-  })
+    const uibutton = oneUIButton({ iconName: "flight_takeoff" })
+    customRender(<ApiButton uiButton={uibutton} />)
 
-  it("sends analytics", async () => {
-    const b = oneUIButton({})
-    const root = mountButton(b)
-    const button = root.find(ApiButton).find("button")
-    await click(button)
-    expectIncrs({
-      name: "ui.web.uibutton",
-      tags: { action: AnalyticsAction.Click, component: "Global" },
-    })
-  })
-
-  it("renders an options button when the button has inputs", () => {
-    const inputs = [1, 2, 3].map((i) => textFieldForUIButton(`text${i}`))
-    const root = mountButton(oneUIButton({ inputSpecs: inputs }))
-    expect(
-      root.find(ApiButton).find(ApiButtonInputsToggleButton).length
-    ).toEqual(1)
-  })
-
-  it("doesn't render an options button when the button has only hidden inputs", () => {
-    const inputs = [1, 2, 3].map((i) =>
-      hiddenFieldForUIButton(`hidden${i}`, `value${i}`)
+    const buttonElement = screen.getByLabelText(
+      `Trigger ${uibutton.spec!.text!}`
     )
-    const root = mountButton(oneUIButton({ inputSpecs: inputs }))
-    expect(
-      root.find(ApiButton).find(ApiButtonInputsToggleButton).length
-    ).toEqual(0)
+    expect(buttonElement).toBeInTheDocument()
+    expect(buttonElement).toHaveTextContent(uibutton.spec!.text!)
+    expect(screen.getByText(uibutton.spec!.iconName!)).toBeInTheDocument()
   })
 
-  it("shows the options form when the options button is clicked", async () => {
-    const inputs = [1, 2, 3].map((i) => textFieldForUIButton(`text${i}`))
-    const root = mountButton(oneUIButton({ inputSpecs: inputs }))
+  it("sends analytics when clicked", async () => {
+    const uibutton = oneUIButton({})
+    customRender(<ApiButton uiButton={uibutton} />)
 
-    const optionsButton = root.find(ApiButtonInputsToggleButton)
-    await click(optionsButton)
-    root.update()
+    userEvent.click(screen.getByRole("button"))
 
-    const optionsForm = root.find(ApiButtonForm)
-    expect(optionsForm.length).toEqual(1)
-
-    const expectedInputNames = inputs.map((i) => i.label)
-    const actualInputNames = optionsForm
-      .find(TextField)
-      .map((i) => i.prop("label"))
-    expect(actualInputNames).toEqual(expectedInputNames)
-  })
-
-  it("allows an empty text string when there's a default value", async () => {
-    const input = textFieldForUIButton("text1", "default_text")
-    const root = mountButton(oneUIButton({ inputSpecs: [input] }))
-
-    const optionsButton = root.find(ApiButtonInputsToggleButton)
-    await click(optionsButton)
-    root.update()
-
-    const tf = root.find(ApiButtonForm).find("input#text1")
-    tf.simulate("change", { target: { value: "" } })
-
-    expect(root.find(ApiButtonForm).find(TextField).prop("value")).toEqual("")
-  })
-
-  it("propagates analytics tags to text inputs", async () => {
-    const input = boolFieldForUIButton("bool1")
-    const root = mountButton(oneUIButton({ inputSpecs: [input] }))
-
-    const optionsButton = root.find(ApiButtonInputsToggleButton)
-    await click(optionsButton)
-    root.update()
-
-    const tf = root.find(ApiButtonForm).find("input#bool1")
-    tf.simulate("change", { target: { value: true } })
-
-    expectIncrs(
-      {
-        name: "ui.web.uibutton.inputMenu",
-        tags: { action: AnalyticsAction.Click, component: "Global" },
-      },
-      {
-        name: "ui.web.uibutton.inputValue",
+    await waitFor(() => {
+      expectIncrs({
+        name: "ui.web.uibutton",
         tags: {
-          action: AnalyticsAction.Edit,
-          component: "Global",
-          inputType: "bool",
+          action: AnalyticsAction.Click,
+          component: ApiButtonType.Global,
         },
-      }
-    )
-  })
-
-  it("submits the current options when the submit button is clicked", async () => {
-    const inputSpecs = [
-      textFieldForUIButton("text1"),
-      boolFieldForUIButton("bool1"),
-      hiddenFieldForUIButton("hidden1", "hidden value 1"),
-    ]
-    const root = mountButton(oneUIButton({ inputSpecs: inputSpecs }))
-
-    const optionsButton = root.find(ApiButtonInputsToggleButton)
-    await click(optionsButton)
-    root.update()
-
-    const tf = root.find(ApiButtonForm).find("input#text1")
-    tf.simulate("change", { target: { value: "new_value" } })
-    const bf = root.find(ApiButtonForm).find("input#bool1")
-    bf.simulate("change", { target: { checked: true } })
-    root.update()
-
-    const submit = root.find(ApiButton).find(Button).at(0)
-    await click(submit)
-    root.update()
-
-    const calls = nonAnalyticsCalls()
-    expect(calls.length).toEqual(1)
-    const call = calls[0]
-    expect(call[0]).toEqual(
-      "/proxy/apis/tilt.dev/v1alpha1/uibuttons/TestButton/status"
-    )
-    expect(call[1]).toBeTruthy()
-    expect(call[1]!.method).toEqual("PUT")
-    expect(call[1]!.body).toBeTruthy()
-    const actualStatus: UIButtonStatus = JSON.parse(
-      call[1]!.body!.toString()
-    ).status
-
-    const expectedStatus: UIButtonStatus = {
-      lastClickedAt: "2016-12-21T23:36:07.071000+00:00",
-      inputs: [
-        {
-          name: "text1",
-          text: {
-            value: "new_value",
-          },
-        },
-        {
-          name: "bool1",
-          bool: {
-            value: true,
-          },
-        },
-        {
-          name: "hidden1",
-          hidden: {
-            value: "hidden value 1",
-          },
-        },
-      ],
-    }
-    expect(actualStatus).toEqual(expectedStatus)
-  })
-
-  it("submits default options when the submit button is clicked", async () => {
-    const inputSpecs = [
-      textFieldForUIButton("text1", "default_text"),
-      boolFieldForUIButton("bool1", true),
-      hiddenFieldForUIButton("hidden1", "hidden value 1"),
-    ]
-    const root = mountButton(oneUIButton({ inputSpecs: inputSpecs }))
-
-    const submit = root.find(ApiButton).find(Button).at(0)
-    await click(submit)
-    root.update()
-
-    const calls = nonAnalyticsCalls()
-    expect(calls.length).toEqual(1)
-    const call = calls[0]
-    expect(call[0]).toEqual(
-      "/proxy/apis/tilt.dev/v1alpha1/uibuttons/TestButton/status"
-    )
-    expect(call[1]).toBeTruthy()
-    expect(call[1]!.method).toEqual("PUT")
-    expect(call[1]!.body).toBeTruthy()
-    const actualStatus: UIButtonStatus = JSON.parse(
-      call[1]!.body!.toString()
-    ).status
-
-    const expectedStatus: UIButtonStatus = {
-      lastClickedAt: "2016-12-21T23:36:07.071000+00:00",
-      inputs: [
-        {
-          name: "text1",
-          text: {
-            value: "default_text",
-          },
-        },
-        {
-          name: "bool1",
-          bool: {
-            value: true,
-          },
-        },
-        {
-          name: "hidden1",
-          hidden: {
-            value: "hidden value 1",
-          },
-        },
-      ],
-    }
-    expect(actualStatus).toEqual(expectedStatus)
-  })
-
-  it("reads options from local storage", async () => {
-    buttonInputsAccessor.set({
-      text1: "text value",
-      bool1: true,
-    })
-    const inputSpecs = [
-      textFieldForUIButton("text1"),
-      boolFieldForUIButton("bool1"),
-    ]
-    const root = mountButton(oneUIButton({ inputSpecs: inputSpecs }))
-
-    const optionsButton = root.find(ApiButtonInputsToggleButton)
-    await click(optionsButton)
-    root.update()
-
-    const tf = root.find(ApiButtonForm).find("input#text1")
-    expect(tf.props().value).toEqual("text value")
-    const bf = root.find(ApiButtonForm).find("input#bool1")
-    expect(bf.props().checked).toEqual(true)
-  })
-
-  it("writes options to local storage", async () => {
-    const inputSpecs = [
-      textFieldForUIButton("text1"),
-      boolFieldForUIButton("bool1"),
-    ]
-    const root = mountButton(oneUIButton({ inputSpecs: inputSpecs }))
-
-    const optionsButton = root.find(ApiButtonInputsToggleButton)
-    await click(optionsButton)
-    root.update()
-
-    const tf = root.find(ApiButtonForm).find("input#text1")
-    tf.simulate("change", { target: { value: "new_value" } })
-    const bf = root.find(ApiButtonForm).find("input#bool1")
-    bf.simulate("change", { target: { checked: true } })
-
-    expect(buttonInputsAccessor.get()).toEqual({
-      text1: "new_value",
-      bool1: true,
+      })
     })
   })
 
   it("sets a hud error when the api request fails", async () => {
-    let error: string | undefined
-    const setError = (e: string) => {
-      error = e
-    }
-
-    const root = mountButton(oneUIButton({}), { setError })
-
+    // To add a mocked error response, reset the current mock
+    // for UIButton API call and add back the mock for analytics calls
+    // Reset the current mock for UIButton to add fake error response
     fetchMock.reset()
     mockAnalyticsCalls()
     fetchMock.put(
@@ -346,94 +128,406 @@ describe("ApiButton", () => {
       { throws: "broken!" }
     )
 
-    const submit = root.find(ApiButton).find(Button).at(0)
-    await click(submit)
-    root.update()
+    let error: string | undefined
+    const setError = (e: string) => (error = e)
+    const uibutton = oneUIButton({})
+    customRender(<ApiButton uiButton={uibutton} />, {}, { setError })
+
+    userEvent.click(screen.getByRole("button"))
+
+    await waitFor(() => {
+      expect(screen.getByRole("button")).not.toBeDisabled()
+    })
 
     expect(error).toEqual("Error submitting button click: broken!")
   })
 
-  it("when requiresConfirmation is set, a second confirmation click to submit", async () => {
-    const b = oneUIButton({ requiresConfirmation: true })
-    const root = mountButton(b)
+  describe("button with visible inputs", () => {
+    let uibutton: UIButton
+    let inputSpecs: UIInputSpec[]
+    beforeEach(() => {
+      inputSpecs = [
+        textFieldForUIButton("text_field"),
+        boolFieldForUIButton("bool_field", false),
+        textFieldForUIButton("text_field_with_default", "default text"),
+        hiddenFieldForUIButton("hidden_field", "hidden value 1"),
+      ]
+      uibutton = oneUIButton({ inputSpecs })
+      customRender(<ApiButton uiButton={uibutton} />).rerender
+    })
 
-    let button = root.find(InstrumentedButton)
-    expect(button.find(ApiButtonLabel).text()).toEqual(b.spec?.text)
+    it("renders an options button", () => {
+      expect(
+        screen.getByLabelText(`Open ${uibutton.spec!.text!} options`)
+      ).toBeInTheDocument()
+    })
 
-    await click(button.find(Button).at(0))
-    root.update()
+    it("shows the options form with inputs when the options button is clicked", () => {
+      const optionButton = screen.getByLabelText(
+        `Open ${uibutton.spec!.text!} options`
+      )
+      userEvent.click(optionButton)
 
-    // after first click, should show a "Confirm", and not have submitted the click to the backend
-    button = root.find(InstrumentedButton)
-    expect(button.find(ApiButtonLabel).text()).toEqual("Confirm")
-    expect(nonAnalyticsCalls().length).toEqual(0)
+      expect(
+        screen.getByText(`Options for ${uibutton.spec!.text!}`)
+      ).toBeInTheDocument()
+    })
 
-    await click(button.find(Button).at(0))
-    root.update()
+    it("only shows inputs for visible inputs", () => {
+      // Open the options dialog first
+      const optionButton = screen.getByLabelText(
+        `Open ${uibutton.spec!.text!} options`
+      )
+      userEvent.click(optionButton)
 
-    // after second click, button text reverts and click is submitted
-    button = root.find(InstrumentedButton)
-    expect(button.find(ApiButtonLabel).text()).toEqual(b.spec?.text)
-    expect(nonAnalyticsCalls().length).toEqual(1)
+      inputSpecs.forEach((spec) => {
+        if (!spec.hidden) {
+          expect(screen.getByLabelText(spec.label!)).toBeInTheDocument()
+        }
+      })
+    })
+
+    it("allows an empty text string when there's a default value", async () => {
+      // Open the options dialog first
+      const optionButton = screen.getByLabelText(
+        `Open ${uibutton.spec!.text!} options`
+      )
+      userEvent.click(optionButton)
+
+      // Get the input element with the hardcoded default text
+      const inputWithDefault = screen.getByDisplayValue("default text")
+      userEvent.clear(inputWithDefault)
+
+      // Use the label text to select and verify the input's value
+      expect(screen.getByLabelText("text_field_with_default")).toHaveValue("")
+    })
+
+    it("propagates analytics tags to text inputs", async () => {
+      // Open the options dialog first
+      const optionButton = screen.getByLabelText(
+        `Open ${uibutton.spec!.text!} options`
+      )
+      userEvent.click(optionButton)
+
+      const booleanInput = screen.getByLabelText("bool_field")
+      userEvent.click(booleanInput)
+
+      expect(screen.getByLabelText("bool_field")).toBeChecked()
+      await waitFor(() => {
+        expectIncrs(
+          {
+            name: "ui.web.uibutton.inputMenu",
+            tags: {
+              action: AnalyticsAction.Click,
+              component: ApiButtonType.Global,
+            },
+          },
+          {
+            name: "ui.web.uibutton.inputValue",
+            tags: {
+              action: AnalyticsAction.Edit,
+              component: ApiButtonType.Global,
+              inputType: "bool",
+            },
+          }
+        )
+      })
+    })
+
+    it("submits the current options when the submit button is clicked", async () => {
+      // Open the options dialog first
+      const optionButton = screen.getByLabelText(
+        `Open ${uibutton.spec!.text!} options`
+      )
+      userEvent.click(optionButton)
+
+      // Make a couple changes to the inputs
+      userEvent.type(screen.getByLabelText("text_field"), "new_value")
+      userEvent.click(screen.getByLabelText("bool_field"))
+      userEvent.type(screen.getByLabelText("text_field_with_default"), "!!!!")
+
+      // Click the submit button
+      userEvent.click(screen.getByLabelText(`Trigger ${uibutton.spec!.text!}`))
+
+      // Wait for the button to be enabled again,
+      // which signals successful trigger button response
+      await waitFor(
+        () =>
+          expect(screen.getByLabelText(`Trigger ${uibutton.spec!.text!}`)).not
+            .toBeDisabled
+      )
+
+      const calls = nonAnalyticsCalls()
+      expect(calls.length).toEqual(1)
+      const call = calls[0]
+      expect(call[0]).toEqual(
+        "/proxy/apis/tilt.dev/v1alpha1/uibuttons/TestButton/status"
+      )
+      expect(call[1]).toBeTruthy()
+      expect(call[1]!.method).toEqual("PUT")
+      expect(call[1]!.body).toBeTruthy()
+      const actualStatus: UIButtonStatus = JSON.parse(
+        call[1]!.body!.toString()
+      ).status
+
+      const expectedStatus: UIButtonStatus = {
+        lastClickedAt: "2016-12-21T23:36:07.071000+00:00",
+        inputs: [
+          {
+            name: inputSpecs[0].name,
+            text: {
+              value: "new_value",
+            },
+          },
+          {
+            name: inputSpecs[1].name,
+            bool: {
+              value: true,
+            },
+          },
+          {
+            name: inputSpecs[2].name,
+            text: {
+              value: "default text!!!!",
+            },
+          },
+          {
+            name: inputSpecs[3].name,
+            hidden: {
+              value: inputSpecs[3].hidden!.value,
+            },
+          },
+        ],
+      }
+      expect(actualStatus).toEqual(expectedStatus)
+    })
+
+    it("submits default options when the submit button is clicked", async () => {
+      // The testing setup already includes a field with default text,
+      // so we can go ahead and click the submit button
+      userEvent.click(screen.getByLabelText(`Trigger ${uibutton.spec!.text!}`))
+
+      // Wait for the button to be enabled again,
+      // which signals successful trigger button response
+      await waitFor(
+        () =>
+          expect(screen.getByLabelText(`Trigger ${uibutton.spec!.text!}`)).not
+            .toBeDisabled
+      )
+
+      const calls = nonAnalyticsCalls()
+      expect(calls.length).toEqual(1)
+      const call = calls[0]
+      expect(call[0]).toEqual(
+        "/proxy/apis/tilt.dev/v1alpha1/uibuttons/TestButton/status"
+      )
+      expect(call[1]).toBeTruthy()
+      expect(call[1]!.method).toEqual("PUT")
+      expect(call[1]!.body).toBeTruthy()
+      const actualStatus: UIButtonStatus = JSON.parse(
+        call[1]!.body!.toString()
+      ).status
+
+      const expectedStatus: UIButtonStatus = {
+        lastClickedAt: "2016-12-21T23:36:07.071000+00:00",
+        inputs: [
+          {
+            name: inputSpecs[0].name,
+            text: {},
+          },
+          {
+            name: inputSpecs[1].name,
+            bool: {
+              value: false,
+            },
+          },
+          {
+            name: inputSpecs[2].name,
+            text: {
+              value: "default text",
+            },
+          },
+          {
+            name: inputSpecs[3].name,
+            hidden: {
+              value: inputSpecs[3].hidden!.value,
+            },
+          },
+        ],
+      }
+      expect(actualStatus).toEqual(expectedStatus)
+    })
   })
 
-  it("when requiresConfirmation is set, allows canceling instead of confirming", async () => {
-    const b = oneUIButton({ requiresConfirmation: true })
-    const root = mountButton(b)
+  describe("local storage for input values", () => {
+    let uibutton: UIButton
+    let inputSpecs: UIInputSpec[]
+    beforeEach(() => {
+      inputSpecs = [
+        textFieldForUIButton("text1"),
+        boolFieldForUIButton("bool1"),
+      ]
+      uibutton = oneUIButton({ inputSpecs })
 
-    let button = root.find(InstrumentedButton)
-    expect(button.find(ApiButtonLabel).text()).toEqual(b.spec?.text)
+      // Store previous values for input fields
+      buttonInputsAccessor.set({
+        text1: "text value",
+        bool1: true,
+      })
 
-    await click(button.find(Button).at(0))
-    root.update()
+      customRender(<ApiButton uiButton={uibutton} />)
+    })
 
-    button = root.find(InstrumentedButton)
-    expect(button.find(ApiButtonLabel).text()).toEqual("Confirm")
-    expect(nonAnalyticsCalls().length).toEqual(0)
+    it("are read from local storage", () => {
+      // Open the options dialog
+      userEvent.click(
+        screen.getByLabelText(`Open ${uibutton.spec!.text!} options`)
+      )
 
-    // second button cancels confirmation
-    const cancelButton = button.find(Button).at(1)
-    expect(cancelButton.props()["aria-label"]).toEqual(`Cancel ${b.spec?.text}`)
+      expect(screen.getByLabelText("text1")).toHaveValue("text value")
+      expect(screen.getByLabelText("bool1")).toBeChecked()
+    })
 
-    await click(cancelButton)
-    root.update()
+    it("are written to local storage when edited", () => {
+      // Open the options dialog
+      userEvent.click(
+        screen.getByLabelText(`Open ${uibutton.spec!.text!} options`)
+      )
 
-    // upon clicking, the button click is aborted and no update is sent to the server
-    button = root.find(InstrumentedButton)
-    expect(button.find(ApiButtonLabel).text()).toEqual(b.spec?.text)
-    expect(nonAnalyticsCalls().length).toEqual(0)
+      // Type a new value in the text field
+      const textField = screen.getByLabelText("text1")
+      userEvent.clear(textField)
+      userEvent.type(textField, "new value!")
+
+      // Uncheck the boolean field
+      userEvent.click(screen.getByLabelText("bool1"))
+
+      // Expect local storage values are updated
+      expect(buttonInputsAccessor.get()).toEqual({
+        text1: "new value!",
+        bool1: false,
+      })
+    })
   })
 
-  // This test makes sure that the `confirming` state resets if a user
-  // clicks a toggle button once, then navigates to another resource
-  // with a toggle button (which will have a different button name)
-  it("it resets the `confirming` state when the button's name changes", async () => {
-    const toggleButton = oneUIButton({
-      requiresConfirmation: true,
-      buttonName: "toggle-button-1",
+  describe("button with only hidden inputs", () => {
+    let uibutton: UIButton
+    beforeEach(() => {
+      const inputSpecs = [1, 2, 3].map((i) =>
+        hiddenFieldForUIButton(`hidden${i}`, `value${i}`)
+      )
+      uibutton = oneUIButton({ inputSpecs })
+      customRender(<ApiButton uiButton={oneUIButton({ inputSpecs })} />)
     })
-    const root = mountButton(toggleButton)
 
-    let buttonComponent = root.find(ApiButton)
-    const buttonElement = buttonComponent.find(Button).at(0)
-    await click(buttonElement)
-    root.update()
-
-    buttonComponent = root.find(ApiButton)
-    expect(buttonComponent.find(ApiButtonLabel).text()).toEqual("Confirm")
-
-    const anotherToggleButton = oneUIButton({
-      requiresConfirmation: true,
-      buttonName: "toggle-button-2",
+    it("doesn't render an options button", () => {
+      expect(
+        screen.queryByLabelText(`Open ${uibutton.spec!.text!} options`)
+      ).not.toBeInTheDocument()
     })
-    root.setProps({ uiButton: anotherToggleButton })
-    root.update()
 
-    buttonComponent = root.find(ApiButton)
-    expect(buttonComponent.find(ApiButtonLabel).text()).not.toEqual("Confirm")
-    expect(buttonComponent.find(ApiButtonLabel).text()).toEqual(
-      anotherToggleButton.spec?.text
-    )
+    it("doesn't render any input elements", () => {
+      expect(screen.queryAllByRole("input").length).toBe(0)
+    })
+  })
+
+  describe("buttons that require confirmation", () => {
+    let uibutton: UIButton
+    let rerender: RenderResult["rerender"]
+    beforeEach(() => {
+      uibutton = oneUIButton({ requiresConfirmation: true })
+      rerender = customRender(<ApiButton uiButton={uibutton} />).rerender
+    })
+
+    it("displays 'confirm' and 'cancel' buttons after a single click", () => {
+      const buttonBeforeClick = screen.getByLabelText(
+        `Trigger ${uibutton.spec!.text!}`
+      )
+      expect(buttonBeforeClick).toBeInTheDocument()
+      expect(buttonBeforeClick).toHaveTextContent(uibutton.spec!.text!)
+
+      userEvent.click(buttonBeforeClick)
+
+      const confirmButton = screen.getByLabelText(
+        `Confirm ${uibutton.spec!.text!}`
+      )
+      expect(confirmButton).toBeInTheDocument()
+      expect(confirmButton).toHaveTextContent("Confirm")
+
+      const cancelButton = screen.getByLabelText(
+        `Cancel ${uibutton.spec!.text!}`
+      )
+      expect(cancelButton).toBeInTheDocument()
+    })
+
+    it("clicking the 'confirm' button triggers a button API call", async () => {
+      // Click the submit button
+      userEvent.click(screen.getByLabelText(`Trigger ${uibutton.spec!.text!}`))
+
+      // Expect that it should not have submitted the click to the backend
+      expect(nonAnalyticsCalls().length).toEqual(0)
+
+      // Click the confirm submit button
+      userEvent.click(screen.getByLabelText(`Confirm ${uibutton.spec!.text!}`))
+
+      // Wait for the button to be enabled again,
+      // which signals successful trigger button response
+      await waitFor(
+        () =>
+          expect(screen.getByLabelText(`Trigger ${uibutton.spec!.text!}`)).not
+            .toBeDisabled
+      )
+
+      // Expect that the click was submitted and the button text resets
+      expect(nonAnalyticsCalls().length).toEqual(1)
+      expect(
+        screen.getByLabelText(`Trigger ${uibutton.spec!.text!}`)
+      ).toHaveTextContent(uibutton.spec!.text!)
+    })
+
+    it("clicking the 'cancel' button resets the button", () => {
+      // Click the submit button
+      userEvent.click(screen.getByLabelText(`Trigger ${uibutton.spec!.text!}`))
+
+      // Expect that it should not have submitted the click to the backend
+      expect(nonAnalyticsCalls().length).toEqual(0)
+
+      // Click the cancel submit button
+      userEvent.click(screen.getByLabelText(`Cancel ${uibutton.spec!.text!}`))
+
+      // Expect that NO click was submitted and the button text resets
+      expect(nonAnalyticsCalls().length).toEqual(0)
+      expect(
+        screen.getByLabelText(`Trigger ${uibutton.spec!.text!}`)
+      ).toHaveTextContent(uibutton.spec!.text!)
+    })
+
+    it("resets the `confirming` state when the button's name changes", () => {
+      // Click the button and verify the confirmation state
+      userEvent.click(screen.getByLabelText(`Trigger ${uibutton.spec!.text!}`))
+      expect(
+        screen.getByLabelText(`Confirm ${uibutton.spec!.text!}`)
+      ).toBeInTheDocument()
+      expect(
+        screen.getByLabelText(`Cancel ${uibutton.spec!.text!}`)
+      ).toBeInTheDocument()
+
+      // Then update the component's props with a new button
+      const anotherUIButton = oneUIButton({
+        buttonName: "another-button",
+        buttonText: "Click another button!",
+        requiresConfirmation: true,
+      })
+      rerender(<ApiButton uiButton={anotherUIButton} />)
+
+      // Verify that the button's confirmation state is reset
+      // and displays the new button text
+      const updatedButton = screen.getByLabelText(
+        `Trigger ${anotherUIButton.spec!.text!}`
+      )
+      expect(updatedButton).toBeInTheDocument()
+      expect(updatedButton).toHaveTextContent(anotherUIButton.spec!.text!)
+    })
   })
 
   describe("helper functions", () => {
@@ -472,13 +566,3 @@ describe("ApiButton", () => {
     })
   })
 })
-
-async function click(button: any) {
-  await act(async () => {
-    button.simulate("click")
-    // the button's onclick updates the button so we need to wait for that to resolve
-    // within the act() before continuing
-    // some related info: https://github.com/testing-library/react-testing-library/issues/281
-    await flushPromises()
-  })
-}

--- a/web/src/ApiButton.test.tsx
+++ b/web/src/ApiButton.test.tsx
@@ -502,6 +502,9 @@ describe("ApiButton", () => {
       ).toHaveTextContent(uibutton.spec!.text!)
     })
 
+    // This test makes sure that the `confirming` state resets if a user
+    // clicks a toggle button once, then navigates to another resource
+    // with a toggle button (which will have a different button name)
     it("resets the `confirming` state when the button's name changes", () => {
       // Click the button and verify the confirmation state
       userEvent.click(screen.getByLabelText(`Trigger ${uibutton.spec!.text!}`))

--- a/web/src/ApiButton.tsx
+++ b/web/src/ApiButton.tsx
@@ -293,6 +293,7 @@ function ApiButtonWithOptions(props: ApiButtonWithOptionsProps & ButtonProps) {
       >
         {props.submit}
         <ApiButtonInputsToggleButton
+          {...buttonProps}
           size="small"
           onClick={() => {
             setOpen((prevOpen) => !prevOpen)
@@ -300,7 +301,6 @@ function ApiButtonWithOptions(props: ApiButtonWithOptionsProps & ButtonProps) {
           analyticsName="ui.web.uibutton.inputMenu"
           analyticsTags={analyticsTags}
           aria-label={`Open ${text} options`}
-          {...buttonProps}
         >
           <ArrowDropDownIcon />
         </ApiButtonInputsToggleButton>


### PR DESCRIPTION
I'm sorry this diff is massively large. 😅 All the tests should be the same, both in title and what they're testing! Some are shorter because RTL has more concise interfaces for stuff like user events, and some are longer because I used more robust assertions, `expect().toBeInDocument()` and `expect().toHaveValue()`, and it can be wordier to query by label text.