### PR TITLE
chore: upgrade GoReleaser to v1.18.2

### DIFF
--- a/scripts/release.Dockerfile
+++ b/scripts/release.Dockerfile
@@ -55,7 +55,7 @@ RUN set -exu && \
     docker --version && \
     rm -rf /var/lib/apt/lists/*
 
-ENV GORELEASER_VERSION=v1.6.3
+ENV GORELEASER_VERSION=v1.18.2
 RUN set -exu \
   && URL="https://github.com/goreleaser/goreleaser/releases/download/${GORELEASER_VERSION}/goreleaser_Linux_x86_64.tar.gz" \
   && echo goreleaser URL: $URL \


### PR DESCRIPTION
## What

Upgrade GoReleaser to v1.18.2.

## Why

- https://github.com/tilt-dev/tilt/issues/6151

To resolve the following warning and build prebuilt binaries for darwin/arm64.

```
      • DEPRECATED: skipped darwin/arm64 build on Go < 1.16 for compatibility, check https://goreleaser.com/deprecations/#builds-for-darwinarm64 for more info.
```

I confirmed the warning was resolved using GoReleaser v1.18.2.

- https://github.com/tilt-dev/tilt/issues/6151#issuecomment-1611322177