### PR TITLE
web: improve handling for links with escape codes in the middle

### DIFF
--- a/web/src/OverviewLogPane.stories.tsx
+++ b/web/src/OverviewLogPane.stories.tsx
@@ -132,6 +132,7 @@ export const StyledLines = () => {
     "Link: https://tilt.dev/\n",
     'Escaped Link: <a href="https://tilt.dev/" >Tilt</a>\n',
     'Escaped Button: <button onClick="alert(\\"you are p0wned\\")" >Tilt</button>\n',
+    "[32m➜[39m  [1mLocal[22m:   [36mhttp://localhost:[1m5173[22m/[39m\n",
   ]
   appendLines(logStore, "fe", ...lines)
   return (

--- a/web/src/third-party/anser/index.js
+++ b/web/src/third-party/anser/index.js
@@ -197,7 +197,7 @@ class Anser {
      * @returns {String} The HTML output containing link elements.
      */
     linkify (txt) {
-        return txt.replace(/(https?:\/\/[^\s]+)/gm, str => `<a href="${str}">${str}</a>`);
+        return txt.replace(/(https?:\/\/[^\s<>"]+)/gm, str => `<a href="${str}">${str}</a>`);
     }
 
     /**


### PR DESCRIPTION
this still isn't perfect, but at least avoids over-escaping html

a better fix would probably to move to a better ansi-to-html library.

fixes https://github.com/tilt-dev/tilt/issues/6170