### PR TITLE
tiltfile: add docker_compose project_name param

### DIFF
--- a/internal/tiltfile/api/__init__.py
+++ b/internal/tiltfile/api/__init__.py
@@ -243,7 +243,7 @@ def docker_build(ref: str,
   """
   pass
 
-def docker_compose(configPaths: Union[str, Blob, List[Union[str, Blob]]], env_file: str = None) -> None:
+def docker_compose(configPaths: Union[str, Blob, List[Union[str, Blob]]], env_file: str = None, project_name: str = "") -> None:
   """Run containers with Docker Compose.
 
   Tilt will read your Docker Compose YAML and separate out the services.
@@ -278,6 +278,7 @@ def docker_compose(configPaths: Union[str, Blob, List[Union[str, Blob]]], env_fi
   Args:
     configPaths: Path(s) and/or Blob(s) to Docker Compose yaml files or content.
     env_file: Path to env file to use; defaults to ``.env`` in current directory.
+    project_name: The Docker Compose project name. If unspecified, the main Tiltfile's directory name is used.
   """
 
 

--- a/internal/tiltfile/docker_compose.go
+++ b/internal/tiltfile/docker_compose.go
@@ -45,9 +45,14 @@ func (dc dcResourceSet) Empty() bool { return reflect.DeepEqual(dc, dcResourceSe
 
 func (s *tiltfileState) dockerCompose(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	var configPaths starlark.Value
+	var projectName string
 	envFile := value.NewLocalPathUnpacker(thread)
 
-	err := s.unpackArgs(fn.Name(), args, kwargs, "configPaths", &configPaths, "env_file?", &envFile)
+	err := s.unpackArgs(fn.Name(), args, kwargs,
+		"configPaths", &configPaths,
+		"env_file?", &envFile,
+		"project_name?", &projectName,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -67,10 +72,14 @@ func (s *tiltfileState) dockerCompose(thread *starlark.Thread, fn *starlark.Buil
 			"(%s, %s)", dc.tiltfilePath, currentTiltfilePath)
 	}
 
+	if projectName == "" {
+		projectName = model.NormalizeName(filepath.Base(filepath.Dir(currentTiltfilePath)))
+	}
+
 	project := v1alpha1.DockerComposeProject{
 		ConfigPaths: dc.configPaths,
 		ProjectPath: dc.Project.ProjectPath,
-		Name:        model.NormalizeName(filepath.Base(filepath.Dir(currentTiltfilePath))),
+		Name:        projectName,
 		EnvFile:     envFile.Value,
 	}
 

--- a/internal/tiltfile/tiltfile_docker_compose_test.go
+++ b/internal/tiltfile/tiltfile_docker_compose_test.go
@@ -171,6 +171,18 @@ func TestDockerComposeServiceEnvFile(t *testing.T) {
 	f.assertConfigFiles(expectedConfFiles...)
 }
 
+func TestDockerComposeProjectName(t *testing.T) {
+	f := newFixture(t)
+
+	f.dockerfile(filepath.Join("foo", "Dockerfile"))
+	f.file("docker-compose.yml", simpleConfig)
+	f.file("Tiltfile", `docker_compose('docker-compose.yml', project_name='hello')`)
+
+	f.load()
+	m := f.assertDcManifest("foo")
+	require.Equal(t, "hello", m.DockerComposeTarget().Spec.Project.Name)
+}
+
 func TestDockerComposeConflict(t *testing.T) {
 	f := newFixture(t)
 


### PR DESCRIPTION
Fixes #5770

We already had and used project name in the ProjectSpec, it just wasn't settable from the Tiltfile