### PR TITLE
kubernetesapply: support extra_pod_selectors with custom_k8s_deploy

### DIFF
--- a/internal/controllers/core/kubernetesapply/disco.go
+++ b/internal/controllers/core/kubernetesapply/disco.go
@@ -158,7 +158,7 @@ func (r *Reconciler) toWatchRefs(ka *v1alpha1.KubernetesApply) ([]v1alpha1.Kuber
 		}
 	}
 
-	entities, err := k8s.ParseYAMLFromString(ka.Spec.YAML)
+	entities, err := k8s.ParseYAMLFromString(ka.Status.ResultYAML)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/controllers/core/kubernetesapply/disco.go
+++ b/internal/controllers/core/kubernetesapply/disco.go
@@ -158,7 +158,15 @@ func (r *Reconciler) toWatchRefs(ka *v1alpha1.KubernetesApply) ([]v1alpha1.Kuber
 		}
 	}
 
-	entities, err := k8s.ParseYAMLFromString(ka.Status.ResultYAML)
+	yaml := ka.Spec.YAML
+	if yaml == "" {
+		// for KAs with ApplyCmds, there is no YAML in the Spec, so get it from the Status instead.
+		// We still prefer Spec YAML when available:
+		//   1. Using the spec YAML allows us to start connecting to pods before the image build starts.
+		//   2. If a deployment error clears the Status YAML, we'd lose all the watchers.
+		yaml = ka.Status.ResultYAML
+	}
+	entities, err := k8s.ParseYAMLFromString(yaml)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fixes #5773

Neither my brain nor the unit tests have come up with a reason it'd be problematic to use the yaml from the status instead of the spec, but I'm not super familiar with this part of the code.