### PR TITLE
test: use `t.Setenv` to set env vars in tests

### DIFF
--- a/integration/analytics_test.go
+++ b/integration/analytics_test.go
@@ -6,7 +6,6 @@ package integration
 import (
 	"context"
 	"fmt"
-	"os"
 	"testing"
 	"time"
 
@@ -57,40 +56,9 @@ func (af *analyticsFixture) TearDown() {
 	}
 }
 
-type envVarValue struct {
-	name  string
-	isSet bool
-	val   string
-}
-
-func saveEnvVar(name string) envVarValue {
-	val, isSet := os.LookupEnv(name)
-	return envVarValue{
-		name:  name,
-		isSet: isSet,
-		val:   val,
-	}
-}
-
-func restoreEnvVar(v envVarValue) error {
-	if !v.isSet {
-		return os.Unsetenv(v.name)
-	} else {
-		return os.Setenv(v.name, v.val)
-	}
-}
-
 func (af *analyticsFixture) SetOpt(opt analytics.Opt) {
-	oldVal := saveEnvVar(WindmillDirEnvVarName)
-	err := os.Setenv(WindmillDirEnvVarName, af.tempDir.Path())
-	if err != nil {
-		af.t.Fatal(err)
-	}
-	err = analytics.SetOpt(opt)
-	if err != nil {
-		af.t.Fatal(err)
-	}
-	err = restoreEnvVar(oldVal)
+	af.t.Setenv(WindmillDirEnvVarName, af.tempDir.Path())
+	err := analytics.SetOpt(opt)
 	if err != nil {
 		af.t.Fatal(err)
 	}

--- a/integration/dc_fixture_test.go
+++ b/integration/dc_fixture_test.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"os"
 	"os/exec"
 	"strings"
 	"testing"
@@ -106,10 +105,9 @@ func (f *dcFixture) CurlUntil(ctx context.Context, service string, url string, e
 
 func doV1V2(t *testing.T, body func(t *testing.T)) {
 	t.Run("docker-compose-v1", func(t *testing.T) {
-		os.Setenv("TILT_DOCKER_COMPOSE_CMD", "docker-compose-v1")
+		t.Setenv("TILT_DOCKER_COMPOSE_CMD", "docker-compose-v1")
 		fmt.Println("Running with docker-compose-v1")
 		body(t)
-		os.Unsetenv("TILT_DOCKER_COMPOSE_CMD")
 	})
 
 	cmd := exec.Command("docker-compose", "version")

--- a/internal/cli/args_test.go
+++ b/internal/cli/args_test.go
@@ -52,7 +52,6 @@ func TestArgsNewValue(t *testing.T) {
 	require.Equal(t, []analytics.CountEvent{
 		{Name: "cmd.args", Tags: map[string]string{"set": "true"}, N: 1},
 	}, f.analytics.Counts)
-
 }
 
 func TestArgsClearAndNewValue(t *testing.T) {
@@ -135,24 +134,18 @@ func TestArgsEdit(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			f := newServerFixture(t)
 
-			origEditor := os.Getenv("EDITOR")
 			contents := tc.contents
 			if runtime.GOOS == "windows" {
 				contents = strings.ReplaceAll(contents, "\n", "\r\n")
 			}
-			err := os.Setenv("EDITOR", editorForString(contents))
-			require.NoError(t, err)
-			defer func() {
-				err := os.Setenv("EDITOR", origEditor)
-				require.NoError(t, err)
-			}()
+			t.Setenv("EDITOR", editorForString(contents))
 
 			originalArgs := []string{"foo", "bar"}
 			createTiltfile(f, originalArgs)
 
 			cmd := newArgsCmd(genericclioptions.NewTestIOStreamsDiscard())
 			c := cmd.register()
-			err = c.Flags().Parse(nil)
+			err := c.Flags().Parse(nil)
 			require.NoError(t, err)
 			err = cmd.run(f.ctx, c.Flags().Args())
 			if tc.expectedError != "" {

--- a/internal/cli/edit_test.go
+++ b/internal/cli/edit_test.go
@@ -35,10 +35,7 @@ func TestEdit(t *testing.T) {
 	cmd := newEditCmd(streams)
 	cmd.register()
 
-	oldEditor := os.Getenv("EDITOR")
-	defer os.Setenv("EDITOR", oldEditor)
-
-	os.Setenv("EDITOR", "true")
+	t.Setenv("EDITOR", "true")
 	err = cmd.run(f.ctx, []string{"cmd", "my-sleep"})
 	require.NoError(t, err)
 

--- a/internal/cli/get_test.go
+++ b/internal/cli/get_test.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"context"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -89,7 +88,7 @@ func newServerFixture(t *testing.T) *serverFixture {
 	client, err := ctrlclient.New(cfg.GenericConfig.LoopbackClientConfig, ctrlclient.Options{Scheme: scheme})
 	require.NoError(t, err)
 
-	_ = os.Setenv("TILT_CONFIG", filepath.Join(f.Path(), "config"))
+	t.Setenv("TILT_CONFIG", filepath.Join(f.Path(), "config"))
 
 	origPort := defaultWebPort
 	defaultWebPort = webPort
@@ -111,6 +110,5 @@ func newServerFixture(t *testing.T) *serverFixture {
 func (f *serverFixture) TearDown() {
 	f.hudsc.TearDown(f.ctx)
 	f.cancel()
-	os.Unsetenv("TILT_CONFIG")
 	defaultWebPort = f.origPort
 }

--- a/internal/docker/client_test.go
+++ b/internal/docker/client_test.go
@@ -59,8 +59,7 @@ func TestProvideBuilderVersion(t *testing.T) {
 
 	for i, c := range cases {
 		t.Run(fmt.Sprintf("Case%d", i), func(t *testing.T) {
-			os.Setenv("DOCKER_BUILDKIT", c.bkEnv)
-			defer os.Setenv("DOCKER_BUILDKIT", "")
+			t.Setenv("DOCKER_BUILDKIT", c.bkEnv)
 
 			v, err := getDockerBuilderVersion(
 				types.Version{APIVersion: c.v}, Env{})
@@ -384,17 +383,9 @@ func TestProvideClusterProduct(t *testing.T) {
 
 	for i, c := range cases {
 		t.Run(fmt.Sprintf("Case%d", i), func(t *testing.T) {
-			origEnv := map[string]string{}
 			for _, k := range envVars {
-				origEnv[k] = os.Getenv(k)
-				os.Setenv(k, c.osEnv[k])
+				t.Setenv(k, c.osEnv[k])
 			}
-
-			defer func() {
-				for k := range c.osEnv {
-					os.Setenv(k, origEnv[k])
-				}
-			}()
 
 			minikubeV := c.minikubeV
 			if minikubeV == "" {

--- a/internal/tiltfile/os/os_test.go
+++ b/internal/tiltfile/os/os_test.go
@@ -17,8 +17,7 @@ import (
 
 func TestEnviron(t *testing.T) {
 	f := NewFixture(t)
-	os.Setenv("FAKE_ENV_VARIABLE", "fakeValue")
-	defer os.Unsetenv("FAKE_ENV_VARIABLE")
+	t.Setenv("FAKE_ENV_VARIABLE", "fakeValue")
 
 	f.File("Tiltfile", `
 print(os.environ['FAKE_ENV_VARIABLE'])
@@ -32,8 +31,7 @@ print(os.environ.get('FAKE_ENV_VARIABLE'))
 
 func TestGetenv(t *testing.T) {
 	f := NewFixture(t)
-	os.Setenv("FAKE_ENV_VARIABLE", "fakeValue")
-	defer os.Unsetenv("FAKE_ENV_VARIABLE")
+	t.Setenv("FAKE_ENV_VARIABLE", "fakeValue")
 
 	f.File("Tiltfile", `
 print(os.getenv('FAKE_ENV_VARIABLE'))
@@ -48,8 +46,7 @@ print(os.getenv('FAKE_ENV_VARIABLE_UNSET', 'bar'))
 
 func TestPutenv(t *testing.T) {
 	f := NewFixture(t)
-	os.Setenv("FAKE_ENV_VARIABLE", "fakeValue")
-	defer os.Unsetenv("FAKE_ENV_VARIABLE")
+	t.Setenv("FAKE_ENV_VARIABLE", "fakeValue")
 
 	f.File("Tiltfile", `
 os.putenv('FAKE_ENV_VARIABLE', 'fakeValue2')
@@ -64,8 +61,7 @@ print(os.getenv('FAKE_ENV_VARIABLE'))
 
 func TestPutenvByDict(t *testing.T) {
 	f := NewFixture(t)
-	os.Setenv("FAKE_ENV_VARIABLE", "fakeValue")
-	defer os.Unsetenv("FAKE_ENV_VARIABLE")
+	t.Setenv("FAKE_ENV_VARIABLE", "fakeValue")
 
 	f.File("Tiltfile", `
 os.environ['FAKE_ENV_VARIABLE'] = 'fakeValueByDict'
@@ -80,8 +76,7 @@ print(os.getenv('FAKE_ENV_VARIABLE'))
 
 func TestUnsetenv(t *testing.T) {
 	f := NewFixture(t)
-	os.Setenv("FAKE_ENV_VARIABLE", "fakeValue")
-	defer os.Unsetenv("FAKE_ENV_VARIABLE")
+	t.Setenv("FAKE_ENV_VARIABLE", "fakeValue")
 
 	f.File("Tiltfile", `
 os.unsetenv('FAKE_ENV_VARIABLE')
@@ -98,8 +93,7 @@ print(os.getenv('FAKE_ENV_VARIABLE', 'unused'))
 
 func TestUnsetenvAsDict(t *testing.T) {
 	f := NewFixture(t)
-	os.Setenv("FAKE_ENV_VARIABLE", "fakeValue")
-	defer os.Unsetenv("FAKE_ENV_VARIABLE")
+	t.Setenv("FAKE_ENV_VARIABLE", "fakeValue")
 
 	f.File("Tiltfile", `
 os.environ.pop('FAKE_ENV_VARIABLE')

--- a/internal/watch/notify_test.go
+++ b/internal/watch/notify_test.go
@@ -23,17 +23,20 @@ import (
 // behavior.
 
 func TestWindowsBufferSize(t *testing.T) {
-	orig := os.Getenv(WindowsBufferSizeEnvVar)
-	defer os.Setenv(WindowsBufferSizeEnvVar, orig)
+	t.Run("empty", func(t *testing.T) {
+		t.Setenv(WindowsBufferSizeEnvVar, "")
+		require.Equal(t, defaultBufferSize, DesiredWindowsBufferSize())
+	})
 
-	os.Setenv(WindowsBufferSizeEnvVar, "")
-	assert.Equal(t, defaultBufferSize, DesiredWindowsBufferSize())
+	t.Run("non-integer", func(t *testing.T) {
+		t.Setenv(WindowsBufferSizeEnvVar, "a")
+		require.Equal(t, defaultBufferSize, DesiredWindowsBufferSize())
+	})
 
-	os.Setenv(WindowsBufferSizeEnvVar, "a")
-	assert.Equal(t, defaultBufferSize, DesiredWindowsBufferSize())
-
-	os.Setenv(WindowsBufferSizeEnvVar, "10")
-	assert.Equal(t, 10, DesiredWindowsBufferSize())
+	t.Run("integer", func(t *testing.T) {
+		t.Setenv(WindowsBufferSizeEnvVar, "10")
+		require.Equal(t, 10, DesiredWindowsBufferSize())
+	})
 }
 
 func TestNoEvents(t *testing.T) {


### PR DESCRIPTION
Starting from Go 1.17, we can use `t.Setenv` to set environment variable in test. The environment variable is automatically restored to its original value when the test and all its subtests complete. This ensures that each test does not start with leftover environment variables from previous completed tests.

Reference: https://pkg.go.dev/testing#T.Setenv

```go
func TestFoo(t *testing.T) {
	// before
	os.Setenv(key, "new value")
	defer os.Unsetenv(key)
	
	// after
	t.Setenv(key, "new value")
}
```