### PR TITLE
dockercompose: fix dc_resource new_name parameter causing depends_on problems (#6325)

### DIFF
--- a/internal/tiltfile/docker_compose.go
+++ b/internal/tiltfile/docker_compose.go
@@ -10,6 +10,8 @@ import (
 	"strconv"
 	"strings"
 
+	"golang.org/x/exp/slices"
+
 	"github.com/compose-spec/compose-go/consts"
 	"github.com/compose-spec/compose-go/loader"
 	"github.com/compose-spec/compose-go/types"
@@ -359,7 +361,9 @@ func (s *tiltfileState) renameDCService(projectName, name, newName string, svc *
 			index = i
 		} else if sd, ok := services[n].ServiceConfig.DependsOn[name]; ok {
 			services[n].ServiceConfig.DependsOn[newName] = sd
-			services[n].Options.resourceDeps = []string{newName}
+			if rdIndex := slices.Index(services[n].Options.resourceDeps, name); rdIndex != -1 {
+				services[n].Options.resourceDeps[rdIndex] = newName
+			}
 			delete(services[n].ServiceConfig.DependsOn, name)
 		}
 	}


### PR DESCRIPTION
This solves the issue I reported in #6325 by modifying the loop in the `renameDCService` function to also patch `s.dc[projectName].services[n].ServiceConfig.DependsOn[name]` and `s.dc[projectName].services[n].Options.resourceDeps[name]`

I also made some temporary local variables because there was a lot of repeated `s.dc[projectName]` and `s.dc[projectName].services` and it was hurting readability, especially after I added the changes to the loop