### PR TITLE
web: fix snapshot bar date format

### DIFF
--- a/web/src/ShareSnapshotModal.tsx
+++ b/web/src/ShareSnapshotModal.tsx
@@ -274,7 +274,7 @@ const CodeSnippet = styled.code`
   white-space: nowrap;
 `
 
-export function formatSnapshotTimestamp(date: moment.Moment) {
+export function formatTimestampForFilename(date: moment.Moment) {
   return date.format("YYYY-MM-DD_HHmmss")
 }
 
@@ -284,7 +284,7 @@ function downloadSnapshot(snapshot: Proto.webviewSnapshot) {
     type: "application/json",
   })
 
-  saveAs(data, `tilt-snapshot_${formatSnapshotTimestamp(timestamp)}.json`)
+  saveAs(data, `tilt-snapshot_${formatTimestampForFilename(timestamp)}.json`)
 }
 
 export function LocalSnapshotDialog(props: DownloadSnapshotModalProps) {

--- a/web/src/SnapshotBar.tsx
+++ b/web/src/SnapshotBar.tsx
@@ -3,7 +3,6 @@ import React from "react"
 import styled from "styled-components"
 import { AnalyticsType } from "./analytics"
 import { usePathBuilder } from "./PathBuilder"
-import { formatSnapshotTimestamp } from "./ShareSnapshotModal"
 import { useSnapshotAction } from "./snapshot"
 import { Color, FontSize, SizeUnit } from "./style-helpers"
 
@@ -40,14 +39,10 @@ export function SnapshotBar(props: { className?: string }) {
 
   let timestampDescription = ""
   if (currentSnapshotTime?.createdAt) {
-    const createdAt = formatSnapshotTimestamp(
-      moment(currentSnapshotTime?.createdAt)
-    )
+    const createdAt = moment(currentSnapshotTime?.createdAt).format("lll")
     timestampDescription = `(created at ${createdAt})`
   } else if (currentSnapshotTime?.tiltUpTime) {
-    const tiltUpTime = formatSnapshotTimestamp(
-      moment(currentSnapshotTime?.tiltUpTime)
-    )
+    const tiltUpTime = moment(currentSnapshotTime?.tiltUpTime).format("lll")
     timestampDescription = `(session started at ${tiltUpTime})`
   }
 


### PR DESCRIPTION
The formatted version for the filename was also being used for
display in the header. Switched it to use `lll` format, which
is friendlier/more readable.

### Before
<img width="347" alt="Screen Shot 2022-05-12 at 1 05 06 PM" src="https://user-images.githubusercontent.com/841263/168130162-13c72090-ac41-41af-a564-70748c6e3e40.png">

### After
<img width="362" alt="Screen Shot 2022-05-12 at 1 05 12 PM" src="https://user-images.githubusercontent.com/841263/168130183-ef3c4e60-2ca2-42d7-9e8e-0d1e7272aa9c.png">

