### PR TITLE
kubernetesapply: prevent some spurious error messages

### DIFF
--- a/internal/controllers/core/kubernetesapply/reconciler.go
+++ b/internal/controllers/core/kubernetesapply/reconciler.go
@@ -104,7 +104,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	}
 
 	if apierrors.IsNotFound(err) || !ka.ObjectMeta.DeletionTimestamp.IsZero() {
-		err = r.manageOwnedKubernetesDiscovery(ctx, nn, nil)
+		result, err := r.manageOwnedKubernetesDiscovery(ctx, nn, nil)
 		if err != nil {
 			return ctrl.Result{}, err
 		}
@@ -115,7 +115,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		r.clearRecord(nn)
 
 		r.st.Dispatch(kubernetesapplys.NewKubernetesApplyDeleteAction(request.NamespacedName.Name))
-		return ctrl.Result{}, nil
+		return result, nil
 	}
 
 	// The apiserver is the source of truth, and will ensure the engine state is up to date.
@@ -167,12 +167,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		return ctrl.Result{}, err
 	}
 
-	err = r.manageOwnedKubernetesDiscovery(ctx, nn, newKA)
-	if err != nil {
-		return ctrl.Result{}, err
-	}
-
-	return ctrl.Result{}, nil
+	return r.manageOwnedKubernetesDiscovery(ctx, nn, newKA)
 }
 
 // Determine if we should deploy the current YAML.


### PR DESCRIPTION
Hello @milas,

Please review the following commits I made in branch nicks/disco:

66d2265b9e086a356205b08fec412f95703ce702 (2022-05-05 16:19:32 -0400)
kubernetesapply: prevent some spurious error messages

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics