### PR TITLE
tiltfile: add kustomize(flags) for passing extra flags

### DIFF
--- a/internal/tiltfile/api/__init__.py
+++ b/internal/tiltfile/api/__init__.py
@@ -702,14 +702,16 @@ def watch_file(file_path: str) -> None:
     file_path: Path to the file locally (absolute, or relative to the location of the Tiltfile)."""
 
 
-def kustomize(pathToDir: str, kustomize_bin: str = None) -> Blob:
+def kustomize(pathToDir: str, kustomize_bin: str = None, flags: List[str] = []) -> Blob:
   """Run `kustomize <https://github.com/kubernetes-sigs/kustomize>`_ on a given directory and return the resulting YAML as a Blob
   Directory is watched (see ``watch_file``). Checks for and uses separately installed kustomize first, if it exists. Otherwise,
   uses kubectl's kustomize. See `blog post <https://blog.tilt.dev/2020/02/04/are-you-my-kustomize.html>`_.
 
   Args:
     pathToDir: Path to the directory locally (absolute, or relative to the location of the Tiltfile).
-    kustomize_bin: Custom path to the ``kustomize`` binary executable. Defaults to searching $PATH for kustomize."""
+    kustomize_bin: Custom path to the ``kustomize`` binary executable. Defaults to searching $PATH for kustomize.
+    flags: Additional flags to pass to ``kustomize build``
+  """
   pass
 
 def helm(pathToChartDir: str, name: str = "", namespace: str = "", values: Union[str, List[str]]=[], set: Union[str, List[str]]=[], kube_version: str = "") -> Blob:

--- a/internal/tiltfile/files.go
+++ b/internal/tiltfile/files.go
@@ -138,7 +138,8 @@ func (s *tiltfileState) execLocalCmd(t *starlark.Thread, cmd model.Cmd, options 
 
 func (s *tiltfileState) kustomize(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	path, kustomizeBin := value.NewLocalPathUnpacker(thread), value.NewLocalPathUnpacker(thread)
-	err := s.unpackArgs(fn.Name(), args, kwargs, "paths", &path, "kustomize_bin?", &kustomizeBin)
+	flags := value.StringList{}
+	err := s.unpackArgs(fn.Name(), args, kwargs, "paths", &path, "kustomize_bin?", &kustomizeBin, "flags?", &flags)
 	if err != nil {
 		return nil, err
 	}
@@ -166,10 +167,10 @@ func (s *tiltfileState) kustomize(thread *starlark.Thread, fn *starlark.Builtin,
 		return nil, err
 	}
 
-	cmd := model.Cmd{Argv: append(kustomizeArgs, relKustomizePath), Dir: starkit.AbsWorkingDir(thread)}
+	cmd := model.Cmd{Argv: append(append(kustomizeArgs, flags...), relKustomizePath), Dir: starkit.AbsWorkingDir(thread)}
 	yaml, err := s.execLocalCmd(thread, cmd, execCommandOptions{
 		logOutput:  false,
-		logCommand: false,
+		logCommand: true,
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
also print kustomize invocation like we do with helm

fixes https://github.com/tilt-dev/tilt/issues/5956
fixes https://github.com/tilt-dev/tilt/issues/5007

Signed-off-by: Nick Santos <nick.santos@docker.com>
