### PR TITLE
buildcontrol: restart should do a full delete of the resource

### DIFF
--- a/internal/controllers/core/dockercomposeservice/reconciler_test.go
+++ b/internal/controllers/core/dockercomposeservice/reconciler_test.go
@@ -188,6 +188,30 @@ func TestContainerEvent(t *testing.T) {
 		s.ManifestTargets["fe"].State.DCRuntimeState().ContainerState.Status)
 }
 
+func TestForceDelete(t *testing.T) {
+	f := newFixture(t)
+	nn := types.NamespacedName{Name: "fe"}
+	obj := v1alpha1.DockerComposeService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "fe",
+			Annotations: map[string]string{
+				v1alpha1.AnnotationManifest: "fe",
+			},
+		},
+		Spec: v1alpha1.DockerComposeServiceSpec{
+			Service: "fe",
+			Project: v1alpha1.DockerComposeProject{
+				YAML: "fake-yaml",
+			},
+		},
+	}
+	f.Create(&obj)
+
+	err := f.r.ForceDelete(f.Context(), nn, obj.Spec, "testing")
+	assert.Nil(f.T(), err)
+	assert.Equal(f.T(), f.dcc.RmCalls()[0].Specs[0].Service, "fe")
+}
+
 type fixture struct {
 	*fake.ControllerFixture
 	r   *Reconciler

--- a/internal/controllers/core/kubernetesapply/reconciler.go
+++ b/internal/controllers/core/kubernetesapply/reconciler.go
@@ -824,12 +824,6 @@ func (r *Reconciler) garbageCollect(nn types.NamespacedName, isDeleting bool) de
 //
 // Namespaces are not deleted by default. Similar to `tilt down`, deleting namespaces
 // is likely to be more destructive than most users want from this operation.
-//
-// TODO(nick): Delete operations aren't currently reflected in the KubernetesApplyStatus
-// in any meaningful way. ForceDelete() deletes our internal bookkeeping, but
-// doesn't otherwise change the KubernetesApplyStatus. We should probably change
-// this, but that's lower priority than a bigger level-based refactor
-// and getting this to be pure API objects.
 func (r *Reconciler) ForceDelete(ctx context.Context, nn types.NamespacedName,
 	spec v1alpha1.KubernetesApplySpec,
 	cluster *v1alpha1.Cluster,

--- a/internal/engine/buildcontrol/image_build_and_deployer_test.go
+++ b/internal/engine/buildcontrol/image_build_and_deployer_test.go
@@ -61,7 +61,7 @@ func TestDeployTwinImages(t *testing.T) {
 		"Expected image to update twice in YAML: %s", f.k8s.Yaml)
 }
 
-func TestForceUpdate(t *testing.T) {
+func TestForceUpdateK8s(t *testing.T) {
 	f := newIBDFixture(t, clusterid.ProductGKE)
 
 	m := NewSanchoDockerBuildManifest(f)


### PR DESCRIPTION
This is similar to how it works for the kubernetes controllers; this is just porting the same logic to the compose controllers.

fixes https://github.com/tilt-dev/tilt/issues/5913

Signed-off-by: Nick Santos <nick.santos@docker.com>