### PR TITLE
k8s_custom_deploy: fix Live Update rebuild

### DIFF
--- a/integration/k8s_custom_deploy/Tiltfile
+++ b/integration/k8s_custom_deploy/Tiltfile
@@ -6,12 +6,12 @@ k8s_custom_deploy(
     # forcibly delete and re-create the deployment whenever run
     apply_cmd='kubectl delete --ignore-not-found=true --wait=true -f "${DEPLOY_FILE}" >/dev/null && kubectl create -oyaml -f "${DEPLOY_FILE}"',
     delete_cmd='kubectl delete --ignore-not-found=true --wait=true -f "${DELETE_FILE}"',
-    deps=['deploy.yaml', 'foo', 'web/'],
+    deps=['deploy.yaml', 'foo', 'web/', 'fallback.txt'],
     image_selector='nginx',
     apply_env={'DEPLOY_FILE': 'deploy.yaml'},
     delete_env={'DELETE_FILE': 'deploy.yaml'},
     live_update=[
-        fall_back_on('./web/fallback.txt'),
+        fall_back_on('./fallback.txt'),
         sync('./web/', '/usr/share/nginx/html/')
     ]
 )

--- a/integration/k8s_custom_deploy/Tiltfile
+++ b/integration/k8s_custom_deploy/Tiltfile
@@ -6,7 +6,7 @@ k8s_custom_deploy(
     # forcibly delete and re-create the deployment whenever run
     apply_cmd='kubectl delete --ignore-not-found=true --wait=true -f "${DEPLOY_FILE}" >/dev/null && kubectl create -oyaml -f "${DEPLOY_FILE}"',
     delete_cmd='kubectl delete --ignore-not-found=true --wait=true -f "${DELETE_FILE}"',
-    deps=['deploy.yaml', 'foo', 'web/', 'fallback.txt'],
+    deps=['.'],
     image_selector='nginx',
     apply_env={'DEPLOY_FILE': 'deploy.yaml'},
     delete_env={'DELETE_FILE': 'deploy.yaml'},

--- a/integration/k8s_custom_deploy_test.go
+++ b/integration/k8s_custom_deploy_test.go
@@ -62,7 +62,7 @@ func TestK8sCustomDeploy(t *testing.T) {
 	defer cancel()
 	f.CurlUntil(ctx, "http://localhost:54871", "Greetings from Live Update!")
 
-	f.Touch(filepath.Join("web", "fallback.txt"))
+	f.Touch("fallback.txt")
 	ctx, cancel = context.WithTimeout(f.ctx, time.Minute)
 	defer cancel()
 	f.CurlUntil(ctx, "http://localhost:54871", "Welcome to nginx!")

--- a/internal/engine/buildcontroller_test.go
+++ b/internal/engine/buildcontroller_test.go
@@ -1016,6 +1016,13 @@ func TestBuildControllerK8sFileDependencies(t *testing.T) {
 			[]string{f.JoinPath("k8s-dep")},
 			[]model.LocalGitRepo{
 				{LocalPath: f.JoinPath("k8s-dep")},
+			},
+			[]model.Dockerignore{
+				{
+					LocalPath: f.Path(),
+					Source:    "test",
+					Patterns:  []string{"ignore-me"},
+				},
 			})
 	m := model.Manifest{Name: "fe"}.WithDeployTarget(kt)
 
@@ -1025,8 +1032,9 @@ func TestBuildControllerK8sFileDependencies(t *testing.T) {
 	assert.Empty(t, call.k8sState().FilesChanged())
 
 	// path dependency is on ./k8s-dep/** with a local repo of ./k8s-dep/.git/** (ignored)
-	f.fsWatcher.Events <- watch.NewFileEvent(f.JoinPath("k8s-dep", "file"))
+	f.fsWatcher.Events <- watch.NewFileEvent(f.JoinPath("k8s-dep", "ignore-me"))
 	f.fsWatcher.Events <- watch.NewFileEvent(f.JoinPath("k8s-dep", ".git", "file"))
+	f.fsWatcher.Events <- watch.NewFileEvent(f.JoinPath("k8s-dep", "file"))
 
 	call = f.nextCall()
 	assert.Equal(t, []string{f.JoinPath("k8s-dep", "file")}, call.k8sState().FilesChanged())

--- a/internal/engine/buildcontroller_test.go
+++ b/internal/engine/buildcontroller_test.go
@@ -1019,7 +1019,7 @@ func TestBuildControllerK8sFileDependencies(t *testing.T) {
 			},
 			[]model.Dockerignore{
 				{
-					LocalPath: f.Path(),
+					LocalPath: f.JoinPath("k8s-dep"),
 					Source:    "test",
 					Patterns:  []string{"ignore-me"},
 				},

--- a/internal/tiltfile/tiltfile_state.go
+++ b/internal/tiltfile/tiltfile_state.go
@@ -1178,8 +1178,10 @@ func (s *tiltfileState) k8sDeployTarget(targetName model.TargetName, r *k8sResou
 	}
 
 	var deps []string
+	var ignores []model.Dockerignore
 	if r.customDeploy != nil {
 		deps = r.customDeploy.deps
+		ignores = r.customDeploy.ignores
 		applySpec.ApplyCmd = toKubernetesApplyCmd(r.customDeploy.applyCmd)
 		applySpec.DeleteCmd = toKubernetesApplyCmd(r.customDeploy.deleteCmd)
 		applySpec.RestartOn = &v1alpha1.RestartOnSpec{
@@ -1207,7 +1209,7 @@ func (s *tiltfileState) k8sDeployTarget(targetName model.TargetName, r *k8sResou
 
 	t = t.WithImageDependencies(model.FilterLiveUpdateOnly(r.imageMapDeps, imageTargets)).
 		WithRefInjectCounts(r.imageRefInjectCounts()).
-		WithPathDependencies(deps, reposForPaths(deps))
+		WithPathDependencies(deps, reposForPaths(deps), ignores)
 
 	return t, nil
 }

--- a/pkg/model/k8s_target.go
+++ b/pkg/model/k8s_target.go
@@ -55,6 +55,7 @@ type K8sTarget struct {
 	// re-evaluated.
 	pathDependencies []string
 	localRepos       []LocalGitRepo
+	ignores          []Dockerignore
 }
 
 func NewK8sTargetForTesting(yaml string) K8sTarget {
@@ -108,7 +109,7 @@ func (k8s K8sTarget) LocalRepos() []LocalGitRepo {
 
 // Dockerignores is part of the WatchableTarget interface.
 func (k8s K8sTarget) Dockerignores() []Dockerignore {
-	return nil
+	return k8s.ignores
 }
 
 // IgnoredLocalDirectories is part of the WatchableTarget interface.
@@ -131,9 +132,10 @@ func (k8s K8sTarget) WithImageDependencies(imageMapDeps []string) K8sTarget {
 }
 
 // WithPathDependencies registers paths that this K8sTarget depends on.
-func (k8s K8sTarget) WithPathDependencies(paths []string, localRepos []LocalGitRepo) K8sTarget {
+func (k8s K8sTarget) WithPathDependencies(paths []string, localRepos []LocalGitRepo, ignores []Dockerignore) K8sTarget {
 	k8s.pathDependencies = sliceutils.DedupedAndSorted(paths)
 	k8s.localRepos = localRepos
+	k8s.ignores = ignores
 	return k8s
 }
 


### PR DESCRIPTION
The `k8s_custom_deploy` is unusual: it's possible to use with
no Tilt-managed image build while still getting Live Update
functionality. This is useful for scenarios where you have an
all-in-one build&deploy tool (e.g. Knative) you want to use
with Tilt.

However, this meant that the value of the `deps` arg was being
passed both to the deploy target (K8s/`apply_cmd`) as well as
the image target (Live Update), which introduced a race between
them. If the Live Update reconciler saw a (supported) file change
first, it would clear it from the pending file list on the deploy
target once done, and so the deploy target would be skipped, as
it no longer had any pending changs. On the other hand, if the
deploy target saw it first, it'd start running because deploy
target changes can't be Live Update'd. At the same time, the Live
Update reconciler would still run, as it does not have a concept
of blocking/waiting for other targets.

To address this, the `deps` arg is now filtered using the generated
`LiveUpdateSpec` and any paths matching it (from `sync()` and
`fall_back_on` rules) are added as ignore rules to the deploy target.