### PR TITLE
docker: add properly namespaced labels

### DIFF
--- a/internal/build/container_test.go
+++ b/internal/build/container_test.go
@@ -7,6 +7,7 @@ package build
 import (
 	"bytes"
 	"context"
+	"regexp"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -48,7 +49,7 @@ ADD dir/c.txt .
 		t.Fatal(err)
 	}
 
-	f.assertImageHasLabels(refs.LocalRef, docker.BuiltByTiltLabel)
+	f.assertImageHasLabels(refs.LocalRef, docker.BuiltLabelSet)
 
 	pcs := []expectedFile{
 		expectedFile{Path: "/src/a.txt", Contents: "a"},
@@ -113,7 +114,7 @@ ADD a.txt .`)
 		t.Fatal(err)
 	}
 
-	f.assertImageHasLabels(refs.LocalRef, docker.BuiltByTiltLabel)
+	f.assertImageHasLabels(refs.LocalRef, docker.BuiltLabelSet)
 
 	pcs := []expectedFile{
 		expectedFile{Path: "/src/a.txt", Contents: "a"},
@@ -141,6 +142,6 @@ RUN echo 'failed to create LLB definition: failed commit on ref "unknown-sha256:
 		model.EmptyMatcher)
 	assert.Error(t, err)
 	assert.Contains(t, out.String(), "Detected Buildkit corruption. Rebuilding without Buildkit")
-	assert.Contains(t, out.String(), "[1/2] FROM docker.io/library/alpine") // buildkit-style output
-	assert.Contains(t, out.String(), "Step 1/3 : FROM alpine")              // Legacy output
+	assert.Contains(t, out.String(), "[1/2] FROM docker.io/library/alpine")                     // buildkit-style output
+	assert.True(t, regexp.MustCompile("Step 1/[0-9]+ : FROM alpine").MatchString(out.String())) // Legacy output
 }

--- a/internal/cli/demo/k3d.go
+++ b/internal/cli/demo/k3d.go
@@ -74,8 +74,8 @@ func (k *K3dClient) CreateCluster(ctx context.Context, clusterName string) error
 		// k3d has a special label syntax which accepts a node filter so you can tag server/agent/LB differently
 		// since we're launching a cluster with no load balancer, there's only a single node named `server[0]`,
 		// but k3d will emit a confusing warning if we don't specify it explicitly, so this will be
-		// `builtby=tilt@server[0]`
-		"--label", fmt.Sprintf("%s@%s", docker.BuiltByTiltLabelStr, "server[0]"),
+		// `dev.tilt.built=true@server[0]`
+		"--label", fmt.Sprintf("%s=true@%s", docker.BuiltLabel, "server[0]"),
 	}
 	stdout := logger.Get(ctx).Writer(logger.DebugLvl)
 	stderr := logger.Get(ctx).Writer(logger.WarnLvl)

--- a/internal/docker/client.go
+++ b/internal/docker/client.go
@@ -37,15 +37,20 @@ import (
 	"github.com/tilt-dev/tilt/pkg/model"
 )
 
-// Label that we attach to all of the images we build.
 const (
-	BuiltByLabel = "builtby"
-	BuiltByValue = "tilt"
+	// Indicates that an image was built by tilt's docker client.
+	BuiltLabel = "dev.tilt.built"
+
+	// Indicates that an image is eligible for garbage collection
+	// by Tilt's pruner.
+	GCEnabledLabel = "dev.tilt.gc"
 )
 
 var (
-	BuiltByTiltLabel    = map[string]string{BuiltByLabel: BuiltByValue}
-	BuiltByTiltLabelStr = fmt.Sprintf("%s=%s", BuiltByLabel, BuiltByValue)
+	BuiltLabelSet = map[string]string{
+		BuiltLabel:     "true",
+		GCEnabledLabel: "true",
+	}
 )
 
 const clientSessionRemote = "client-session"
@@ -540,7 +545,7 @@ func (c *Cli) ImageBuild(ctx context.Context, buildContext io.Reader, options Bu
 		opts.RemoteContext = clientSessionRemote
 	}
 
-	opts.Labels = BuiltByTiltLabel // label all images as built by us
+	opts.Labels = BuiltLabelSet // label all images as built by us
 
 	response, err := c.Client.ImageBuild(ctx, buildContext, opts)
 	if err != nil {
@@ -660,7 +665,7 @@ func (c *Cli) Run(ctx context.Context, opts RunConfig) (RunResult, error) {
 		AttachStdout: opts.Stdout != nil,
 		AttachStderr: opts.Stderr != nil,
 		Cmd:          opts.Cmd,
-		Labels:       BuiltByTiltLabel,
+		Labels:       BuiltLabelSet,
 	}
 
 	hc := &mobycontainer.HostConfig{

--- a/internal/engine/dockerprune/docker_pruner.go
+++ b/internal/engine/dockerprune/docker_pruner.go
@@ -24,6 +24,8 @@ import (
 	"github.com/tilt-dev/tilt/pkg/logger"
 )
 
+var gcEnabledSelector = fmt.Sprintf("%s=true", docker.GCEnabledLabel)
+
 type DockerPruner struct {
 	dCli docker.Client
 
@@ -142,7 +144,7 @@ func (dp *DockerPruner) prune(ctx context.Context, maxAge time.Duration, keepRec
 	}
 
 	f := filters.NewArgs(
-		filters.Arg("label", docker.BuiltByTiltLabelStr),
+		filters.Arg("label", gcEnabledSelector),
 		filters.Arg("until", maxAge.String()),
 	)
 
@@ -262,7 +264,7 @@ func (dp *DockerPruner) filterOutMostRecentInspects(ctx context.Context, inspect
 func (dp *DockerPruner) deleteOldImages(ctx context.Context, maxAge time.Duration, keepRecent int, selectors []container.RefSelector) (types.ImagesPruneReport, error) {
 	opts := types.ImageListOptions{
 		Filters: filters.NewArgs(
-			filters.Arg("label", docker.BuiltByTiltLabelStr),
+			filters.Arg("label", gcEnabledSelector),
 		),
 	}
 	imgs, err := dp.dCli.ImageList(ctx, opts)

--- a/internal/engine/dockerprune/docker_pruner_test.go
+++ b/internal/engine/dockerprune/docker_pruner_test.go
@@ -45,11 +45,11 @@ func TestPruneFilters(t *testing.T) {
 	require.NoError(t, err)
 
 	expectedFilters := filters.NewArgs(
-		filters.Arg("label", docker.BuiltByTiltLabelStr),
+		filters.Arg("label", gcEnabledSelector),
 		filters.Arg("until", maxAge.String()),
 	)
 	expectedImageFilters := filters.NewArgs(
-		filters.Arg("label", docker.BuiltByTiltLabelStr),
+		filters.Arg("label", gcEnabledSelector),
 	)
 
 	assert.Equal(t, expectedFilters, f.dCli.BuildCachePruneOpts.Filters, "build cache prune filters")
@@ -135,7 +135,7 @@ func TestDeleteOldImages(t *testing.T) {
 	expectedDeleted := []string{id}
 	assert.Equal(t, expectedDeleted, f.dCli.RemovedImageIDs)
 
-	expectedFilters := filters.NewArgs(filters.Arg("label", docker.BuiltByTiltLabelStr))
+	expectedFilters := filters.NewArgs(filters.Arg("label", gcEnabledSelector))
 	if assert.Len(t, f.dCli.ImageListOpts, 1, "expected exactly one call to ImageList") {
 		assert.Equal(t, expectedFilters, f.dCli.ImageListOpts[0].Filters,
 			"expected ImageList to called with label=builtby:tilt filter")


### PR DESCRIPTION
fixes https://github.com/tilt-dev/tilt/issues/6000

note that after this PR, tilt will only prune images with the new label. we could add backcompat code to prune the old images, but i'm not sure it's worth the ongoing performance hit.