### PR TITLE
portforward: deprecate implicit container port behavior

### DIFF
--- a/internal/controllers/core/kubernetesdiscovery/portforwards.go
+++ b/internal/controllers/core/kubernetesdiscovery/portforwards.go
@@ -95,7 +95,8 @@ func (r *Reconciler) toDesiredPortForward(kd *v1alpha1.KubernetesDiscovery) (*v1
 
 	pf := &v1alpha1.PortForward{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: fmt.Sprintf("%s-%s", kd.Name, pod.Name),
+			Name:      fmt.Sprintf("%s-%s", kd.Name, pod.Name),
+			Namespace: kd.Namespace,
 			Annotations: map[string]string{
 				v1alpha1.AnnotationManifest: kd.Annotations[v1alpha1.AnnotationManifest],
 				v1alpha1.AnnotationSpanID:   kd.Annotations[v1alpha1.AnnotationSpanID],

--- a/internal/controllers/fake/fixture.go
+++ b/internal/controllers/fake/fixture.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -238,4 +239,10 @@ func (f *ControllerFixture) Delete(o object) (bool, ctrl.Result) {
 
 func (f *ControllerFixture) Actions() []store.Action {
 	return f.Store.Actions()
+}
+
+func (f *ControllerFixture) AssertStdOutContains(v string) bool {
+	f.t.Helper()
+	return assert.True(f.t, strings.Contains(f.Stdout(), v),
+		"Stdout did not include output: %q", v)
 }


### PR DESCRIPTION
Tilt supports a bunch of variations when defining a port forward in
a Tiltfile.

It's possible to specify a single value (a local port), and in this
case, Tilt will look for a matching exposed port to use. If none
is found, it'll use the first exposed port.

This behavior is confusing and doesn't match existing functionality
in e.g. `kubectl`.

Allowing a single port that will be used identically for local and
container is reasonable short-hand, but picking an implicit port
to map to adds extra complexity for questionable value.

In this latter case, a warning is now emitted along with the mapping
and instructions for the user to update their `Tiltfile` to make it
explicit before it breaks in a future release of Tilt.

To fully deprecate this, we can change the logic to always default
the container port to local port. However, as this will change the
behavior in the aforementioned case, it's a breaking change, so
let's provide a heads up first :)

Fixes #5728.