### PR TITLE
cloud: use GET instead of POST for fetching latest tilt version

### DIFF
--- a/internal/cloud/cloud_status_manager.go
+++ b/internal/cloud/cloud_status_manager.go
@@ -81,7 +81,7 @@ func (c *CloudStatusManager) CheckStatus(ctx context.Context, st store.RStore, c
 	u.Path = "/api/whoami"
 
 	body := &bytes.Buffer{}
-	req, err := http.NewRequest("POST", u.String(), body)
+	req, err := http.NewRequest("GET", u.String(), body)
 	if err != nil {
 		logger.Get(ctx).Debugf("error making whoami request: %v", err)
 		c.error()


### PR DESCRIPTION
this should make it slightly easier to replace this endpoint with cloudfront