### PR TITLE
cli: add a --namespace flag for ci and down

### DIFF
--- a/internal/cli/ci.go
+++ b/internal/cli/ci.go
@@ -48,6 +48,7 @@ See blog post for additional information: https://blog.tilt.dev/2020/04/16/how-t
 	addDevServerFlags(cmd)
 	addTiltfileFlag(cmd, &c.fileName)
 	addKubeContextFlag(cmd)
+	addNamespaceFlag(cmd)
 
 	cmd.Flags().BoolVar(&logActionsFlag, "logactions", false, "log all actions and state changes")
 	cmd.Flags().Lookup("logactions").Hidden = true

--- a/internal/cli/down.go
+++ b/internal/cli/down.go
@@ -59,6 +59,7 @@ See https://docs.tilt.dev/tiltfile_config.html for examples.
 
 	addTiltfileFlag(cmd, &c.fileName)
 	addKubeContextFlag(cmd)
+	addNamespaceFlag(cmd)
 	cmd.Flags().BoolVar(&c.deleteNamespaces, "delete-namespaces", false, "delete namespaces defined in the Tiltfile (by default, don't)")
 
 	return cmd


### PR DESCRIPTION
this just matches the behavior of `tilt up --namespace`

fixes https://github.com/tilt-dev/tilt/issues/6258