### PR TITLE
kubernetesapply: inject frozen kubeconfig into the delete cmd as well

### DIFF
--- a/internal/controllers/core/kubernetesapply/reconciler_test.go
+++ b/internal/controllers/core/kubernetesapply/reconciler_test.go
@@ -212,10 +212,22 @@ func TestApplyCmdWithKubeconfig(t *testing.T) {
 
 	if assert.Len(t, f.execer.Calls(), 1) {
 		call := f.execer.Calls()[0]
+		assert.Equal(t, []string{"custom-apply-cmd"}, call.Cmd.Argv)
 		assert.Equal(t, []string{
 			"KUBECONFIG=/path/to/my/kubeconfig",
 		}, call.Cmd.Env)
 	}
+
+	f.Delete(&ka)
+
+	if assert.Len(t, f.execer.Calls(), 2) {
+		call := f.execer.Calls()[1]
+		assert.Equal(t, []string{"custom-delete-cmd"}, call.Cmd.Argv)
+		assert.Equal(t, []string{
+			"KUBECONFIG=/path/to/my/kubeconfig",
+		}, call.Cmd.Env)
+	}
+
 }
 
 func TestBasicApplyCmd_ExecError(t *testing.T) {
@@ -591,7 +603,7 @@ func TestForceDelete(t *testing.T) {
 	}
 	f.Create(&ka)
 
-	err := f.r.ForceDelete(f.Context(), nn, ka.Spec, "testing")
+	err := f.r.ForceDelete(f.Context(), nn, ka.Spec, nil, "testing")
 	assert.Nil(f.T(), err)
 	assert.Contains(f.T(), f.kClient.DeletedYaml, "sancho")
 }
@@ -615,7 +627,7 @@ func TestForceDeleteWithCmd(t *testing.T) {
 	}
 	f.Create(&ka)
 
-	err := f.r.ForceDelete(f.Context(), nn, ka.Spec, "testing")
+	err := f.r.ForceDelete(f.Context(), nn, ka.Spec, nil, "testing")
 	assert.Nil(f.T(), err)
 
 	calls := f.execer.Calls()

--- a/internal/engine/buildcontrol/image_build_and_deployer_test.go
+++ b/internal/engine/buildcontrol/image_build_and_deployer_test.go
@@ -114,7 +114,7 @@ func TestDeleteShouldHappenInReverseOrder(t *testing.T) {
 
 	m := newK8sMultiEntityManifest("sancho")
 
-	err := f.ibd.delete(f.ctx, m.K8sTarget())
+	err := f.ibd.delete(f.ctx, m.K8sTarget(), nil)
 	require.NoError(t, err)
 
 	assert.Regexp(t, "(?s)name: sancho-deployment.*name: sancho-pvc", f.k8s.DeletedYaml) // pvc comes after deployment


### PR DESCRIPTION
Hello @milas,

Please review the following commits I made in branch nicks/minify6:

65c17cd8abce54b36f99ac36f998322da13ee4a2 (2022-05-09 14:34:00 -0400)
kubernetesapply: inject frozen kubeconfig into the delete cmd as well

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics