### PR TITLE
docker: use errgroup for build session error handling

### DIFF
--- a/internal/docker/exploding.go
+++ b/internal/docker/exploding.go
@@ -7,6 +7,7 @@ import (
 	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/tilt-dev/tilt/internal/container"
 	"github.com/tilt-dev/tilt/pkg/model"
@@ -65,7 +66,7 @@ func (c explodingClient) ImagePull(_ context.Context, _ reference.Named) (refere
 func (c explodingClient) ImagePush(ctx context.Context, ref reference.NamedTagged) (io.ReadCloser, error) {
 	return nil, c.err
 }
-func (c explodingClient) ImageBuild(ctx context.Context, buildContext io.Reader, options BuildOptions) (types.ImageBuildResponse, error) {
+func (c explodingClient) ImageBuild(ctx context.Context, g *errgroup.Group, buildContext io.Reader, options BuildOptions) (types.ImageBuildResponse, error) {
 	return types.ImageBuildResponse{}, c.err
 }
 func (c explodingClient) ImageTag(ctx context.Context, source, target string) error {

--- a/internal/docker/fake_client.go
+++ b/internal/docker/fake_client.go
@@ -13,6 +13,7 @@ import (
 	"github.com/docker/go-units"
 	"github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/api/types"
@@ -299,7 +300,7 @@ func (c *FakeClient) ImagePush(ctx context.Context, ref reference.NamedTagged) (
 	return NewFakeDockerResponse(c.PushOutput), nil
 }
 
-func (c *FakeClient) ImageBuild(ctx context.Context, buildContext io.Reader, options BuildOptions) (types.ImageBuildResponse, error) {
+func (c *FakeClient) ImageBuild(ctx context.Context, g *errgroup.Group, buildContext io.Reader, options BuildOptions) (types.ImageBuildResponse, error) {
 	c.BuildCount++
 	c.BuildOptions = options
 

--- a/internal/docker/switch.go
+++ b/internal/docker/switch.go
@@ -8,6 +8,7 @@ import (
 	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/tilt-dev/tilt/internal/container"
 	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
@@ -100,8 +101,8 @@ func (c *switchCli) ImagePull(ctx context.Context, ref reference.Named) (referen
 func (c *switchCli) ImagePush(ctx context.Context, ref reference.NamedTagged) (io.ReadCloser, error) {
 	return c.client(ctx).ImagePush(ctx, ref)
 }
-func (c *switchCli) ImageBuild(ctx context.Context, buildContext io.Reader, options BuildOptions) (types.ImageBuildResponse, error) {
-	return c.client(ctx).ImageBuild(ctx, buildContext, options)
+func (c *switchCli) ImageBuild(ctx context.Context, g *errgroup.Group, buildContext io.Reader, options BuildOptions) (types.ImageBuildResponse, error) {
+	return c.client(ctx).ImageBuild(ctx, g, buildContext, options)
 }
 func (c *switchCli) ImageTag(ctx context.Context, source, target string) error {
 	return c.client(ctx).ImageTag(ctx, source, target)


### PR DESCRIPTION
we really should convert this code to vendor buildx directly like Compose does, but for now this makes the implementations closer together.