### PR TITLE
kubernetesapply: inject a frozen kubeconfig into k8s_custom_deploy

### DIFF
--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -422,8 +422,16 @@ func (b *fakeBuildAndDeployer) updateKubernetesApplyStatus(ctx context.Context, 
 		imageMapSet[nn] = &im
 	}
 
+	clusterName := kTarg.KubernetesApplySpec.Cluster
+	if clusterName == "" {
+		clusterName = v1alpha1.ClusterNameDefault
+	}
+
+	var cluster v1alpha1.Cluster
+	require.NoError(b.t, b.ctrlClient.Get(ctx, types.NamespacedName{Name: clusterName}, &cluster))
+
 	nn := types.NamespacedName{Name: kTarg.ID().Name.String()}
-	status := b.kaReconciler.ForceApply(ctx, nn, kTarg.KubernetesApplySpec, imageMapSet)
+	status := b.kaReconciler.ForceApply(ctx, nn, kTarg.KubernetesApplySpec, &cluster, imageMapSet)
 
 	// We want our fake stub to only propagate apiserver problems.
 	_ = status


### PR DESCRIPTION
Hello @milas,

Please review the following commits I made in branch nicks/minify5:

2e180a76f290e5e3c04392b75a9e281bc78c4040 (2022-05-09 12:42:22 -0400)
kubernetesapply: inject a frozen kubeconfig into k8s_custom_deploy
Fixes https://github.com/tilt-dev/tilt/issues/5703

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics