### PR TITLE
circleci: move images to docker org

### DIFF
--- a/.circleci/Dockerfile.integration
+++ b/.circleci/Dockerfile.integration
@@ -54,4 +54,4 @@ RUN curl -fLo ./kind-linux-amd64 https://github.com/kubernetes-sigs/kind/release
   && kind version
 
 # install ctlptl from the ctlptl release image
-COPY --from=tiltdev/ctlptl /usr/local/bin/ctlptl /usr/local/bin/
+COPY --from=docker/tilt-ctlptl /usr/local/bin/ctlptl /usr/local/bin/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
   build-linux:
     resource_class: medium+
     docker:
-      - image: gcr.io/windmill-public-containers/tilt-ci@sha256:0ded7ab32c6af85004a97e39d14ab02f0744af59949ede84ad139ed5f7112e4d
+      - image: docker/tilt-ci@sha256:89016e491fa0dc8a23ea3c023b184fec8e966def190ab29d5631260fe43959c8
     # apiserver code generation scripts require being in GOPATH
     working_directory: /home/circleci/go/src/github.com/tilt-dev/tilt
 
@@ -50,7 +50,7 @@ jobs:
 
   publish-assets:
     docker:
-      - image: gcr.io/windmill-public-containers/tilt-ci@sha256:0ded7ab32c6af85004a97e39d14ab02f0744af59949ede84ad139ed5f7112e4d
+      - image: docker/tilt-ci@sha256:89016e491fa0dc8a23ea3c023b184fec8e966def190ab29d5631260fe43959c8
     steps:
       - checkout
       - gcp-cli/install
@@ -83,7 +83,7 @@ jobs:
   build-integration:
     resource_class: medium+
     docker:
-      - image: gcr.io/windmill-public-containers/tilt-integration-ci@sha256:571c499cb9b8a94dcaf0d847ee367f9cad7dbb17cf035f255c829e9bfd1d2758
+      - image: docker/tilt-integration-ci@sha256:03089fe7d21de858bbbe5e45759b8b4f2e39bc5426051e947d4295fd17e047fc
     steps:
       - checkout
       - run: echo 'export PATH=/go/bin:$PATH' >> $BASH_ENV
@@ -132,7 +132,7 @@ jobs:
   release-dry-run:
     docker:
       # keep image in sync with scripts/build.toast.yml
-      - image: gcr.io/windmill-public-containers/tilt-releaser@sha256:80a0b6ec5276ae81b119b0fc3fa149b02b52e314eda33b0229bd60eb89649893
+      - image: docker/tilt-releaser@sha256:80a0b6ec5276ae81b119b0fc3fa149b02b52e314eda33b0229bd60eb89649893
     environment:
       DOCKER_CLI_EXPERIMENTAL: enabled
     steps:
@@ -150,7 +150,7 @@ jobs:
     resource_class: medium+
     docker:
       # keep image in sync with scripts/build.toast.yml
-      - image: gcr.io/windmill-public-containers/tilt-releaser@sha256:80a0b6ec5276ae81b119b0fc3fa149b02b52e314eda33b0229bd60eb89649893
+      - image: docker/tilt-releaser@sha256:80a0b6ec5276ae81b119b0fc3fa149b02b52e314eda33b0229bd60eb89649893
     environment:
       DOCKER_CLI_EXPERIMENTAL: enabled
     steps:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -128,6 +128,7 @@ dockers:
   goarch: amd64
   image_templates:
     - "tiltdev/tilt:{{ .Tag }}-amd64"
+    - "docker/tilt:{{ .Tag }}-amd64"
   dockerfile: scripts/tilt.Dockerfile
   use: buildx
   build_flag_templates:
@@ -145,6 +146,7 @@ dockers:
   goarm: ''
   image_templates:
     - "tiltdev/tilt:{{ .Tag }}-arm64"
+    - "docker/tilt:{{ .Tag }}-arm64"
   dockerfile: scripts/tilt.Dockerfile
   use: buildx
   build_flag_templates:
@@ -166,6 +168,14 @@ docker_manifests:
   image_templates:
   - tiltdev/{{ .ProjectName }}:{{ .Tag }}-amd64
   - tiltdev/{{ .ProjectName }}:{{ .Tag }}-arm64
+- name_template: docker/{{ .ProjectName }}:{{ .Tag }}
+  image_templates:
+  - docker/{{ .ProjectName }}:{{ .Tag }}-amd64
+  - docker/{{ .ProjectName }}:{{ .Tag }}-arm64
+- name_template: docker/{{ .ProjectName }}:latest
+  image_templates:
+  - docker/{{ .ProjectName }}:{{ .Tag }}-amd64
+  - docker/{{ .ProjectName }}:{{ .Tag }}-arm64
 scoop:
   url_template: "https://github.com/tilt-dev/tilt/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
   bucket:

--- a/Makefile
+++ b/Makefile
@@ -147,12 +147,12 @@ release-container:
 	scripts/build-tilt-releaser.sh
 
 ci-container:
