### PR TITLE
web: update document HTML title based on snapshot status

### DIFF
--- a/web/src/ResourceStatusSummary.test.tsx
+++ b/web/src/ResourceStatusSummary.test.tsx
@@ -1,7 +1,11 @@
 import { render, screen } from "@testing-library/react"
 import React from "react"
 import { MemoryRouter } from "react-router"
-import { ResourceGroupStatus, StatusCounts } from "./ResourceStatusSummary"
+import {
+  getDocumentTitle,
+  ResourceGroupStatus,
+  StatusCounts,
+} from "./ResourceStatusSummary"
 
 function expectStatusCounts(expected: { label: string; counts: number[] }[]) {
   const actual = expected.map(({ label, counts }) => {
@@ -35,6 +39,42 @@ const testCounts: StatusCounts = {
   unhealthy: 4,
   pending: 0,
   disabled: 2,
+}
+
+const testCountsUnhealthy: StatusCounts = {
+  totalEnabled: 5,
+  healthy: 3,
+  unhealthy: 2,
+  disabled: 0,
+  pending: 0,
+  warning: 0,
+}
+
+const testCountsHealthy: StatusCounts = {
+  totalEnabled: 5,
+  healthy: 5,
+  disabled: 3,
+  unhealthy: 0,
+  pending: 0,
+  warning: 0,
+}
+
+const testCountsPending: StatusCounts = {
+  totalEnabled: 5,
+  healthy: 3,
+  pending: 2,
+  disabled: 2,
+  unhealthy: 0,
+  warning: 0,
+}
+
+const testCountsAllDisabled: StatusCounts = {
+  totalEnabled: 0,
+  disabled: 5,
+  healthy: 0,
+  pending: 0,
+  unhealthy: 0,
+  warning: 0,
 }
 
 it("shows the counts it's given", () => {
@@ -101,4 +141,86 @@ it("does NOT link to warning and unhealthy resources when `linkToLogFilters` is 
   )
 
   expect(screen.queryByRole("link")).toBeNull()
+})
+
+describe("document metadata based on resource statuses", () => {
+  test.each<
+    [
+      caseName: string,
+      args: {
+        counts: StatusCounts
+        isSnapshot: boolean
+        isSocketConnected: boolean
+      },
+      title: string,
+      faviconColor: string
+    ]
+  >([
+    [
+      "no socket connection",
+      {
+        counts: testCountsUnhealthy,
+        isSnapshot: false,
+        isSocketConnected: false,
+      },
+      "Disconnected ┊ Tilt",
+      "gray",
+    ],
+    [
+      "viewing a snapshot",
+      {
+        counts: testCountsUnhealthy,
+        isSnapshot: true,
+        isSocketConnected: false,
+      },
+      "Snapshot: ✖︎ 2 ┊ Tilt",
+      "red",
+    ],
+    [
+      "some resources are unhealthy",
+      {
+        counts: testCountsUnhealthy,
+        isSnapshot: false,
+        isSocketConnected: true,
+      },
+      "✖︎ 2 ┊ Tilt",
+      "red",
+    ],
+    [
+      "all enabled resources are healthy",
+      { counts: testCountsHealthy, isSnapshot: false, isSocketConnected: true },
+      "✔︎ 5/5 ┊ Tilt",
+      "green",
+    ],
+    [
+      "some resources are pending",
+      { counts: testCountsPending, isSnapshot: false, isSocketConnected: true },
+      "… 3/5 ┊ Tilt",
+      "gray",
+    ],
+    [
+      "all resources are disabled",
+      {
+        counts: testCountsAllDisabled,
+        isSnapshot: false,
+        isSocketConnected: true,
+      },
+      "… 0/0 ┊ Tilt",
+      "gray",
+    ],
+  ])(
+    "has correct title and icon when %p",
+    (_testTitle, args, expectedTitle, expectedIconColor) => {
+      const { counts, isSnapshot, isSocketConnected } = args
+      const { title, faviconHref } = getDocumentTitle(
+        counts,
+        isSnapshot,
+        isSocketConnected
+      )
+      expect(title).toBe(expectedTitle)
+      expect(faviconHref).toStrictEqual(
+        expect.stringContaining(expectedIconColor)
+      )
+    }
+  )
 })

--- a/web/src/ResourceStatusSummary.test.tsx
+++ b/web/src/ResourceStatusSummary.test.tsx
@@ -205,7 +205,7 @@ describe("document metadata based on resource statuses", () => {
         isSnapshot: false,
         isSocketConnected: true,
       },
-      "… 0/0 ┊ Tilt",
+      "✔︎ 0/0 ┊ Tilt",
       "gray",
     ],
   ])(

--- a/web/src/ResourceStatusSummary.tsx
+++ b/web/src/ResourceStatusSummary.tsx
@@ -310,8 +310,11 @@ export function getDocumentTitle(
   } else if (unhealthy > 0) {
     title = `✖︎ ${unhealthy} ┊ Tilt`
     faviconHref = "/static/ico/favicon-red.ico"
-  } else if (pending || totalEnabled === 0) {
+  } else if (pending) {
     title = `… ${healthy}/${totalEnabled} ┊ Tilt`
+    faviconHref = "/static/ico/favicon-gray.ico"
+  } else if (totalEnabled === 0) {
+    title = `✔︎ 0/0 ┊ Tilt`
     faviconHref = "/static/ico/favicon-gray.ico"
   }
 


### PR DESCRIPTION
This PR fixes the misleading `... disconnected | Tilt` document title that displays for snapshots when there's no socket connection. Instead, snapshots will have `Snapshot:` prepended to the usual (connected) resource status title. 

This PR also moves the document metadata calculations into a separate helper function, so it's easier to test.

You can test this PR by creating and viewing snapshots using the CLI or web UI with `offline_snapshot_creation` flag enabled.

[Closes ch13500](https://app.shortcut.com/windmill/story/13500/fix-snapshots-json-disconnected-html-title)