### PR TITLE
script: add local release build `Makefile` task

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -150,20 +150,11 @@ jobs:
       - slack/notify-on-failure:
           only_for_branches: master
 
-  release-verify:
-    resource_class: medium+
-    docker:
-      - image: gcr.io/windmill-public-containers/tilt-releaser@sha256:a17867de17e04c8a8ea2150f9b48f9fa8588617cebe0bb36dc8521d1546414a3
-    steps:
-      - checkout
-      # `goreleaser build` generates binaries but does not publish
-      - run: goreleaser build --snapshot --rm-dist
-      - run: make build-js
-
   release:
     resource_class: medium+
     docker:
-      - image: gcr.io/windmill-public-containers/tilt-releaser@sha256:a17867de17e04c8a8ea2150f9b48f9fa8588617cebe0bb36dc8521d1546414a3
+      # keep image in sync with scripts/build.toast.yml
+      - image: gcr.io/windmill-public-containers/tilt-releaser@sha256:bfad52954a4d26c75cdb5094474cc6c005b347baebcfc460af895cc87d5e1279
     steps:
       - setup_remote_docker:
           version: 20.10.11
@@ -180,22 +171,15 @@ jobs:
       - slack/status:
           mentions: "nick"
 
-parameters:
-  verify_release:
-    default: false
-    type: boolean
-
 workflows:
   version: 2
   shellcheck:
-    unless: << pipeline.parameters.verify_release >>
     jobs:
       - shellcheck/check:
           dir: scripts
           exclude: SC2001
 
   build:
-    unless: << pipeline.parameters.verify_release >>
     # The linux job is cheaper than the others, so run that first.
     jobs:
       - build-linux
@@ -229,13 +213,7 @@ workflows:
             branches:
               only: master
 
-  release-verify:
-    when: << pipeline.parameters.verify_release >>
-    jobs:
-      - release-verify
-
   release:
-    unless: << pipeline.parameters.verify_release >>
     jobs:
       - release:
           context:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -312,6 +312,20 @@ CircleCI will automatically start building your release, and notify the
 at https://github.com/tilt-dev/tilt/releases, with a Changelog prepopulated automatically.
 (Give it a few moments. It appears as a tag first, before turning into a full release.)
 
+### Verifying
+You can build from source locally using the same toolchain as CI by running:
+
+```shell
+make release-build
+```
+> You will need `toast` installed (see optional prerequisites)
+
+This will take quite some time, but will create a `dist/` directory in the repo
+root on your host machine.
+Within the `dist/` directory, there will be directories for each of the OS and
+architecture combinations, e.g. `dist/tilt-linux-amd64_linux_amd64/` for 64-bit
+x86 Linux.
+
 ### Version numbers
 For pre-v1.0:
 * If adding backwards-compatible functionality increment the patch version (0.x.Y).

--- a/Makefile
+++ b/Makefile
@@ -196,3 +196,6 @@ update-codegen-starlark:
 
 update-codegen-ts:
 	toast proto-ts
+
+release-build:
+	toast -f build.toast.yml

--- a/build.toast.yml
+++ b/build.toast.yml
@@ -1,0 +1,33 @@
+# keep image in sync with .circleci/config.yml
+image: gcr.io/windmill-public-containers/tilt-releaser@sha256:bfad52954a4d26c75cdb5094474cc6c005b347baebcfc460af895cc87d5e1279
+# location: /go/src/github.com/tilt-dev/tilt
+command_prefix: set -euo pipefail
+tasks:
+  build-js:
+    command: make build-js
+    input_paths:
+      - pkg/assets/build
+      - web/
+      - Makefile
+    excluded_input_paths:
+      - web/build
+      - web/node_modules
+
+  build:
+    dependencies:
+      - build-js
+    command: goreleaser build --snapshot --rm-dist
+    input_paths:
+      - .git/
+      - cmd/
+      - internal/
+      - pkg/
+      - vendor/
+      - .goreleaser.yml
+      - go.mod
+      - go.sum
+      - Makefile
+    excluded_input_paths:
+      - pkg/assets/build
+    output_paths:
+      - dist/

--- a/scripts/release.Dockerfile
+++ b/scripts/release.Dockerfile
@@ -51,6 +51,3 @@ RUN git clone https://github.com/Homebrew/brew /home/linuxbrew/.linuxbrew
 ENV PATH=/home/linuxbrew/.linuxbrew/bin:$PATH
 
 RUN mkdir -p ~/.windmill
-
-ENTRYPOINT ["goreleaser"]
-CMD ["-h"]


### PR DESCRIPTION
Our builds have gotten more complicated recently with the new
requirement of CGO on _all_ platforms (due to Tree-sitter for
the LSP) as well as the embedded assets mode.

As a result, I added an alternate CI flow to build (but not
publish) binaries to ensure things were working as expected.
However, this requires having sufficient CircleCI access, has
a confusing UX, and complicates the `.circleci/config.yml` file
pretty significantly.

This commit eliminates that in favor of a `Makefile` task that
can be executed locally and uses Toast to do a containerized build
that will include embedde JS assets and produce cross-compiled
binaries for all supported OS/arch combinations using the same
underlying builder image as CI.

(Users who wish to build Tilt from source can also take advantage
of this to avoid having a complex build setup locally, though we
will continue to recommend using our binary releases.)