### PR TITLE
More verbose timeout reason

### DIFF
--- a/internal/controllers/core/session/reconciler_test.go
+++ b/internal/controllers/core/session/reconciler_test.go
@@ -173,7 +173,7 @@ func TestExitControlCI_Timeout(t *testing.T) {
 
 	f.clock.Advance(20 * time.Second)
 	f.MustReconcile(sessionKey)
-	f.requireDoneWithError("Timeout after 1m0s")
+	f.requireDoneWithError("Timeout after 1m0s: 2 resources waiting (fe:runtime waiting-for-pod,fe:update waiting-for-cluster)")
 }
 
 func TestExitControlCI_PodRunningContainerError(t *testing.T) {


### PR DESCRIPTION
Related to #6231

## Background

We've been trying out a new setup where we pre-create environments ahead of time using `tilt up`. Then we pass the environment to `tilt ci` for CI runs. That's been working well, but we've noticed a few Timeout failures where every service in the snapshot has a `RuntimeStatus: ok`. 

It seems like there may be something stuck that isn't visible from the `UIResources` stored in the snapshot.

## Changes

This PR attempts to expose more detail about why `tilt ci` reached the timeout. I'll do some testing of this internally using this patch to see if we can isolate the problem a bit further.

This message could be too verbose in some cases. Maybe instead of printing all 3 categories it only includes the first category that includes resources? Any retrying resources, then not ready resource,  then finally waiting?
