### PR TITLE
chore: replace GoReleaser's deprecated option `--rm-dist` to `--clean`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,7 +147,7 @@ jobs:
       - run: ssh remote-docker "sudo apt-get update; sudo apt-get install -y qemu-user-static binfmt-support"
       - checkout
       - run: make build-js
-      - run: goreleaser --debug --rm-dist --skip-publish --snapshot
+      - run: goreleaser --debug --clean --skip-publish --snapshot
       - slack/notify-on-failure:
           only_for_branches: main
 

--- a/build.toast.yml
+++ b/build.toast.yml
@@ -22,7 +22,7 @@ tasks:
       GR_ARGS: ""
     dependencies:
       - build-js
-    command: goreleaser --debug build --snapshot --rm-dist $GR_ARGS
+    command: goreleaser --debug build --snapshot --clean $GR_ARGS
     input_paths:
       - .git/
       - cmd/

--- a/scripts/release-ci.sh
+++ b/scripts/release-ci.sh
@@ -41,7 +41,7 @@ VERSION=$(git describe --abbrev=0 --tags)
 ./scripts/upload-assets.py --clean "$VERSION"
 ./scripts/upload-assets.py "$VERSION"
 
-goreleaser --rm-dist
+goreleaser --clean
 
 ./scripts/release-update-tilt-repo.sh "$VERSION"
 ./scripts/release-update-tilt-docs-repo.sh "$VERSION"


### PR DESCRIPTION
To resolve the warning of GoReleaser v1.18.2.

```
    • DEPRECATED: --rm-dist was deprecated in favor of --clean, check https://goreleaser.com/deprecations#-rm-dist for more details
```

https://goreleaser.com/deprecations#-rm-dist

⚠️ This pull request needs to update the Docker image `docker/tilt-ci` because goreleaser v1.6.3 doesn't support this option.

https://github.com/tilt-dev/tilt/pull/6152 upgraded GoReleaser v1.18.2 in Dockerfile, so we need to release a new Docker image and update image tags.

https://github.com/tilt-dev/tilt/blob/afb1422a3bd17388b6dd0f68d156dba16f352bfb/build.toast.yml#L2

https://github.com/tilt-dev/tilt/blob/afb1422a3bd17388b6dd0f68d156dba16f352bfb/.circleci/config.yml#L141