### PR TITLE
vendor: update tilt-dev/go-get

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,7 @@ require (
 	github.com/tilt-dev/dockerignore v0.1.1
 	github.com/tilt-dev/fsevents v0.0.0-20200515134857-2efe37af20de
 	github.com/tilt-dev/fsnotify v1.4.8-0.20220602155310-fff9c274a375
-	github.com/tilt-dev/go-get v0.2.2
+	github.com/tilt-dev/go-get v0.2.3
 	github.com/tilt-dev/localregistry-go v0.0.0-20201021185044-ffc4c827f097
 	github.com/tilt-dev/probe v0.3.1
 	github.com/tilt-dev/starlark-lsp v0.0.0-20220812175527-c0c1958f8166

--- a/go.sum
+++ b/go.sum
@@ -1424,8 +1424,8 @@ github.com/tilt-dev/fsnotify v1.4.8-0.20220602155310-fff9c274a375 h1:QB54BJwA6x8
 github.com/tilt-dev/fsnotify v1.4.8-0.20220602155310-fff9c274a375/go.mod h1:xRroudyp5iVtxKqZCrA6n2TLFRBf8bmnjr1UD4x+z7g=
 github.com/tilt-dev/fsutil v0.0.0-tilt-20220505 h1:N3tk/EUOxnHXJS5g6YiRseO348IpxZXg1kELykYlKWY=
 github.com/tilt-dev/fsutil v0.0.0-tilt-20220505/go.mod h1:a7cilN64dG941IOXfhJhlH0qB92hxJ9A1ewrdUmJ6xo=
-github.com/tilt-dev/go-get v0.2.2 h1:FXHQDCXsicgCez2X/TljVzQS7NbJ7EbpIwLzBHIfTIU=
-github.com/tilt-dev/go-get v0.2.2/go.mod h1:sqJ1OH6ggqbd2+J5TFsDGP/CXeRAXBxR52m5FtL0+xo=
+github.com/tilt-dev/go-get v0.2.3 h1:en+uZDENUWg31fxdoXb5O/5MC+b6SK7DplCm5cUSs4o=
+github.com/tilt-dev/go-get v0.2.3/go.mod h1:sqJ1OH6ggqbd2+J5TFsDGP/CXeRAXBxR52m5FtL0+xo=
 github.com/tilt-dev/localregistry-go v0.0.0-20201021185044-ffc4c827f097 h1:CiCHb20O+poFO331eFOiXRscunvAhKBfDmDoY2mf45A=
 github.com/tilt-dev/localregistry-go v0.0.0-20201021185044-ffc4c827f097/go.mod h1:SX7bKYACP+RsddxA+NBkfVzr5DOr5ranTirgT7xlxjA=
 github.com/tilt-dev/probe v0.3.1 h1:PQhXSBkgcGBUU/eKt4vgAUKsAWWjBr2F53xNAc0E7zs=

--- a/vendor/github.com/tilt-dev/go-get/vcs.go
+++ b/vendor/github.com/tilt-dev/go-get/vcs.go
@@ -822,6 +822,15 @@ var vcsPaths = []*vcsPath{
 		check:  noVCSSuffix,
 	},
 
+	// Gitlab
+	{
+		prefix: "gitlab.com/",
+		regexp: regexp.MustCompile(`^(?P<root>gitlab\.com/[A-Za-z0-9_.\-]+/[A-Za-z0-9_.\-]+)(/[\p{L}0-9_.\-]+)*$`),
+		vcs:    "git",
+		repo:   "https://{root}",
+		check:  noVCSSuffix,
+	},
+
 	// Bitbucket
 	{
 		prefix: "bitbucket.org/",

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -659,7 +659,7 @@ github.com/tilt-dev/fsevents
 # github.com/tilt-dev/fsnotify v1.4.8-0.20220602155310-fff9c274a375
 ## explicit; go 1.16
 github.com/tilt-dev/fsnotify
-# github.com/tilt-dev/go-get v0.2.2
+# github.com/tilt-dev/go-get v0.2.3
 ## explicit; go 1.14
 github.com/tilt-dev/go-get
 github.com/tilt-dev/go-get/internal/auth


### PR DESCRIPTION
adds support for gitlab modules
Pulls in https://github.com/tilt-dev/go-get/pull/13 Fixes https://github.com/tilt-dev/tilt/issues/5909