### PR TITLE
engine: remove an error message from the event watcher

### DIFF
--- a/internal/controllers/core/kubernetesdiscovery/reconciler.go
+++ b/internal/controllers/core/kubernetesdiscovery/reconciler.go
@@ -581,6 +581,8 @@ func (w *Reconciler) triagePodTree(nsKey nsKey, pod *v1.Pod, objTree k8s.ObjectR
 func (w *Reconciler) handlePodChange(ctx context.Context, nsKey nsKey, ownerFetcher k8s.OwnerFetcher, pod *v1.Pod) {
 	objTree, err := ownerFetcher.OwnerTreeOf(ctx, k8s.NewK8sEntity(pod))
 	if err != nil {
+		// In locked-down clusters, the user may not have access to certain types of resources
+		// so it's normal for there to be errors. Ignore them.
 		return
 	}
 

--- a/internal/engine/k8swatch/event_watch_manager.go
+++ b/internal/engine/k8swatch/event_watch_manager.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/tilt-dev/tilt/internal/k8s"
 	"github.com/tilt-dev/tilt/internal/store"
-	"github.com/tilt-dev/tilt/pkg/logger"
 	"github.com/tilt-dev/tilt/pkg/model"
 )
 
@@ -219,7 +218,8 @@ func (m *EventWatchManager) triageEventUpdate(clusterNN types.NamespacedName, ev
 func (m *EventWatchManager) dispatchEventChange(ctx context.Context, of k8s.OwnerFetcher, clusterNN types.NamespacedName, event *v1.Event, st store.RStore) {
 	objTree, err := of.OwnerTreeOfRef(ctx, event.InvolvedObject)
 	if err != nil {
-		logger.Get(ctx).Infof("Error handling event update (%q): %v", event.Name, err)
+		// In locked-down clusters, the user may not have access to certain types of resources
+		// so it's normal for there to be errors. Ignore them.
 		return
 	}
 


### PR DESCRIPTION
Hello @landism, @milas,

Please review the following commits I made in branch nicks/events:

195cbd53d69b353685a7fc9913dcf44299edfda5 (2022-04-18 18:51:00 -0400)
engine: remove an error message from the event watcher

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics