### PR TITLE
execer: fix flaky TestWorkdir

### DIFF
--- a/internal/controllers/core/cmd/execer_test.go
+++ b/internal/controllers/core/cmd/execer_test.go
@@ -264,7 +264,9 @@ func (f *processExecFixture) waitForStatus(expectedStatus status) {
 }
 
 func (f *processExecFixture) assertLogContains(s string) {
-	require.Contains(f.t, f.testWriter.String(), s)
+	require.Eventuallyf(f.t, func() bool {
+		return strings.Contains(f.testWriter.String(), s)
+	}, time.Second, 5*time.Millisecond, "log contains %q", s)
 }
 
 func (f *processExecFixture) waitForError() {


### PR DESCRIPTION
I've seen this fail in CI a decent number of times in recent months. I haven't taken the time to 100% confirm this hypothesis, but it seems [assertCmdSucceeds](https://github.com/tilt-dev/tilt/blob/7e0994075b6cea84b1df12cb408f844906474696/internal/controllers/core/cmd/execer_test.go#L43-L44) (which waits for the process to report an exit) can return before all output has been written to the stdout Writer.

I'm guessing this is due to the complications discussed in [this execer comment](https://github.com/tilt-dev/tilt/blob/52f56d1aab323169e33a97f1bd94c4bbd0764a9d/internal/controllers/core/cmd/execer.go#L188-L195)

This is arguably actually a bug in execer, but I'm not sure it's a problem in practice, am not aware of any manifestations of it outside of tests, and suspect it's non-trivial to fix.

On my laptop, this test was failing ~1/5000 times before this change and passed 50000/50000 afterwards.