### PR TITLE
watch: ignore the watched dir on all platforms

### DIFF
--- a/internal/watch/notify_test.go
+++ b/internal/watch/notify_test.go
@@ -196,6 +196,25 @@ func TestWatchNonExistentPath(t *testing.T) {
 	f.assertEvents(path)
 }
 
+func TestWatchDirectoryAndTouchIt(t *testing.T) {
+	f := newNotifyFixture(t)
+
+	cTime := time.Now()
+	root := f.TempDir("root")
+	path := filepath.Join(root, "change")
+	a := filepath.Join(path, "a.txt")
+	f.WriteFile(a, "a")
+
+	f.watch(path)
+	f.fsync()
+
+	err := os.Chtimes(path, cTime, time.Now())
+	assert.NoError(t, err)
+	err = os.Chmod(path, 0770)
+	assert.NoError(t, err)
+	f.assertEvents()
+}
+
 func TestWatchNonExistentPathDoesNotFireSiblingEvent(t *testing.T) {
 	f := newNotifyFixture(t)
 

--- a/internal/watch/watcher_darwin.go
+++ b/internal/watch/watcher_darwin.go
@@ -38,9 +38,9 @@ func (d *darwinNotify) loop() {
 				e.Path = filepath.Join("/", e.Path)
 
 				_, isPathWereWatching := d.pathsWereWatching[e.Path]
-				if e.Flags&fsevents.ItemIsDir == fsevents.ItemIsDir && e.Flags&fsevents.ItemCreated == fsevents.ItemCreated && isPathWereWatching {
-					// This is the first create for the path that we're watching. We always get exactly one of these
-					// even after we get the HistoryDone event. Skip it.
+				if e.Flags&fsevents.ItemIsDir == fsevents.ItemIsDir && isPathWereWatching {
+					// For consistency with Linux and Windows, don't fire any events
+					// for directories that we're watching -- only their contents.
 					continue
 				}
 


### PR DESCRIPTION
before this change, we would ignore on linux and windows, but emit events on linux

fixes https://github.com/tilt-dev/tilt/issues/6160