### PR TITLE
store: fix a segfault when events come in out of order

### DIFF
--- a/internal/store/kubernetesapplys/reducers_test.go
+++ b/internal/store/kubernetesapplys/reducers_test.go
@@ -1,0 +1,82 @@
+package kubernetesapplys
+
+import (
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/tilt-dev/tilt/internal/store"
+	"github.com/tilt-dev/tilt/internal/store/kubernetesdiscoverys"
+	"github.com/tilt-dev/tilt/pkg/apis"
+	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
+)
+
+const resultYAML = `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: postgres-config
+  uid: abc-123
+  labels:
+    app: postgres
+data:
+  POSTGRES_DB: postgresdb
+  POSTGRES_USER: postgresadmin
+  POSTGRES_PASSWORD: admin123
+`
+
+func TestCacheFilter(t *testing.T) {
+	ka := &v1alpha1.KubernetesApply{
+		ObjectMeta: metav1.ObjectMeta{Name: "a"},
+		Status: v1alpha1.KubernetesApplyStatus{
+			ResultYAML:    resultYAML,
+			LastApplyTime: apis.NowMicro(),
+		},
+	}
+	kd := &v1alpha1.KubernetesDiscovery{ObjectMeta: metav1.ObjectMeta{Name: "a"}}
+
+	state := store.NewState()
+	HandleKubernetesApplyUpsertAction(state, KubernetesApplyUpsertAction{
+		KubernetesApply: ka,
+	})
+	kubernetesdiscoverys.HandleKubernetesDiscoveryUpsertAction(state, kubernetesdiscoverys.KubernetesDiscoveryUpsertAction{
+		KubernetesDiscovery: kd,
+	})
+
+	res := state.KubernetesResources[kd.Name]
+	assert.Equal(t, kd, res.Discovery)
+
+	ka2 := ka.DeepCopy()
+	ka2.Status.LastApplyTime = apis.NewMicroTime(time.Now().Add(time.Second))
+	HandleKubernetesApplyUpsertAction(state, KubernetesApplyUpsertAction{
+		KubernetesApply: ka2,
+	})
+	assert.Same(t, state.KubernetesResources[kd.Name].ApplyFilter, res.ApplyFilter)
+}
+
+func TestOutOfOrderSegfault(t *testing.T) {
+	ka := &v1alpha1.KubernetesApply{
+		ObjectMeta: metav1.ObjectMeta{Name: "a"},
+		Status: v1alpha1.KubernetesApplyStatus{
+			ResultYAML:    resultYAML,
+			LastApplyTime: apis.NowMicro(),
+		},
+	}
+	kd := &v1alpha1.KubernetesDiscovery{ObjectMeta: metav1.ObjectMeta{Name: "a"}}
+
+	state := store.NewState()
+	kubernetesdiscoverys.HandleKubernetesDiscoveryUpsertAction(state, kubernetesdiscoverys.KubernetesDiscoveryUpsertAction{
+		KubernetesDiscovery: kd,
+	})
+	res := state.KubernetesResources[kd.Name]
+	assert.Equal(t, kd, res.Discovery)
+	assert.Nil(t, res.ApplyFilter)
+
+	HandleKubernetesApplyUpsertAction(state, KubernetesApplyUpsertAction{
+		KubernetesApply: ka,
+	})
+	assert.NotNil(t, state.KubernetesResources[kd.Name].ApplyFilter)
+}

--- a/internal/store/kubernetesdiscoverys/reducers.go
+++ b/internal/store/kubernetesdiscoverys/reducers.go
@@ -52,7 +52,7 @@ func filterForResource(state *store.EngineState, name string) (*k8sconv.Kubernet
 	// if the yaml matches the existing resource, use its filter to save re-parsing
 	// (https://github.com/tilt-dev/tilt/issues/5837)
 	if prevResource, ok := state.KubernetesResources[name]; ok {
-		if a.Status.ResultYAML == prevResource.ApplyStatus.ResultYAML {
+		if prevResource.ApplyStatus != nil && a.Status.ResultYAML == prevResource.ApplyStatus.ResultYAML {
 			return prevResource.ApplyFilter, nil
 		}
 	}


### PR DESCRIPTION
Hello @landism, @milas,

Please review the following commits I made in branch nicks/issue-5866:

c66e333e1696a1bac5ba439ebd729ca38b330cb0 (2022-06-15 12:02:10 -0400)
store: fix a segfault when events come in out of order

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics