### PR TITLE
tiltfile: handle docker compose build urls correctly

### DIFF
--- a/internal/tiltfile/tiltfile_docker_compose_test.go
+++ b/internal/tiltfile/tiltfile_docker_compose_test.go
@@ -93,6 +93,22 @@ func TestDockerComposeNothingError(t *testing.T) {
 	f.loadErrString("Nothing to compose")
 }
 
+func TestBuildURL(t *testing.T) {
+	f := newFixture(t)
+
+	f.file("Tiltfile", "docker_compose('docker-compose.yml')")
+
+	f.file("docker-compose.yml", `services:
+  app:
+    command: sh -c 'node server.js'
+    build: https://github.com/tilt-dev/tilt-docker-compose-example.git
+    ports:
+    - published: 3000
+      target: 30
+`)
+	f.load()
+}
+
 func TestDockerComposeBadTypeError(t *testing.T) {
 	f := newFixture(t)
 


### PR DESCRIPTION
this check is vestigial from the days when we didn't always normalize the path correctly. now that we use the Go parser, i feel more confident in this.

fixes https://github.com/tilt-dev/tilt/issues/6097