### PR TITLE
Improve output of multi-line stderr from local command

### DIFF
--- a/internal/tiltfile/files.go
+++ b/internal/tiltfile/files.go
@@ -122,11 +122,7 @@ func (s *tiltfileState) execLocalCmd(t *starlark.Thread, cmd model.Cmd, options 
 			// getting output 2x
 
 			stdout, stderr := stdoutBuf.String(), stderrBuf.String()
-			if strings.Contains(stdout, "\n") || strings.Contains(stderr, "\n") {
-				fmt.Fprintf(&errMessage, "\nstdout:\n%v\nstderr:\n%v\n", stdout, stderr)
-			} else {
-				fmt.Fprintf(&errMessage, "\nstdout: %q\nstderr: %q\n", stdout, stderr)
-			}
+			fmt.Fprintf(&errMessage, "\nstdout:\n%v\nstderr:\n%v\n", stdout, stderr)
 		}
 
 		return "", errors.New(errMessage.String())

--- a/internal/tiltfile/files.go
+++ b/internal/tiltfile/files.go
@@ -120,8 +120,13 @@ func (s *tiltfileState) execLocalCmd(t *starlark.Thread, cmd model.Cmd, options 
 		if !options.logOutput {
 			// if we already logged the output, don't include it in the error message to prevent it from
 			// getting output 2x
-			errMessage.WriteString(fmt.Sprintf("\nstdout: %q\nstderr: %q",
-				stdoutBuf.String(), stderrBuf.String()))
+
+			stdout, stderr := stdoutBuf.String(), stderrBuf.String()
+			if strings.Contains(stdout, "\n") || strings.Contains(stderr, "\n") {
+				fmt.Fprintf(&errMessage, "\nstdout:\n%v\nstderr:\n%v\n", stdout, stderr)
+			} else {
+				fmt.Fprintf(&errMessage, "\nstdout: %q\nstderr: %q\n", stdout, stderr)
+			}
 		}
 
 		return "", errors.New(errMessage.String())


### PR DESCRIPTION
### Background

We have a few [local](https://docs.tilt.dev/api.html#api.local) commands that run from the `Tiltfile` before starting resources.  We use these commands to output kubernetes yaml that is passed to [k8s_yaml](https://docs.tilt.dev/api.html#api.k8s_yaml). These commands have rather verbose stdout (thousands of lines of yaml), so it's important for us to run these with `quiet = True`. When one of these commands fail, the stderr is also relatively verbose, it will contain multiple lines to help the user understand why it failed and where the problem occurred. 

### Problem

We've noticed that it can be difficult to read these multi-line error messages because they are printed using `%q`. This escapes backslashes and replaces newlines with `\n`. For example:

```
stderr: "\nFailed to do some thing:\n at src/myproject/dir/file:2:40\n - reason one\n - reason two\nAlso failed this other thing\n at src/myproject/dir/other:2:40\n - more reasons\n"
```

### Changes in this PR

This PR changes the format string to use `%v` for this output so that it reads better.

```
Error in local: command "./script.sh" failed.
error: exit status 1
stdout:
...
stderr:
Failed to do some thing:
 at src/myproject/dir/file:2:40
 - reason one
 - reason two
Also failed this other thing
 at src/myproject/dir/other:2:40
 - more reasons
```

Does this seem reasonable? Any concerns about where this wouldn't work well?