### PR TITLE
controllers: move status updates into the reconcile loop

### DIFF
--- a/internal/controllers/core/cmdimage/reconciler.go
+++ b/internal/controllers/core/cmdimage/reconciler.go
@@ -99,6 +99,9 @@ func (r *Reconciler) ForceApply(
 	startTime := apis.NowMicro()
 	nn := types.NamespacedName{Name: iTarget.CmdImageName}
 	r.setImageStatus(nn, ToBuildingStatus(iTarget, startTime))
+
+	// Requeue the reconciler twice: once when the build has started and once
+	// after it has finished.
 	r.requeuer.Add(nn)
 	defer r.requeuer.Add(nn)
 

--- a/internal/controllers/core/cmdimage/status.go
+++ b/internal/controllers/core/cmdimage/status.go
@@ -1,51 +1,13 @@
 package cmdimage
 
 import (
-	"context"
-
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
-	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/tilt-dev/tilt/internal/container"
-	"github.com/tilt-dev/tilt/internal/controllers/apicmp"
 	"github.com/tilt-dev/tilt/pkg/apis"
 	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
-	"github.com/tilt-dev/tilt/pkg/logger"
 	"github.com/tilt-dev/tilt/pkg/model"
 )
-
-// Write the image status to the API server, if necessary.
-// If the image write fails, log it to the debug logs and move on.
-func MaybeUpdateStatus(ctx context.Context, ctrlClient ctrlclient.Client,
-	iTarget model.ImageTarget, status v1alpha1.CmdImageStatus) {
-	if iTarget.CmdImageName == "" {
-		return
-	}
-
-	nn := types.NamespacedName{Name: iTarget.CmdImageName}
-	var di v1alpha1.CmdImage
-	err := ctrlClient.Get(ctx, nn, &di)
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			return
-		}
-		logger.Get(ctx).Debugf("fetching cmdimage %s: %v", nn.Name, err)
-		return
-	}
-
-	if apicmp.DeepEqual(status, di.Status) {
-		return
-	}
-
-	updated := di.DeepCopy()
-	updated.Status = status
-	err = ctrlClient.Status().Update(ctx, updated)
-	if err != nil {
-		logger.Get(ctx).Debugf("updating cmdimage %s: %v", nn.Name, err)
-	}
-}
 
 // Return a basic Building Status.
 func ToBuildingStatus(iTarget model.ImageTarget, startTime metav1.MicroTime) v1alpha1.CmdImageStatus {

--- a/internal/controllers/core/dockerimage/imagemap.go
+++ b/internal/controllers/core/dockerimage/imagemap.go
@@ -7,7 +7,6 @@ import (
 	"github.com/docker/distribution/reference"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/tilt-dev/tilt/internal/container"
 	"github.com/tilt-dev/tilt/internal/docker"
@@ -21,7 +20,6 @@ import (
 // This is mainly for easing the transition to reconcilers.
 func UpdateImageMap(
 	ctx context.Context,
-	client ctrlclient.Client,
 	docker docker.Client,
 	iTarget model.ImageTarget,
 	cluster *v1alpha1.Cluster,
@@ -50,12 +48,7 @@ func UpdateImageMap(
 		return store.ImageBuildResult{}, fmt.Errorf("apiserver missing ImageMap: %s", iTarget.ID().Name)
 	}
 	im.Status = result.ImageMapStatus
-	err := client.Status().Update(ctx, im)
-	if err != nil {
-		return store.ImageBuildResult{}, fmt.Errorf("updating ImageMap: %v", err)
-	}
-
-	return result, err
+	return result, nil
 }
 
 // tagWithExpected tags the given ref as whatever Docker Compose expects, i.e. as

--- a/internal/controllers/core/dockerimage/reconciler.go
+++ b/internal/controllers/core/dockerimage/reconciler.go
@@ -101,6 +101,9 @@ func (r *Reconciler) ForceApply(
 	startTime := apis.NowMicro()
 	nn := types.NamespacedName{Name: iTarget.DockerImageName}
 	r.setImageStatus(nn, ToBuildingStatus(iTarget, startTime))
+
+	// Requeue the reconciler twice: once when the build has started and once
+	// after it has finished.
 	r.requeuer.Add(nn)
 	defer r.requeuer.Add(nn)
 

--- a/internal/controllers/core/dockerimage/reconciler.go
+++ b/internal/controllers/core/dockerimage/reconciler.go
@@ -2,10 +2,12 @@ package dockerimage
 
 import (
 	"context"
+	"sync"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
@@ -15,6 +17,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/tilt-dev/tilt/internal/build"
+	"github.com/tilt-dev/tilt/internal/controllers/apicmp"
 	"github.com/tilt-dev/tilt/internal/controllers/indexer"
 	"github.com/tilt-dev/tilt/internal/docker"
 	"github.com/tilt-dev/tilt/internal/store"
@@ -27,33 +30,54 @@ var clusterGVK = v1alpha1.SchemeGroupVersion.WithKind("Cluster")
 
 // Manages the DockerImage API object.
 type Reconciler struct {
-	client  ctrlclient.Client
-	indexer *indexer.Indexer
-	docker  docker.Client
-	ib      *build.ImageBuilder
+	client   ctrlclient.Client
+	indexer  *indexer.Indexer
+	docker   docker.Client
+	ib       *build.ImageBuilder
+	requeuer *indexer.Requeuer
+
+	mu      sync.Mutex
+	results map[types.NamespacedName]*result
 }
 
 var _ reconcile.Reconciler = &Reconciler{}
 
 func NewReconciler(client ctrlclient.Client, scheme *runtime.Scheme, docker docker.Client, ib *build.ImageBuilder) *Reconciler {
 	return &Reconciler{
-		client:  client,
-		indexer: indexer.NewIndexer(scheme, indexDockerImage),
-		docker:  docker,
-		ib:      ib,
+		client:   client,
+		indexer:  indexer.NewIndexer(scheme, indexDockerImage),
+		docker:   docker,
+		ib:       ib,
+		results:  make(map[types.NamespacedName]*result),
+		requeuer: indexer.NewRequeuer(),
 	}
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	nn := req.NamespacedName
 	obj := &v1alpha1.DockerImage{}
-	err := r.client.Get(ctx, req.NamespacedName, obj)
+	err := r.client.Get(ctx, nn, obj)
 	if err != nil && !apierrors.IsNotFound(err) {
 		return ctrl.Result{}, err
 	}
-	r.indexer.OnReconcile(req.NamespacedName, obj)
+	r.indexer.OnReconcile(nn, obj)
 
 	if apierrors.IsNotFound(err) || obj.ObjectMeta.DeletionTimestamp != nil {
+		delete(r.results, nn)
 		return ctrl.Result{}, nil
+	}
+
+	err = r.maybeUpdateImageStatus(ctx, nn, obj)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	err = r.maybeUpdateImageMapStatus(ctx, nn)
+	if err != nil {
+		return ctrl.Result{}, err
 	}
 
 	return ctrl.Result{}, nil
@@ -75,24 +99,103 @@ func (r *Reconciler) ForceApply(
 	// if you want the live container to keep receiving updates
 	// while an image build is going on in parallel.
 	startTime := apis.NowMicro()
-	MaybeUpdateStatus(ctx, r.client, iTarget, ToBuildingStatus(iTarget, startTime))
+	nn := types.NamespacedName{Name: iTarget.DockerImageName}
+	r.setImageStatus(nn, ToBuildingStatus(iTarget, startTime))
+	r.requeuer.Add(nn)
+	defer r.requeuer.Add(nn)
 
 	refs, stages, err := r.ib.Build(ctx, iTarget, cluster, imageMaps, ps)
 	if err != nil {
-		MaybeUpdateStatus(ctx, r.client, iTarget, ToCompletedFailStatus(iTarget, startTime, stages, err))
+		r.setImageStatus(nn, ToCompletedFailStatus(iTarget, startTime, stages, err))
 		return store.ImageBuildResult{}, err
 	}
 
-	MaybeUpdateStatus(ctx, r.client, iTarget, ToCompletedSuccessStatus(iTarget, startTime, stages, refs))
+	r.setImageStatus(nn, ToCompletedSuccessStatus(iTarget, startTime, stages, refs))
 
-	return UpdateImageMap(
-		ctx, r.client, r.docker,
+	buildResult, err := UpdateImageMap(
+		ctx, r.docker,
 		iTarget, cluster, imageMaps, &startTime, refs)
+	if err != nil {
+		return store.ImageBuildResult{}, err
+	}
+	r.setImageMapStatus(nn, iTarget, buildResult.ImageMapStatus)
+	return buildResult, nil
+}
+
+func (r *Reconciler) ensureResult(nn types.NamespacedName) *result {
+	res, ok := r.results[nn]
+	if !ok {
+		res = &result{}
+		r.results[nn] = res
+	}
+	return res
+}
+
+func (r *Reconciler) setImageStatus(nn types.NamespacedName, status v1alpha1.DockerImageStatus) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	result := r.ensureResult(nn)
+	result.image = status
+}
+
+func (r *Reconciler) setImageMapStatus(nn types.NamespacedName, iTarget model.ImageTarget, status v1alpha1.ImageMapStatus) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	result := r.ensureResult(nn)
+	result.imageMapName = iTarget.ImageMapName()
+	result.imageMap = status
+}
+
+// Update the DockerImage status if necessary.
+func (r *Reconciler) maybeUpdateImageStatus(ctx context.Context, nn types.NamespacedName, obj *v1alpha1.DockerImage) error {
+	newStatus := v1alpha1.DockerImageStatus{}
+	existing, ok := r.results[nn]
+	if ok {
+		newStatus = existing.image
+	}
+
+	if apicmp.DeepEqual(obj.Status, newStatus) {
+		return nil
+	}
+
+	update := obj.DeepCopy()
+	update.Status = *(newStatus.DeepCopy())
+
+	return r.client.Status().Update(ctx, update)
+}
+
+// Update the ImageMap status if necessary.
+func (r *Reconciler) maybeUpdateImageMapStatus(ctx context.Context, nn types.NamespacedName) error {
+
+	existing, ok := r.results[nn]
+	if !ok || existing.imageMapName == "" {
+		return nil
+	}
+
+	var obj v1alpha1.ImageMap
+	imNN := types.NamespacedName{Name: existing.imageMapName}
+	err := r.client.Get(ctx, imNN, &obj)
+	if err != nil {
+		return client.IgnoreNotFound(err)
+	}
+
+	newStatus := existing.imageMap
+	if apicmp.DeepEqual(obj.Status, newStatus) {
+		return nil
+	}
+
+	update := obj.DeepCopy()
+	update.Status = *(newStatus.DeepCopy())
+
+	return r.client.Status().Update(ctx, update)
 }
 
 func (r *Reconciler) CreateBuilder(mgr ctrl.Manager) (*builder.Builder, error) {
 	b := ctrl.NewControllerManagedBy(mgr).
 		For(&v1alpha1.DockerImage{}).
+		Watches(r.requeuer, handler.Funcs{}).
 		Watches(&source.Kind{Type: &v1alpha1.Cluster{}},
 			handler.EnqueueRequestsFromMapFunc(r.indexer.Enqueue))
 
@@ -114,4 +217,10 @@ func indexDockerImage(obj ctrlclient.Object) []indexer.Key {
 	}
 
 	return keys
+}
+
+type result struct {
+	image        v1alpha1.DockerImageStatus
+	imageMapName string
+	imageMap     v1alpha1.ImageMapStatus
 }

--- a/internal/controllers/core/dockerimage/status.go
+++ b/internal/controllers/core/dockerimage/status.go
@@ -1,51 +1,13 @@
 package dockerimage
 
 import (
-	"context"
-
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
-	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/tilt-dev/tilt/internal/container"
-	"github.com/tilt-dev/tilt/internal/controllers/apicmp"
 	"github.com/tilt-dev/tilt/pkg/apis"
 	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
-	"github.com/tilt-dev/tilt/pkg/logger"
 	"github.com/tilt-dev/tilt/pkg/model"
 )
-
-// Write the image status to the API server, if necessary.
-// If the image write fails, log it to the debug logs and move on.
-func MaybeUpdateStatus(ctx context.Context, ctrlClient ctrlclient.Client,
-	iTarget model.ImageTarget, status v1alpha1.DockerImageStatus) {
-	if iTarget.DockerImageName == "" {
-		return
-	}
-
-	nn := types.NamespacedName{Name: iTarget.DockerImageName}
-	var di v1alpha1.DockerImage
-	err := ctrlClient.Get(ctx, nn, &di)
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			return
-		}
-		logger.Get(ctx).Debugf("fetching dockerimage %s: %v", nn.Name, err)
-		return
-	}
-
-	if apicmp.DeepEqual(status, di.Status) {
-		return
-	}
-
-	updated := di.DeepCopy()
-	updated.Status = status
-	err = ctrlClient.Status().Update(ctx, updated)
-	if err != nil {
-		logger.Get(ctx).Debugf("updating dockerimage %s: %v", nn.Name, err)
-	}
-}
 
 // Return a basic Building Status.
 func ToBuildingStatus(iTarget model.ImageTarget, startTime metav1.MicroTime) v1alpha1.DockerImageStatus {

--- a/internal/controllers/wire.go
+++ b/internal/controllers/wire.go
@@ -77,7 +77,7 @@ func ProvideControllers(
 		lur,
 		cmr,
 		dir,
-		dir,
+		cir,
 		clr,
 		dcr,
 		imr,

--- a/internal/engine/buildcontrol/image_build_and_deployer_test.go
+++ b/internal/engine/buildcontrol/image_build_and_deployer_test.go
@@ -18,6 +18,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ktypes "k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/tilt-dev/clusterid"
@@ -869,6 +870,8 @@ func TestDockerBuildStatus(t *testing.T) {
 	_, err = f.BuildAndDeploy(BuildTargets(manifest), store.BuildStateSet{})
 	require.NoError(t, err)
 
+	f.ibd.dr.Reconcile(f.ctx, ctrl.Request{NamespacedName: nn})
+
 	var di v1alpha1.DockerImage
 	err = f.ctrlClient.Get(f.ctx, nn, &di)
 	require.NoError(t, err)
@@ -901,6 +904,8 @@ func TestCustomBuildStatus(t *testing.T) {
 
 	_, err = f.BuildAndDeploy(BuildTargets(manifest), store.BuildStateSet{})
 	require.NoError(t, err)
+
+	f.ibd.cr.Reconcile(f.ctx, ctrl.Request{NamespacedName: nn})
 
 	var ci v1alpha1.CmdImage
 	err = f.ctrlClient.Get(f.ctx, nn, &ci)


### PR DESCRIPTION
Hello @milas, @landism,

Please review the following commits I made in branch nicks/imager:

878270caabcd9c2990e768bcf7220d4c442b3c99 (2022-04-15 11:33:28 -0400)
controllers: move status updates into the reconcile loop

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics