### PR TITLE
server: send Cluster as part of partial update

### DIFF
--- a/internal/cli/wire_gen.go
+++ b/internal/cli/wire_gen.go
@@ -347,7 +347,7 @@ func wireCmdUp(ctx context.Context, analytics3 *analytics.TiltAnalytics, cmdTags
 	cmdimageReconciler := cmdimage.NewReconciler(deferredClient, scheme, compositeClient, imageBuilder)
 	dockerClientFactory := _wireDockerClientFuncValue
 	kubernetesClientFactory := _wireKubernetesClientFuncValue
-	clusterReconciler := cluster.NewReconciler(ctx, deferredClient, storeStore, clock, connectionManager, localEnv, dockerClientFactory, kubernetesClientFactory)
+	clusterReconciler := cluster.NewReconciler(ctx, deferredClient, storeStore, clock, connectionManager, localEnv, dockerClientFactory, kubernetesClientFactory, websocketList)
 	disableSubscriber := dockercomposeservice.NewDisableSubscriber(ctx, dockerComposeClient, clock)
 	dockercomposeserviceReconciler := dockercomposeservice.NewReconciler(deferredClient, dockerComposeClient, compositeClient, storeStore, scheme, disableSubscriber)
 	imagemapReconciler := imagemap.NewReconciler(deferredClient, storeStore)
@@ -560,7 +560,7 @@ func wireCmdCI(ctx context.Context, analytics3 *analytics.TiltAnalytics, subcomm
 	cmdimageReconciler := cmdimage.NewReconciler(deferredClient, scheme, compositeClient, imageBuilder)
 	dockerClientFactory := _wireDockerClientFuncValue
 	kubernetesClientFactory := _wireKubernetesClientFuncValue
-	clusterReconciler := cluster.NewReconciler(ctx, deferredClient, storeStore, clock, connectionManager, localEnv, dockerClientFactory, kubernetesClientFactory)
+	clusterReconciler := cluster.NewReconciler(ctx, deferredClient, storeStore, clock, connectionManager, localEnv, dockerClientFactory, kubernetesClientFactory, websocketList)
 	disableSubscriber := dockercomposeservice.NewDisableSubscriber(ctx, dockerComposeClient, clock)
 	dockercomposeserviceReconciler := dockercomposeservice.NewReconciler(deferredClient, dockerComposeClient, compositeClient, storeStore, scheme, disableSubscriber)
 	imagemapReconciler := imagemap.NewReconciler(deferredClient, storeStore)
@@ -769,7 +769,7 @@ func wireCmdUpdog(ctx context.Context, analytics3 *analytics.TiltAnalytics, cmdT
 	cmdimageReconciler := cmdimage.NewReconciler(deferredClient, scheme, compositeClient, imageBuilder)
 	dockerClientFactory := _wireDockerClientFuncValue
 	kubernetesClientFactory := _wireKubernetesClientFuncValue
-	clusterReconciler := cluster.NewReconciler(ctx, deferredClient, storeStore, clock, connectionManager, localEnv, dockerClientFactory, kubernetesClientFactory)
+	clusterReconciler := cluster.NewReconciler(ctx, deferredClient, storeStore, clock, connectionManager, localEnv, dockerClientFactory, kubernetesClientFactory, websocketList)
 	disableSubscriber := dockercomposeservice.NewDisableSubscriber(ctx, dockerComposeClient, clock)
 	dockercomposeserviceReconciler := dockercomposeservice.NewReconciler(deferredClient, dockerComposeClient, compositeClient, storeStore, scheme, disableSubscriber)
 	imagemapReconciler := imagemap.NewReconciler(deferredClient, storeStore)

--- a/internal/controllers/core/cluster/reconciler_test.go
+++ b/internal/controllers/core/cluster/reconciler_test.go
@@ -13,6 +13,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
+	"github.com/tilt-dev/tilt/internal/hud/server"
 	"github.com/tilt-dev/wmclient/pkg/analytics"
 
 	"github.com/tilt-dev/tilt/internal/controllers/apicmp"
@@ -251,7 +252,8 @@ func newFixture(t *testing.T) *fixture {
 
 	r := NewReconciler(cfb.Context(), cfb.Client, st, clock, NewConnectionManager(), docker.LocalEnv{},
 		FakeDockerClientOrError(dockerClient, nil),
-		FakeKubernetesClientOrError(k8sClient, nil))
+		FakeKubernetesClientOrError(k8sClient, nil),
+		server.NewWebsocketList())
 	requeueChan := make(chan indexer.RequeueForTestResult, 1)
 	indexer.StartSourceForTesting(cfb.Context(), r.requeuer, r, requeueChan)
 	return &fixture{

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -3394,7 +3394,8 @@ func newTestFixture(t *testing.T, options ...fixtureOptions) *testFixture {
 	cir := cmdimage.NewReconciler(cdc, sch, dockerClient, ib)
 	clr := cluster.NewReconciler(ctx, cdc, st, clock, clusterClients, docker.LocalEnv{},
 		cluster.FakeDockerClientOrError(dockerClient, nil),
-		cluster.FakeKubernetesClientOrError(kClient, nil))
+		cluster.FakeKubernetesClientOrError(kClient, nil),
+		wsl)
 
 	cb := controllers.NewControllerBuilder(tscm, controllers.ProvideControllers(
 		fwc,

--- a/internal/feature/flags.go
+++ b/internal/feature/flags.go
@@ -79,6 +79,10 @@ var MainDefaults = Defaults{
 		Enabled: false,
 		Status:  Obsolete,
 	},
+	ClusterRefresh: Value{
+		Enabled: false,
+		Status:  Active,
+	},
 }
 
 // FeatureSet is a mutable set of Features.

--- a/internal/hud/server/websocket_test.go
+++ b/internal/hud/server/websocket_test.go
@@ -160,11 +160,17 @@ func TestMergeUpdates(t *testing.T) {
 	f.ws.SendUIButtonUpdate(f.ctx, types.NamespacedName{Name: "ba"},
 		&v1alpha1.UIButton{ObjectMeta: metav1.ObjectMeta{Name: "ba"}})
 	f.ws.SendUIButtonUpdate(f.ctx, types.NamespacedName{Name: "bb"}, nil)
+	f.ws.SendClusterUpdate(f.ctx, types.NamespacedName{Name: "ca"},
+		&v1alpha1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "ca"}})
+	f.ws.SendClusterUpdate(f.ctx, types.NamespacedName{Name: "ca"},
+		&v1alpha1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "ca"}})
+	f.ws.SendClusterUpdate(f.ctx, types.NamespacedName{Name: "cb"}, nil)
 
 	view := f.ws.toViewUpdate()
 	assert.Equal(t, "sb", view.UiSession.ObjectMeta.Name)
 	assert.Equal(t, 2, len(view.UiResources))
 	assert.Equal(t, 2, len(view.UiButtons))
+	assert.Len(t, view.Clusters, 2, "Cluster updates")
 
 	view2 := f.ws.toViewUpdate()
 	assert.Nil(t, view2)
@@ -174,6 +180,10 @@ func TestMergeUpdates(t *testing.T) {
 	assert.Nil(t, view3.UiSession)
 	assert.Equal(t, 0, len(view3.UiResources))
 	assert.Equal(t, 1, len(view3.UiButtons))
+
+	f.ws.SendClusterUpdate(f.ctx, types.NamespacedName{Name: "cb"}, nil)
+	view4 := f.ws.toViewUpdate()
+	assert.Len(t, view4.Clusters, 1, "Cluster updates")
 }
 
 type wsFixture struct {

--- a/web/src/HUD.tsx
+++ b/web/src/HUD.tsx
@@ -454,6 +454,13 @@ export function mergeAppUpdate<K extends keyof HudState>(
     })
   }
 
+  const clusterUpdates = state.view?.clusters
+  if (clusterUpdates) {
+    result.view = Object.assign({}, result.view, {
+      clusters: mergeObjectUpdates(clusterUpdates, result.view?.clusters),
+    })
+  }
+
   // If no references have changed, don't re-render.
   //
   // LogStore handles its own update events, so a change


### PR DESCRIPTION
We were only sending this on the full view, so it wouldn't get
re-sent at runtime without a refresh.