### PR TITLE
k8s: use a different config validation codepath.

### DIFF
--- a/internal/k8s/env.go
+++ b/internal/k8s/env.go
@@ -43,7 +43,9 @@ func ProvideAPIConfig(clientLoader clientcmd.ClientConfig, contextOverride KubeC
 		}
 	}
 
-	err = clientcmd.ConfirmUsable(config, config.CurrentContext)
+	// Use ClientConfig() to workaround bugs in the validation api.
+	// See: https://github.com/tilt-dev/tilt/issues/5831
+	_, err = clientcmd.NewDefaultClientConfig(config, nil).ClientConfig()
 	if err != nil {
 		return APIConfigOrError{Error: errors.Wrap(err, "Loading Kubernetes config")}
 	}


### PR DESCRIPTION
Hello @nicksieger,

Please review the following commits I made in branch nicks/issue5831:

1b6ff4c60d7bf58e6b707085984ce1171b13436d (2022-06-07 16:35:39 -0400)
k8s: use a different config validation codepath.
Fixes https://github.com/tilt-dev/tilt/issues/5831

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics