### PR TITLE
ci: use Compose v2.4.1 for integration tests

### DIFF
--- a/.circleci/Dockerfile.integration
+++ b/.circleci/Dockerfile.integration
@@ -18,7 +18,7 @@ RUN apt update && apt install -y --no-install-recommends apt-transport-https \
 # Install docker
 # Adapted from https://github.com/circleci/circleci-images/blob/staging/shared/images/Dockerfile-basic.template
 # Check https://download.docker.com/linux/static/stable/x86_64/ for latest versions
-ENV DOCKER_VERSION=20.10.6
+ENV DOCKER_VERSION=20.10.9
 RUN set -exu \
   && DOCKER_URL="https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_VERSION}.tgz" \
   && echo Docker URL: $DOCKER_URL \
@@ -30,14 +30,14 @@ RUN set -exu \
   && which docker \
   && (docker version || true)
 
-# Install docker-compose
-ARG DOCKER_COMPOSE_V1_VERSION=1.29.1
+# docker-compose v1
+ARG DOCKER_COMPOSE_V1_VERSION=1.29.2
 RUN curl -fL "https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_V1_VERSION}/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose-v1 \
   && chmod a+x /usr/local/bin/docker-compose-v1 \
   && docker-compose-v1 version
 
-# pinned to v2.2.2 until https://github.com/docker/compose/issues/9291 is fixed
-ARG DOCKER_COMPOSE_V2_VERSION=v2.2.2
+# docker-compose v2
+ARG DOCKER_COMPOSE_V2_VERSION=v2.4.1
 RUN curl -fL "https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_V2_VERSION}/docker-compose-$(uname -s | tr '[A-Z]' '[a-z]')-$(uname -m)" -o /usr/local/bin/docker-compose \
   && chmod a+x /usr/local/bin/docker-compose \
   && docker-compose version

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,7 +83,7 @@ jobs:
   build-integration:
     resource_class: medium+
     docker:
-      - image: gcr.io/windmill-public-containers/tilt-integration-ci@sha256:7811af195fea29a4a6c46ff54320d1178416a85282914ffd564a12bf974b38b8
+      - image: gcr.io/windmill-public-containers/tilt-integration-ci@sha256:a6586bb234b7d8fec4a2532395092a75ad569d7a90011f9a3afe1373d74e80fa
     steps:
       - checkout
       - run: echo 'export PATH=/go/bin:$PATH' >> $BASH_ENV


### PR DESCRIPTION
We were pinned to v2.2.2 previously because v2.3.x had a regression
that made it unsuitable for use with Tilt, but v2.4.x is now out
(and shipping with latest Docker Desktop releases).

A couple of other bits were behind so I bumped them as well. (Note
that the Docker CLI is still behind because the latest static
binaries are mysteriously missing from the download site, but that's
not really a big deal.)