### PR TITLE
web: more gracefully handle server errors when posting snapshots

### DIFF
--- a/internal/hud/server/server.go
+++ b/internal/hud/server/server.go
@@ -351,7 +351,7 @@ func (s *HeadsUpServer) HandleNewSnapshot(w http.ResponseWriter, req *http.Reque
 	if err != nil {
 		msg := fmt.Sprintf("Error creating snapshot: %v", err)
 		log.Println(msg)
-		http.Error(w, msg, http.StatusInternalServerError)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 

--- a/web/src/HUD.tsx
+++ b/web/src/HUD.tsx
@@ -133,26 +133,35 @@ export default class HUD extends Component<HudProps, HudState> {
 
     let body = JSON.stringify(snapshot)
 
-    // TODO(dmiller): we need to figure out a way to get human readable error messages from the server
     fetch(url, {
       method: "post",
       body: body,
     })
       .then((res) => {
-        res
-          .json()
-          .then((value: Proto.webviewUploadSnapshotResponse) => {
-            this.setState({
-              snapshotLink: value.url ? value.url : "",
+        if (res.ok) {
+          return res
+            .json()
+            .then((value: Proto.webviewUploadSnapshotResponse) => {
+              this.setState({
+                snapshotLink: value.url ? value.url : "",
+              })
             })
-          })
-          .catch((err) => {
-            console.error(err)
+            .catch((err) => {
+              console.error(err)
+              this.setState({
+                showSnapshotModal: false,
+                error: "Error decoding JSON response",
+              })
+            })
+        } else {
+          return res.text().then((text) => {
+            console.error(`Snapshot error: ${text}`)
             this.setState({
               showSnapshotModal: false,
-              error: "Error decoding JSON response",
+              error: `Snapshot error: ${text}`,
             })
           })
+        }
       })
       .catch((err) => {
         console.error(err)


### PR DESCRIPTION
Hello @lizzthabet, @landism,

Please review the following commits I made in branch nicks/apierrors:

5bbbb0cc016b7788981c8e0501504ee84099a743 (2022-05-03 17:56:04 -0400)
web: more gracefully handle server errors when posting snapshots

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics