### PR TITLE
dockercompose: Add ability to suppress automatic links in UI (#6270)

### DIFF
--- a/internal/store/engine_state.go
+++ b/internal/store/engine_state.go
@@ -860,7 +860,7 @@ func ManifestTargetEndpoints(mt *ManifestTarget) (endpoints []model.Link) {
 	if mt.Manifest.IsDC() {
 		hostPorts := make(map[int32]bool)
 		publishedPorts := mt.Manifest.DockerComposeTarget().PublishedPorts()
-		inferLinks := mt.Manifest.DockerComposeTarget().InferLinks
+		inferLinks := mt.Manifest.DockerComposeTarget().InferLinks()
 		for _, p := range publishedPorts {
 			if p == 0 || hostPorts[int32(p)] {
 				continue

--- a/internal/store/engine_state.go
+++ b/internal/store/engine_state.go
@@ -860,12 +860,15 @@ func ManifestTargetEndpoints(mt *ManifestTarget) (endpoints []model.Link) {
 	if mt.Manifest.IsDC() {
 		hostPorts := make(map[int32]bool)
 		publishedPorts := mt.Manifest.DockerComposeTarget().PublishedPorts()
+		inferLinks := mt.Manifest.DockerComposeTarget().InferLinks
 		for _, p := range publishedPorts {
 			if p == 0 || hostPorts[int32(p)] {
 				continue
 			}
 			hostPorts[int32(p)] = true
-			endpoints = append(endpoints, model.MustNewLink(fmt.Sprintf("http://localhost:%d/", p), ""))
+			if inferLinks {
+				endpoints = append(endpoints, model.MustNewLink(fmt.Sprintf("http://localhost:%d/", p), ""))
+			}
 		}
 
 		for _, binding := range mt.State.DCRuntimeState().Ports {
@@ -876,7 +879,9 @@ func ManifestTargetEndpoints(mt *ManifestTarget) (endpoints []model.Link) {
 				continue
 			}
 			hostPorts[p] = true
-			endpoints = append(endpoints, model.MustNewLink(fmt.Sprintf("http://localhost:%d/", p), ""))
+			if inferLinks {
+				endpoints = append(endpoints, model.MustNewLink(fmt.Sprintf("http://localhost:%d/", p), ""))
+			}
 		}
 
 		endpoints = append(endpoints, mt.Manifest.DockerComposeTarget().Links...)

--- a/internal/tiltfile/api/__init__.py
+++ b/internal/tiltfile/api/__init__.py
@@ -435,7 +435,8 @@ def dc_resource(name: str,
                 labels: Union[str, List[str]] = [],
                 auto_init: bool = True,
                 project_name: str = "",
-                new_name: str = "") -> None:
+                new_name: str = "",
+                infer_links: bool = True) -> None:
   """Configures the Docker Compose resource of the given name. Note: Tilt does an amount of resource configuration
   for you(for more info, see `Tiltfile Concepts: Resources <tiltfile_concepts.html#resources>`_); you only need
   to invoke this function if you want to configure your resource beyond what Tilt does automatically.
@@ -454,6 +455,7 @@ def dc_resource(name: str,
     project_name: The Docker Compose project name to match the corresponding project loaded by
       ``docker_compose``, if necessary for disambiguation.
     new_name: If non-empty, will be used as the new name for this resource.
+    infer_links: whether to include the default localhost links. Defaults to ``True``. If ``False``, only links explicitly provided via the links argument will be displayed.
   """
 
   pass

--- a/internal/tiltfile/docker_compose.go
+++ b/internal/tiltfile/docker_compose.go
@@ -212,6 +212,7 @@ func (s *tiltfileState) dcResource(thread *starlark.Thread, fn *starlark.Builtin
 	var imageVal starlark.Value
 	var triggerMode triggerMode
 	var resourceDepsVal starlark.Sequence
+	var inferLinks bool
 	var links links.LinkList
 	var labels value.LabelSet
 	var autoInit = value.Optional[starlark.Bool]{Value: true}
@@ -223,6 +224,7 @@ func (s *tiltfileState) dcResource(thread *starlark.Thread, fn *starlark.Builtin
 		"image?", &imageVal,
 		"trigger_mode?", &triggerMode,
 		"resource_deps?", &resourceDepsVal,
+		"infer_links?", &inferLinks,
 		"links?", &links,
 		"labels?", &labels,
 		"auto_init?", &autoInit,
@@ -267,6 +269,7 @@ func (s *tiltfileState) dcResource(thread *starlark.Thread, fn *starlark.Builtin
 		options.TriggerMode = triggerMode
 	}
 
+	options.InferLinks = inferLinks
 	options.Links = append(options.Links, links.Links...)
 
 	for key, val := range labels.Values {
@@ -383,6 +386,7 @@ type dcService struct {
 type dcResourceOptions struct {
 	imageRefFromUser reference.Named
 	TriggerMode      triggerMode
+	InferLinks       bool
 	Links            []model.Link
 	AutoInit         value.Optional[starlark.Bool]
 
@@ -497,6 +501,7 @@ func (s *tiltfileState) dcServiceToManifest(service *dcService, dcSet *dcResourc
 			Project: dcSet.Project,
 		},
 		ServiceYAML: string(service.ServiceYAML),
+		InferLinks:  options.InferLinks,
 		Links:       options.Links,
 	}.WithImageMapDeps(model.FilterLiveUpdateOnly(service.ImageMapDeps, iTargets)).
 		WithPublishedPorts(service.PublishedPorts)

--- a/pkg/model/docker_compose_target.go
+++ b/pkg/model/docker_compose_target.go
@@ -16,8 +16,12 @@ type DockerComposeTarget struct {
 
 	publishedPorts []int
 
-	InferLinks bool
-	Links      []Link
+	inferLinks struct {
+		IsSet bool
+		Value bool
+	}
+
+	Links []Link
 }
 
 // TODO(nick): This is a temporary hack until we figure out how we want
@@ -48,6 +52,20 @@ func (t DockerComposeTarget) DependencyIDs() []TargetID {
 
 func (t DockerComposeTarget) PublishedPorts() []int {
 	return append([]int{}, t.publishedPorts...)
+}
+
+func (t DockerComposeTarget) InferLinks() bool {
+	if t.inferLinks.IsSet {
+		return t.inferLinks.Value
+	} else {
+		return true
+	}
+}
+
+func (t DockerComposeTarget) WithInferLinks(inferLinks bool) DockerComposeTarget {
+	t.inferLinks.IsSet = true
+	t.inferLinks.Value = inferLinks
+	return t
 }
 
 func (t DockerComposeTarget) WithLinks(links []Link) DockerComposeTarget {

--- a/pkg/model/docker_compose_target.go
+++ b/pkg/model/docker_compose_target.go
@@ -17,7 +17,7 @@ type DockerComposeTarget struct {
 	publishedPorts []int
 
 	InferLinks bool
-	Links []Link
+	Links      []Link
 }
 
 // TODO(nick): This is a temporary hack until we figure out how we want

--- a/pkg/model/docker_compose_target.go
+++ b/pkg/model/docker_compose_target.go
@@ -16,6 +16,7 @@ type DockerComposeTarget struct {
 
 	publishedPorts []int
 
+	InferLinks bool
 	Links []Link
 }
 


### PR DESCRIPTION
There was a suggestion in #6270 to suppress the "http://localhost:${port}" links that get added automatically when using docker_compose. I liked the idea, so I took a swing at implementing this.