### PR TITLE
test: add a channel drain during test teardown

### DIFF
--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -3447,6 +3447,7 @@ func (f *testFixture) Init(action InitAction) {
 			fmt.Println("writing to upperInitResult would block!")
 			panic(err)
 		}
+		close(f.upperInitResult)
 	}()
 
 	f.WaitUntil("tiltfile build finishes", func(st store.EngineState) bool {
@@ -3777,6 +3778,11 @@ func (f *testFixture) TearDown() {
 	close(f.fsWatcher.Events)
 	close(f.fsWatcher.Errors)
 	f.cancel()
+
+	// If the test started an Init() in a goroutine, drain it.
+	if f.upperInitResult != nil {
+		<-f.upperInitResult
+	}
 }
 
 func (f *testFixture) registerForDeployer(manifest model.Manifest) podbuilder.PodBuilder {


### PR DESCRIPTION
hoping this will help with some recent test flakes where assertions were running after the test exited

eg https://app.circleci.com/pipelines/github/tilt-dev/tilt/12529/workflows/7f94f22d-c92a-4f69-b8f7-543b56558bac/jobs/93616