### PR TITLE
build: adjust file sync server

### DIFF
--- a/integration/ignores/.dockerignore
+++ b/integration/ignores/.dockerignore
@@ -1,1 +1,3 @@
 ignored_by_dockerignore.txt
+topdir
+!topdir/subdir

--- a/integration/ignores/topdir/subdir/src.txt
+++ b/integration/ignores/topdir/subdir/src.txt
@@ -1,0 +1,1 @@
+hello world

--- a/integration/ignores_test.go
+++ b/integration/ignores_test.go
@@ -48,4 +48,8 @@ func TestIgnores(t *testing.T) {
 	res, err = http.Get("http://localhost:31234/ignored_by_tiltfile.txt")
 	assert.NoError(t, err)
 	assert.Equal(t, res.StatusCode, http.StatusNotFound)
+
+	_, body, err = f.Curl("http://localhost:31234/topdir/subdir/src.txt")
+	assert.NoError(t, err)
+	assert.Contains(t, body, "hello")
 }

--- a/internal/build/docker_builder.go
+++ b/internal/build/docker_builder.go
@@ -566,16 +566,17 @@ func toSyncedDirs(context string, dockerfileSyncDir string, filter model.PathMat
 			path = filepath.Join(context, path)
 		}
 
-		matches, _ := filter.Matches(path)
-		if matches {
-			isDir := s != nil && s.IsDir()
-			if isDir {
-				entireDir, _ := filter.MatchesEntireDir(path)
-				if entireDir {
-					return fsutil.MapResultSkipDir
-				}
+		isDir := s != nil && s.IsDir()
+		if isDir {
+			entireDir, _ := filter.MatchesEntireDir(path)
+			if entireDir {
+				return fsutil.MapResultSkipDir
 			}
-			return fsutil.MapResultExclude
+		} else {
+			matches, _ := filter.Matches(path)
+			if matches {
+				return fsutil.MapResultExclude
+			}
 		}
 		s.Uid = 0
 		s.Gid = 0


### PR DESCRIPTION
the sync protocol should always send over the directory file info when it sends over files in its subtree, even if the directory path itself is marked as ignored

fixes https://github.com/tilt-dev/tilt/issues/6102