### PR TITLE
k8s: adjust how tilt handles two-step deletes

### DIFF
--- a/internal/cli/down.go
+++ b/internal/cli/down.go
@@ -206,7 +206,7 @@ func deleteK8sEntities(ctx context.Context, manifests []model.Manifest, updateSe
 	errs := []error{}
 	if len(entities) > 0 {
 		dCtx, cancel := context.WithTimeout(ctx, updateSettings.K8sUpsertTimeout())
-		err = downDeps.kClient.Delete(dCtx, entities, false)
+		err = downDeps.kClient.Delete(dCtx, entities, 0)
 		cancel()
 		if err != nil {
 			errs = append(errs, errors.Wrap(err, "Deleting k8s entities"))

--- a/internal/k8s/client_test.go
+++ b/internal/k8s/client_test.go
@@ -58,7 +58,7 @@ func TestDelete(t *testing.T) {
 	f := newClientTestFixture(t)
 	postgres, err := ParseYAMLFromString(testyaml.PostgresYAML)
 	assert.Nil(t, err)
-	err = f.client.Delete(f.ctx, postgres, true)
+	err = f.client.Delete(f.ctx, postgres, time.Minute)
 	assert.Nil(t, err)
 	assert.Equal(t, 5, len(f.resourceClient.deletes))
 }
@@ -74,7 +74,7 @@ func TestDeleteMissingKind(t *testing.T) {
 
 	postgres, err := ParseYAMLFromString(testyaml.PostgresYAML)
 	assert.Nil(t, err)
-	err = f.client.Delete(f.ctx, postgres, true)
+	err = f.client.Delete(f.ctx, postgres, time.Minute)
 	assert.Nil(t, err)
 	assert.Equal(t, 4, len(f.resourceClient.deletes))
 

--- a/internal/k8s/exploding_client.go
+++ b/internal/k8s/exploding_client.go
@@ -29,7 +29,7 @@ func (ec *explodingClient) Upsert(ctx context.Context, entities []K8sEntity, tim
 	return nil, errors.Wrap(ec.err, "could not set up kubernetes client")
 }
 
-func (ec *explodingClient) Delete(ctx context.Context, entities []K8sEntity, wait bool) error {
+func (ec *explodingClient) Delete(ctx context.Context, entities []K8sEntity, wait time.Duration) error {
 	return errors.Wrap(ec.err, "could not set up kubernetes client")
 }
 

--- a/internal/k8s/fake_client.go
+++ b/internal/k8s/fake_client.go
@@ -427,7 +427,7 @@ func (c *FakeK8sClient) Upsert(_ context.Context, entities []K8sEntity, timeout 
 	return result, nil
 }
 
-func (c *FakeK8sClient) Delete(_ context.Context, entities []K8sEntity, wait bool) error {
+func (c *FakeK8sClient) Delete(_ context.Context, entities []K8sEntity, wait time.Duration) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 


### PR DESCRIPTION
before this change, force refresh would delete, then wait for 30s for the delete to finalize. if the delete timeout failed, the force refresh would ignore it and continue applying resources as if nothing had happened.

after this change, force refresh does an asynchronous deletion. When it applies, it checks if the resource is still in the delete phase, and waits for the delete to finish before continuing the apply.

I think this is likely to be a lot more robust and better for parallelization (since now, deletes can happen in parallel with image builds).

Fixes https://github.com/tilt-dev/tilt/issues/6048