### PR TITLE
web: show the build tooltip over the build bar, not just the status icon

### DIFF
--- a/web/src/OverviewTableStatus.tsx
+++ b/web/src/OverviewTableStatus.tsx
@@ -14,7 +14,7 @@ import { formatBuildDuration } from "./time"
 import Tooltip from "./Tooltip"
 import { ResourceStatus } from "./types"
 
-const StatusMsg = styled.span`
+const StatusMsg = styled.div`
   text-overflow: ellipsis;
   overflow: hidden;
 `

--- a/web/src/SidebarIcon.test.tsx
+++ b/web/src/SidebarIcon.test.tsx
@@ -16,9 +16,7 @@ describe("SidebarIcon", () => {
   test.each(cases)(
     "renders with the correct classes - %s",
     (className, status) => {
-      render(
-        <SidebarIcon status={status} alertCount={0} tooltipText={"help"} />
-      )
+      render(<SidebarIcon status={status} tooltipText={"help"} />)
 
       const iconWrapper = screen.getByTitle("help")
       expect(iconWrapper).toHaveClass(className)
@@ -29,7 +27,6 @@ describe("SidebarIcon", () => {
     render(
       <SidebarIcon
         status={ResourceStatus.Unhealthy}
-        alertCount={0}
         tooltipText="What a tip!"
       />
     )

--- a/web/src/SidebarIcon.tsx
+++ b/web/src/SidebarIcon.tsx
@@ -17,8 +17,7 @@ import { ResourceStatus } from "./types"
 
 type SidebarIconProps = {
   status: ResourceStatus
-  alertCount: number
-  tooltipText: string
+  tooltipText?: string
 }
 
 let SidebarIconRoot = styled.div`
@@ -91,17 +90,8 @@ export default class SidebarIcon extends PureComponent<SidebarIconProps> {
       icon = <CheckmarkSmallSvg role="presentation" />
     }
 
-    if (!this.props.tooltipText.length) {
-      return (
-        <SidebarIconRoot
-          className={`${ClassNameFromResourceStatus(this.props.status)}`}
-        >
-          {icon}
-        </SidebarIconRoot>
-      )
-    }
     return (
-      <Tooltip title={this.props.tooltipText}>
+      <Tooltip title={this.props.tooltipText || ""}>
         <SidebarIconRoot
           className={`${ClassNameFromResourceStatus(this.props.status)}`}
         >

--- a/web/src/SidebarItemView.tsx
+++ b/web/src/SidebarItemView.tsx
@@ -27,6 +27,7 @@ import { formatBuildDuration, isZeroTime } from "./time"
 import { timeAgoFormatter } from "./timeFormatters"
 import { startBuild } from "./trigger"
 import { ResourceStatus, ResourceView } from "./types"
+import Tooltip from "./Tooltip"
 
 export const SidebarItemRoot = styled.li`
   & + & {
@@ -367,7 +368,6 @@ export function EnabledSidebarItemView(props: SidebarItemViewProps) {
             <SidebarIcon
               tooltipText={runtimeTooltipText(item.runtimeStatus)}
               status={item.runtimeStatus}
-              alertCount={item.runtimeAlertCount}
             />
             <SidebarItemName name={item.name} />
             <SidebarItemTimeAgo>
@@ -385,14 +385,12 @@ export function EnabledSidebarItemView(props: SidebarItemViewProps) {
               stopBuildButton={item.stopBuildButton}
             />
           </SidebarItemRuntimeBox>
-          <SidebarItemBuildBox>
-            <SidebarIcon
-              tooltipText={buildTooltipText(item.buildStatus, item.hold)}
-              status={item.buildStatus}
-              alertCount={item.buildAlertCount}
-            />
-            <SidebarItemText>{buildStatusText(item)}</SidebarItemText>
-          </SidebarItemBuildBox>
+          <Tooltip title={buildTooltipText(item.buildStatus, item.hold)}>
+            <SidebarItemBuildBox>
+              <SidebarIcon status={item.buildStatus} />
+              <SidebarItemText>{buildStatusText(item)}</SidebarItemText>
+            </SidebarItemBuildBox>
+          </Tooltip>
         </SidebarItemInnerBox>
       </SidebarItemBox>
     </SidebarItemRoot>


### PR DESCRIPTION

the tooltip often shows the names of resources that the build is waiting on, so it's useful to make the hover target a bit bigger.

![Screenshot from 2023-07-05 16-57-40](https://github.com/tilt-dev/tilt/assets/278641/fc8394c1-35dd-428c-8761-d8a3395bdc72)