### PR TITLE
kubernetesapply: only use `delete_cmd` for GC with `k8s_custom_deploy`

### DIFF
--- a/internal/controllers/core/kubernetesapply/reconciler.go
+++ b/internal/controllers/core/kubernetesapply/reconciler.go
@@ -710,9 +710,11 @@ func (r *Reconciler) garbageCollect(nn types.NamespacedName, isDeleting bool) de
 		return deleteSpec{}
 	}
 
-	if isDeleting && result.Spec.DeleteCmd != nil {
-		if !result.CmdApplied {
-			// Make sure we only run the DeleteCmd once per apply.
+	if result.Spec.DeleteCmd != nil {
+		if !isDeleting || !result.CmdApplied {
+			// If there's a custom apply + delete command, GC only happens if
+			// the KubernetesApply object is being deleted (or disabled) and
+			// the apply command was actually executed (by Tilt).
 			return deleteSpec{}
 		}
 


### PR DESCRIPTION
In some cases, the GC logic for `KubernetesApply` objects with custom
apply + delete commands would fallback to the YAML based GC, which
looks at dangling objects.

We want to explicitly avoid that: the `delete_cmd` should _always_ be
used (and must handle dangling objects). This is critical for the
`k8s_attach`[1] use case (provided by an extension), where we do NOT want
Tilt to potentially delete the externally managed resource. (The
extension uses a no-op `delete_cmd`[2].)

Fixes #5722.

[1]: https://github.com/tilt-dev/tilt-extensions/tree/master/k8s_attach
[2]: https://github.com/tilt-dev/tilt-extensions/blob/106042efccd0149854f40619493257e305b5c755/k8s_attach/Tiltfile#L32