### PR TITLE
ci: update dependencies

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -3,19 +3,29 @@ FROM cimg/go:1.18-node
 # --- DEPENDENCIES ---
 USER root
 
-# NOTE: cimg/go already includes Docker Compose v2
 RUN curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose-v1 \
     && chmod +x /usr/local/bin/docker-compose-v1
 
-RUN curl --silent --show-error --location --fail --retry 3 --output /tmp/kustomize.tar.gz  https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv3.9.2/kustomize_v3.9.2_linux_amd64.tar.gz \
+# NOTE: cimg/go already includes Docker Compose v2, but it's not always up-to-date
+ARG COMPOSE_V2_VERSION="2.6.0"
+RUN mkdir -p "${HOME}/.docker/cli-plugins" \
+    && curl -sSL "https://github.com/docker/compose/releases/download/v${COMPOSE_V2_VERSION}/docker-compose-linux-$(uname -m)" -o "${HOME}/.docker/cli-plugins/docker-compose" \
+    && chmod +x "${HOME}/.docker/cli-plugins/docker-compose" \
+    && docker compose version --short | grep -q -F "${COMPOSE_V2_VERSION}"
+
+ARG KUSTOMIZE_VERSION="4.5.5"
+RUN curl --silent --show-error --location --fail --retry 3 --output /tmp/kustomize.tar.gz "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv${KUSTOMIZE_VERSION}/kustomize_v${KUSTOMIZE_VERSION}_linux_amd64.tar.gz" \
   && tar -xz -C /tmp -f /tmp/kustomize.tar.gz \
   && mv /tmp/kustomize /usr/bin/kustomize \
-  && rm -f /tmp/kustomize.tar.gz
+  && rm -f /tmp/kustomize.tar.gz \
+  && kustomize version --short | grep -q -F "${KUSTOMIZE_VERSION}"
 
-RUN curl --silent --show-error --location --fail --retry 3 --output /tmp/helm.tar.gz  https://get.helm.sh/helm-v3.8.1-linux-amd64.tar.gz \
+ARG HELM_VERSION="3.9.0"
+RUN curl --silent --show-error --location --fail --retry 3 --output /tmp/helm.tar.gz "https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz" \
   && tar -xz -C /tmp -f /tmp/helm.tar.gz \
   && mv /tmp/linux-amd64/helm /usr/bin/helm3 \
-  && rm -f /tmp/helm.tar.gz
+  && rm -f /tmp/helm.tar.gz \
+  && helm3 version --short | grep -q -F "${HELM_VERSION}"
 
 # --- GO UTILITIES / LINTERS ---
 USER circleci
@@ -23,4 +33,4 @@ RUN go install github.com/google/wire/cmd/wire@latest \
     && go install golang.org/x/tools/cmd/goimports@latest \
     && go clean -cache -modcache
 
-RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.46.0
+RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.46.2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
   build-linux:
     resource_class: medium+
     docker:
-      - image: gcr.io/windmill-public-containers/tilt-ci@sha256:fe50fe62079403c1dfd2e0257c32701cf224e70cf05217d04bfb1d8e8155fc67
+      - image: gcr.io/windmill-public-containers/tilt-ci@sha256:0ded7ab32c6af85004a97e39d14ab02f0744af59949ede84ad139ed5f7112e4d
     # apiserver code generation scripts require being in GOPATH
     working_directory: /home/circleci/go/src/github.com/tilt-dev/tilt
 
@@ -50,7 +50,7 @@ jobs:
 
   publish-assets:
     docker:
-      - image: gcr.io/windmill-public-containers/tilt-ci@sha256:fe50fe62079403c1dfd2e0257c32701cf224e70cf05217d04bfb1d8e8155fc67
+      - image: gcr.io/windmill-public-containers/tilt-ci@sha256:0ded7ab32c6af85004a97e39d14ab02f0744af59949ede84ad139ed5f7112e4d
     steps:
       - checkout
       - gcp-cli/install


### PR DESCRIPTION
* Docker Compose v2.6.0
* Helm v3.9.0
* kustomize v4.5.5
* golangci-lint v1.46.2

The only major bump here is for kustomize, but `kubectl` now ships
v4.x built-in, so this should be safe and keep things more in
alignment with what many users are likely using implicitly.