### PR TITLE
fix docker_compose with both profiles and dependencies failing to start (#6322)

### DIFF
--- a/internal/dockercompose/client.go
+++ b/internal/dockercompose/client.go
@@ -94,6 +94,10 @@ func (c *cmdDCClient) projectArgs(p v1alpha1.DockerComposeProject) []string {
 		result = append(result, "-f", cp)
 	}
 
+	for _, p := range p.Profiles {
+		result = append(result, "--profile", p)
+	}
+
 	return result
 }
 


### PR DESCRIPTION
This solves the issue I reported in #6322 by adding `--profile ___` to the docker compose up command