### PR TITLE
Update emacs ignore patterns

### DIFF
--- a/internal/ignore/ephemeral.go
+++ b/internal/ignore/ephemeral.go
@@ -18,7 +18,7 @@ var EphemeralPathMatcher = initEphemeralPathMatcher()
 
 func initEphemeralPathMatcher() model.PathMatcher {
 	golandPatterns := []string{"**/*___jb_old___", "**/*___jb_tmp___", "**/.idea/**"}
-	emacsPatterns := []string{"**/.#*"}
+	emacsPatterns := []string{"**/.#*", "**/#*#"}
 	// if .swp is taken (presumably because multiple vims are running in that dir),
 	// vim will go with .swo, .swn, etc, and then even .svz, .svy!
 	// https://github.com/vim/vim/blob/ea781459b9617aa47335061fcc78403495260315/src/memline.c#L5076

--- a/internal/ignore/path_matcher_test.go
+++ b/internal/ignore/path_matcher_test.go
@@ -107,6 +107,12 @@ func TestIgnores(t *testing.T) {
 			ignoreInBuildContext: false,
 			ignoreInFileChange:   true,
 		},
+		{
+			target:               target,
+			change:               "dir/#my-machine#",
+			ignoreInBuildContext: false,
+			ignoreInFileChange:   true,
+		},
 	}
 
 	for i, c := range cases {


### PR DESCRIPTION
Currently the emacs ignore patterns include `**/.#*` (lock files), but
doesn't include `**/#*#` (autosave files;
https://www.emacswiki.org/emacs/AutoSave, not to be confused with
`**/*~` backup files, which are ignored.)

Add autosave files.