### PR TITLE
cli: remove deprecated --hud flag in favor of --legacy

### DIFF
--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -76,7 +76,6 @@ local resources--i.e. those using serve_cmd--are terminated when you exit Tilt.
 
 	cmd.Flags().StringVar(&updateModeFlag, "update-mode", string(liveupdates.UpdateModeAuto),
 		fmt.Sprintf("Control the strategy Tilt uses for updating instances. Possible values: %v", liveupdates.AllUpdateModes))
-	cmd.Flags().BoolVar(&c.legacy, "hud", false, "If true, tilt will open in legacy terminal mode. (deprecated: please use --legacy)") // TODO: remove --hud completely by v0.27.0
 	cmd.Flags().BoolVar(&c.legacy, "legacy", false, "If true, tilt will open in legacy terminal mode.")
 	cmd.Flags().BoolVar(&c.stream, "stream", false, "If true, tilt will stream logs in the terminal.")
 	cmd.Flags().BoolVar(&logActionsFlag, "logactions", false, "log all actions and state changes")
@@ -87,13 +86,6 @@ local resources--i.e. those using serve_cmd--are terminated when you exit Tilt.
 	addNamespaceFlag(cmd)
 	cmd.Flags().Lookup("logactions").Hidden = true
 	cmd.Flags().StringVar(&c.outputSnapshotOnExit, "output-snapshot-on-exit", "", "If specified, Tilt will dump a snapshot of its state to the specified path when it exits")
-
-	cmd.PreRun = func(cmd *cobra.Command, args []string) {
-		if cmd.Flag("hud").Changed {
-			fmt.Fprint(os.Stderr, "--hud is deprecated.  Please switch to --legacy.") // TODO: remove --hud completely by v0.27.0
-			time.Sleep(3 * time.Second)
-		}
-	}
 
 	return cmd
 }

--- a/internal/cli/up_test.go
+++ b/internal/cli/up_test.go
@@ -15,9 +15,9 @@ func TestHudEnabled(t *testing.T) {
 		args     string
 		expected store.TerminalMode
 	}{
-		{"old behavior: no --hud", "", store.TerminalModePrompt},
-		{"old behavior: --legacy", "--legacy", store.TerminalModeHUD},
-		{"old behavior: --stream=true", "--stream=true", store.TerminalModeStream},
+		{"no flags (default)", "", store.TerminalModePrompt},
+		{"legacy flag", "--legacy", store.TerminalModeHUD},
+		{"stream flag", "--stream=true", store.TerminalModeStream},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			cmd := upCmd{}
@@ -27,9 +27,6 @@ func TestHudEnabled(t *testing.T) {
 			c := cmd.register()
 			err := c.Flags().Parse(args)
 			require.NoError(t, err)
-
-			c.PreRun(c, args)
-
 			require.Equal(t, test.expected, cmd.initialTermMode(true), test.args)
 		})
 	}


### PR DESCRIPTION
The `--hud` flag has been deprecated for a bit and thrown a warning
on start (with a forced multi-second wait).

Users who wish to continue using the TUI may do so for now by running
`tilt up --legacy`.