### PR TITLE
tiltfile: improve path argument parsing. Allow docker_build(dockerfile=None).

### DIFF
--- a/internal/tiltfile/encoding/json.go
+++ b/internal/tiltfile/encoding/json.go
@@ -16,17 +16,13 @@ import (
 
 // reads json from a file
 func readJSON(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-	var path starlark.String
+	path := value.NewLocalPathUnpacker(thread)
 	var defaultValue starlark.Value
 	if err := starkit.UnpackArgs(thread, fn.Name(), args, kwargs, "paths", &path, "default?", &defaultValue); err != nil {
 		return nil, err
 	}
 
-	localPath, err := value.ValueToAbsPath(thread, path)
-	if err != nil {
-		return nil, fmt.Errorf("Argument 0 (paths): %v", err)
-	}
-
+	localPath := path.Value
 	contents, err := tiltfile_io.ReadFile(thread, localPath)
 	if err != nil {
 		// Return the default value if the file doesn't exist AND a default value was given
@@ -36,7 +32,7 @@ func readJSON(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple
 		return nil, err
 	}
 
-	return jsonStringToStarlark(string(contents), path.GoString())
+	return jsonStringToStarlark(string(contents), localPath)
 }
 
 // reads json from a string

--- a/internal/tiltfile/encoding/json_test.go
+++ b/internal/tiltfile/encoding/json_test.go
@@ -81,7 +81,8 @@ func TestMalformedJSON(t *testing.T) {
 	f.File("Tiltfile", `result = read_json("options.json")`)
 	result, err := f.ExecFile("Tiltfile")
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "error parsing JSON from options.json: unexpected end of JSON input")
+	require.Contains(t, err.Error(), "error parsing JSON from")
+	require.Contains(t, err.Error(), "options.json: unexpected end of JSON input")
 
 	rs, err := io.GetState(result)
 	require.NoError(t, err)

--- a/internal/tiltfile/files.go
+++ b/internal/tiltfile/files.go
@@ -190,7 +190,7 @@ func (s *tiltfileState) kustomize(thread *starlark.Thread, fn *starlark.Builtin,
 }
 
 func (s *tiltfileState) helm(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-	var path starlark.Value
+	path := value.NewLocalPathUnpacker(thread)
 	var name string
 	var namespace string
 	var valueFiles value.StringOrStringList
@@ -209,11 +209,7 @@ func (s *tiltfileState) helm(thread *starlark.Thread, fn *starlark.Builtin, args
 		return nil, err
 	}
 
-	localPath, err := value.ValueToAbsPath(thread, path)
-	if err != nil {
-		return nil, fmt.Errorf("Argument 0 (paths): %v", err)
-	}
-
+	localPath := path.Value
 	info, err := os.Stat(localPath)
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -154,6 +154,17 @@ k8s_yaml('foo.yaml')
 	f.assertConfigFiles("Tiltfile", ".tiltignore", "foo.yaml", "other/Dockerfile", "foo/.dockerignore")
 }
 
+func TestDockerfileNone(t *testing.T) {
+	f := newFixture(t)
+	f.setupFoo()
+	f.file("Tiltfile", `
+docker_build('gcr.io/foo', 'foo', dockerfile=None)
+k8s_yaml('foo.yaml')
+`)
+	f.load()
+	f.assertConfigFiles("Tiltfile", ".tiltignore", "foo.yaml", "foo/Dockerfile", "foo/.dockerignore")
+}
+
 func TestExplicitDockerfileAsLocalPath(t *testing.T) {
 	f := newFixture(t)
 	f.setupFoo()

--- a/internal/tiltfile/value/path.go
+++ b/internal/tiltfile/value/path.go
@@ -9,6 +9,7 @@ import (
 type LocalPath struct {
 	t     *starlark.Thread
 	Value string
+	IsSet bool
 }
 
 func NewLocalPathUnpacker(t *starlark.Thread) LocalPath {
@@ -24,6 +25,7 @@ func (p *LocalPath) Unpack(v starlark.Value) error {
 	}
 
 	p.Value = str
+	p.IsSet = true
 	return nil
 }
 


### PR DESCRIPTION
Hello @landism, @nicksieger,

Please review the following commits I made in branch nicks/none:

8fd07614d1c84b4911c708f9311a61f53bf69dc2 (2022-05-02 16:02:16 -0400)
tiltfile: improve path argument parsing. Allow docker_build(dockerfile=None).
Fixes https://github.com/tilt-dev/tilt/issues/5753

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics