### PR TITLE
filewatch: if the Start() fails, clean up immediately

### DIFF
--- a/internal/controllers/core/filewatch/watcher.go
+++ b/internal/controllers/core/filewatch/watcher.go
@@ -57,8 +57,11 @@ func (w *watcher) cleanupWatch(ctx context.Context) {
 	if w.done {
 		return
 	}
-	if err := w.notify.Close(); err != nil {
-		logger.Get(ctx).Debugf("Failed to close notifier for %q: %v", w.name.String(), err)
+
+	if w.notify != nil {
+		if err := w.notify.Close(); err != nil {
+			logger.Get(ctx).Debugf("Failed to close notifier for %q: %v", w.name.String(), err)
+		}
 	}
 
 	w.restartBackoff *= 2


### PR DESCRIPTION
Hello @milas,

Please review the following commits I made in branch nicks/watcher:

1cdad91ea324e30fa213c228e5593fd4977b04c1 (2022-07-08 16:50:10 -0400)
filewatch: if the Start() fails, clean up immediately

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics