### PR TITLE
web: starred resources log pane

### DIFF
--- a/web/src/LogStore.test.ts
+++ b/web/src/LogStore.test.ts
@@ -572,4 +572,49 @@ describe("LogStore", () => {
       "fe          ┊ build 1\nbe          ┊ build 7\nglobal line 1"
     )
   })
+
+  it("handles starred resource logs", () => {
+    let logs = new LogStore()
+    logs.append({
+      spans: {
+        "": {},
+        "build:1": { manifestName: "res1" },
+        "build:2": { manifestName: "res2" },
+        "build:3": { manifestName: "res3" },
+      },
+      segments: [
+        newManifestSegment("build:1", "build 1\n"),
+        newManifestSegment("build:2", "build 2\n"),
+        newManifestSegment("build:3", "build 3\n"),
+      ],
+      fromCheckpoint: 0,
+      toCheckpoint: 3,
+    })
+
+    let patch = logs.starredLogPatchSet(["res1", "res2"], 0)
+    expect(logLinesToString(patch.lines, false)).toEqual(
+      "build 1\nbuild 2"
+    )
+
+    logs.append({
+      spans: {
+        "": {},
+        "build:1": { manifestName: "res1" },
+        "build:2": { manifestName: "res2" },
+        "build:3": { manifestName: "res3" },
+      },
+      segments: [
+        newManifestSegment("build:1", "build 4\n"),
+        newManifestSegment("build:2", "build 5\n"),
+        newManifestSegment("build:3", "build 6\n"),
+      ],
+      fromCheckpoint: 3,
+      toCheckpoint: 6,
+    })
+
+    let patch3 = logs.starredLogPatchSet(["res1", "res2"], patch.checkpoint)
+    expect(logLinesToString(patch3.lines, false)).toEqual(
+      "build 4\nbuild 5"
+    )
+  })
 })

--- a/web/src/LogStore.ts
+++ b/web/src/LogStore.ts
@@ -513,6 +513,17 @@ class LogStore implements LogAlertIndex {
     return this.logHelper(spans, checkpoint)
   }
 
+  starredLogPatchSet(stars: string[], checkpoint: number): LogPatchSet {
+    let result: { [key: string]: LogSpan } = {}
+    for (let spanId in this.spans) {
+      let span = this.spans[spanId]
+      if (stars.includes(span.manifestName)) {
+        result[spanId] = span
+      }
+    }
+    return this.logHelper(result, checkpoint)
+  }
+
   // Return all the logs for the given options.
   //
   // spansToLog: Filtering by an arbitrary set of spans.

--- a/web/src/OverviewLogPane.stories.tsx
+++ b/web/src/OverviewLogPane.stories.tsx
@@ -8,6 +8,7 @@ import {
 } from "./logfilters"
 import LogStore, { LogStoreProvider } from "./LogStore"
 import OverviewLogPane from "./OverviewLogPane"
+import { StarredResourceMemoryProvider } from "./StarredResourcesContext"
 import { appendLines } from "./testlogs"
 import { LogLevel } from "./types"
 
@@ -54,6 +55,22 @@ export const ThreeLinesAllLog = () => {
     <LogStoreProvider value={logStore}>
       <OverviewLogPane manifestName="" filterSet={defaultFilter} />
     </LogStoreProvider>
+  )
+}
+
+export const StarredResourcesLog = () => {
+  let logStore = new LogStore()
+  appendLines(logStore, "starA", "A line 1\n", "A line 2\n", "A line 3\n")
+  appendLines(logStore, "starB", "B line 1\n", "B line 2\n", "B line 3\n")
+  appendLines(logStore, "starC", "C line 1\n", "C line 2\n", "C line 3\n")
+  return (
+    <StarredResourceMemoryProvider
+      initialValueForTesting={["starA", "starB", "starC"]}
+    >
+      <LogStoreProvider value={logStore}>
+        <OverviewLogPane manifestName="(starred)" filterSet={defaultFilter} />
+      </LogStoreProvider>
+    </StarredResourceMemoryProvider>
   )
 }
 

--- a/web/src/OverviewLogPane.test.tsx
+++ b/web/src/OverviewLogPane.test.tsx
@@ -20,6 +20,7 @@ import {
   StyledLines,
   ThreeLines,
   ThreeLinesAllLog,
+  StarredResourcesLog,
 } from "./OverviewLogPane.stories"
 import { newFakeRaf, RafProvider, SyncRafProvider, TestRafContext } from "./raf"
 import { renderTestComponent } from "./test-helpers"
@@ -45,6 +46,11 @@ describe("OverviewLogPane", () => {
   it("renders all log lines in the all log view", () => {
     const { container } = customRender(<ThreeLinesAllLog />)
     expect(container.querySelectorAll(".LogLine")).toHaveLength(3)
+  })
+
+  it("renders log lines of starred resources", () => {
+    const { container } = customRender(<StarredResourcesLog />)
+    expect(container.querySelectorAll(".LogLine")).toHaveLength(9)
   })
 
   it("escapes html and linkifies", () => {

--- a/web/src/OverviewResourceDetails.tsx
+++ b/web/src/OverviewResourceDetails.tsx
@@ -37,7 +37,8 @@ export default function OverviewResourceDetails(
   let { name, resource, alerts, buttons } = props
   let manifestName = resource?.metadata?.name || ""
   let all = name === "" || name === ResourceName.all
-  let notFound = !all && !manifestName
+  let starred = name === "" || name === ResourceName.starred
+  let notFound = !all && !starred && !manifestName
   let filterSet = useFilterSet()
 
   return (
@@ -51,7 +52,10 @@ export default function OverviewResourceDetails(
       {notFound ? (
         <NotFound>No resource '{name}'</NotFound>
       ) : (
-        <OverviewLogPane manifestName={manifestName} filterSet={filterSet} />
+        <OverviewLogPane
+          manifestName={starred ? name : manifestName}
+          filterSet={filterSet}
+        />
       )}
     </OverviewResourceDetailsRoot>
   )

--- a/web/src/OverviewResourcePane.stories.tsx
+++ b/web/src/OverviewResourcePane.stories.tsx
@@ -82,6 +82,12 @@ export const TenResources = () => (
   <OverviewResourcePaneHarness name="vigoda_1" view={tenResourceView()} />
 )
 
+export const TwoStarredResources = () => (
+  <StarredResourceMemoryProvider initialValueForTesting={["_1", "_2"]}>
+    <OverviewResourcePaneHarness name="vigoda_1" view={tenResourceView()} />
+  </StarredResourceMemoryProvider>
+)
+
 export const TenResourcesLongNames = () => {
   let view = tenResourceView()
   view.uiResources.forEach((r, n) => {

--- a/web/src/SidebarResources.tsx
+++ b/web/src/SidebarResources.tsx
@@ -81,7 +81,7 @@ let SidebarListSectionName = styled.div`
   font-size: ${FontSize.small};
 `
 
-const AllResourceLinkRoot = styled(Link)`
+const BuiltinResourceLinkRoot = styled(Link)`
   background-color: ${Color.gray40};
   border: 1px solid ${Color.gray50};
   border-radius: ${SizeUnit(1 / 8)};
@@ -189,13 +189,29 @@ function AllResourcesLink(props: {
 }) {
   const isSelectedClass = props.selected === "" ? "isSelected" : ""
   return (
-    <AllResourceLinkRoot
+    <BuiltinResourceLinkRoot
       className={isSelectedClass}
       aria-label="View all resource logs"
       to={props.pathBuilder.encpath`/r/(all)/overview`}
     >
       All Resources
-    </AllResourceLinkRoot>
+    </BuiltinResourceLinkRoot>
+  )
+}
+
+function StarredResourcesLink(props: {
+  pathBuilder: PathBuilder
+  selected: string
+}) {
+  const isSelectedClass = props.selected === "" ? "isSelected" : ""
+  return (
+    <BuiltinResourceLinkRoot
+      className={isSelectedClass}
+      aria-label="View starred resource logs"
+      to={props.pathBuilder.encpath`/r/(starred)/overview`}
+    >
+      Starred Resources
+    </BuiltinResourceLinkRoot>
   )
 }
 
@@ -515,6 +531,10 @@ export class SidebarResources extends React.Component<SidebarProps> {
         >
           <OverviewSidebarOptions items={filteredItems} />
           <AllResourcesLink
+            pathBuilder={this.props.pathBuilder}
+            selected={this.props.selected}
+          />
+          <StarredResourcesLink
             pathBuilder={this.props.pathBuilder}
             selected={this.props.selected}
           />

--- a/web/src/StarredResourceBar.test.tsx
+++ b/web/src/StarredResourceBar.test.tsx
@@ -26,6 +26,10 @@ describe("StarredResourceBar", () => {
     expect(screen.getByRole("button", { name: "bar" })).toBeInTheDocument()
   })
 
+  it("renders starred logs link", () => {
+    expect(screen.getByText("Logs")).toBeInTheDocument()
+  })
+
   it("calls unstar", () => {
     userEvent.click(screen.getByLabelText("Unstar foo"))
 

--- a/web/src/StarredResourceBar.tsx
+++ b/web/src/StarredResourceBar.tsx
@@ -230,8 +230,26 @@ export function StarredResource(props: {
 }
 
 export default function StarredResourceBar(props: StarredResourceBarProps) {
+  const pb = usePathBuilder()
+  const history = useHistory()
   return (
     <StarredResourceBarRoot aria-label="Starred resources">
+      {props.resources.length ? (
+        <TiltTooltip title={"View starred resource logs"}>
+          <StarredResourceRoot className={""}>
+            <StarButton
+              name="starredLogs"
+              onClick={() => {
+                history.push(pb.encpath`/r/(starred)/overview`)
+              }}
+              analyticsName="ui.web.starredResourcesAggregatedLogs"
+            >
+              <StarIcon style={{ marginRight: 10 }} />
+              Logs
+            </StarButton>
+          </StarredResourceRoot>
+        </TiltTooltip>
+      ) : null}
       {props.resources.map((r) => (
         <StarredResource
           resource={r}

--- a/web/src/StarredResourcesContext.tsx
+++ b/web/src/StarredResourcesContext.tsx
@@ -37,7 +37,7 @@ export function StarredResourceMemoryProvider(
       return prevState.includes(name) ? prevState : [...prevState, name]
     })
   }
-  1
+
   function unstarResource(name: string) {
     setStarredResources((prevState) => {
       return prevState.filter((s) => s !== name)

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -145,6 +145,7 @@ export type LogTraceNav = {
 export enum ResourceName {
   tiltfile = "(Tiltfile)",
   all = "(all)",
+  starred = "(starred)",
 }
 
 export type UISession = Proto.v1alpha1UISession


### PR DESCRIPTION
Aims to resolve https://github.com/tilt-dev/tilt/issues/5955

## Notes
- Adds ResourceName enum for `(starred)`
- When path is `/r/(starred)/overview`, only display logs matching the starred resources.

## Placement
I wasn't sure where to place a link/button for starred resource logs so I put it in two places:
- At the top, always to the left of starred resources
- Under the `All Resources` button/link

![image](https://user-images.githubusercontent.com/14914028/223610801-446beac5-7748-4976-b4a5-6284653ee069.png)

