### PR TITLE
docker: use the CLI library for creating our docker client.

### DIFF
--- a/internal/build/test_utils.go
+++ b/internal/build/test_utils.go
@@ -49,7 +49,7 @@ func newDockerBuildFixture(t testing.TB) *dockerBuildFixture {
 	ctx, _, _ := testutils.CtxAndAnalyticsForTest()
 	env := clusterid.ProductGKE
 
-	dEnv := docker.ProvideClusterEnv(ctx, "gke", env, wmcontainer.RuntimeDocker, k8s.FakeMinikube{})
+	dEnv := docker.ProvideClusterEnv(ctx, docker.RealClientCreator{}, "gke", env, wmcontainer.RuntimeDocker, k8s.FakeMinikube{})
 	dCli := docker.NewDockerClient(ctx, docker.Env(dEnv))
 	_, ok := dCli.(*docker.Cli)
 	// If it wasn't an actual Docker client, it's an exploding client

--- a/internal/cli/demo.go
+++ b/internal/cli/demo.go
@@ -44,7 +44,7 @@ func (c *demoCmd) register() *cobra.Command {
 Tilt will create a temporary, local Kubernetes development cluster running in Docker.
 The cluster will be removed when Tilt is exited with Ctrl-C.
 
-A sample project (%s) will be cloned locally to a temporary directory using Git and launched. 
+A sample project (%s) will be cloned locally to a temporary directory using Git and launched.
 `, sampleProjPackage),
 	}
 
@@ -119,7 +119,7 @@ func (c *demoCmd) run(ctx context.Context, args []string) error {
 		if err != nil {
 			return fmt.Errorf("tilt demo requires Docker to be installed and running: %v", err)
 		}
-		if !isLocalDockerHost(client.Env().Host) {
+		if !isLocalDockerHost(client.Env().DaemonHost()) {
 			// properly supporting remote Docker connections is very tricky - either:
 			//
 			// the remote host will need more ports accessible (for K8s API + registry API) and we have to ensure
@@ -130,7 +130,7 @@ func (c *demoCmd) run(ctx context.Context, args []string) error {
 			//
 			// for now, it's not supported as it's a pretty advanced setup to begin with, so we're not really targeting
 			// it with the `tilt demo` functionality
-			return fmt.Errorf("tilt demo requires a local Docker daemon to create a temporary Kubernetes cluster (current Docker host: %s)", client.Env().Host)
+			return fmt.Errorf("tilt demo requires a local Docker daemon to create a temporary Kubernetes cluster (current Docker host: %s)", client.Env().DaemonHost())
 		}
 
 		//

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -64,7 +64,7 @@ func (c *doctorCmd) run(ctx context.Context, args []string) error {
 		printField("Host", nil, clusterDockerErr)
 	} else {
 		dockerEnv := clusterDocker.Env()
-		host := dockerEnv.Host
+		host := dockerEnv.DaemonHost()
 		if host == "" {
 			host = "[default]"
 		}
@@ -86,7 +86,7 @@ func (c *doctorCmd) run(ctx context.Context, args []string) error {
 			printField("Host", nil, localDockerErr)
 		} else {
 			dockerEnv := localDocker.Env()
-			host := dockerEnv.Host
+			host := dockerEnv.DaemonHost()
 			if host == "" {
 				host = "[default]"
 			}

--- a/internal/cli/wire_gen.go
+++ b/internal/cli/wire_gen.go
@@ -120,6 +120,7 @@ func wireTiltfileResult(ctx context.Context, analytics2 *analytics.TiltAnalytics
 	scheme := v1alpha1.NewScheme()
 	extensionReconciler := extension.NewReconciler(deferredClient, scheme, analytics2)
 	tiltextensionPlugin := tiltextension.NewPlugin(reconciler, extensionReconciler)
+	realClientCreator := _wireRealClientCreatorValue
 	restConfigOrError := k8s.ProvideRESTConfig(clientConfig)
 	clientsetOrError := k8s.ProvideClientset(restConfigOrError)
 	portForwardClient := k8s.ProvidePortForwardClient(restConfigOrError, clientsetOrError)
@@ -128,8 +129,8 @@ func wireTiltfileResult(ctx context.Context, analytics2 *analytics.TiltAnalytics
 	minikubeClient := k8s.ProvideMinikubeClient(kubeContext)
 	client := k8s.ProvideK8sClient(ctx, product, restConfigOrError, clientsetOrError, portForwardClient, kubeContext, clusterName, namespace, minikubeClient, clientConfig)
 	runtime := k8s.ProvideContainerRuntime(ctx, client)
-	clusterEnv := docker.ProvideClusterEnv(ctx, kubeContext, product, runtime, minikubeClient)
-	localEnv := docker.ProvideLocalEnv(ctx, kubeContext, product, clusterEnv)
+	clusterEnv := docker.ProvideClusterEnv(ctx, realClientCreator, kubeContext, product, runtime, minikubeClient)
+	localEnv := docker.ProvideLocalEnv(ctx, realClientCreator, kubeContext, product, clusterEnv)
 	dockerComposeClient := dockercompose.NewDockerComposeClient(localEnv)
 	webHost := provideWebHost()
 	webPort := provideWebPort()
@@ -142,11 +143,13 @@ func wireTiltfileResult(ctx context.Context, analytics2 *analytics.TiltAnalytics
 }
 
 var (
-	_wireReducerValue  = engine.UpperReducer
-	_wireDefaultsValue = feature.MainDefaults
+	_wireReducerValue           = engine.UpperReducer
+	_wireRealClientCreatorValue = docker.RealClientCreator{}
+	_wireDefaultsValue          = feature.MainDefaults
 )
 
 func wireDockerPrune(ctx context.Context, analytics2 *analytics.TiltAnalytics, subcommand model.TiltSubcommand) (dpDeps, error) {
+	realClientCreator := _wireRealClientCreatorValue
 	k8sKubeContextOverride := ProvideKubeContextOverride()
 	k8sNamespaceOverride := ProvideNamespaceOverride()
 	clientConfig := k8s.ProvideClientConfig(k8sKubeContextOverride, k8sNamespaceOverride)
@@ -167,8 +170,8 @@ func wireDockerPrune(ctx context.Context, analytics2 *analytics.TiltAnalytics, s
 	minikubeClient := k8s.ProvideMinikubeClient(kubeContext)
 	client := k8s.ProvideK8sClient(ctx, product, restConfigOrError, clientsetOrError, portForwardClient, kubeContext, clusterName, namespace, minikubeClient, clientConfig)
 	runtime := k8s.ProvideContainerRuntime(ctx, client)
-	clusterEnv := docker.ProvideClusterEnv(ctx, kubeContext, product, runtime, minikubeClient)
-	localEnv := docker.ProvideLocalEnv(ctx, kubeContext, product, clusterEnv)
+	clusterEnv := docker.ProvideClusterEnv(ctx, realClientCreator, kubeContext, product, runtime, minikubeClient)
+	localEnv := docker.ProvideLocalEnv(ctx, realClientCreator, kubeContext, product, clusterEnv)
 	localClient := docker.ProvideLocalCli(ctx, localEnv)
 	clusterClient, err := docker.ProvideClusterCli(ctx, localEnv, clusterEnv, localClient)
 	if err != nil {
@@ -298,9 +301,10 @@ func wireCmdUp(ctx context.Context, analytics3 *analytics.TiltAnalytics, cmdTags
 	connectionManager := cluster.NewConnectionManager()
 	containerRestartDetector := kubernetesdiscovery.NewContainerRestartDetector()
 	reconciler := kubernetesdiscovery.NewReconciler(deferredClient, scheme, connectionManager, containerRestartDetector, storeStore)
+	realClientCreator := _wireRealClientCreatorValue
 	runtime := k8s.ProvideContainerRuntime(ctx, client)
-	clusterEnv := docker.ProvideClusterEnv(ctx, kubeContext, product, runtime, minikubeClient)
-	localEnv := docker.ProvideLocalEnv(ctx, kubeContext, product, clusterEnv)
+	clusterEnv := docker.ProvideClusterEnv(ctx, realClientCreator, kubeContext, product, runtime, minikubeClient)
+	localEnv := docker.ProvideLocalEnv(ctx, realClientCreator, kubeContext, product, clusterEnv)
 	localClient := docker.ProvideLocalCli(ctx, localEnv)
 	clusterClient, err := docker.ProvideClusterCli(ctx, localEnv, clusterEnv, localClient)
 	if err != nil {
@@ -511,9 +515,10 @@ func wireCmdCI(ctx context.Context, analytics3 *analytics.TiltAnalytics, subcomm
 	connectionManager := cluster.NewConnectionManager()
 	containerRestartDetector := kubernetesdiscovery.NewContainerRestartDetector()
 	reconciler := kubernetesdiscovery.NewReconciler(deferredClient, scheme, connectionManager, containerRestartDetector, storeStore)
+	realClientCreator := _wireRealClientCreatorValue
 	runtime := k8s.ProvideContainerRuntime(ctx, client)
-	clusterEnv := docker.ProvideClusterEnv(ctx, kubeContext, product, runtime, minikubeClient)
-	localEnv := docker.ProvideLocalEnv(ctx, kubeContext, product, clusterEnv)
+	clusterEnv := docker.ProvideClusterEnv(ctx, realClientCreator, kubeContext, product, runtime, minikubeClient)
+	localEnv := docker.ProvideLocalEnv(ctx, realClientCreator, kubeContext, product, clusterEnv)
 	localClient := docker.ProvideLocalCli(ctx, localEnv)
 	clusterClient, err := docker.ProvideClusterCli(ctx, localEnv, clusterEnv, localClient)
 	if err != nil {
@@ -720,9 +725,10 @@ func wireCmdUpdog(ctx context.Context, analytics3 *analytics.TiltAnalytics, cmdT
 	connectionManager := cluster.NewConnectionManager()
 	containerRestartDetector := kubernetesdiscovery.NewContainerRestartDetector()
 	reconciler := kubernetesdiscovery.NewReconciler(deferredClient, scheme, connectionManager, containerRestartDetector, storeStore)
+	realClientCreator := _wireRealClientCreatorValue
 	runtime := k8s.ProvideContainerRuntime(ctx, k8sClient)
-	clusterEnv := docker.ProvideClusterEnv(ctx, kubeContext, product, runtime, minikubeClient)
-	localEnv := docker.ProvideLocalEnv(ctx, kubeContext, product, clusterEnv)
+	clusterEnv := docker.ProvideClusterEnv(ctx, realClientCreator, kubeContext, product, runtime, minikubeClient)
+	localEnv := docker.ProvideLocalEnv(ctx, realClientCreator, kubeContext, product, clusterEnv)
 	localClient := docker.ProvideLocalCli(ctx, localEnv)
 	clusterClient, err := docker.ProvideClusterCli(ctx, localEnv, clusterEnv, localClient)
 	if err != nil {
@@ -921,6 +927,7 @@ func wireK8sVersion(ctx context.Context) (*version2.Info, error) {
 }
 
 func wireDockerClusterClient(ctx context.Context) (docker.ClusterClient, error) {
+	realClientCreator := _wireRealClientCreatorValue
 	k8sKubeContextOverride := ProvideKubeContextOverride()
 	k8sNamespaceOverride := ProvideNamespaceOverride()
 	clientConfig := k8s.ProvideClientConfig(k8sKubeContextOverride, k8sNamespaceOverride)
@@ -941,8 +948,8 @@ func wireDockerClusterClient(ctx context.Context) (docker.ClusterClient, error) 
 	minikubeClient := k8s.ProvideMinikubeClient(kubeContext)
 	k8sClient := k8s.ProvideK8sClient(ctx, product, restConfigOrError, clientsetOrError, portForwardClient, kubeContext, clusterName, namespace, minikubeClient, clientConfig)
 	runtime := k8s.ProvideContainerRuntime(ctx, k8sClient)
-	clusterEnv := docker.ProvideClusterEnv(ctx, kubeContext, product, runtime, minikubeClient)
-	localEnv := docker.ProvideLocalEnv(ctx, kubeContext, product, clusterEnv)
+	clusterEnv := docker.ProvideClusterEnv(ctx, realClientCreator, kubeContext, product, runtime, minikubeClient)
+	localEnv := docker.ProvideLocalEnv(ctx, realClientCreator, kubeContext, product, clusterEnv)
 	localClient := docker.ProvideLocalCli(ctx, localEnv)
 	clusterClient, err := docker.ProvideClusterCli(ctx, localEnv, clusterEnv, localClient)
 	if err != nil {
@@ -952,6 +959,7 @@ func wireDockerClusterClient(ctx context.Context) (docker.ClusterClient, error) 
 }
 
 func wireDockerLocalClient(ctx context.Context) (docker.LocalClient, error) {
+	realClientCreator := _wireRealClientCreatorValue
 	k8sKubeContextOverride := ProvideKubeContextOverride()
 	k8sNamespaceOverride := ProvideNamespaceOverride()
 	clientConfig := k8s.ProvideClientConfig(k8sKubeContextOverride, k8sNamespaceOverride)
@@ -972,13 +980,14 @@ func wireDockerLocalClient(ctx context.Context) (docker.LocalClient, error) {
 	minikubeClient := k8s.ProvideMinikubeClient(kubeContext)
 	k8sClient := k8s.ProvideK8sClient(ctx, product, restConfigOrError, clientsetOrError, portForwardClient, kubeContext, clusterName, namespace, minikubeClient, clientConfig)
 	runtime := k8s.ProvideContainerRuntime(ctx, k8sClient)
-	clusterEnv := docker.ProvideClusterEnv(ctx, kubeContext, product, runtime, minikubeClient)
-	localEnv := docker.ProvideLocalEnv(ctx, kubeContext, product, clusterEnv)
+	clusterEnv := docker.ProvideClusterEnv(ctx, realClientCreator, kubeContext, product, runtime, minikubeClient)
+	localEnv := docker.ProvideLocalEnv(ctx, realClientCreator, kubeContext, product, clusterEnv)
 	localClient := docker.ProvideLocalCli(ctx, localEnv)
 	return localClient, nil
 }
 
 func wireDockerCompositeClient(ctx context.Context) (docker.CompositeClient, error) {
+	realClientCreator := _wireRealClientCreatorValue
 	k8sKubeContextOverride := ProvideKubeContextOverride()
 	k8sNamespaceOverride := ProvideNamespaceOverride()
 	clientConfig := k8s.ProvideClientConfig(k8sKubeContextOverride, k8sNamespaceOverride)
@@ -999,8 +1008,8 @@ func wireDockerCompositeClient(ctx context.Context) (docker.CompositeClient, err
 	minikubeClient := k8s.ProvideMinikubeClient(kubeContext)
 	k8sClient := k8s.ProvideK8sClient(ctx, product, restConfigOrError, clientsetOrError, portForwardClient, kubeContext, clusterName, namespace, minikubeClient, clientConfig)
 	runtime := k8s.ProvideContainerRuntime(ctx, k8sClient)
-	clusterEnv := docker.ProvideClusterEnv(ctx, kubeContext, product, runtime, minikubeClient)
-	localEnv := docker.ProvideLocalEnv(ctx, kubeContext, product, clusterEnv)
+	clusterEnv := docker.ProvideClusterEnv(ctx, realClientCreator, kubeContext, product, runtime, minikubeClient)
+	localEnv := docker.ProvideLocalEnv(ctx, realClientCreator, kubeContext, product, clusterEnv)
 	localClient := docker.ProvideLocalCli(ctx, localEnv)
 	clusterClient, err := docker.ProvideClusterCli(ctx, localEnv, clusterEnv, localClient)
 	if err != nil {
@@ -1039,6 +1048,7 @@ func wireDownDeps(ctx context.Context, tiltAnalytics *analytics.TiltAnalytics, s
 	scheme := v1alpha1.NewScheme()
 	extensionReconciler := extension.NewReconciler(deferredClient, scheme, tiltAnalytics)
 	tiltextensionPlugin := tiltextension.NewPlugin(reconciler, extensionReconciler)
+	realClientCreator := _wireRealClientCreatorValue
 	restConfigOrError := k8s.ProvideRESTConfig(clientConfig)
 	clientsetOrError := k8s.ProvideClientset(restConfigOrError)
 	portForwardClient := k8s.ProvidePortForwardClient(restConfigOrError, clientsetOrError)
@@ -1047,8 +1057,8 @@ func wireDownDeps(ctx context.Context, tiltAnalytics *analytics.TiltAnalytics, s
 	minikubeClient := k8s.ProvideMinikubeClient(kubeContext)
 	k8sClient := k8s.ProvideK8sClient(ctx, product, restConfigOrError, clientsetOrError, portForwardClient, kubeContext, clusterName, namespace, minikubeClient, clientConfig)
 	runtime := k8s.ProvideContainerRuntime(ctx, k8sClient)
-	clusterEnv := docker.ProvideClusterEnv(ctx, kubeContext, product, runtime, minikubeClient)
-	localEnv := docker.ProvideLocalEnv(ctx, kubeContext, product, clusterEnv)
+	clusterEnv := docker.ProvideClusterEnv(ctx, realClientCreator, kubeContext, product, runtime, minikubeClient)
+	localEnv := docker.ProvideLocalEnv(ctx, realClientCreator, kubeContext, product, clusterEnv)
 	dockerComposeClient := dockercompose.NewDockerComposeClient(localEnv)
 	webHost := provideWebHost()
 	webPort := provideWebPort()
@@ -1074,6 +1084,7 @@ func wireLogsDeps(ctx context.Context, tiltAnalytics *analytics.TiltAnalytics, s
 }
 
 func wireDumpImageDeployRefDeps(ctx context.Context) (DumpImageDeployRefDeps, error) {
+	realClientCreator := _wireRealClientCreatorValue
 	k8sKubeContextOverride := ProvideKubeContextOverride()
 	k8sNamespaceOverride := ProvideNamespaceOverride()
 	clientConfig := k8s.ProvideClientConfig(k8sKubeContextOverride, k8sNamespaceOverride)
@@ -1094,8 +1105,8 @@ func wireDumpImageDeployRefDeps(ctx context.Context) (DumpImageDeployRefDeps, er
 	minikubeClient := k8s.ProvideMinikubeClient(kubeContext)
 	k8sClient := k8s.ProvideK8sClient(ctx, product, restConfigOrError, clientsetOrError, portForwardClient, kubeContext, clusterName, namespace, minikubeClient, clientConfig)
 	runtime := k8s.ProvideContainerRuntime(ctx, k8sClient)
-	clusterEnv := docker.ProvideClusterEnv(ctx, kubeContext, product, runtime, minikubeClient)
-	localEnv := docker.ProvideLocalEnv(ctx, kubeContext, product, clusterEnv)
+	clusterEnv := docker.ProvideClusterEnv(ctx, realClientCreator, kubeContext, product, runtime, minikubeClient)
+	localEnv := docker.ProvideLocalEnv(ctx, realClientCreator, kubeContext, product, clusterEnv)
 	localClient := docker.ProvideLocalCli(ctx, localEnv)
 	clusterClient, err := docker.ProvideClusterCli(ctx, localEnv, clusterEnv, localClient)
 	if err != nil {

--- a/internal/controllers/core/cluster/reconciler.go
+++ b/internal/controllers/core/cluster/reconciler.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/docker/docker/client"
 	"github.com/jonboulle/clockwork"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -192,7 +193,11 @@ func (r *Reconciler) createDockerClient(obj *v1alpha1.DockerClusterConnection) (
 	// If no Host is specified, use the default Env from environment variables.
 	env := docker.Env(r.localDockerEnv)
 	if obj.Host != "" {
-		env = docker.Env{Host: obj.Host}
+		d, err := client.NewClientWithOpts(client.WithHost(obj.Host))
+		env.Client = d
+		if err != nil {
+			env.Error = err
+		}
 	}
 
 	client, err := r.dockerClientFactory.New(r.globalCtx, env)

--- a/internal/docker/client_integration_test.go
+++ b/internal/docker/client_integration_test.go
@@ -18,7 +18,7 @@ import (
 
 func TestCli_Run(t *testing.T) {
 	ctx, _, _ := testutils.CtxAndAnalyticsForTest()
-	dEnv := ProvideClusterEnv(ctx, "gke", clusterid.ProductGKE, wmcontainer.RuntimeDocker, k8s.FakeMinikube{})
+	dEnv := ProvideClusterEnv(ctx, RealClientCreator{}, "gke", clusterid.ProductGKE, wmcontainer.RuntimeDocker, k8s.FakeMinikube{})
 	cli := NewDockerClient(ctx, Env(dEnv))
 	defer func() {
 		// release any idle connections to avoid out of file errors if running test many times

--- a/internal/docker/clients.go
+++ b/internal/docker/clients.go
@@ -2,8 +2,6 @@ package docker
 
 import (
 	"context"
-
-	"github.com/google/go-cmp/cmp"
 )
 
 type LocalClient Client
@@ -15,10 +13,10 @@ type ClusterClient Client
 // We may need both or just one or neither, depending on what options the
 // Tiltfile has set to drive the build
 func ProvideClusterCli(ctx context.Context, lEnv LocalEnv, cEnv ClusterEnv, lClient LocalClient) (ClusterClient, error) {
-	// If the Cluster Env and the LocalEnv are the same, we can re-use the cluster
-	// client as a local client.
+	// If the Cluster Env and the LocalEnv talk to the same daemon,
+	// we can re-use the cluster client as a local client.
 	var cClient ClusterClient
-	if cmp.Equal(Env(lEnv), Env(cEnv)) {
+	if Env(lEnv).DaemonHost() == Env(cEnv).DaemonHost() {
 		cClient = ClusterClient(lClient)
 	} else {
 		cClient = NewDockerClient(ctx, Env(cEnv))

--- a/internal/docker/switch.go
+++ b/internal/docker/switch.go
@@ -138,5 +138,5 @@ func (c *switchCli) ClientFor(cluster v1alpha1.Cluster) Client {
 	return c.DefaultLocalClient()
 }
 func (c *switchCli) HasMultipleClients() bool {
-	return c.localCli.Env().Host != c.clusterCli.Env().Host
+	return c.localCli.Env().DaemonHost() != c.clusterCli.Env().DaemonHost()
 }

--- a/internal/docker/wire.go
+++ b/internal/docker/wire.go
@@ -9,6 +9,10 @@ func ProvideClusterAsDefault(cli ClusterClient) Client {
 	return Client(cli)
 }
 
+var ClientCreatorWireSet = wire.NewSet(
+	wire.Value(RealClientCreator{}),
+	wire.Bind(new(ClientCreator), new(RealClientCreator)))
+
 // Bind a docker client that can either talk to the in-cluster
 // Docker daemon or to the local Docker daemon.
 var SwitchWireSet = wire.NewSet(
@@ -17,7 +21,8 @@ var SwitchWireSet = wire.NewSet(
 	ProvideSwitchCli,
 	ProvideLocalEnv,
 	ProvideClusterEnv,
-	wire.Bind(new(Client), new(CompositeClient)))
+	wire.Bind(new(Client), new(CompositeClient)),
+	ClientCreatorWireSet)
 
 // Bind a docker client that talks to the in-cluster Docker daemon.
 var ClusterWireSet = wire.NewSet(
@@ -25,14 +30,16 @@ var ClusterWireSet = wire.NewSet(
 	ProvideLocalCli,
 	ProvideLocalEnv,
 	ProvideClusterEnv,
-	ProvideClusterAsDefault)
+	ProvideClusterAsDefault,
+	ClientCreatorWireSet)
 
 // Bind a docker client that can only talk to the local Docker daemon.
 var LocalWireSet = wire.NewSet(
 	ProvideLocalCli,
 	ProvideLocalEnv,
 	ProvideEmptyClusterEnv,
-	ProvideLocalAsDefault)
+	ProvideLocalAsDefault,
+	ClientCreatorWireSet)
 
 func ProvideEmptyClusterEnv() ClusterEnv {
 	return ClusterEnv{}


### PR DESCRIPTION
Hello @milas, @lizzthabet,

Please review the following commits I made in branch nicks/dockerclient2:

6b1917e34eb65c0935a3753770abd4acd2753635 (2022-04-22 12:38:47 -0400)
docker: use the CLI library for creating our docker client.
Fixes https://github.com/tilt-dev/tilt/issues/4769
Fixes https://github.com/tilt-dev/tilt/issues/4878

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics