### PR TITLE
docker: remove ping from boot sequence

### DIFF
--- a/internal/build/docker_builder.go
+++ b/internal/build/docker_builder.go
@@ -232,8 +232,13 @@ func (d *DockerBuilder) buildToDigest(ctx context.Context, spec v1alpha1.DockerI
 		return "", nil, fmt.Errorf("reading build context: %v", err)
 	}
 
+	builderVersion, err := d.dCli.BuilderVersion(ctx)
+	if err != nil {
+		return "", nil, err
+	}
+
 	// Buildkit allows us to use a fs sync server instead of uploading up-front.
-	useFSSync := allowBuildkit && d.dCli.BuilderVersion() == types.BuilderBuildKit
+	useFSSync := allowBuildkit && builderVersion == types.BuilderBuildKit
 	if !useFSSync {
 		pipeReader, pipeWriter := io.Pipe()
 		w := NewProgressWriter(ctx, pipeWriter)

--- a/internal/cli/docker.go
+++ b/internal/cli/docker.go
@@ -46,7 +46,10 @@ func (c *dockerCmd) run(ctx context.Context, args []string) error {
 	}
 
 	dockerEnv := client.Env()
-	builder := client.BuilderVersion()
+	builder, err := client.BuilderVersion(ctx)
+	if err != nil {
+		return errors.Wrap(err, "Failed to get Docker builder")
+	}
 
 	buildkitEnv := "DOCKER_BUILDKIT=0"
 	if builder == types.BuilderBuildKit {

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -71,12 +71,12 @@ func (c *doctorCmd) run(ctx context.Context, args []string) error {
 		}
 		printField("Host", host, nil)
 
-		version := clusterDocker.ServerVersion()
-		printField("Server Version", version.Version, nil)
-		printField("API Version", version.APIVersion, nil)
+		version, err := clusterDocker.ServerVersion(ctx)
+		printField("Server Version", version.Version, err)
+		printField("API Version", version.APIVersion, err)
 
-		builderVersion := clusterDocker.BuilderVersion()
-		printField("Builder", builderVersion, nil)
+		builderVersion, err := clusterDocker.BuilderVersion(ctx)
+		printField("Builder", builderVersion, err)
 	}
 
 	if multipleClients {
@@ -93,12 +93,12 @@ func (c *doctorCmd) run(ctx context.Context, args []string) error {
 			}
 			printField("Host", host, nil)
 
-			version := localDocker.ServerVersion()
-			printField("Server Version", version.Version, nil)
-			printField("Version", version.APIVersion, nil)
+			version, err := localDocker.ServerVersion(ctx)
+			printField("Server Version", version.Version, err)
+			printField("Version", version.APIVersion, err)
 
-			builderVersion := localDocker.BuilderVersion()
-			printField("Builder", builderVersion, nil)
+			builderVersion, err := localDocker.BuilderVersion(ctx)
+			printField("Builder", builderVersion, err)
 		}
 	}
 

--- a/internal/controllers/core/cluster/reconciler.go
+++ b/internal/controllers/core/cluster/reconciler.go
@@ -262,7 +262,11 @@ func (r *Reconciler) readKubernetesArch(ctx context.Context, client k8s.Client) 
 // Reads the arch from a Docker cluster, or "unknown" if we can't
 // figure out the architecture.
 func (r *Reconciler) readDockerArch(ctx context.Context, client docker.Client) string {
-	arch := client.ServerVersion().Arch
+	serverVersion, err := client.ServerVersion(ctx)
+	if err != nil {
+		return ArchUnknown
+	}
+	arch := serverVersion.Arch
 	if arch == "" {
 		return ArchUnknown
 	}
@@ -432,8 +436,10 @@ func (r *Reconciler) populateDockerMetadata(ctx context.Context, conn *connectio
 	}
 
 	if conn.serverVersion == "" {
-		versionInfo := conn.dockerClient.ServerVersion()
-		conn.serverVersion = versionInfo.Version
+		versionInfo, err := conn.dockerClient.ServerVersion(ctx)
+		if err == nil {
+			conn.serverVersion = versionInfo.Version
+		}
 	}
 }
 

--- a/internal/docker/exploding.go
+++ b/internal/docker/exploding.go
@@ -36,11 +36,11 @@ func (c explodingClient) CheckConnected() error {
 func (c explodingClient) Env() Env {
 	return Env{}
 }
-func (c explodingClient) BuilderVersion() types.BuilderVersion {
-	return types.BuilderVersion("")
+func (c explodingClient) BuilderVersion(ctx context.Context) (types.BuilderVersion, error) {
+	return types.BuilderV1, c.err
 }
-func (c explodingClient) ServerVersion() types.Version {
-	return types.Version{}
+func (c explodingClient) ServerVersion(ctx context.Context) (types.Version, error) {
+	return types.Version{}, c.err
 }
 func (c explodingClient) ContainerLogs(ctx context.Context, containerID string, options types.ContainerLogsOptions) (io.ReadCloser, error) {
 	return nil, c.err

--- a/internal/docker/fake_client.go
+++ b/internal/docker/fake_client.go
@@ -167,14 +167,14 @@ func (c *FakeClient) CheckConnected() error {
 func (c *FakeClient) Env() Env {
 	return c.FakeEnv
 }
-func (c *FakeClient) BuilderVersion() types.BuilderVersion {
-	return types.BuilderV1
+func (c *FakeClient) BuilderVersion(ctx context.Context) (types.BuilderVersion, error) {
+	return types.BuilderV1, nil
 }
-func (c *FakeClient) ServerVersion() types.Version {
+func (c *FakeClient) ServerVersion(ctx context.Context) (types.Version, error) {
 	return types.Version{
 		Arch:    "amd64",
 		Version: "20.10.11",
-	}
+	}, nil
 }
 
 func (c *FakeClient) SetExecError(err error) {

--- a/internal/docker/switch.go
+++ b/internal/docker/switch.go
@@ -71,11 +71,11 @@ func (c *switchCli) CheckConnected() error {
 func (c *switchCli) Env() Env {
 	return c.client(context.Background()).Env()
 }
-func (c *switchCli) BuilderVersion() types.BuilderVersion {
-	return c.client(context.Background()).BuilderVersion()
+func (c *switchCli) BuilderVersion(ctx context.Context) (types.BuilderVersion, error) {
+	return c.client(ctx).BuilderVersion(ctx)
 }
-func (c *switchCli) ServerVersion() types.Version {
-	return c.client(context.Background()).ServerVersion()
+func (c *switchCli) ServerVersion(ctx context.Context) (types.Version, error) {
+	return c.client(ctx).ServerVersion(ctx)
 }
 func (c *switchCli) ContainerLogs(ctx context.Context, containerID string, options types.ContainerLogsOptions) (io.ReadCloser, error) {
 	return c.client(ctx).ContainerLogs(ctx, containerID, options)


### PR DESCRIPTION
this ensures that if the Docker daemon
is dead or not responding, it doesn't
block tiltfile execution.

now that we have reconcilers that are
checking the cluster status, i think this
is safer than it used to be.

fixes https://github.com/tilt-dev/tilt/issues/5841

Signed-off-by: Nick Santos <nick.santos@docker.com>
