### PR TITLE
cluster: refactor health monitoring to avoid getting stuck

### DIFF
--- a/internal/controllers/core/cluster/cache.go
+++ b/internal/controllers/core/cluster/cache.go
@@ -1,7 +1,6 @@
 package cluster
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"sync"
@@ -52,14 +51,10 @@ type connection struct {
 	dockerClient docker.Client
 	k8sClient    k8s.Client
 
-	// statusError is populated if the client has been successfully initialized
-	// but is failing a health/readiness check.
-	statusError   string
 	arch          string
 	serverVersion string
 	registry      *v1alpha1.RegistryHosting
 	connStatus    *v1alpha1.ClusterConnectionStatus
-	cancelMonitor context.CancelFunc
 }
 
 func (k *ConnectionManager) GetK8sClient(clusterKey types.NamespacedName) (k8s.Client, metav1.MicroTime, error) {
@@ -112,11 +107,5 @@ func (k *ConnectionManager) load(key types.NamespacedName) (connection, bool) {
 }
 
 func (k *ConnectionManager) delete(key types.NamespacedName) {
-	v, ok := k.connections.LoadAndDelete(key)
-	if ok {
-		conn := v.(connection)
-		if conn.cancelMonitor != nil {
-			conn.cancelMonitor()
-		}
-	}
+	k.connections.LoadAndDelete(key)
 }

--- a/internal/controllers/core/cluster/monitor.go
+++ b/internal/controllers/core/cluster/monitor.go
@@ -91,6 +91,12 @@ func (c *clusterHealthMonitor) run(ctx context.Context, clusterNN types.Namespac
 	defer ticker.Stop()
 	for {
 		err := doKubernetesHealthCheck(ctx, conn.k8sClient)
+		if ctx.Err() != nil {
+			// if the context as canceled while the health check was running,
+			// it'll be the cause of the error, which isn't actually a health
+			// check failure
+			return
+		}
 		if err != nil {
 			c.UpdateStatus(clusterNN, err.Error())
 		} else {

--- a/internal/controllers/core/cluster/monitor.go
+++ b/internal/controllers/core/cluster/monitor.go
@@ -3,33 +3,98 @@ package cluster
 import (
 	"context"
 	"errors"
+	"sync"
 
+	"github.com/jonboulle/clockwork"
 	"k8s.io/apimachinery/pkg/types"
 
+	"github.com/tilt-dev/tilt/internal/controllers/indexer"
 	"github.com/tilt-dev/tilt/internal/k8s"
 )
 
-func (r *Reconciler) monitorConn(ctx context.Context, clusterNN types.NamespacedName, conn connection) {
+type clusterHealthMonitor struct {
+	mu        sync.Mutex
+	globalCtx context.Context
+	clock     clockwork.Clock
+	requeuer  *indexer.Requeuer
+	monitors  map[types.NamespacedName]monitor
+}
+
+func newClusterHealthMonitor(globalCtx context.Context, clock clockwork.Clock, requeuer *indexer.Requeuer) *clusterHealthMonitor {
+	return &clusterHealthMonitor{
+		globalCtx: globalCtx,
+		clock:     clock,
+		requeuer:  requeuer,
+		monitors:  make(map[types.NamespacedName]monitor),
+	}
+}
+
+func (c *clusterHealthMonitor) Start(clusterNN types.NamespacedName, conn connection) context.Context {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.cleanup(clusterNN)
+	ctx, cancel := context.WithCancel(c.globalCtx)
+	c.monitors[clusterNN] = monitor{cancel: cancel}
+	go c.run(ctx, clusterNN, conn)
+
+	return ctx
+}
+
+func (c *clusterHealthMonitor) GetStatus(clusterNN types.NamespacedName) string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.monitors[clusterNN].error
+}
+
+func (c *clusterHealthMonitor) UpdateStatus(clusterNN types.NamespacedName, error string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if m, ok := c.monitors[clusterNN]; ok {
+		if m.error == error {
+			return
+		}
+		m.error = error
+		c.monitors[clusterNN] = m
+		c.requeuer.Add(clusterNN)
+	}
+}
+
+func (c *clusterHealthMonitor) Stop(clusterNN types.NamespacedName) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.cleanup(clusterNN)
+	delete(c.monitors, clusterNN)
+}
+
+func (c *clusterHealthMonitor) cleanup(clusterNN types.NamespacedName) {
+	m := c.monitors[clusterNN]
+	if m.cancel != nil {
+		m.cancel()
+	}
+}
+
+type monitor struct {
+	cancel context.CancelFunc
+	error  string
+}
+
+func (c *clusterHealthMonitor) run(ctx context.Context, clusterNN types.NamespacedName, conn connection) {
 	if conn.connType != connectionTypeK8s {
 		// live connection monitoring for Docker not yet supported
 		return
 	}
 
-	ticker := r.clock.NewTicker(clientHealthPollInterval)
+	ticker := c.clock.NewTicker(clientHealthPollInterval)
 	defer ticker.Stop()
 	for {
-		lastErr := conn.statusError
-
 		err := doKubernetesHealthCheck(ctx, conn.k8sClient)
 		if err != nil {
-			conn.statusError = err.Error()
+			c.UpdateStatus(clusterNN, err.Error())
 		} else {
-			conn.statusError = ""
-		}
-
-		if conn.statusError != lastErr {
-			r.connManager.store(clusterNN, conn)
-			r.requeuer.Add(clusterNN)
+			c.UpdateStatus(clusterNN, "")
 		}
 
 		select {


### PR DESCRIPTION
I'm not 100% sure this is the root cause of the cluster health
monitoring getting stuck, but it's definitely not totally correct
in its current state.

The `ConnectionManager` is a fancy wrapper over a `sync.Map` and
expects the `connection` objects to be immutable — we replace them
entirely on change. Within the context of the reconciliation loop,
this is good. However, the health status monitor also needs to store
the result of the health checks and was doing so on the same object,
which resulted in a race condition.

Now, the cluster health state is stored independently and used within
reconciliation. The main `Reconcile()` loop still replaces objects
in their entirety in the `ConnectionManager`, but as its the only writer
now, there's no potential for stale data/races.

See #5729.