### PR TITLE
ci: switch to M1 runner for macOS builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,6 +130,7 @@ jobs:
           only_for_branches: master
 
   build-macos:
+    resource_class: macos.m1.medium.gen1
     macos:
       xcode: "13.4.1"
 
@@ -137,7 +138,7 @@ jobs:
       - checkout
       - go/install:
           version: "1.20"
-      - run: curl -fsSL "https://github.com/gotestyourself/gotestsum/releases/download/v1.7.0/gotestsum_1.7.0_darwin_amd64.tar.gz" | sudo tar -xz -C /usr/local/bin gotestsum
+      - run: curl -fsSL "https://github.com/gotestyourself/gotestsum/releases/download/v1.11.0/gotestsum_1.11.0_darwin_arm64.tar.gz" | sudo tar -xz -C /usr/local/bin gotestsum
       # We can't run the container tests on macos because nested
       # VMs don't work on circleci.
       - run: mkdir -p test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,7 +132,7 @@ jobs:
   build-macos:
     resource_class: macos.m1.medium.gen1
     macos:
-      xcode: "13.4.1"
+      xcode: "15.0.0"
 
     steps:
       - checkout


### PR DESCRIPTION
Per the banner in the CircleCI dashboard leading to: https://discuss.circleci.com/t/macos-intel-support-deprecation-in-january-2024/48718

Intel runners are going away, so opting into the M1/medium runner now, which will be the default as the others are retired.

Note that this is only used to verify compilation and run OS-specific integration tests (file system watching) via Go, so everything should continue working 🤞