### PR TITLE
Update ReadRune to support Windows

### DIFF
--- a/internal/hud/prompt/prompt.go
+++ b/internal/hud/prompt/prompt.go
@@ -157,6 +157,8 @@ func (p *TerminalPrompt) OnChange(ctx context.Context, st store.RStore, _ store.
 				st.Dispatch(store.ErrorAction{Error: err})
 				return
 			}
+			
+			if r == '\000' { continue } //ensure windows support for tty rune reading
 
 			msg := runeMessage{
 				rune:   r,


### PR DESCRIPTION
Currently, when using `ReadRune` on windows OSes, the input comes prefixed with 'empty' characters (as described here: https://github.com/mattn/go-tty/issues/22)