### PR TITLE
web: collapse sections by default

### DIFF
--- a/web/src/OverviewSidebarOptions.tsx
+++ b/web/src/OverviewSidebarOptions.tsx
@@ -162,6 +162,7 @@ export function OverviewSidebarOptions(props: { items?: SidebarItem[] }) {
         />
         <div>
           <ExpandButton
+            groups={groups}
             disabled={!displayResourceGroups}
             analyticsType={AnalyticsType.Detail}
           />

--- a/web/src/OverviewTable.test.tsx
+++ b/web/src/OverviewTable.test.tsx
@@ -512,6 +512,13 @@ describe("overview table with groups", () => {
     })
 
     it("is collapsed when an expanded resource group summary is clicked on", () => {
+      // Because groups are collapsed by default, click on it once to get it
+      // into an expanded state for testing
+      const initialGroup = groups[0]
+      expect(initialGroup.classList.contains("Mui-expanded")).toBe(false)
+
+      userEvent.click(initialGroup.querySelector('[role="button"]') as Element)
+
       const group = groups[0]
       expect(group.classList.contains("Mui-expanded")).toBe(true)
 
@@ -525,13 +532,6 @@ describe("overview table with groups", () => {
     })
 
     it("is expanded when a collapsed resource group summary is clicked on", () => {
-      // Because groups are expanded by default, click on it once to get it
-      // into a collapsed state for testing
-      const initialGroup = groups[0]
-      expect(initialGroup.classList.contains("Mui-expanded")).toBe(true)
-
-      userEvent.click(initialGroup.querySelector('[role="button"]') as Element)
-
       const group = getResourceGroups()[0]
       expect(group.classList.contains("Mui-expanded")).toBe(false)
 

--- a/web/src/OverviewTableDisplayOptions.tsx
+++ b/web/src/OverviewTableDisplayOptions.tsx
@@ -109,6 +109,7 @@ export function OverviewTableDisplayOptions(props: {
         label="Show disabled resources"
       />
       <ExpandButton
+        groups={groups}
         disabled={!displayResourceGroups}
         analyticsType={AnalyticsType.Grid}
       />

--- a/web/src/ResourceGroupsContext.test.tsx
+++ b/web/src/ResourceGroupsContext.test.tsx
@@ -98,7 +98,7 @@ describe("ResourceGroupsContext", () => {
       expect(labelState()).toBe(JSON.stringify({ expanded: false }))
     })
 
-    it("sets expanded to `false` if a group isn't saved yet and is toggled", () => {
+    it("sets expanded to `true` if a group isn't saved yet and is toggled", () => {
       wrapper = renderContainer(
         <ResourceGroupsContextProvider>
           <TestConsumer labelName="a-non-existent-group" />
@@ -106,7 +106,7 @@ describe("ResourceGroupsContext", () => {
       )
       clickButton()
 
-      expect(labelState()).toBe(JSON.stringify({ expanded: false }))
+      expect(labelState()).toBe(JSON.stringify({ expanded: true }))
     })
 
     it("makes an analytics call with the right payload", () => {

--- a/web/src/resourceListOptionsButtons.tsx
+++ b/web/src/resourceListOptionsButtons.tsx
@@ -46,20 +46,24 @@ const CollapseButtonRoot = styled(InstrumentedButton)`
 const analyticsTags = { type: AnalyticsType.Detail }
 
 export function ExpandButton(props: {
+  groups: string[]
   disabled: boolean
   analyticsType: AnalyticsType
 }) {
   let { expandAll } = useResourceGroups()
-  let { analyticsType } = props
+  let { analyticsType, groups } = props
   let analyticsTags = useMemo(() => {
     return { type: analyticsType }
   }, [analyticsType])
+  let onClick = useCallback(() => {
+    expandAll(groups)
+  }, [groups, expandAll])
 
   return (
     <ExpandButtonRoot
       title={"Expand All"}
       variant={"text"}
-      onClick={expandAll}
+      onClick={onClick}
       analyticsName={"ui.web.expandAllGroups"}
       analyticsTags={analyticsTags}
       disabled={props.disabled}


### PR DESCRIPTION
If you have a lot of resources, tilt let's you group them by label.

By default, all groups are expanded.
But presumably if you added labels, it's because the resource list is getting unwieldy! Let's try collapsing by default and see if people complain.

https://github.com/tilt-dev/tilt/issues/6201