### PR TITLE
engine: consider apply conditions for runtime status

### DIFF
--- a/internal/controllers/core/kubernetesapply/reconciler_test.go
+++ b/internal/controllers/core/kubernetesapply/reconciler_test.go
@@ -8,11 +8,13 @@ import (
 	"time"
 
 	"github.com/davecgh/go-spew/spew"
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	batchv1 "k8s.io/api/batch/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/uuid"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/tilt-dev/tilt/internal/build"
@@ -293,6 +295,55 @@ func TestBasicApplyCmd_MalformedYAML(t *testing.T) {
 	if assert.Contains(t, ka.Status.Error, "apply command returned malformed YAML") {
 		assert.Contains(t, ka.Status.Error, "stdout:\nthis is not yaml\n")
 	}
+}
+
+func TestBasicApplyYAML_JobComplete(t *testing.T) {
+	f := newFixture(t)
+
+	jobYAML := testyaml.JobYAML
+	entities, err := k8s.ParseYAMLFromString(jobYAML)
+	require.NoError(t, err, "Invalid JobYAML")
+	require.Len(t, entities, 1, "Expected exactly 1 Job entity")
+	require.IsType(t, entities[0].Obj, &batchv1.Job{}, "Expected exactly 1 Job entity")
+	job := entities[0].Obj.(*batchv1.Job)
+	job.SetUID(uuid.NewUUID())
+	job.Status = batchv1.JobStatus{
+		Conditions: []batchv1.JobCondition{
+			{
+				Type:   batchv1.JobComplete,
+				Status: v1.ConditionTrue,
+			},
+		},
+	}
+	f.kClient.UpsertResult = entities
+
+	ka := v1alpha1.KubernetesApply{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "a",
+		},
+		Spec: v1alpha1.KubernetesApplySpec{
+			YAML: testyaml.JobYAML,
+		},
+	}
+	f.Create(&ka)
+
+	f.MustReconcile(types.NamespacedName{Name: "a"})
+	f.MustGet(types.NamespacedName{Name: "a"}, &ka)
+
+	expected := []metav1.Condition{
+		{
+			Type:   "JobComplete",
+			Status: metav1.ConditionTrue,
+		},
+	}
+
+	assert.Equal(f.T(), ka.Status.Conditions, expected,
+		"KubernetesApply status should reflect Job completion")
+
+	// Make sure that re-reconciling doesn't clear the conditions
+	f.MustReconcile(types.NamespacedName{Name: "a"})
+	assert.Equal(f.T(), ka.Status.Conditions, expected,
+		"KubernetesApply status should reflect Job completion")
 }
 
 func TestGarbageCollectAllOnDelete_YAML(t *testing.T) {
@@ -767,7 +818,7 @@ func (f *fixture) createApplyCmd(name string, yaml string) (v1alpha1.KubernetesA
 	entities, err := k8s.ParseYAMLFromString(yaml)
 	require.NoErrorf(f.T(), err, "Could not parse YAML: %s", yaml)
 	for i := range entities {
-		entities[i].SetUID(uuid.New().String())
+		entities[i].SetUID(string(uuid.NewUUID()))
 	}
 	yamlOut, err := k8s.SerializeSpecYAML(entities)
 	require.NoErrorf(f.T(), err, "Failed to re-serialize YAML for entities: %s", spew.Sdump(entities))

--- a/internal/controllers/core/kubernetesapply/reconciler_test.go
+++ b/internal/controllers/core/kubernetesapply/reconciler_test.go
@@ -342,6 +342,7 @@ func TestBasicApplyYAML_JobComplete(t *testing.T) {
 
 	// Make sure that re-reconciling doesn't clear the conditions
 	f.MustReconcile(types.NamespacedName{Name: "a"})
+	f.MustGet(types.NamespacedName{Name: "a"}, &ka)
 	assert.Equal(f.T(), ka.Status.Conditions, expected,
 		"KubernetesApply status should reflect Job completion")
 }

--- a/internal/store/kubernetesdiscoverys/reducers.go
+++ b/internal/store/kubernetesdiscoverys/reducers.go
@@ -91,21 +91,7 @@ func RefreshKubernetesResource(state *store.EngineState, name string) {
 			krs.FilteredPods = r.FilteredPods
 			krs.Conditions = r.ApplyStatus.Conditions
 
-			isReadyOrSucceeded := false
-			if len(r.FilteredPods) != 0 {
-				for _, pod := range r.FilteredPods {
-					if krs.PodReadinessMode == model.PodReadinessSucceeded {
-						// for jobs, we don't care about whether it's ready, only whether it's succeeded
-						isReadyOrSucceeded = pod.Phase == string(v1.PodSucceeded)
-					} else {
-						isReadyOrSucceeded = len(pod.Containers) != 0 && store.AllPodContainersReady(pod)
-					}
-				}
-			} else {
-				isReadyOrSucceeded = meta.IsStatusConditionTrue(r.ApplyStatus.Conditions, v1alpha1.ApplyConditionJobComplete)
-			}
-
-			if isReadyOrSucceeded {
+			if isReadyOrSucceeded(r, krs.PodReadinessMode) {
 				// NOTE(nick): It doesn't seem right to update this timestamp everytime
 				// we get a new event, but it's what the old code did.
 				krs.LastReadyOrSucceededTime = time.Now()
@@ -114,4 +100,35 @@ func RefreshKubernetesResource(state *store.EngineState, name string) {
 			ms.RuntimeState = krs
 		}
 	}
+}
+
+func isReadyOrSucceeded(r *k8sconv.KubernetesResource, podReadinessMode model.PodReadinessMode) bool {
+	// 1. Apply operation indicated that it was for a Job that already completed,
+	// 	  so we can consider it successful without inspecting Pods, which avoids
+	//    issues in the case that the Job's Pod was GC'd.
+	if meta.IsStatusConditionTrue(r.ApplyStatus.Conditions, v1alpha1.ApplyConditionJobComplete) {
+		return true
+	}
+
+	// 2. We are still waiting on Pods to appear, so indicate we are not ready
+	//    until that happens.
+	if len(r.FilteredPods) == 0 {
+		return false
+	}
+
+	// 3. Ensure that _all_ Pods are in a valid (ready or succeeded) state as
+	//    defined by the PodReadinessMode.
+	for _, pod := range r.FilteredPods {
+		var podReady bool
+		if podReadinessMode == model.PodReadinessSucceeded {
+			// for jobs, we don't care about whether it's ready, only whether it's succeeded
+			podReady = pod.Phase == string(v1.PodSucceeded)
+		} else {
+			podReady = len(pod.Containers) != 0 && store.AllPodContainersReady(pod)
+		}
+		if !podReady {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/store/runtime_state.go
+++ b/internal/store/runtime_state.go
@@ -5,6 +5,8 @@ import (
 	"net/url"
 	"time"
 
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/tilt-dev/tilt/internal/store/k8sconv"
@@ -79,6 +81,10 @@ type K8sRuntimeState struct {
 	// This must match the FilteredPods field of k8sconv.KubernetesResource
 	FilteredPods []v1alpha1.Pod
 
+	// Conditions from the apply operation; must match the Conditions field
+	// from k8sconv.KubernetesResource::ApplyStatus.
+	Conditions []metav1.Condition
+
 	LastReadyOrSucceededTime    time.Time
 	HasEverDeployedSuccessfully bool
 
@@ -124,8 +130,17 @@ func (s K8sRuntimeState) RuntimeStatus() v1alpha1.RuntimeStatus {
 		return v1alpha1.RuntimeStatusOK
 	}
 
-	pod := s.MostRecentPod()
+	if len(s.FilteredPods) == 0 {
+		// if there's no Pods available but the apply indicated that the Job
+		// had already completed, we likely re-attached to an existing env,
+		// and the Pod for the Job has been GC'd, but the resource is actually
+		// in the desired state, so short-circuit here
+		if meta.IsStatusConditionTrue(s.Conditions, v1alpha1.ApplyConditionJobComplete) {
+			return v1alpha1.RuntimeStatusOK
+		}
+	}
 
+	pod := s.MostRecentPod()
 	switch v1.PodPhase(pod.Phase) {
 	case v1.PodRunning:
 		if AllPodContainersReady(pod) && s.PodReadinessMode != model.PodReadinessSucceeded {

--- a/internal/store/runtime_state.go
+++ b/internal/store/runtime_state.go
@@ -130,14 +130,11 @@ func (s K8sRuntimeState) RuntimeStatus() v1alpha1.RuntimeStatus {
 		return v1alpha1.RuntimeStatusOK
 	}
 
-	if len(s.FilteredPods) == 0 {
-		// if there's no Pods available but the apply indicated that the Job
-		// had already completed, we likely re-attached to an existing env,
-		// and the Pod for the Job has been GC'd, but the resource is actually
-		// in the desired state, so short-circuit here
-		if meta.IsStatusConditionTrue(s.Conditions, v1alpha1.ApplyConditionJobComplete) {
-			return v1alpha1.RuntimeStatusOK
-		}
+	// if the apply indicated that the Job had already completed, we can skip
+	// inspecting the Pods, which avoids issues in the event that the Job's
+	// Pod was GC'd
+	if meta.IsStatusConditionTrue(s.Conditions, v1alpha1.ApplyConditionJobComplete) {
+		return v1alpha1.RuntimeStatusOK
 	}
 
 	pod := s.MostRecentPod()


### PR DESCRIPTION
If a Job ran to completion in the past, so the apply was a no-op,
and the Pod is now gone, consider the Job as being in an "OK"
state. See #5858 for API changes.

Fixes #5822.