### PR TITLE
Adds additional exclusions for linkerd logs in addition to Istio

### DIFF
--- a/internal/container/ignore.go
+++ b/internal/container/ignore.go
@@ -2,3 +2,6 @@ package container
 
 const IstioInitContainerName = Name("istio-init")
 const IstioSidecarContainerName = Name("istio-proxy")
+
+const LinkerdInitContainerName = Name("linkerd-init")
+const LinkerdSidecarContainerName = Name("linkerd-proxy")

--- a/internal/tiltfile/tiltfile_state.go
+++ b/internal/tiltfile/tiltfile_state.go
@@ -1188,6 +1188,8 @@ func (s *tiltfileState) k8sDeployTarget(targetName model.TargetName, r *k8sResou
 			IgnoreContainers: []string{
 				string(container.IstioInitContainerName),
 				string(container.IstioSidecarContainerName),
+				string(container.LinkerdSidecarContainerName),
+				string(container.LinkerdInitContainerName),
 			},
 		},
 	}


### PR DESCRIPTION
Currently Istio container logs are ignored, this adds the same functionality for Linkerd