### PR TITLE
k8s: remove container runtime loading from the boot sequence

### DIFF
--- a/internal/build/test_utils.go
+++ b/internal/build/test_utils.go
@@ -49,7 +49,9 @@ func newDockerBuildFixture(t testing.TB) *dockerBuildFixture {
 	ctx, _, _ := testutils.CtxAndAnalyticsForTest()
 	env := clusterid.ProductGKE
 
-	dEnv := docker.ProvideClusterEnv(ctx, docker.RealClientCreator{}, "gke", env, wmcontainer.RuntimeDocker, k8s.FakeMinikube{})
+	kCli := k8s.NewFakeK8sClient(t)
+	kCli.Runtime = wmcontainer.RuntimeDocker
+	dEnv := docker.ProvideClusterEnv(ctx, docker.RealClientCreator{}, "gke", env, kCli, k8s.FakeMinikube{})
 	dCli := docker.NewDockerClient(ctx, docker.Env(dEnv))
 	_, ok := dCli.(*docker.Cli)
 	// If it wasn't an actual Docker client, it's an exploding client

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -137,7 +137,7 @@ func (c *doctorCmd) run(ctx context.Context, args []string) error {
 	ns, err := wireNamespace(ctx)
 	printField("Namespace", ns, err)
 
-	runtime, err := wireRuntime(ctx)
+	runtime, err := containerRuntime(ctx)
 	printField("Container Runtime", runtime, err)
 
 	kVersion, err := wireK8sVersion(ctx)
@@ -166,6 +166,14 @@ func (c *doctorCmd) run(ctx context.Context, args []string) error {
 	fmt.Printf("- Repo: %s\n", a.GitRepoHash())
 
 	return nil
+}
+
+func containerRuntime(ctx context.Context) (container.Runtime, error) {
+	kClient, err := wireK8sClient(ctx)
+	if err != nil {
+		return "", err
+	}
+	return kClient.ContainerRuntime(ctx), nil
 }
 
 func clusterLocalRegistryDisplay(ctx context.Context) (string, error) {

--- a/internal/cli/wire.go
+++ b/internal/cli/wire.go
@@ -26,7 +26,6 @@ import (
 	"github.com/tilt-dev/tilt/internal/build"
 	"github.com/tilt-dev/tilt/internal/cloud"
 	"github.com/tilt-dev/tilt/internal/cloud/cloudurl"
-	"github.com/tilt-dev/tilt/internal/container"
 	"github.com/tilt-dev/tilt/internal/controllers"
 	"github.com/tilt-dev/tilt/internal/controllers/core/kubernetesdiscovery"
 	"github.com/tilt-dev/tilt/internal/docker"
@@ -69,7 +68,6 @@ var K8sWireSet = wire.NewSet(
 	k8s.ProvideRESTConfig,
 	k8s.ProvidePortForwardClient,
 	k8s.ProvideConfigNamespace,
-	k8s.ProvideContainerRuntime,
 	k8s.ProvideServerVersion,
 	k8s.ProvideK8sClient,
 	ProvideKubeContextOverride,
@@ -244,14 +242,6 @@ func wireNamespace(ctx context.Context) (k8s.Namespace, error) {
 
 func wireClusterName(ctx context.Context) (k8s.ClusterName, error) {
 	wire.Build(K8sWireSet)
-	return "", nil
-}
-
-func wireRuntime(ctx context.Context) (container.Runtime, error) {
-	wire.Build(
-		K8sWireSet,
-		k8s.ProvideMinikubeClient,
-	)
 	return "", nil
 }
 

--- a/internal/docker/client_integration_test.go
+++ b/internal/docker/client_integration_test.go
@@ -18,7 +18,10 @@ import (
 
 func TestCli_Run(t *testing.T) {
 	ctx, _, _ := testutils.CtxAndAnalyticsForTest()
-	dEnv := ProvideClusterEnv(ctx, RealClientCreator{}, "gke", clusterid.ProductGKE, wmcontainer.RuntimeDocker, k8s.FakeMinikube{})
+	k8sClient := k8s.NewFakeK8sClient(t)
+	k8sClient.Runtime = wmcontainer.RuntimeDocker
+
+	dEnv := ProvideClusterEnv(ctx, RealClientCreator{}, "gke", clusterid.ProductGKE, k8sClient, k8s.FakeMinikube{})
 	cli := NewDockerClient(ctx, Env(dEnv))
 	defer func() {
 		// release any idle connections to avoid out of file errors if running test many times

--- a/internal/docker/client_test.go
+++ b/internal/docker/client_test.go
@@ -403,7 +403,9 @@ func TestProvideClusterProduct(t *testing.T) {
 
 			mkClient := k8s.FakeMinikube{DockerEnvMap: c.mkEnv, FakeVersion: minikubeV}
 			kubeContext := k8s.KubeContext(fmt.Sprintf("%s-me", c.env))
-			cluster := ProvideClusterEnv(context.Background(), fakeClientCreator{}, kubeContext, c.env, c.runtime, mkClient)
+			kCli := k8s.NewFakeK8sClient(t)
+			kCli.Runtime = c.runtime
+			cluster := ProvideClusterEnv(context.Background(), fakeClientCreator{}, kubeContext, c.env, kCli, mkClient)
 			assert.Equal(t, c.expectedCluster, Env(cluster))
 
 			local := ProvideLocalEnv(context.Background(), fakeClientCreator{}, kubeContext, c.env, cluster)

--- a/internal/k8s/runtime.go
+++ b/internal/k8s/runtime.go
@@ -60,7 +60,3 @@ func (r *runtimeAsync) Runtime(ctx context.Context) container.Runtime {
 func (c K8sClient) ContainerRuntime(ctx context.Context) container.Runtime {
 	return c.runtimeAsync.Runtime(ctx)
 }
-
-func ProvideContainerRuntime(ctx context.Context, kCli Client) container.Runtime {
-	return kCli.ContainerRuntime(ctx)
-}


### PR DESCRIPTION
this should make tilt faster to load when connecting to a remote or non-responsive k8s cluster

fixes https://github.com/tilt-dev/tilt/issues/6265