### PR TITLE
circleci: use a go 1.20 release image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,7 +138,7 @@ jobs:
     resource_class: medium+
     docker:
       # keep image in sync with build.toast.yml
-      - image: docker/tilt-releaser@sha256:31e51c6441faa5021a20ebe84cf974145d2975f792dd880a5d1c2fa578818458
+      - image: docker/tilt-releaser@sha256:8b5a18a178c32f52652cd22cb8704fc33c1b8897ebd2b1ed2eb92b97a63107dd
     environment:
       DOCKER_CLI_EXPERIMENTAL: enabled
     steps:
@@ -155,7 +155,7 @@ jobs:
     resource_class: medium+
     docker:
       # keep image in sync with build.toast.yml
-      - image: docker/tilt-releaser@sha256:31e51c6441faa5021a20ebe84cf974145d2975f792dd880a5d1c2fa578818458
+      - image: docker/tilt-releaser@sha256:8b5a18a178c32f52652cd22cb8704fc33c1b8897ebd2b1ed2eb92b97a63107dd
     environment:
       DOCKER_CLI_EXPERIMENTAL: enabled
     steps:

--- a/build.toast.yml
+++ b/build.toast.yml
@@ -1,5 +1,5 @@
 # keep image in sync with .circleci/config.yml
-image: docker/tilt-releaser@sha256:31e51c6441faa5021a20ebe84cf974145d2975f792dd880a5d1c2fa578818458
+image: docker/tilt-releaser@sha256:8b5a18a178c32f52652cd22cb8704fc33c1b8897ebd2b1ed2eb92b97a63107dd
 location: /go/src/github.com/tilt-dev/tilt
 command_prefix: set -euo pipefail
 tasks:

--- a/scripts/build-tilt-releaser.sh
+++ b/scripts/build-tilt-releaser.sh
@@ -8,5 +8,4 @@ set -ex
 DIR=$(dirname "$0")
 cd "$DIR/.."
 
-docker buildx build --load -t docker/tilt-releaser -f scripts/release.Dockerfile scripts
-docker push docker/tilt-releaser
+docker buildx build --push -t docker/tilt-releaser -f scripts/release.Dockerfile scripts


### PR DESCRIPTION
Before this change, we did all our own cross-compilation.

After this change, we pull the cross-compiling logic from a shared image. Loosely based on the Compose approach.

Does not yet switch to go 1.20 by default.