### PR TITLE
scripts: add build-js to release process

### DIFF
--- a/scripts/release-ci.sh
+++ b/scripts/release-ci.sh
@@ -39,6 +39,7 @@ git config --global user.name "Tilt Dev"
 
 VERSION=$(git describe --abbrev=0 --tags)
 
+CI=false make build-js
 goreleaser --clean
 
 ./scripts/release-update-tilt-repo.sh "$VERSION"


### PR DESCRIPTION
this got accidentally removed
in https://github.com/tilt-dev/tilt/pull/6241
when i removed the publish step