### PR TITLE
web: fix table view trigger mode button

### DIFF
--- a/web/src/OverviewTable.test.tsx
+++ b/web/src/OverviewTable.test.tsx
@@ -23,6 +23,7 @@ import OverviewTable, {
   TableGroupedByLabels,
 } from "./OverviewTable"
 import { Name, RowValues, SelectionCheckbox } from "./OverviewTableColumns"
+import { ToggleTriggerModeTooltip } from "./OverviewTableTriggerModeToggle"
 import {
   DEFAULT_GROUP_STATE,
   GroupsState,
@@ -43,7 +44,7 @@ import {
   oneUIButton,
   TestDataView,
 } from "./testdata"
-import { RuntimeStatus, UpdateStatus } from "./types"
+import { RuntimeStatus, TriggerMode, UpdateStatus } from "./types"
 
 // Helpers
 const tableViewWithSettings = ({
@@ -948,6 +949,28 @@ describe("bulk disable actions", () => {
       expect(firstColumnHeaderText.includes("star.svg")).toBe(true)
     })
   })
+})
+
+// https://github.com/tilt-dev/tilt/issues/5754
+it("renders the trigger mode column correctly", () => {
+  const view = nResourceView(2)
+  view.uiResources = [
+    oneResource({ name: "r1", triggerMode: TriggerMode.TriggerModeAuto }),
+    oneResource({ name: "r2", triggerMode: TriggerMode.TriggerModeManual }),
+  ]
+  const container = renderContainer(tableViewWithSettings({ view: view }))
+
+  const isToggleContent = (content: string) =>
+    content == ToggleTriggerModeTooltip.isAuto ||
+    content == ToggleTriggerModeTooltip.isManual
+
+  let modes = Array.from(screen.getAllByTitle(isToggleContent)).map(
+    (n) => n.title
+  )
+  expect(modes).toEqual([
+    ToggleTriggerModeTooltip.isAuto,
+    ToggleTriggerModeTooltip.isManual,
+  ])
 })
 
 function renderContainer(x: ReactElement) {

--- a/web/src/OverviewTable.tsx
+++ b/web/src/OverviewTable.tsx
@@ -433,7 +433,7 @@ function uiResourceToCell(
     },
     podId: res.k8sResourceInfo?.podName ?? "",
     endpoints: res.endpointLinks ?? [],
-    triggerMode: res.triggerMode ?? TriggerMode.TriggerModeAuto,
+    mode: res.triggerMode ?? TriggerMode.TriggerModeAuto,
     buttons: buttons,
     analyticsTags: analyticsTags,
     selectable,

--- a/web/src/OverviewTableColumns.tsx
+++ b/web/src/OverviewTableColumns.tsx
@@ -63,7 +63,7 @@ export type RowValues = {
   statusLine: OverviewTableResourceStatus
   podId: string
   endpoints: UILink[]
-  triggerMode: TriggerMode
+  mode: TriggerMode
   buttons: ButtonSet
   analyticsTags: Tags
   selectable: boolean
@@ -385,7 +385,7 @@ export function TableBuildButtonColumn({ row }: CellProps<RowValues>) {
         hasPendingChanges={trigger.hasPendingChanges}
         hasBuilt={trigger.hasBuilt}
         isBuilding={trigger.isBuilding}
-        triggerMode={row.values.triggerMode}
+        triggerMode={row.values.mode}
         isQueued={trigger.isQueued}
         analyticsTags={row.values.analyticsTags}
         onStartBuild={onStartBuild}
@@ -534,7 +534,7 @@ export function TableTriggerModeColumn({ row }: CellProps<RowValues>) {
   return (
     <OverviewTableTriggerModeToggle
       resourceName={row.values.name}
-      triggerMode={row.values.triggerMode}
+      triggerMode={row.values.mode}
     />
   )
 }
@@ -576,7 +576,7 @@ export function TableWidgetsColumn({ row }: CellProps<RowValues>) {
 const modeColumn: Column<RowValues> = {
   Header: "Mode",
   id: "mode",
-  accessor: "triggerMode",
+  accessor: "mode",
   Cell: TableTriggerModeColumn,
   width: "auto",
 }

--- a/web/src/OverviewTableTriggerModeToggle.test.tsx
+++ b/web/src/OverviewTableTriggerModeToggle.test.tsx
@@ -1,0 +1,74 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import fetchMock from "fetch-mock"
+import {
+  cleanupMockAnalyticsCalls,
+  mockAnalyticsCalls,
+  nonAnalyticsCalls,
+} from "./analytics_test_helpers"
+import OverviewTableTriggerModeToggle, {
+  ToggleTriggerModeTooltip,
+} from "./OverviewTableTriggerModeToggle"
+import { TriggerMode } from "./types"
+
+function mockTriggerModeCalls() {
+  fetchMock.mock(
+    (url) => url.startsWith("/api/override/trigger_mode"),
+    JSON.stringify({})
+  )
+}
+
+describe("OverviewTableTriggerModeToggle", () => {
+  beforeEach(() => {
+    fetchMock.reset()
+    mockAnalyticsCalls()
+    mockTriggerModeCalls()
+  })
+
+  afterEach(() => {
+    cleanupMockAnalyticsCalls()
+  })
+
+  test.each([TriggerMode.TriggerModeManual, TriggerMode.TriggerModeAuto])(
+    "sets trigger mode on click when trigger mode is %s",
+    (triggerMode) => {
+      render(
+        <OverviewTableTriggerModeToggle
+          resourceName="foo"
+          triggerMode={triggerMode}
+        />
+      )
+
+      const tooltipText =
+        triggerMode == TriggerMode.TriggerModeAuto
+          ? ToggleTriggerModeTooltip.isAuto
+          : ToggleTriggerModeTooltip.isManual
+      const triggerModeButton = screen.getByTitle(tooltipText)
+      userEvent.click(triggerModeButton)
+
+      const calls = nonAnalyticsCalls()
+      expect(calls.length).toEqual(1)
+      const call = calls[0]
+      expect(call[0]).toEqual("/api/override/trigger_mode")
+      expect(call[1]).toBeTruthy()
+      expect(call[1]!.method).toEqual("post")
+      expect(call[1]!.body).toBeTruthy()
+      const request = JSON.parse(call[1]!.body!.toString())
+      let expectedTriggerMode: TriggerMode
+      switch (triggerMode) {
+        case TriggerMode.TriggerModeAuto:
+          expectedTriggerMode = TriggerMode.TriggerModeManual
+          break
+        case TriggerMode.TriggerModeManual:
+          expectedTriggerMode = TriggerMode.TriggerModeAuto
+          break
+        default:
+          fail(`unknown trigger mode: ${triggerMode}`)
+      }
+      expect(request).toEqual({
+        manifest_names: ["foo"],
+        trigger_mode: expectedTriggerMode,
+      })
+    }
+  )
+})

--- a/web/src/testdata.tsx
+++ b/web/src/testdata.tsx
@@ -41,6 +41,7 @@ export type TestResourceOptions = {
   labels?: number
   name?: string
   order?: number
+  triggerMode?: TriggerMode
 }
 
 type TestButtonOptions = {
@@ -136,6 +137,7 @@ export function oneResource({
   labels,
   name,
   order,
+  triggerMode,
 }: TestResourceOptions): UIResource {
   const ts = new Date(Date.now()).toISOString()
   const tsPast = new Date(Date.now() - 12300).toISOString()
@@ -208,7 +210,7 @@ export function oneResource({
       endpointLinks,
       runtimeStatus: "ok",
       queued,
-      triggerMode: TriggerMode.TriggerModeAuto,
+      triggerMode: triggerMode ?? TriggerMode.TriggerModeAuto,
       specs: resourceSpecs(resourceName),
       disableStatus,
       order: resourceOrder,


### PR DESCRIPTION
fixes #5754

This was broken by #5582 - the addition of `id` to the "mode" column definition caused the trigger mode to be written to RowValues as "mode" rather than "triggerMode", and this somehow didn't cause a compilation failure. The react-table docs around id vs accessor are not very clarifying, and I'm not sure it's worth getting to the bottom of that at the moment.

I'm happy to hear if there's a more idiomatic way to write the test.