### PR TITLE
fix: fix typos using typos

### DIFF
--- a/internal/README.md
+++ b/internal/README.md
@@ -87,7 +87,7 @@ Most subscribers are subpackages of `engine`. Here's a partial listing of import
 - [engine/fswatch](engine/fswatch) - Sets up file system watches, and dispatches
   actions when files have changed
 
-- [engine/k8swatch](engine/k8swatch) - Watches Kuberentes resources, and
+- [engine/k8swatch](engine/k8swatch) - Watches Kubernetes resources, and
   dispatches actions when objects (like pods and events) are created, updated,
   or deleted.
   

--- a/internal/build/custom_builder_test.go
+++ b/internal/build/custom_builder_test.go
@@ -282,7 +282,7 @@ func TestEnvVars_ConfigRefWithLocalRegistry(t *testing.T) {
 	// generally, config refs (value in Tiltfile) are $prod_registry/$image:$tag
 	// and Tilt rewrites it to $local_registry/$sanitized_prod_registry_$image
 	// however, some users explicitly use the $local_registry in their Tiltfile
-	// refs, so instead of producing a redudant and confusing ref like
+	// refs, so instead of producing a redundant and confusing ref like
 	// $local_registry/$sanitized_local_registry_$image, it just gets passed
 	// through
 	expectedVars := map[string]string{

--- a/internal/build/docker_builder.go
+++ b/internal/build/docker_builder.go
@@ -307,9 +307,9 @@ func (d *DockerBuilder) getDigestFromBuildOutput(ctx context.Context, reader io.
 }
 
 var dockerBuildCleanupRexes = []*regexp.Regexp{
-	// the "runc did not determinate sucessfully" just seems redundant on top of "executor failed running"
+	// the "runc did not determinate successfully" just seems redundant on top of "executor failed running"
 	// nolint
-	regexp.MustCompile("(executor failed running.*): runc did not terminate sucessfully"), // sucessfully (sic)
+	regexp.MustCompile("(executor failed running.*): runc did not terminate successfully"), // successfully (sic)
 	// when a file is missing, it generates an error like "failed to compute cache key: foo.txt not found: not found"
 	// most of that seems redundant and/or confusing
 	regexp.MustCompile("failed to compute cache key: (.* not found): not found"),

--- a/internal/build/docker_builder_test.go
+++ b/internal/build/docker_builder_test.go
@@ -117,15 +117,15 @@ func TestCleanUpBuildKitErrors(t *testing.T) {
 		// actual error currently emitted by buildkit when a `RUN` fails
 		{
 			//nolint
-			buildKitError:     "failed to solve with frontend dockerfile.v0: failed to build LLB: executor failed running [/bin/sh -c go install github.com/tilt-dev/servantes/vigoda]: runc did not terminate sucessfully",
+			buildKitError:     "failed to solve with frontend dockerfile.v0: failed to build LLB: executor failed running [/bin/sh -c go install github.com/tilt-dev/servantes/vigoda]: runc did not terminate successfully",
 			expectedTiltError: "executor failed running [/bin/sh -c go install github.com/tilt-dev/servantes/vigoda]",
 		},
 		//nolint
-		// artificial error - in case docker for some reason doesn't have "executor failed running", don't trim "runc did not terminate sucessfully"
+		// artificial error - in case docker for some reason doesn't have "executor failed running", don't trim "runc did not terminate successfully"
 		{
 			//nolint
-			buildKitError:     "failed to solve with frontend dockerfile.v0: failed to build LLB: [/bin/sh -c go install github.com/tilt-dev/servantes/vigoda]: runc did not terminate sucessfully",
-			expectedTiltError: "[/bin/sh -c go install github.com/tilt-dev/servantes/vigoda]: runc did not terminate sucessfully",
+			buildKitError:     "failed to solve with frontend dockerfile.v0: failed to build LLB: [/bin/sh -c go install github.com/tilt-dev/servantes/vigoda]: runc did not terminate successfully",
+			expectedTiltError: "[/bin/sh -c go install github.com/tilt-dev/servantes/vigoda]: runc did not terminate successfully",
 		},
 		// actual error currently emitted by buildkit when an `ADD` file is missing
 		{
@@ -158,7 +158,7 @@ func TestCleanUpBuildKitErrors(t *testing.T) {
 			// Error message when using
 			// # syntax=docker/dockerfile:experimental
 			//nolint
-			buildKitError:     "failed to solve with frontend dockerfile.v0: failed to solve with frontend gateway.v0: rpc error: code = Unknown desc = failed to build LLB: executor failed running [/bin/sh -c pip install python-dateutil]: runc did not terminate sucessfully",
+			buildKitError:     "failed to solve with frontend dockerfile.v0: failed to solve with frontend gateway.v0: rpc error: code = Unknown desc = failed to build LLB: executor failed running [/bin/sh -c pip install python-dateutil]: runc did not terminate successfully",
 			expectedTiltError: "executor failed running [/bin/sh -c pip install python-dateutil]",
 		},
 	} {

--- a/internal/controllers/core/liveupdate/input.go
+++ b/internal/controllers/core/liveupdate/input.go
@@ -11,7 +11,7 @@ type Input struct {
 	// Derived from DockerResource
 	IsDC bool
 
-	// Derived from KubernetesResource + KubenetesSelector + DockerResource
+	// Derived from KubernetesResource + KubernetesSelector + DockerResource
 	Containers []liveupdates.Container
 
 	// Derived from FileWatch + Sync rules

--- a/internal/controllers/core/podlogstream/podlogstreamcontroller.go
+++ b/internal/controllers/core/podlogstream/podlogstreamcontroller.go
@@ -388,7 +388,7 @@ func (c *Controller) consumeLogs(watch *podLogWatch, st store.RStore) {
 					// In the common case (where we just haven't gotten any logs in the
 					// last 15 seconds), this will ensure we don't duplicate logs.
 					//
-					// In the uncommon case (where the Kuberentes log buffer exceeded 10MB
+					// In the uncommon case (where the Kubernetes log buffer exceeded 10MB
 					// and got rotated), this will create a 2 second gap in the log, but
 					// we think this is acceptable to avoid the duplicate case.
 					startReadTime = lastRead.Add(podLogReconnectGap)

--- a/internal/controllers/core/tiltfile/reducers.go
+++ b/internal/controllers/core/tiltfile/reducers.go
@@ -47,7 +47,7 @@ func HandleConfigsReloadStarted(
 // In the medium-term, we resolve this in the EngineState in three different ways:
 //  1. If a data structure supports merging (like the Manifest map), do a merge.
 //  2. If merging fails (like if two Tiltfiles define the same Manifest), log an Error
-//     and try to do something resonable.
+//     and try to do something reasonable.
 //  3. If a data structure does not support merging (like UpdateSettings), only
 //     accept that data structure from the "main" tiltfile.
 func HandleConfigsReloaded(

--- a/internal/docker/client.go
+++ b/internal/docker/client.go
@@ -91,7 +91,7 @@ type Client interface {
 	ForOrchestrator(orc model.Orchestrator) Client
 
 	ContainerLogs(ctx context.Context, container string, options types.ContainerLogsOptions) (io.ReadCloser, error)
-	ContainerInspect(ctx context.Context, contianerID string) (types.ContainerJSON, error)
+	ContainerInspect(ctx context.Context, containerID string) (types.ContainerJSON, error)
 	ContainerList(ctx context.Context, options types.ContainerListOptions) ([]types.Container, error)
 	ContainerRestartNoWait(ctx context.Context, containerID string) error
 

--- a/internal/engine/buildcontrol/build_control_test.go
+++ b/internal/engine/buildcontrol/build_control_test.go
@@ -662,7 +662,7 @@ func completedPod(podID k8s.PodID, ref string) *v1alpha1.Pod {
 					Terminated: &v1alpha1.ContainerStateTerminated{
 						StartedAt:  metav1.Now(),
 						FinishedAt: metav1.Now(),
-						Reason:     "Succcess!",
+						Reason:     "Success!",
 						ExitCode:   0,
 					}},
 			},

--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -251,7 +251,7 @@ func handleServiceEvent(ctx context.Context, state *store.EngineState, action k8
 }
 
 func handleK8sEvent(ctx context.Context, state *store.EngineState, action store.K8sEventAction) {
-	// TODO(nick): I think we whould so something more intelligent here, where we
+	// TODO(nick): I think we would so something more intelligent here, where we
 	// have special treatment for different types of events, e.g.:
 	//
 	// - Attach Image Pulling/Pulled events to the pod state, and display how much

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -538,7 +538,7 @@ func (b *fakeBuildAndDeployer) getOrCreateBuildCompletionChannel(key string) bui
 	var ok bool
 	ch, ok = val.(buildCompletionChannel)
 	if !ok {
-		panic(fmt.Sprintf("exected map value of type: buildCompletionChannel, got %T", val))
+		panic(fmt.Sprintf("expected map value of type: buildCompletionChannel, got %T", val))
 	}
 
 	return ch

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -962,7 +962,7 @@ k8s_yaml('snack.yaml')`
 	_ = f.nextCall("first call")
 
 	// Second call: change Tiltfile, break manifest
-	f.WriteConfigFiles("Tiltfile", "borken")
+	f.WriteConfigFiles("Tiltfile", "broken")
 	f.WaitUntil("tiltfile error set", func(st store.EngineState) bool {
 		return st.LastMainTiltfileError() != nil
 	})
@@ -1005,7 +1005,7 @@ k8s_yaml('snack.yaml')
 	_ = f.nextCall("first call")
 
 	// Second call: change Tiltfile, break manifest
-	f.WriteConfigFiles("Tiltfile", "borken")
+	f.WriteConfigFiles("Tiltfile", "broken")
 	f.WaitUntil("tiltfile error set", func(st store.EngineState) bool {
 		return st.LastMainTiltfileError() != nil
 	})

--- a/internal/engine/wire.go
+++ b/internal/engine/wire.go
@@ -93,7 +93,7 @@ func provideFakeKubeContext(env clusterid.Product) k8s.KubeContext {
 }
 
 // A simplified version of the normal calculation we do
-// about whether we can build direct to a cluser
+// about whether we can build direct to a cluster
 func provideFakeDockerClusterEnv(c docker.Client, k8sEnv clusterid.Product, kubeContext k8s.KubeContext, runtime container.Runtime) docker.ClusterEnv {
 	env := c.Env()
 	isDockerRuntime := runtime == container.RuntimeDocker

--- a/internal/engine/wire_gen.go
+++ b/internal/engine/wire_gen.go
@@ -97,7 +97,7 @@ func provideFakeKubeContext(env clusterid.Product) k8s.KubeContext {
 }
 
 // A simplified version of the normal calculation we do
-// about whether we can build direct to a cluser
+// about whether we can build direct to a cluster
 func provideFakeDockerClusterEnv(c docker.Client, k8sEnv clusterid.Product, kubeContext k8s.KubeContext, runtime container.Runtime) docker.ClusterEnv {
 	env := c.Env()
 	isDockerRuntime := runtime == container.RuntimeDocker

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -394,7 +394,7 @@ func (k *K8sClient) applyEntity(ctx context.Context, entity K8sEntity) ([]K8sEnt
 	}
 
 	// Under rare circumstances, an apply() may result in a 3-way merge
-	// where the object has the new spec, but is simulataneously being removed.
+	// where the object has the new spec, but is simultaneously being removed.
 	//
 	// In that case, wait for the deletion to finish, then retry the apply.
 	//

--- a/internal/k8s/entity_test.go
+++ b/internal/k8s/entity_test.go
@@ -111,7 +111,7 @@ func TestHasName(t *testing.T) {
 		t.Fatal(err)
 	}
 	if len(entities) != 2 {
-		t.Fatalf("expected 2 entites, got %d: %v", len(entities), entities)
+		t.Fatalf("expected 2 entities, got %d: %v", len(entities), entities)
 	}
 
 	doggos := entities[0]
@@ -127,7 +127,7 @@ func TestHasNamespace(t *testing.T) {
 		t.Fatal(err)
 	}
 	if len(entities) != 2 {
-		t.Fatalf("expected 2 entites, got %d: %v", len(entities), entities)
+		t.Fatalf("expected 2 entities, got %d: %v", len(entities), entities)
 	}
 
 	doggos := entities[0]
@@ -143,7 +143,7 @@ func TestHasKind(t *testing.T) {
 		t.Fatal(err)
 	}
 	if len(entities) != 2 {
-		t.Fatalf("expected 2 entites, got %d: %v", len(entities), entities)
+		t.Fatalf("expected 2 entities, got %d: %v", len(entities), entities)
 	}
 
 	depl := entities[0]

--- a/internal/k8s/jsonpath/jsonpath_test.go
+++ b/internal/k8s/jsonpath/jsonpath_test.go
@@ -149,7 +149,7 @@ func TestStructInput(t *testing.T) {
 			{"green", 20.01, false},
 		},
 		Labels: map[string]int{
-			"engieer":  10,
+			"engineer":  10,
 			"web/html": 15,
 			"k8s-app":  20,
 		},
@@ -276,7 +276,7 @@ func TestKubernetes(t *testing.T) {
 	nodesTests := []jsonpathTest{
 		{"range item", `{range .items[*]}{.metadata.name}, {end}{.kind}`, nodesData, "127.0.0.1, 127.0.0.2, List", false},
 		{"range item with quote", `{range .items[*]}{.metadata.name}{"\t"}{end}`, nodesData, "127.0.0.1\t127.0.0.2\t", false},
-		{"range addresss", `{.items[*].status.addresses[*].address}`, nodesData,
+		{"range address", `{.items[*].status.addresses[*].address}`, nodesData,
 			"127.0.0.1 127.0.0.2 127.0.0.3", false},
 		{"double range", `{range .items[*]}{range .status.addresses[*]}{.address}, {end}{end}`, nodesData,
 			"127.0.0.1, 127.0.0.2, 127.0.0.3, ", false},

--- a/internal/rty/layouts.go
+++ b/internal/rty/layouts.go
@@ -680,7 +680,7 @@ func (ml *MinLengthLayout) Size(width int, height int) (int, int, error) {
 	}
 	sizedWidth, sizedHeight = ldToWh(sizedLen, sizedDep, ml.inner.dir)
 
-	// It should be impossible to make the container bigger than the size alloted,
+	// It should be impossible to make the container bigger than the size allotted,
 	// even with minLength.
 	if sizedWidth > width {
 		sizedWidth = width

--- a/internal/store/k8sconv/resource.go
+++ b/internal/store/k8sconv/resource.go
@@ -74,7 +74,7 @@ func NewKubernetesResourceWithFilter(
 }
 
 // Filter to determine whether a pod or resource belongs to the current
-// KubernetesApply. Used to filter out pods from previous applys
+// KubernetesApply. Used to filter out pods from previous applies
 // when looking at a KubernetesDiscovery object.
 //
 // Considered immutable once created.

--- a/internal/tiltfile/api/__init__.py
+++ b/internal/tiltfile/api/__init__.py
@@ -230,7 +230,7 @@ def docker_build(ref: str,
     match_in_env_vars: specifies that k8s objects can reference this image in their environment variables, and Tilt will handle those variables the same as it usually handles a k8s container spec's ``image`` s.
     ignore: set of file patterns that will be ignored, in addition to ``.git`` directory that's `ignored by default <file_changes.html#where-ignores-come-from>`_. Ignored files will not trigger builds and will not be included in images. Follows the `dockerignore syntax <https://docs.docker.com/engine/reference/builder/#dockerignore-file>`_. Patterns will be evaluated relative to the ``context`` parameter.
     only: set of file paths that should be considered for the build. All other changes will not trigger a build and will not be included in images. Inverse of ignore parameter. Only accepts real paths, not file globs. Patterns will be evaluated relative to the ``context`` parameter.
-    entrypoint: command to run when this container starts. Takes precedence over the container's ``CMD`` or ``ENTRYPOINT``, and over a `container command specified in k8s YAML <https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/>`_. If specified as a string, will be evaluated in a shell context (e.g. ``entrypoint="foo.sh bar"`` will be executed in the container as ``/bin/sh -c 'foo.sh bar'``); if specifed as a list, will be passed to the operating system as program name and args.
+    entrypoint: command to run when this container starts. Takes precedence over the container's ``CMD`` or ``ENTRYPOINT``, and over a `container command specified in k8s YAML <https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/>`_. If specified as a string, will be evaluated in a shell context (e.g. ``entrypoint="foo.sh bar"`` will be executed in the container as ``/bin/sh -c 'foo.sh bar'``); if specified as a list, will be passed to the operating system as program name and args.
     target: Specify a build stage in the Dockerfile. Equivalent to the ``docker build --target`` flag.
     ssh: Include SSH secrets in your build. Use ssh='default' to clone private repositories inside a Dockerfile. Uses the syntax in the `docker build --ssh flag <https://docs.docker.com/develop/develop-images/build_enhancements/#using-ssh-to-access-private-data-in-builds>`_.
     network: Set the networking mode for RUN instructions. Equivalent to the ``docker build --network`` flag.
@@ -445,7 +445,7 @@ def dc_resource(name: str,
       See the `Resource Dependencies docs <resource_dependencies.html>`_.
     links: one or more links to be associated with this resource in the UI. For more info, see
       `Accessing Resource Endpoints <accessing_resource_endpoints.html#arbitrary-links>`_.
-    labels: used to group resources in the Web UI, (e.g. you want all frontend services displayed together, while test and backend services are displayed seperately). A label must start and end with an alphanumeric character, can include ``_``, ``-``, and ``.``, and must be 63 characters or less. For an example, see `Resource Grouping <tiltfile_concepts.html#resource-groups>`_.
+    labels: used to group resources in the Web UI, (e.g. you want all frontend services displayed together, while test and backend services are displayed separately). A label must start and end with an alphanumeric character, can include ``_``, ``-``, and ``.``, and must be 63 characters or less. For an example, see `Resource Grouping <tiltfile_concepts.html#resource-groups>`_.
     auto_init: whether this resource runs on ``tilt up``. Defaults to ``True``. For more info, see the
       `Manual Update Control docs <manual_update_control.html>`_.
     project_name: The Docker Compose project name to match the corresponding project loaded by
@@ -561,7 +561,7 @@ def k8s_resource(workload: str = "", new_name: str = "",
       thinks a resource has pods.
     links: one or more links to be associated with this resource in the UI. For more info, see
       `Accessing Resource Endpoints <accessing_resource_endpoints.html#arbitrary-links>`_.
-    labels: used to group resources in the Web UI, (e.g. you want all frontend services displayed together, while test and backend services are displayed seperately). A label must start and end with an alphanumeric character, can include ``_``, ``-``, and ``.``, and must be 63 characters or less. For an example, see `Resource Grouping <tiltfile_concepts.html#resource-groups>`_.
+    labels: used to group resources in the Web UI, (e.g. you want all frontend services displayed together, while test and backend services are displayed separately). A label must start and end with an alphanumeric character, can include ``_``, ``-``, and ``.``, and must be 63 characters or less. For an example, see `Resource Grouping <tiltfile_concepts.html#resource-groups>`_.
     discovery_strategy: Possible values: '', 'default', 'selectors-only'. When '' or 'default', Tilt both uses `extra_pod_selectors` and traces k8s owner references to identify this resource's pods. When 'selectors-only', Tilt uses only `extra_pod_selectors`.
   """
   pass
@@ -701,7 +701,7 @@ def read_file(file_path: str, default: str = None) -> Blob:
   pass
 
 def watch_file(file_path: str) -> None:
-  """Watches a file. If the file is changed a re-exectution of the Tiltfile is triggered.
+  """Watches a file. If the file is changed a re-execution of the Tiltfile is triggered.
 
   If the path is a directory, its contents will be recursively watched.
 
@@ -966,7 +966,7 @@ def custom_build(
     live_update: set of steps for updating a running container (see `Live Update documentation <live_update_reference.html>`_).
     match_in_env_vars: specifies that k8s objects can reference this image in their environment variables, and Tilt will handle those variables the same as it usually handles a k8s container spec's ``image`` s.
     ignore: set of file patterns that will be ignored. Ignored files will not trigger builds and will not be included in images. Follows the `dockerignore syntax <https://docs.docker.com/engine/reference/builder/#dockerignore-file>`_. Patterns/filepaths will be evaluated relative to each ``dep`` (e.g. if you specify ``deps=['dep1', 'dep2']`` and ``ignores=['foobar']``, Tilt will ignore both ``deps1/foobar`` and ``dep2/foobar``).
-    entrypoint: command to run when this container starts. Takes precedence over the container's ``CMD`` or ``ENTRYPOINT``, and over a `container command specified in k8s YAML <https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/>`_. If specified as a string, will be evaluated in a shell context (e.g. ``entrypoint="foo.sh bar"`` will be executed in the container as ``/bin/sh -c 'foo.sh bar'``); if specifed as a list, will be passed to the operating system as program name and args. Kubernetes-only.
+    entrypoint: command to run when this container starts. Takes precedence over the container's ``CMD`` or ``ENTRYPOINT``, and over a `container command specified in k8s YAML <https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/>`_. If specified as a string, will be evaluated in a shell context (e.g. ``entrypoint="foo.sh bar"`` will be executed in the container as ``/bin/sh -c 'foo.sh bar'``); if specified as a list, will be passed to the operating system as program name and args. Kubernetes-only.
     command_bat_val: Deprecated, use command_bat.
     outputs_image_ref_to: Specifies a file path. When set, the custom build command must write a content-based
       tagged image ref to this file. Tilt will read that file after the cmd runs to get the image ref,
@@ -1162,7 +1162,7 @@ def local_resource(name: str,
     readiness_probe: Optional readiness probe to use for determining ``serve_cmd`` health state. Fore more info, see the :meth:`probe` function.
     dir: Working directory for ``cmd``. Defaults to the Tiltfile directory.
     serve_dir: Working directory for ``serve_cmd``. Defaults to the Tiltfile directory.
-    labels: used to group resources in the Web UI, (e.g. you want all frontend services displayed together, while test and backend services are displayed seperately). A label must start and end with an alphanumeric character, can include ``_``, ``-``, and ``.``, and must be 63 characters or less. For an example, see `Resource Grouping <tiltfile_concepts.html#resource-groups>`_.
+    labels: used to group resources in the Web UI, (e.g. you want all frontend services displayed together, while test and backend services are displayed separately). A label must start and end with an alphanumeric character, can include ``_``, ``-``, and ``.``, and must be 63 characters or less. For an example, see `Resource Grouping <tiltfile_concepts.html#resource-groups>`_.
   """
   pass
 
@@ -1383,7 +1383,7 @@ def http_get_action(port: int, host: str='localhost', scheme: str='http', path: 
     host: Hostname to use for HTTP request.
     port: Port to use for HTTP request.
     scheme: URI scheme to use for HTTP request, valid values are `http` and `https`.
-    path: URI path for HTTP reqeust.
+    path: URI path for HTTP request.
   """
   pass
 

--- a/internal/tiltfile/api/sys/__init__.py
+++ b/internal/tiltfile/api/sys/__init__.py
@@ -11,5 +11,5 @@ executable: str = ""
 
 Based on how Tilt was originally invoked. There is no guarantee that
 the path is still pointing to a valid Tilt binary. If the path has
-a symlink, the behavior is operating system depdendent.
+a symlink, the behavior is operating system dependent.
 """

--- a/internal/tiltfile/helm_test.go
+++ b/internal/tiltfile/helm_test.go
@@ -162,7 +162,7 @@ yml = helm('helm')
 k8s_yaml(yml)
 `)
 
-	f.loadErrString("error unmarshaling JSON")
+	f.loadErrString("error unmarshalling JSON")
 	f.assertConfigFiles(
 		"Tiltfile",
 		".tiltignore",

--- a/internal/tiltfile/k8s/state.go
+++ b/internal/tiltfile/k8s/state.go
@@ -28,7 +28,7 @@ type ObjectSpec struct {
 	StackTrace string
 }
 
-// Keeps track of all the Kuberentes objects registered during Tiltfile Execution.
+// Keeps track of all the Kubernetes objects registered during Tiltfile Execution.
 type State struct {
 	ObjectSpecRefs  []v1.ObjectReference
 	ObjectSpecIndex map[v1.ObjectReference]ObjectSpec

--- a/internal/tiltfile/value/name.go
+++ b/internal/tiltfile/value/name.go
@@ -7,7 +7,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/validation/path"
 )
 
-// Names in Tilt should be valid Kuberentes API names.
+// Names in Tilt should be valid Kubernetes API names.
 //
 // We use the loosest validation rules: valid path segment names.
 //

--- a/internal/watch/notify.go
+++ b/internal/watch/notify.go
@@ -52,7 +52,7 @@ type Notify interface {
 // - Watch /src/repo, but ignore /src/repo/.git
 // - Watch /src/repo, but ignore everything in /src/repo/bazel-bin except /src/repo/bazel-bin/app-binary
 //
-// The PathMatcher inteface helps us manage these ignores.
+// The PathMatcher interface helps us manage these ignores.
 type PathMatcher interface {
 	Matches(file string) (bool, error)
 

--- a/pkg/apis/core/v1alpha1/uiresource_types.go
+++ b/pkg/apis/core/v1alpha1/uiresource_types.go
@@ -273,12 +273,12 @@ type UIResourceTargetSpec struct {
 	// +optional
 	Type UIResourceTargetType `json:"type,omitempty" protobuf:"bytes,2,opt,name=type,casttype=UIResourceTargetType"`
 
-	// Whether the target has a live update assocated with it.
+	// Whether the target has a live update associated with it.
 	// +optional
 	HasLiveUpdate bool `json:"hasLiveUpdate,omitempty" protobuf:"varint,3,opt,name=hasLiveUpdate"`
 }
 
-// UIBuildRunning respresents an in-progress build/update in the user interface.
+// UIBuildRunning represents an in-progress build/update in the user interface.
 type UIBuildRunning struct {
 	// The time when the build started.
 	// +optional
@@ -289,7 +289,7 @@ type UIBuildRunning struct {
 	SpanID string `json:"spanID,omitempty" protobuf:"bytes,2,opt,name=spanID"`
 }
 
-// UIBuildRunning respresents a finished build/update in the user interface.
+// UIBuildRunning represents a finished build/update in the user interface.
 type UIBuildTerminated struct {
 	// A non-empty string if the build failed with an error.
 	// +optional

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -652,7 +652,7 @@ func equalForBuildInvalidation(x, y interface{}) bool {
 
 		// We don't want a change to the DockerCompose Project to invalidate
 		// all individual services. We track the service-specific YAML with
-		// a seprate ServiceYAML field.
+		// a separate ServiceYAML field.
 		ignoreDockerComposeProject,
 
 		// the RegistryHosting spec includes informational fields (Help) as

--- a/pkg/openapi/zz_generated.openapi.go
+++ b/pkg/openapi/zz_generated.openapi.go
@@ -7261,7 +7261,7 @@ func schema_pkg_apis_core_v1alpha1_UIBuildRunning(ref common.ReferenceCallback) 
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "UIBuildRunning respresents an in-progress build/update in the user interface.",
+				Description: "UIBuildRunning represents an in-progress build/update in the user interface.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"startTime": {
@@ -7290,7 +7290,7 @@ func schema_pkg_apis_core_v1alpha1_UIBuildTerminated(ref common.ReferenceCallbac
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "UIBuildRunning respresents a finished build/update in the user interface.",
+				Description: "UIBuildRunning represents a finished build/update in the user interface.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"error": {
@@ -8388,7 +8388,7 @@ func schema_pkg_apis_core_v1alpha1_UIResourceTargetSpec(ref common.ReferenceCall
 					},
 					"hasLiveUpdate": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Whether the target has a live update assocated with it.",
+							Description: "Whether the target has a live update associated with it.",
 							Type:        []string{"boolean"},
 							Format:      "",
 						},

--- a/pkg/webview/view.pb.go
+++ b/pkg/webview/view.pb.go
@@ -772,7 +772,7 @@ type View struct {
 	TiltCloudTeamID           string           `protobuf:"bytes,10,opt,name=tilt_cloud_teamID,json=tiltCloudTeamID,proto3" json:"tilt_cloud_teamID,omitempty"`
 	FatalError                string           `protobuf:"bytes,11,opt,name=fatal_error,json=fatalError,proto3" json:"fatal_error,omitempty"`
 	LogList                   *LogList         `protobuf:"bytes,13,opt,name=log_list,json=logList,proto3" json:"log_list,omitempty"`
-	// Allows us to synchronize on a running Tilt intance,
+	// Allows us to synchronize on a running Tilt instance,
 	// so we can tell when Tilt restarted.
 	TiltStartTime *timestamppb.Timestamp `protobuf:"bytes,14,opt,name=tilt_start_time,json=tiltStartTime,proto3" json:"tilt_start_time,omitempty"`
 	// an identifier for the tiltfile that is running, so that the web ui can store data per tiltfile
@@ -1278,7 +1278,7 @@ type AckWebsocketRequest struct {
 
 	// The to_checkpoint on the received LogList
 	ToCheckpoint int32 `protobuf:"varint,1,opt,name=to_checkpoint,json=toCheckpoint,proto3" json:"to_checkpoint,omitempty"`
-	// Allows us to synchronize on a running Tilt intance,
+	// Allows us to synchronize on a running Tilt instance,
 	// so we can tell when we're talking to the same Tilt.
 	TiltStartTime *timestamppb.Timestamp `protobuf:"bytes,2,opt,name=tilt_start_time,json=tiltStartTime,proto3" json:"tilt_start_time,omitempty"`
 }

--- a/pkg/webview/view.proto
+++ b/pkg/webview/view.proto
@@ -197,7 +197,7 @@ message View {
 
   LogList log_list = 13;
 
-  // Allows us to synchronize on a running Tilt intance,
+  // Allows us to synchronize on a running Tilt instance,
   // so we can tell when Tilt restarted.
   google.protobuf.Timestamp tilt_start_time = 14;
 
@@ -257,7 +257,7 @@ message AckWebsocketRequest {
   // The to_checkpoint on the received LogList
   int32 to_checkpoint = 1;
 
-  // Allows us to synchronize on a running Tilt intance,
+  // Allows us to synchronize on a running Tilt instance,
   // so we can tell when we're talking to the same Tilt.
   google.protobuf.Timestamp tilt_start_time = 2;
 }

--- a/pkg/webview/view.swagger.json
+++ b/pkg/webview/view.swagger.json
@@ -1207,7 +1207,7 @@
         "tilt_start_time": {
           "type": "string",
           "format": "date-time",
-          "description": "Allows us to synchronize on a running Tilt intance,\nso we can tell when we're talking to the same Tilt."
+          "description": "Allows us to synchronize on a running Tilt instance,\nso we can tell when we're talking to the same Tilt."
         }
       },
       "description": "NOTE(nick): This is obsolete.\n\nOur websocket service has two kinds of messages:\n1) On initialization, we send down the complete view state\n2) On every change, we send down the resources that have\n   changed since the last send()."
@@ -1601,7 +1601,7 @@
         "tilt_start_time": {
           "type": "string",
           "format": "date-time",
-          "description": "Allows us to synchronize on a running Tilt intance,\nso we can tell when Tilt restarted."
+          "description": "Allows us to synchronize on a running Tilt instance,\nso we can tell when Tilt restarted."
         },
         "tiltfile_key": {
           "type": "string",

--- a/pkg/webview/view.swagger.json
+++ b/pkg/webview/view.swagger.json
@@ -606,7 +606,7 @@
           "title": "The log span where the build logs are stored in the logstore.\n+optional"
         }
       },
-      "description": "UIBuildRunning respresents an in-progress build/update in the user interface."
+      "description": "UIBuildRunning represents an in-progress build/update in the user interface."
     },
     "v1alpha1UIBuildTerminated": {
       "type": "object",
@@ -639,7 +639,7 @@
           "title": "A crash rebuild happens when Tilt live-updated a container, then\nthe pod crashed, wiping out the live-updates. Tilt does a full\nbuild+deploy to reset the pod state to what's on disk.\n+optional"
         }
       },
-      "description": "UIBuildRunning respresents a finished build/update in the user interface."
+      "description": "UIBuildRunning represents a finished build/update in the user interface."
     },
     "v1alpha1UIButton": {
       "type": "object",
@@ -1091,7 +1091,7 @@
         },
         "hasLiveUpdate": {
           "type": "boolean",
-          "title": "Whether the target has a live update assocated with it.\n+optional"
+          "title": "Whether the target has a live update associated with it.\n+optional"
         }
       },
       "description": "UIResourceTargetSpec represents the spec of a build or deploy that a resource summarizes."

--- a/web/src/AnalyticsNudge.test.tsx
+++ b/web/src/AnalyticsNudge.test.tsx
@@ -77,7 +77,7 @@ describe("AnalyticsNudge", () => {
     userEvent.click(screen.getByRole("button", { name: /I'm in/i }))
 
     await waitFor(() => {
-      expect(screen.getByTestId("optin-success")).toBeInTheDocument()
+      expect(screen.getByTestId("option-success")).toBeInTheDocument()
     })
   })
 
@@ -100,7 +100,7 @@ describe("AnalyticsNudge", () => {
     userEvent.click(screen.getByRole("button", { name: /I'm in/i }))
 
     await waitFor(() => {
-      expect(screen.getByTestId("optin-success")).toBeInTheDocument()
+      expect(screen.getByTestId("option-success")).toBeInTheDocument()
     })
 
     jest.advanceTimersByTime(NUDGE_TIMEOUT_MS)

--- a/web/src/AnalyticsNudge.tsx
+++ b/web/src/AnalyticsNudge.tsx
@@ -21,7 +21,7 @@ const nudgeElem = (): JSX.Element => {
 }
 const successOptInElem = (): JSX.Element => {
   return (
-    <p data-testid="optin-success">
+    <p data-testid="option-success">
       Thanks for helping us improve Tilt for you and everyone! (You can change
       your mind by running <code>tilt analytics opt out</code> in your
       terminal.)

--- a/web/src/HelpSearchBar.test.tsx
+++ b/web/src/HelpSearchBar.test.tsx
@@ -39,7 +39,7 @@ describe("HelpSearchBar", () => {
     expect(screen.getByRole("textbox")).toHaveValue(searchTerm)
   })
 
-  it("should open search in new tab on submision", () => {
+  it("should open search in new tab on submission", () => {
     const windowOpenSpy = jest.fn()
     window.open = windowOpenSpy
     const searchTerm = "such term"

--- a/web/src/LogStore.test.ts
+++ b/web/src/LogStore.test.ts
@@ -506,7 +506,7 @@ describe("LogStore", () => {
     expect(logLinesToString(logs.manifestLog("be"), false)).toEqual("")
   })
 
-  it("weights on recenty and length", () => {
+  it("weights on recently and length", () => {
     let logs = new LogStore()
     expect(
       logs.heaviestManifestName({

--- a/web/src/ResourceStatusSummary.tsx
+++ b/web/src/ResourceStatusSummary.tsx
@@ -304,7 +304,7 @@ export function getDocumentTitle(
   let title = `✔︎ ${healthy}/${totalEnabled} ┊ Tilt`
   if (!isSocketConnected && !isSnapshot) {
     title = "Disconnected ┊ Tilt"
-    // Use a publically-hosted favicon since Tilt is disconnected
+    // Use a publicly-hosted favicon since Tilt is disconnected
     // and it's not guaranteed that the favicon will be cached
     faviconHref = linkToTiltAsset("ico", "dashboard-favicon-gray.ico")
   } else if (unhealthy > 0) {

--- a/web/src/SidebarItemView.tsx
+++ b/web/src/SidebarItemView.tsx
@@ -71,7 +71,7 @@ export let SidebarItemBox = styled.div`
   border: 1px solid ${Color.gray40};
   color: ${Color.white};
   font-family: ${Font.monospace};
-  position: relative; /* Anchor the .isBuilding::after psuedo-element */
+  position: relative; /* Anchor the .isBuilding::after pseudo-element */
 
   &:hover {
     background-color: ${ColorRGBA(Color.gray30, ColorAlpha.translucent)};

--- a/web/src/StarredResourceBar.stories.tsx
+++ b/web/src/StarredResourceBar.stories.tsx
@@ -61,7 +61,7 @@ MixedNames.args = {
     { name: "benchmark-muxer", status: ResourceStatus.Healthy },
     { name: "benchmark-all", status: ResourceStatus.Healthy },
     { name: "recompile-storage", status: ResourceStatus.Unhealthy },
-    { name: "benchamrk-rectangle-test", status: ResourceStatus.Healthy },
+    { name: "benchmark-rectangle-test", status: ResourceStatus.Healthy },
     { name: "benchmark-storage", status: ResourceStatus.Healthy },
     { name: "(Tiltfile)", status: ResourceStatus.Pending },
     { name: "recompile-rectangle-test", status: ResourceStatus.Unhealthy },

--- a/web/src/StarredResourceBar.tsx
+++ b/web/src/StarredResourceBar.tsx
@@ -76,7 +76,7 @@ const StarredResourceRoot = styled.div`
   background-color: ${Color.gray30};
   padding-top: ${SizeUnit(0.125)};
   padding-bottom: ${SizeUnit(0.125)};
-  position: relative; // Anchor the .isBuilding::after psuedo-element
+  position: relative; // Anchor the .isBuilding::after pseudo-element
 
   &:hover {
     background-color: ${ColorRGBA(Color.gray30, ColorAlpha.translucent)};

--- a/web/src/third-party/anser/index.js
+++ b/web/src/third-party/anser/index.js
@@ -176,7 +176,7 @@ class Anser {
      * @name escapeForHtml
      * @function
      * @param {String} txt The input text.
-     * @returns {String} The escpaed HTML output.
+     * @returns {String} The escaped HTML output.
      */
     escapeForHtml (txt) {
         return txt.replace(/[&<>\"]/gm, str =>
@@ -306,7 +306,7 @@ class Anser {
      *  - `fg_truecolor` (String|null): The foreground true color (if 16m color is enabled).
      *  - `bg_truecolor` (String|null): The background true color (if 16m color is enabled).
      *  - `clearLine` (Boolean): `true` if a carriageReturn \r was fount at end of line.
-     *  - `was_processed` (Bolean): `true` if the colors were processed, `false` otherwise.
+     *  - `was_processed` (Boolean): `true` if the colors were processed, `false` otherwise.
      *  - `isEmpty` (Function): A function returning `true` if the content is empty, or `false` otherwise.
      *
      */

--- a/web/src/view.d.ts
+++ b/web/src/view.d.ts
@@ -21,7 +21,7 @@ declare namespace Proto {
     fatalError?: string;
     logList?: webviewLogList;
     /**
-     * Allows us to synchronize on a running Tilt intance,
+     * Allows us to synchronize on a running Tilt instance,
      * so we can tell when Tilt restarted.
      */
     tiltStartTime?: string;
@@ -160,7 +160,7 @@ declare namespace Proto {
   export interface webviewAckWebsocketRequest {
     toCheckpoint?: number;
     /**
-     * Allows us to synchronize on a running Tilt intance,
+     * Allows us to synchronize on a running Tilt instance,
      * so we can tell when we're talking to the same Tilt.
      */
     tiltStartTime?: string;


### PR DESCRIPTION
Fix typos using typos.

https://github.com/crate-ci/typos

```console
$ typos --version
typos-cli 1.15.7
```

_typos.toml

```toml
[default.extend-words]
servantes = "servantes"
Servantes = "Servantes"
O_WRONLY = "O_WRONLY"
WRONLY = "WRONLY"
whosAGoodBoy = "whosAGoodBoy"
supercede = "supercede"
dne = "dne"
Anser = "Anser"

[default.extend-identifiers]
whosAGoodBoy = "whosAGoodBoy"
whosAGoodCat = "whosAGoodCat"
KubernetesApplys = "KubernetesApplys"
KubernetesDiscoverys = "KubernetesDiscoverys"
ANDed = "ANDed"
TestEncodeYAMLNonYAMLable = "TestEncodeYAMLNonYAMLable"

[files]
extend-exclude = ["vendor/*", "pkg/apis/core/v1alpha1/generated.pb.go", "pkg/snapshot/testdata/snapshot.json", "pkg/snapshot/testdata/snapshot_new.json", "internal/hud/webview/testdata/snapshot.json", "pkg/apis/core/v1alpha1/generated.proto"]
```

```console
$ typos --no-check-filenames -w
```

And I fixed some typos manually.

1. fix a typo "intance" to "instance" b48b26153c5c91006df5665425eb7f5f3b6cd474
2. fix typo "exected" to "expected" fb06417471faa0fcb5f5c67e79b5e5dc4ad298e2