### PR TITLE
dockercompose: watch service env files

### DIFF
--- a/internal/tiltfile/docker_compose.go
+++ b/internal/tiltfile/docker_compose.go
@@ -145,6 +145,12 @@ func (s *tiltfileState) dockerCompose(thread *starlark.Thread, fn *starlark.Buil
 			return nil, err
 		}
 		svc.Options = s.dcResOptions[svc.Name]
+		for _, f := range svc.ServiceConfig.EnvFile {
+			err = io.RecordReadPath(thread, io.WatchFileOnly, f)
+			if err != nil {
+				return nil, err
+			}
+		}
 		s.dcByName[svc.Name] = svc
 	}
 

--- a/internal/tiltfile/docker_compose.go
+++ b/internal/tiltfile/docker_compose.go
@@ -146,6 +146,9 @@ func (s *tiltfileState) dockerCompose(thread *starlark.Thread, fn *starlark.Buil
 		}
 		svc.Options = s.dcResOptions[svc.Name]
 		for _, f := range svc.ServiceConfig.EnvFile {
+			if !filepath.IsAbs(f) {
+				f = filepath.Join(project.ProjectPath, f)
+			}
 			err = io.RecordReadPath(thread, io.WatchFileOnly, f)
 			if err != nil {
 				return nil, err

--- a/internal/tiltfile/tiltfile_docker_compose_test.go
+++ b/internal/tiltfile/tiltfile_docker_compose_test.go
@@ -147,6 +147,30 @@ func TestDockerComposeEnvFile(t *testing.T) {
 	f.assertConfigFiles(expectedConfFiles...)
 }
 
+func TestDockerComposeServiceEnvFile(t *testing.T) {
+	f := newFixture(t)
+
+	f.file("docker-compose.yml", `services:
+  bar:
+    image: bar-image
+    env_file:
+      - bar.env
+`)
+	f.file("bar.env", "BAR_PORT=4000\n")
+	f.file("Tiltfile", "docker_compose('docker-compose.yml')")
+
+	f.load()
+	f.assertDcManifest("bar")
+
+	expectedConfFiles := []string{
+		"Tiltfile",
+		".tiltignore",
+		"docker-compose.yml",
+		"bar.env",
+	}
+	f.assertConfigFiles(expectedConfFiles...)
+}
+
 func TestDockerComposeConflict(t *testing.T) {
 	f := newFixture(t)
 


### PR DESCRIPTION
This simple fix appears to give the desired behavior described in #5605. It also causes the Tiltfile to be reevaluated, and may causes an image build (which should be fast because everything is cached), but it does reload the service with the env file changes injected.

I put up a branch https://github.com/tilt-dev/tilt-example-docker-compose/tree/nicksieger/env-files with two env files, `compose.env` as well as `app.env`. Changing either file causes the app to be reloaded.

Fixes #5605.
