### PR TITLE
Include CustomBuild in HasBuild condition

### DIFF
--- a/internal/engine/dockerprune/docker_pruner.go
+++ b/internal/engine/dockerprune/docker_pruner.go
@@ -83,7 +83,7 @@ func (dp *DockerPruner) OnChange(ctx context.Context, st store.RStore, summary s
 	// 	* Engine is currently building something
 	// 	* There are NO `docker_build`s in the Tiltfile
 	// 	* Something is queued for building
-	if !settings.Enabled || len(state.CurrentBuildSet) > 0 || !state.HasDockerBuild() || buildcontrol.NextManifestNameToBuild(state) != "" {
+	if !settings.Enabled || len(state.CurrentBuildSet) > 0 || !state.HasBuild() || buildcontrol.NextManifestNameToBuild(state) != "" {
 		st.RUnlockState()
 		return nil
 	}

--- a/internal/engine/dockerprune/docker_pruner_test.go
+++ b/internal/engine/dockerprune/docker_pruner_test.go
@@ -309,7 +309,7 @@ func TestDockerPrunerFirstRunButNoCompletedBuilds(t *testing.T) {
 	f.assertNoPrune()
 }
 
-func TestDockerPrunerNoDockerManifests(t *testing.T) {
+func TestDockerPrunerNoBuildManifests(t *testing.T) {
 	f := newFixture(t)
 	f.withK8sOnlyManifest()
 	f.withBuildCount(11)
@@ -318,6 +318,20 @@ func TestDockerPrunerNoDockerManifests(t *testing.T) {
 	_ = f.dp.OnChange(f.ctx, f.st, store.LegacyChangeSummary())
 
 	f.assertNoPrune()
+}
+
+func TestDockerPrunerOnlyCustomBuildManifests(t *testing.T) {
+	f := newFixture(t)
+	f.withBuildCount(11)
+	f.withDockerPruneSettings(true, 0, 5, 0)
+
+	iTarget := model.MustNewImageTarget(refSel).WithBuildDetails(model.CustomBuild{})
+	m := model.Manifest{Name: "custom-build-manifest"}.WithImageTarget(iTarget)
+	f.withManifestTarget(store.NewManifestTarget(m), true)
+
+	_ = f.dp.OnChange(f.ctx, f.st, store.LegacyChangeSummary())
+
+	f.assertPrune()
 }
 
 func TestDockerPrunerDisabled(t *testing.T) {

--- a/internal/store/engine_state.go
+++ b/internal/store/engine_state.go
@@ -379,10 +379,10 @@ func (e *EngineState) MainConfigPaths() []string {
 	return e.TiltfileConfigPaths[model.MainTiltfileManifestName]
 }
 
-func (e *EngineState) HasDockerBuild() bool {
+func (e *EngineState) HasBuild() bool {
 	for _, m := range e.Manifests() {
 		for _, targ := range m.ImageTargets {
-			if targ.IsDockerBuild() {
+			if targ.IsDockerBuild() || targ.IsCustomBuild() {
 				return true
 			}
 		}


### PR DESCRIPTION
So that docker pruner will run when the manifest only includes custom builds.

More details in #6131
Related to #4023