### PR TITLE
Update error message for port_forwards

### DIFF
--- a/internal/controllers/core/kubernetesdiscovery/portforwards.go
+++ b/internal/controllers/core/kubernetesdiscovery/portforwards.go
@@ -207,7 +207,7 @@ func warnDeprecatedImplicitForwards(ctx context.Context, kd *v1alpha1.Kubernetes
 		for _, f := range pf.Spec.Forwards {
 			if pft.LocalPort == f.LocalPort && f.LocalPort != f.ContainerPort {
 				logger.Get(ctx).Warnf(
-					"k8s_resource(name='%s', port_forward='%d') currently maps localhost:%d to port %d in your container.\n"+
+					"k8s_resource(name='%s', port_forwards='%d') currently maps localhost:%d to port %d in your container.\n"+
 						"A future version of Tilt will change this default and will map localhost:%d to port %d in your container.\n"+
 						"To keep your project working, change your Tiltfile to k8s_resource(name='%s', port_forwards='%d:%d')",
 					resourceName,    // name=%s

--- a/internal/controllers/core/kubernetesdiscovery/portforwards.go
+++ b/internal/controllers/core/kubernetesdiscovery/portforwards.go
@@ -209,7 +209,7 @@ func warnDeprecatedImplicitForwards(ctx context.Context, kd *v1alpha1.Kubernetes
 				logger.Get(ctx).Warnf(
 					"k8s_resource(name='%s', port_forward='%d') currently maps localhost:%d to port %d in your container.\n"+
 						"A future version of Tilt will change this default and will map localhost:%d to port %d in your container.\n"+
-						"To keep your project working, change your Tiltfile to k8s_resource(name='%s', port_forward='%d:%d')",
+						"To keep your project working, change your Tiltfile to k8s_resource(name='%s', port_forwards='%d:%d')",
 					resourceName,    // name=%s
 					f.LocalPort,     // port_forward=%d
 					f.LocalPort,     // localhost:%d

--- a/internal/controllers/core/kubernetesdiscovery/reconciler_test.go
+++ b/internal/controllers/core/kubernetesdiscovery/reconciler_test.go
@@ -424,9 +424,9 @@ func TestReconcileManagesPortForward(t *testing.T) {
 	}
 
 	f.AssertStdOutContains(
-		`k8s_resource(name='my-resource', port_forward='1234') currently maps localhost:1234 to port 7890 in your container.
+		`k8s_resource(name='my-resource', port_forwards='1234') currently maps localhost:1234 to port 7890 in your container.
 A future version of Tilt will change this default and will map localhost:1234 to port 1234 in your container.
-To keep your project working, change your Tiltfile to k8s_resource(name='my-resource', port_forward='1234:7890')`)
+To keep your project working, change your Tiltfile to k8s_resource(name='my-resource', port_forwards='1234:7890')`)
 
 	// simulate a pod delete and ensure that after it's observed + reconciled, the PF is also deleted
 	kCli := f.clients.MustK8sClient(clusterNN(*kd))


### PR DESCRIPTION
Update error message for port_forwards to say `port_forwards` to reduce possible copy paste confusion