### PR TITLE
docs: correctly format code block

### DIFF
--- a/internal/tiltfile/api/config/__init__.py
+++ b/internal/tiltfile/api/config/__init__.py
@@ -68,12 +68,11 @@ def define_bool(name: str, args: bool=False, usage: str="") -> None:
     dict returned by :meth:`parse`.
 
     For instance, at runtime, to set a flag of this type named `foo` to value `True`, run ``tilt up -- --foo``.
-    To set a value to ``False``, you can run ``tilt up -- --foo=False``, or use a default value, e.g.:
-    ```python
-    config.define_bool('foo')
-    cfg = config.parse()
-    do_stuff = cfg.get('foo', False)
-    ```
+    To set a value to ``False``, you can run ``tilt up -- --foo=False``, or use a default value, e.g.::
+
+      config.define_bool('foo')
+      cfg = config.parse()
+      do_stuff = cfg.get('foo', False)
 
     See the `Tiltfile config documentation <tiltfile_config.html>`_ for examples
     and more information.


### PR DESCRIPTION
Hello @landism, @nicksieger,

Please review the following commits I made in branch nicks/docs2:

f1bc36ccc6ee346747bc78ec203161a06f76a15b (2022-04-29 12:02:15 -0400)
docs: correctly format code block
fixes https://github.com/tilt-dev/tilt.build/issues/1096

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics