### PR TITLE
web: don't display the account menu item when offline snapshots are enabled

### DIFF
--- a/web/src/AccountMenu.stories.tsx
+++ b/web/src/AccountMenu.stories.tsx
@@ -31,7 +31,6 @@ export const SignedOut = () => (
     tiltCloudSchemeHost="http://cloud.tilt.dev"
     tiltCloudTeamID=""
     tiltCloudTeamName=""
-    isSnapshot={false}
   />
 )
 
@@ -41,6 +40,5 @@ export const SignedIn = () => (
     tiltCloudSchemeHost="http://cloud.tilt.dev"
     tiltCloudTeamID="cactus inc"
     tiltCloudTeamName=""
-    isSnapshot={false}
   />
 )

--- a/web/src/AccountMenu.test.tsx
+++ b/web/src/AccountMenu.test.tsx
@@ -1,42 +1,85 @@
 import { render, screen } from "@testing-library/react"
 import React from "react"
-import ReactModal from "react-modal"
-import { AccountMenuContent } from "./AccountMenu"
+import { AccountMenuContent, AccountMenuDialog } from "./AccountMenu"
+import Features, { FeaturesTestProvider, Flag } from "./feature"
 
-beforeEach(() => {
-  // Note: `body` is used as the app element _only_ in a test env
-  // since the app root element isn't available; in prod, it should
-  // be set as the app root so that accessibility features are set correctly
-  ReactModal.setAppElement(document.body)
-})
+describe("AccountMenuDialog", () => {
+  it("does render when offline snapshot creation is NOT enabled", () => {
+    const features = new Features({ [Flag.OfflineSnapshotCreation]: false })
+    render(
+      <AccountMenuDialog
+        open={true}
+        onClose={() => {}}
+        anchorEl={document.body}
+        tiltCloudUsername=""
+        tiltCloudSchemeHost="http://cloud.tilt.dev"
+        tiltCloudTeamID=""
+        tiltCloudTeamName=""
+      />,
+      {
+        wrapper: ({ children }) => (
+          <FeaturesTestProvider value={features} children={children} />
+        ),
+      }
+    )
 
-it("renders Sign Up button when user is not signed in", () => {
-  render(
-    <AccountMenuContent
-      tiltCloudUsername=""
-      tiltCloudSchemeHost="http://cloud.tilt.dev"
-      tiltCloudTeamID=""
-      tiltCloudTeamName=""
-      isSnapshot={false}
-    />
-  )
+    expect(
+      screen.getByRole("button", { name: "Link Tilt to Tilt Cloud" })
+    ).toBeInTheDocument()
+  })
 
-  expect(
-    screen.getByRole("button", { name: "Link Tilt to Tilt Cloud" })
-  ).toBeInTheDocument()
-})
+  it("does NOT render when offline snapshot creation is enabled", () => {
+    const features = new Features({ [Flag.OfflineSnapshotCreation]: true })
+    render(
+      <AccountMenuDialog
+        open={true}
+        onClose={() => {}}
+        anchorEl={document.body}
+        tiltCloudUsername=""
+        tiltCloudSchemeHost="http://cloud.tilt.dev"
+        tiltCloudTeamID=""
+        tiltCloudTeamName=""
+      />,
+      {
+        wrapper: ({ children }) => (
+          <FeaturesTestProvider value={features} children={children} />
+        ),
+      }
+    )
 
-it("renders TiltCloud button when user is signed in", () => {
-  render(
-    <AccountMenuContent
-      tiltCloudUsername="amaia"
-      tiltCloudSchemeHost="http://cloud.tilt.dev"
-      tiltCloudTeamID="cactus inc"
-      tiltCloudTeamName=""
-      isSnapshot={false}
-    />
-  )
-  expect(
-    screen.getByRole("link", { name: "View Tilt Cloud" })
-  ).toBeInTheDocument()
+    expect(
+      screen.queryByRole("button", { name: "Link Tilt to Tilt Cloud" })
+    ).toBeNull()
+  })
+
+  describe("AccountMenuContent", () => {
+    it("renders Sign Up button when user is not signed in", () => {
+      render(
+        <AccountMenuContent
+          tiltCloudUsername=""
+          tiltCloudSchemeHost="http://cloud.tilt.dev"
+          tiltCloudTeamID=""
+          tiltCloudTeamName=""
+        />
+      )
+
+      expect(
+        screen.getByRole("button", { name: "Link Tilt to Tilt Cloud" })
+      ).toBeInTheDocument()
+    })
+
+    it("renders TiltCloud button when user is signed in", () => {
+      render(
+        <AccountMenuContent
+          tiltCloudUsername="amaia"
+          tiltCloudSchemeHost="http://cloud.tilt.dev"
+          tiltCloudTeamID="cactus inc"
+          tiltCloudTeamName=""
+        />
+      )
+      expect(
+        screen.getByRole("link", { name: "View Tilt Cloud" })
+      ).toBeInTheDocument()
+    })
+  })
 })

--- a/web/src/AccountMenu.tsx
+++ b/web/src/AccountMenu.tsx
@@ -4,6 +4,8 @@ import styled from "styled-components"
 import { ReactComponent as TiltCloudLogoSvg } from "./assets/svg/logo-Tilt-Cloud.svg"
 import ButtonInput from "./ButtonInput"
 import ButtonLink from "./ButtonLink"
+import { Flag, useFeatures } from "./feature"
+import FloatDialog from "./FloatDialog"
 import { AnimDuration, Color, Font, FontSize, SizeUnit } from "./style-helpers"
 
 let AccountMenuContentRoot = styled.div`
@@ -66,7 +68,6 @@ function notifyTiltOfRegistration() {
 }
 
 type AccountMenuProps = {
-  isSnapshot: boolean
   tiltCloudUsername: string | null
   tiltCloudSchemeHost: string
   tiltCloudTeamID: string | null
@@ -164,5 +165,35 @@ export function AccountMenuHeader(props: AccountMenuProps) {
       <AccountMenuLogo />
       {optionalLearnMore}
     </AccountMenuHeaderRoot>
+  )
+}
+
+type AccountMenuDialogProps = {
+  open: boolean
+  anchorEl: HTMLElement | null
+  onClose: () => void
+} & AccountMenuProps
+
+export function AccountMenuDialog(props: AccountMenuDialogProps) {
+  const { open, anchorEl, onClose, ...accountMenuProps } = props
+  const features = useFeatures()
+
+  const hideAccountDialog = features.isEnabled(Flag.OfflineSnapshotCreation)
+  if (hideAccountDialog) {
+    return null
+  }
+
+  const accountMenuHeader = <AccountMenuHeader {...accountMenuProps} />
+  const accountMenuContent = <AccountMenuContent {...accountMenuProps} />
+  return (
+    <FloatDialog
+      id="accountMenu"
+      title={accountMenuHeader}
+      open={open}
+      anchorEl={anchorEl}
+      onClose={onClose}
+    >
+      {accountMenuContent}
+    </FloatDialog>
   )
 }

--- a/web/src/ShareSnapshotModal.stories.tsx
+++ b/web/src/ShareSnapshotModal.stories.tsx
@@ -1,6 +1,8 @@
 import React from "react"
 import ReactModal from "react-modal"
+import Features, { FeaturesTestProvider, Flag } from "./feature"
 import ShareSnapshotModal from "./ShareSnapshotModal"
+import { nResourceView } from "./testdata"
 
 ReactModal.setAppElement("#root")
 
@@ -11,9 +13,7 @@ let signedOut = () => {
   return (
     <ShareSnapshotModal
       handleSendSnapshot={handleSendSnapshot}
-      getSnapshot={() => {
-        return {}
-      }}
+      getSnapshot={() => ({})}
       handleClose={handleClose}
       snapshotUrl={""}
       tiltCloudUsername={""}
@@ -49,9 +49,7 @@ let withUrl = () => {
   return (
     <ShareSnapshotModal
       handleSendSnapshot={handleSendSnapshot}
-      getSnapshot={() => {
-        return {}
-      }}
+      getSnapshot={() => ({})}
       handleClose={handleClose}
       snapshotUrl={"https://cloud.tilt.dev/snapshot/garnet"}
       tiltCloudUsername={"peridot"}
@@ -68,9 +66,7 @@ let withUrlOverflow = () => {
   return (
     <ShareSnapshotModal
       handleSendSnapshot={handleSendSnapshot}
-      getSnapshot={() => {
-        return {}
-      }}
+      getSnapshot={() => ({})}
       handleClose={handleClose}
       snapshotUrl={
         "https://cloud.tilt.dev/snapshot/rose-quartz-long-overflow-string"
@@ -89,9 +85,7 @@ let withTeam = () => {
   return (
     <ShareSnapshotModal
       handleSendSnapshot={handleSendSnapshot}
-      getSnapshot={() => {
-        return {}
-      }}
+      getSnapshot={() => ({})}
       handleClose={handleClose}
       snapshotUrl={""}
       tiltCloudUsername={"peridot"}
@@ -104,16 +98,39 @@ let withTeam = () => {
   )
 }
 
+const offlineSnapshot = () => {
+  const features = new Features({ [Flag.OfflineSnapshotCreation]: true })
+  const anchorEl: HTMLElement | null = document.body.querySelector("#root")
+  return (
+    <FeaturesTestProvider value={features}>
+      <ShareSnapshotModal
+        handleSendSnapshot={handleSendSnapshot}
+        getSnapshot={() => ({ view: nResourceView(1) })}
+        handleClose={handleClose}
+        snapshotUrl=""
+        tiltCloudUsername=""
+        tiltCloudSchemeHost=""
+        tiltCloudTeamID=""
+        isOpen={true}
+        highlightedLines={null}
+        dialogAnchor={anchorEl}
+      />
+    </FeaturesTestProvider>
+  )
+}
+
 export default {
   title: "New UI/Shared/ShareSnapshotModal",
 }
 
-export const SignedOut = signedOut
+export const CloudSignedOut = signedOut
 
-export const SignedIn = signedIn
+export const CloudSignedIn = signedIn
 
-export const WithUrl = withUrl
+export const CloudWithUrl = withUrl
 
-export const WithUrlOverflow = withUrlOverflow
+export const CloudWithUrlOverflow = withUrlOverflow
 
-export const WithTeam = withTeam
+export const CloudWithTeam = withTeam
+
+export const OfflineSnapshot = offlineSnapshot


### PR DESCRIPTION
This PR hides the account menu item and dialog when offline snapshot creation is enabled. Since people won't need an account to create an offline snapshot, account information is no longer relevant.

[Closes 13514](https://app.shortcut.com/windmill/story/13514)