### PR TITLE
Hide duplicate exit code log message

### DIFF
--- a/internal/controllers/core/cmd/execer.go
+++ b/internal/controllers/core/cmd/execer.go
@@ -225,7 +225,7 @@ func (e *processExecer) processRun(ctx context.Context, cmd model.Cmd, w io.Writ
 			status = Error
 			exitCode = ee.ExitCode()
 			reason = err.Error()
-			logger.Get(ctx).Errorf("%s exited with exit code %d", cmd.String(), ee.ExitCode())
+			logger.Get(ctx).Debugf("%s exited with exit code %d", cmd.String(), ee.ExitCode())
 		} else {
 			status = Error
 			exitCode = 1


### PR DESCRIPTION
Implementation of proposal 2 from https://github.com/tilt-dev/tilt/issues/6192

Changing a log message from `Error` to `Debug` to prevent it from being printed twice.

I tested this with the following resource:
* `local` - does not appear to run this code path, the error output from a failure has not changed
* `local_resource` - was printing the error twice, and now only prints it once
* `custom_build` -  was printing the error twice, and now only prints it once
* `k8s_custom_deploy` - still prints the full command and stdout, not sure if it changed

The call graph looks something like this:

```mermaid
flowchart TD
cmd.Controller.Reconcile --> cmd.Controller.runInternal
cmd.Controller.ForceRun --> cmd.Controller.runInternal
cmd.Controller.runInternal --> 
processExecer.Start --> processExecer.processRun
```

`runInternal` handles the status from `processRun` by calling `processStatuses`, which updates `CmdStatus.Terminated`. 

Is there anything else I can do to track down which other functions use the `cmd.Controller` ? So far it seems like everything still prints the result correctly.