### PR TITLE
prefer user specified registry over discovered

### DIFF
--- a/internal/container/registry.go
+++ b/internal/container/registry.go
@@ -54,13 +54,14 @@ func RegistryFromCluster(cluster *v1alpha1.Cluster) (*v1alpha1.RegistryHosting, 
 		return nil, fmt.Errorf("cluster not ready: %s", cluster.Status.Error)
 	}
 
-	if cluster.Status.Registry != nil {
-		return cluster.Status.Registry.DeepCopy(), nil
+	if cluster.Spec.DefaultRegistry != nil {
+		// user specified registry
+		return cluster.Spec.DefaultRegistry.DeepCopy(), nil
 	}
 
-	if cluster.Spec.DefaultRegistry != nil {
-		// no local registry is configured for this cluster, so use the default
-		return cluster.Spec.DefaultRegistry.DeepCopy(), nil
+	if cluster.Status.Registry != nil {
+		// discovered registry
+		return cluster.Status.Registry.DeepCopy(), nil
 	}
 
 	return nil, nil

--- a/internal/controllers/core/cluster/reconciler.go
+++ b/internal/controllers/core/cluster/reconciler.go
@@ -334,7 +334,9 @@ func (r *Reconciler) populateK8sMetadata(ctx context.Context, clusterNN types.Na
 
 	if conn.registry == nil {
 		reg := conn.k8sClient.LocalRegistry(ctx)
-		if !container.IsEmptyRegistry(reg) {
+		if conn.spec.DefaultRegistry != nil {
+			logger.Get(ctx).Debugf("Using default registry from Tiltfile: %s", conn.spec.DefaultRegistry)
+		} else if !container.IsEmptyRegistry(reg) {
 			// If we've found a local registry in the cluster at run-time, use that
 			// instead of the default_registry (if any) declared in the Tiltfile
 			logger.Get(ctx).Infof("Auto-detected local registry from environment: %s", reg)
@@ -343,8 +345,6 @@ func (r *Reconciler) populateK8sMetadata(ctx context.Context, clusterNN types.Na
 				// The user has specified a default registry in their Tiltfile, but it will be ignored.
 				logger.Get(ctx).Infof("Default registry specified, but will be ignored in favor of auto-detected registry.")
 			}
-		} else if conn.spec.DefaultRegistry != nil {
-			logger.Get(ctx).Debugf("Using default registry from Tiltfile: %s", conn.spec.DefaultRegistry)
 		} else {
 			logger.Get(ctx).Debugf(
 				"No local registry detected and no default registry set for cluster %q",


### PR DESCRIPTION
Current implementation is checking config map to see if there is registry in the cluster of the current context. 
If you have vm (e.g. in azure) with microk8s cluster and registry addon enabled, then tilt will discover that registry as localhosts:32000 which is correct if you push from localhost, but pushing to the registry from your local dev machine wouldn't work unless you use  VM_IP:32000. This can be configured using default_registry() in tilt but tilt ignores this call.