### PR TITLE
cluster: reduce timeout/retries on cluster health check

### DIFF
--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -759,7 +759,14 @@ func (k *K8sClient) ClusterHealth(ctx context.Context, verbose bool) (ClusterHea
 //
 // See https://kubernetes.io/docs/reference/using-api/health-checks/
 func (k *K8sClient) apiServerHealthCheck(ctx context.Context, route string, verbose bool) (bool, string, error) {
-	req := k.discovery.RESTClient().Get().AbsPath(route)
+	req := k.discovery.RESTClient().
+		Get().
+		AbsPath(route).
+		// timeout will both be passed as a param to server as well as used to
+		// create a child context with a deadline
+		Timeout(10 * time.Second).
+		MaxRetries(1)
+
 	if verbose {
 		req = req.Param("verbose", "")
 	}


### PR DESCRIPTION
Set a timeout on the request, which will both be passed onto the
server as well as used to create a child context with a deadline.
A fixed value of 10sec is used here for now.

Additionally, max retries is set to 1 vs the default of up to 10.

See #5729.