### PR TITLE
dockercompose: support compose profiles

### DIFF
--- a/internal/dockercompose/client.go
+++ b/internal/dockercompose/client.go
@@ -291,6 +291,7 @@ func composeProjectOptions(modelProj v1alpha1.DockerComposeProject, env []string
 		compose.WithName(modelProj.Name),
 		compose.WithResolvedPaths(true),
 		compose.WithEnv(env),
+		compose.WithProfiles(modelProj.Profiles),
 	)
 	if modelProj.EnvFile != "" {
 		allProjectOptions = append(allProjectOptions, compose.WithEnvFiles(modelProj.EnvFile))
@@ -328,7 +329,7 @@ func (c *cmdDCClient) loadProjectCLI(ctx context.Context, proj v1alpha1.DockerCo
 			},
 		},
 		// no environment specified because the CLI call will already have resolved all variables
-	}, dcLoaderOption(proj.Name))
+	}, dcLoaderOption(proj.Name), loader.WithProfiles(proj.Profiles))
 }
 
 // dcLoaderOption is used when loading Docker Compose projects via the CLI and fallback and for tests.

--- a/internal/tiltfile/api/__init__.py
+++ b/internal/tiltfile/api/__init__.py
@@ -245,7 +245,7 @@ def docker_build(ref: str,
   """
   pass
 
-def docker_compose(configPaths: Union[str, Blob, List[Union[str, Blob]]], env_file: str = None, project_name: str = "") -> None:
+def docker_compose(configPaths: Union[str, Blob, List[Union[str, Blob]]], env_file: str = None, project_name: str = "", profiles: Union[str, List[str]] = []) -> None:
   """Run containers with Docker Compose.
 
   Tilt will read your Docker Compose YAML and separate out the services.
@@ -283,6 +283,7 @@ def docker_compose(configPaths: Union[str, Blob, List[Union[str, Blob]]], env_fi
     project_name: The Docker Compose project name. If unspecified, uses either the
       name of the directory containing the first compose file, or, in the case of
       inline YAML, the current Tiltfile's directory name.
+    profiles: List of Docker Compose profiles to use.
   """
 
 

--- a/internal/tiltfile/docker_compose.go
+++ b/internal/tiltfile/docker_compose.go
@@ -57,12 +57,14 @@ func (dcm dcResourceMap) ServiceCount() int {
 func (s *tiltfileState) dockerCompose(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	var configPaths starlark.Value
 	var projectName string
+	var profiles value.StringOrStringList
 	envFile := value.NewLocalPathUnpacker(thread)
 
 	err := s.unpackArgs(fn.Name(), args, kwargs,
 		"configPaths", &configPaths,
 		"env_file?", &envFile,
 		"project_name?", &projectName,
+		"profiles?", &profiles,
 	)
 	if err != nil {
 		return nil, err
@@ -75,8 +77,9 @@ func (s *tiltfileState) dockerCompose(thread *starlark.Thread, fn *starlark.Buil
 	}
 
 	project := v1alpha1.DockerComposeProject{
-		Name:    projectName,
-		EnvFile: envFile.Value,
+		Name:     projectName,
+		EnvFile:  envFile.Value,
+		Profiles: profiles.Values,
 	}
 
 	if project.EnvFile != "" {

--- a/pkg/apis/core/v1alpha1/dockercomposeservice_types.go
+++ b/pkg/apis/core/v1alpha1/dockercomposeservice_types.go
@@ -216,6 +216,12 @@ type DockerComposeProject struct {
 
 	// Path to an env file to use. Passed to docker-compose as `--env-file FILE`.
 	EnvFile string `json:"envFile,omitempty" protobuf:"bytes,5,opt,name=envFile"`
+
+	// Optional docker-compose profiles to use.
+	//
+	// Services with defined profiles will only be included if their profile matches
+	// one in this list.
+	Profiles []string `json:"profiles,omitempty" protobuf:"bytes,6,rep,name=profiles"`
 }
 
 // State of a standalone container in Docker.

--- a/pkg/apis/core/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/core/v1alpha1/zz_generated.deepcopy.go
@@ -961,6 +961,11 @@ func (in *DockerComposeProject) DeepCopyInto(out *DockerComposeProject) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.Profiles != nil {
+		in, out := &in.Profiles, &out.Profiles
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/openapi/zz_generated.openapi.go
+++ b/pkg/openapi/zz_generated.openapi.go
@@ -1935,6 +1935,21 @@ func schema_pkg_apis_core_v1alpha1_DockerComposeProject(ref common.ReferenceCall
 							Format:      "",
 						},
 					},
+					"profiles": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Optional docker-compose profiles to use.\n\nServices with defined profiles will only be included if their profile matches one in this list.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
+									},
+								},
+							},
+						},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
Adds support for compose profiles to both provide a solution for https://github.com/tilt-dev/tilt/issues/6250 and to improve the integration with docker compose.

The PR which changed the previous functionality from compose-go between `v1.6.0` and `v1.18.4` is most likely https://github.com/compose-spec/compose-go/pull/359.