### PR TITLE
controllers: objects need to be cloned before update

### DIFF
--- a/internal/controllers/core/cluster/reconciler.go
+++ b/internal/controllers/core/cluster/reconciler.go
@@ -274,9 +274,10 @@ func (r *Reconciler) maybeUpdateStatus(ctx context.Context, obj *v1alpha1.Cluste
 		return nil
 	}
 
-	oldStatus := obj.Status
-	obj.Status = newStatus
-	err := r.ctrlClient.Status().Update(ctx, obj)
+	update := obj.DeepCopy()
+	oldStatus := update.Status
+	update.Status = newStatus
+	err := r.ctrlClient.Status().Update(ctx, update)
 	if err != nil {
 		return fmt.Errorf("updating cluster %s status: %v", obj.Name, err)
 	}
@@ -285,7 +286,7 @@ func (r *Reconciler) maybeUpdateStatus(ctx context.Context, obj *v1alpha1.Cluste
 		logger.Get(ctx).Errorf("Cluster status error: %v", newStatus.Error)
 	}
 
-	r.reportConnectionEvent(ctx, obj)
+	r.reportConnectionEvent(ctx, update)
 
 	return nil
 }

--- a/internal/controllers/core/togglebutton/reconciler.go
+++ b/internal/controllers/core/togglebutton/reconciler.go
@@ -87,6 +87,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	origError := tb.Status.Error
 	// clear the error - if its conditions still apply, it will get re-set
+	tb = tb.DeepCopy()
 	tb.Status.Error = ""
 
 	err = r.processClick(ctx, tb)


### PR DESCRIPTION
controller-runtime Get() sets the pointer to an object in the cache.

Status().Update(obj) modifies the object :\

this was leading to really weird race conditions
that were nagging at me.

Signed-off-by: Nick Santos <nick.santos@docker.com>