### PR TITLE
Detect non-admin socket for Rancher Desktop on Mac

### DIFF
--- a/internal/docker/client_test.go
+++ b/internal/docker/client_test.go
@@ -349,6 +349,22 @@ func TestProvideClusterProduct(t *testing.T) {
 				Client: hostClient{Host: "unix:///var/run/docker.sock"},
 			},
 		},
+		{
+			env:     clusterid.ProductRancherDesktop,
+			runtime: container.RuntimeDocker,
+			// Set DOCKER_HOST here to mimic rancher-desktop docker context in non-admin mode
+			osEnv: map[string]string{
+				"DOCKER_HOST": "unix:///Users/tilt/.rd/docker.sock",
+			},
+			expectedCluster: Env{
+				Client:              hostClient{Host: "unix:///Users/tilt/.rd/docker.sock"},
+				BuildToKubeContexts: []string{"rancher-desktop-me"},
+			},
+			expectedLocal: Env{
+				Client:              hostClient{Host: "unix:///Users/tilt/.rd/docker.sock"},
+				BuildToKubeContexts: []string{"rancher-desktop-me"},
+			},
+		},
 	}
 
 	for i, c := range cases {

--- a/internal/docker/env.go
+++ b/internal/docker/env.go
@@ -303,7 +303,10 @@ func isDefaultHost(e Env) bool {
 			host == "unix:///var/run/docker.sock" ||
 
 			// Docker Desktop for Linux - socket is in ~/.docker/desktop/docker.sock
-			(strings.HasPrefix(host, "unix://") && strings.HasSuffix(host, "/.docker/desktop/docker.sock"))
+			(strings.HasPrefix(host, "unix://") && strings.HasSuffix(host, "/.docker/desktop/docker.sock")) ||
+
+			// Rancher Desktop without admin access on Linux/Mac is in ~/.rd/docker.sock
+			(strings.HasPrefix(host, "unix://") && strings.HasSuffix(host, "/.rd/docker.sock"))
 
 	if isStandardHost {
 		return true


### PR DESCRIPTION
Rancher Desktop has an option to run in a mode that does not require `sudo` access on Linux and Mac.  In these cases, Rancher Desktop creates the docker socket at `~/.rd/docker.sock`.  This PR updates the docker socket connection logic to account for this case.

Related issues:
#5367 
#5751 