### PR TITLE
web: switch HUD tests to use react test-utils instead of enzyme

### DIFF
--- a/web/src/HUD.test.tsx
+++ b/web/src/HUD.test.tsx
@@ -50,8 +50,8 @@ beforeEach(() => {
 
 it("renders reconnecting bar", async () => {
   let root = emptyHUD()
-  let rootTree = renderIntoDocument(root)
-  let container = ReactDOM.findDOMNode(rootTree)
+  let rootTree = renderIntoDocument(root) as any
+  let container = ReactDOM.findDOMNode(rootTree)! as HTMLElement
   expect(container.textContent).toEqual(expect.stringContaining("Loading"))
 
   const hud = findRenderedComponentWithType(rootTree, HUD)
@@ -60,7 +60,7 @@ it("renders reconnecting bar", async () => {
     view: oneResourceView(),
     socketState: SocketState.Reconnecting,
   })
-  container = ReactDOM.findDOMNode(rootTree)
+  container = ReactDOM.findDOMNode(rootTree)! as HTMLElement
 
   let socketBar = Array.from(container.querySelectorAll(SocketBarRoot))
   expect(socketBar).toHaveLength(1)
@@ -70,8 +70,7 @@ it("renders reconnecting bar", async () => {
 })
 
 it("loads logs incrementally", async () => {
-  const root = renderIntoDocument(emptyHUD())
-  const container = ReactDOM.findDOMNode(root)
+  const root = renderIntoDocument(emptyHUD()) as any
   const hud = findRenderedComponentWithType(root, HUD)
 
   let now = new Date().toString()
@@ -118,8 +117,7 @@ it("loads logs incrementally", async () => {
 })
 
 it("renders logs to snapshot", async () => {
-  const root = renderIntoDocument(emptyHUD())
-  const container = ReactDOM.findDOMNode(root)
+  const root = renderIntoDocument(emptyHUD()) as any
   const hud = findRenderedComponentWithType(root, HUD)
 
   let now = new Date().toString()

--- a/web/src/HUD.test.tsx
+++ b/web/src/HUD.test.tsx
@@ -1,12 +1,15 @@
-import { mount } from "enzyme"
 import { createMemoryHistory } from "history"
 import React from "react"
 import ReactDOM from "react-dom"
+import {
+  findRenderedComponentWithType,
+  renderIntoDocument,
+} from "react-dom/test-utils"
 import ReactModal from "react-modal"
 import { MemoryRouter } from "react-router"
 import HUD, { mergeAppUpdate } from "./HUD"
 import LogStore from "./LogStore"
-import SocketBar from "./SocketBar"
+import { SocketBarRoot } from "./SocketBar"
 import {
   logList,
   nButtonView,
@@ -40,44 +43,36 @@ const emptyHUD = () => {
     </MemoryRouter>
   )
 }
-const HUDAtPath = (path: string) => {
-  return (
-    <MemoryRouter initialEntries={[path]}>
-      <HUD history={fakeHistory} interfaceVersion={interfaceVersion} />
-    </MemoryRouter>
-  )
-}
 
 beforeEach(() => {
   Date.now = jest.fn(() => 1482363367071)
 })
 
-it("renders without crashing", () => {
-  const div = document.createElement("div")
-  ReactDOM.render(emptyHUD(), div)
-  ReactDOM.unmountComponentAtNode(div)
-})
-
 it("renders reconnecting bar", async () => {
-  const root = mount(emptyHUD())
-  const hud = root.find(HUD)
-  expect(hud.text()).toEqual(expect.stringContaining("Loading"))
+  let root = emptyHUD()
+  let rootTree = renderIntoDocument(root)
+  let container = ReactDOM.findDOMNode(rootTree)
+  expect(container.textContent).toEqual(expect.stringContaining("Loading"))
+
+  const hud = findRenderedComponentWithType(rootTree, HUD)
 
   hud.setState({
     view: oneResourceView(),
     socketState: SocketState.Reconnecting,
   })
+  container = ReactDOM.findDOMNode(rootTree)
 
-  let socketBar = root.find(SocketBar)
+  let socketBar = Array.from(container.querySelectorAll(SocketBarRoot))
   expect(socketBar).toHaveLength(1)
-  expect(socketBar.at(0).text()).toEqual(
+  expect(socketBar[0].textContent).toEqual(
     expect.stringContaining("reconnecting")
   )
 })
 
 it("loads logs incrementally", async () => {
-  const root = mount(emptyHUD())
-  const hud = root.find(HUD).instance() as HUD
+  const root = renderIntoDocument(emptyHUD())
+  const container = ReactDOM.findDOMNode(root)
+  const hud = findRenderedComponentWithType(root, HUD)
 
   let now = new Date().toString()
   let resourceView = oneResourceView()
@@ -108,7 +103,6 @@ it("loads logs incrementally", async () => {
   }
   hud.onAppChange({ view: resourceView2 })
 
-  root.update()
   let snapshot = hud.snapshotFromState(hud.state)
   expect(snapshot.view?.logList).toEqual({
     spans: {
@@ -124,8 +118,9 @@ it("loads logs incrementally", async () => {
 })
 
 it("renders logs to snapshot", async () => {
-  const root = mount(emptyHUD())
-  const hud = root.find(HUD).instance() as HUD
+  const root = renderIntoDocument(emptyHUD())
+  const container = ReactDOM.findDOMNode(root)
+  const hud = findRenderedComponentWithType(root, HUD)
 
   let now = new Date().toString()
   let resourceView = oneResourceView()
@@ -142,7 +137,6 @@ it("renders logs to snapshot", async () => {
   }
   hud.onAppChange({ view: resourceView })
 
-  root.update()
   let snapshot = hud.snapshotFromState(hud.state)
   expect(snapshot.view?.logList).toEqual({
     spans: {

--- a/web/src/SocketBar.tsx
+++ b/web/src/SocketBar.tsx
@@ -19,7 +19,7 @@ let pulse = keyframes`
   }
 `
 
-let SocketBarRoot = styled.div`
+export let SocketBarRoot = styled.div`
   position: fixed;
   z-index: ${ZIndex.SocketBar};
   width: 100vw;


### PR DESCRIPTION
Hello @lizzthabet,

Please review the following commits I made in branch nicks/reacttesting:

a729e8594ffe49a65515beb5ffa2e323e97c2624 (2022-04-19 14:31:46 -0400)
web: switch HUD tests to use react test-utils instead of enzyme

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics