### PR TITLE
dockercomposelogstream: fix a panic in DeepEqual

### DIFF
--- a/internal/controllers/core/dockercomposelogstream/project.go
+++ b/internal/controllers/core/dockercomposelogstream/project.go
@@ -111,7 +111,7 @@ func (r *Reconciler) runProjectWatch(pw *ProjectWatch) {
 }
 
 // Fetch the state of the given container and convert it into our internal model.
-func (r *Reconciler) getContainerInfo(ctx context.Context, id string) (*containerInfo, error) {
+func (r *Reconciler) getContainerInfo(ctx context.Context, id string) (*ContainerInfo, error) {
 	containerJSON, err := r.dc.ContainerInspect(ctx, id)
 	if err != nil {
 		return nil, err
@@ -124,16 +124,16 @@ func (r *Reconciler) getContainerInfo(ctx context.Context, id string) (*containe
 	}
 
 	cState := containerJSON.ContainerJSONBase.State
-	return &containerInfo{
-		id:    id,
-		state: dockercompose.ToContainerState(cState),
-		tty:   containerJSON.Config.Tty,
+	return &ContainerInfo{
+		ID:    id,
+		State: dockercompose.ToContainerState(cState),
+		TTY:   containerJSON.Config.Tty,
 	}, nil
 }
 
 // Record the container event and re-reconcile. Caller must hold the lock.
 // Returns true on change.
-func (r *Reconciler) recordContainerInfo(key serviceKey, c *containerInfo) bool {
+func (r *Reconciler) recordContainerInfo(key serviceKey, c *ContainerInfo) bool {
 	existing := r.containers[key]
 	if apicmp.DeepEqual(c, existing) {
 		return false

--- a/internal/controllers/core/dockercomposelogstream/project_test.go
+++ b/internal/controllers/core/dockercomposelogstream/project_test.go
@@ -1,0 +1,17 @@
+package dockercomposelogstream
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/tilt-dev/tilt/internal/controllers/apicmp"
+)
+
+func TestDeepEqual(t *testing.T) {
+	c1 := &ContainerInfo{ID: "x-1"}
+	c1b := &ContainerInfo{ID: "x-1"}
+	c2 := &ContainerInfo{ID: "x-2"}
+	assert.False(t, apicmp.DeepEqual(c1, c2))
+	assert.True(t, apicmp.DeepEqual(c1, c1b))
+}

--- a/internal/controllers/core/dockercomposelogstream/reconciler.go
+++ b/internal/controllers/core/dockercomposelogstream/reconciler.go
@@ -28,10 +28,10 @@ import (
 	"github.com/tilt-dev/tilt/pkg/model"
 )
 
-type containerInfo struct {
-	id    string
-	state *v1alpha1.DockerContainerState
-	tty   bool
+type ContainerInfo struct {
+	ID    string
+	State *v1alpha1.DockerContainerState
+	TTY   bool
 }
 
 type Reconciler struct {
@@ -45,7 +45,7 @@ type Reconciler struct {
 
 	// Protected by the mutex.
 	results        map[types.NamespacedName]*Result
-	containers     map[serviceKey]*containerInfo
+	containers     map[serviceKey]*ContainerInfo
 	projectWatches map[string]*ProjectWatch
 }
 
@@ -60,7 +60,7 @@ func NewReconciler(client ctrlclient.Client, store store.RStore,
 		dc:             dc.ForOrchestrator(model.OrchestratorDC),
 		projectWatches: make(map[string]*ProjectWatch),
 		results:        make(map[types.NamespacedName]*Result),
-		containers:     make(map[serviceKey]*containerInfo),
+		containers:     make(map[serviceKey]*ContainerInfo),
 		requeuer:       indexer.NewRequeuer(),
 	}
 }
@@ -146,8 +146,8 @@ func (r *Reconciler) manageLogWatch(ctx context.Context, nn types.NamespacedName
 	if container == nil {
 		return
 	}
-	containerState := container.state
-	containerID := container.id
+	containerState := container.State
+	containerID := container.ID
 
 	// Docker evidently records the container start time asynchronously, so it can actually be AFTER
 	// the first log timestamps (also reported by Docker), so we pad it by a second to reduce the
@@ -181,7 +181,7 @@ func (r *Reconciler) manageLogWatch(ctx context.Context, nn types.NamespacedName
 		spec:           obj.Spec,
 		startWatchTime: startWatchTime,
 		containerID:    containerID,
-		tty:            container.tty,
+		tty:            container.TTY,
 	}
 	result.watch = w
 	go r.consumeLogs(w)

--- a/pkg/webview/view.pb.go
+++ b/pkg/webview/view.pb.go
@@ -741,12 +741,12 @@ func (x *VersionSettings) GetCheckUpdates() bool {
 
 // Our websocket service has two kinds of View messages:
 //
-// 1) On initialization, we send down the complete view state
-//    (TiltStartTime, UISession, UIResources, and LogList)
+//  1. On initialization, we send down the complete view state
+//     (TiltStartTime, UISession, UIResources, and LogList)
 //
-// 2) On every change, we send down the resources that have
-//    changed since the last send().
-//    (new logs and any updated UISession/UIResource objects).
+//  2. On every change, we send down the resources that have
+//     changed since the last send().
+//     (new logs and any updated UISession/UIResource objects).
 //
 // All other fields are obsolete, but are needed for deserializing
 // old snapshots.
@@ -1268,9 +1268,9 @@ func (x *UploadSnapshotResponse) GetUrl() string {
 // NOTE(nick): This is obsolete.
 //
 // Our websocket service has two kinds of messages:
-// 1) On initialization, we send down the complete view state
-// 2) On every change, we send down the resources that have
-//    changed since the last send().
+//  1. On initialization, we send down the complete view state
+//  2. On every change, we send down the resources that have
+//     changed since the last send().
 type AckWebsocketRequest struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache


### PR DESCRIPTION
the k8s api infra really wants all fields to be public