### PR TITLE
cmdimage: reconcile() should hold the lock

### DIFF
--- a/internal/controllers/core/cmdimage/reconciler.go
+++ b/internal/controllers/core/cmdimage/reconciler.go
@@ -58,6 +58,9 @@ func NewReconciler(client ctrlclient.Client, st store.RStore, scheme *runtime.Sc
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
 	nn := req.NamespacedName
 	obj := &v1alpha1.CmdImage{}
 	err := r.client.Get(ctx, nn, obj)


### PR DESCRIPTION
this ensures that a ForceApply doesn't modify the internal data structures during reconcilation

Mirrors the similar code in the dockerimage reconciler: https://github.com/tilt-dev/tilt/blob/31595cfb3ca178c1f7f36b24f0f935068c838398/internal/controllers/core/dockerimage/reconciler.go#L60

fixes https://github.com/tilt-dev/tilt/issues/6120