-	docker build --pull --platform linux/amd64 -t gcr.io/windmill-public-containers/tilt-ci -f .circleci/Dockerfile .circleci
-	docker push gcr.io/windmill-public-containers/tilt-ci
+	docker build --pull --platform linux/amd64 -t docker/tilt-ci -f .circleci/Dockerfile .circleci
+	docker push docker/tilt-ci
 
 ci-integration-container:
-	docker build --pull --platform linux/amd64 -t gcr.io/windmill-public-containers/tilt-integration-ci -f .circleci/Dockerfile.integration .circleci
-	docker push gcr.io/windmill-public-containers/tilt-integration-ci
+	docker build --pull --platform linux/amd64 -t docker/tilt-integration-ci -f .circleci/Dockerfile.integration .circleci
+	docker push docker/tilt-integration-ci
 
 clean:
 	go clean -cache -testcache -r -i ./...
@@ -166,8 +166,8 @@ storybook:
 	cd web && yarn storybook
 
 tilt-toast-container:
-	docker build --platform linux/amd64 -t gcr.io/windmill-public-containers/tilt-toast -f Dockerfile.toast .circleci
-	docker push gcr.io/windmill-public-containers/tilt-toast
+	docker build --platform linux/amd64 -t docker/tilt-toast -f Dockerfile.toast .circleci
+	docker push docker/tilt-toast
 
 ensure: vendor
 

--- a/build.toast.yml
+++ b/build.toast.yml
@@ -1,5 +1,5 @@
 # keep image in sync with .circleci/config.yml
-image: gcr.io/windmill-public-containers/tilt-releaser@sha256:80a0b6ec5276ae81b119b0fc3fa149b02b52e314eda33b0229bd60eb89649893
+image: docker/tilt-releaser@sha256:80a0b6ec5276ae81b119b0fc3fa149b02b52e314eda33b0229bd60eb89649893
 location: /go/src/github.com/tilt-dev/tilt
 command_prefix: set -euo pipefail
 tasks:

--- a/scripts/build-tilt-releaser.sh
+++ b/scripts/build-tilt-releaser.sh
@@ -8,5 +8,5 @@ set -ex
 DIR=$(dirname "$0")
 cd "$DIR/.."
 
-docker build -t gcr.io/windmill-public-containers/tilt-releaser -f scripts/release.Dockerfile scripts
-docker push gcr.io/windmill-public-containers/tilt-releaser
+docker build -t docker/tilt-releaser -f scripts/release.Dockerfile scripts
+docker push docker/tilt-releaser

--- a/scripts/goreleaser.sh
+++ b/scripts/goreleaser.sh
@@ -14,7 +14,7 @@ DIR=$(dirname "$0")
 cd "$DIR/.."
 
 docker login
-docker pull gcr.io/windmill-public-containers/tilt-releaser
+docker pull docker/tilt-releaser
 mkdir -p ~/.cache/tilt/release/go-build
 
 docker run --rm --privileged \
@@ -24,5 +24,5 @@ docker run --rm --privileged \
        -v ~/.cache/tilt/release/go-build:/root/.cache/go-build \
        -v "$PWD:/src/tilt:delegated" \
        -v /var/run/docker.sock:/var/run/docker.sock \
-       gcr.io/windmill-public-containers/tilt-releaser \
+       docker/tilt-releaser \
        --rm-dist

--- a/scripts/release.Dockerfile
+++ b/scripts/release.Dockerfile
@@ -4,7 +4,7 @@
 # 1) Better leverage OS-specific C headers
 # 2) Be able to do releases from a CI job
 
-FROM gcr.io/windmill-public-containers/golang-cross:1.18.0-1
+FROM docker/tilt-golang-cross:1.18.0-1
 
 RUN apt-get update && \
     apt-get install -y -q --no-install-recommends \

--- a/scripts/tilt.Dockerfile
+++ b/scripts/tilt.Dockerfile
@@ -12,16 +12,9 @@
 #
 # Built with goreleaser.
 
-FROM tiltdev/ctlptl
+FROM docker/tilt-ctlptl
 
 # Tilt's extension downloader requires git
 RUN apt update && apt install -y git
-
-# install circleci helpers from
-# https://github.com/tilt-dev/kind-local/tree/master/.circleci
-# for backwards-compatibility. These are largely obsoleted by the ctlptl image.
-COPY --from=tiltdev/circleci-kind:v1.4.0 /usr/local/bin/start-portforward-service.sh /usr/local/bin/
-COPY --from=tiltdev/circleci-kind:v1.4.0 /usr/local/bin/portforward.sh /usr/local/bin/
-COPY --from=tiltdev/circleci-kind:v1.4.0 /usr/local/bin/with-kind-cluster.sh /usr/local/bin/
 
 COPY tilt /usr/local/bin/tilt


### PR DESCRIPTION
Hello @nicksieger,

Please review the following commits I made in branch nicks/images:

85190daa499b9a65ae7606d9b0e9999a2808ffff (2022-06-10 14:57:15 -0400)
circleci: move images to docker org

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics