### PR TITLE
docker_compose: infer resource deps from compose project

### DIFF
--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -1979,9 +1979,9 @@ func TestDockerComposeUp(t *testing.T) {
 
 func TestDockerComposeRedeployFromFileChange(t *testing.T) {
 	f := newTestFixture(t)
-	_, m := f.setupDCFixture()
+	r, m := f.setupDCFixture()
 
-	f.Start([]model.Manifest{m})
+	f.Start([]model.Manifest{r, m})
 
 	// Initial build
 	call := f.nextCall()

--- a/internal/tiltfile/docker_compose_test.go
+++ b/internal/tiltfile/docker_compose_test.go
@@ -157,7 +157,13 @@ func (f dcFixture) parse(configOutput string) []*dcService {
 
 	f.dcCli.ConfigOutput = configOutput
 
-	services, err := parseDCConfig(f.ctx, f.dcCli, v1alpha1.DockerComposeProject{ConfigPaths: []string{"doesn't-matter.yml"}})
+	dc := &dcResourceSet{
+		Project:    v1alpha1.DockerComposeProject{ConfigPaths: []string{"doesn't-matter.yml"}},
+		services:   make(map[string]*dcService),
+		resOptions: make(map[string]*dcResourceOptions),
+	}
+
+	services, err := parseDCConfig(f.ctx, f.dcCli, dc)
 	if err != nil {
 		f.t.Fatalf("dcFixture.Parse: %v", err)
 	}

--- a/internal/tiltfile/tiltfile_docker_compose_test.go
+++ b/internal/tiltfile/tiltfile_docker_compose_test.go
@@ -913,7 +913,21 @@ dc_resource('foo', trigger_mode=TRIGGER_MODE_AUTO)
 	f.load()
 }
 
-func TestDCDependsOn(t *testing.T) {
+func TestDCDependsOnInferredFromComposeFile(t *testing.T) {
+	f := newFixture(t)
+
+	f.dockerfile(filepath.Join("foo", "Dockerfile"))
+	f.file("docker-compose.yml", twoServiceConfig)
+	f.file("Tiltfile", `
+docker_compose('docker-compose.yml')
+`)
+
+	f.load()
+	f.assertNextManifest("foo", resourceDeps())
+	f.assertNextManifest("bar", resourceDeps("foo"))
+}
+
+func TestDCDependsOnResourceDepSpecified(t *testing.T) {
 	f := newFixture(t)
 
 	f.dockerfile(filepath.Join("foo", "Dockerfile"))


### PR DESCRIPTION
`depends_on` or other dependencies in the compose file implicitly add a resource dependency, so you won't have to declare duplicate information with `dc_resource(..., resource_deps=...)`.
