### PR TITLE
tiltfile: make docker compose dependency order deterministic

### DIFF
--- a/internal/tiltfile/docker_compose.go
+++ b/internal/tiltfile/docker_compose.go
@@ -454,9 +454,8 @@ func dockerComposeConfigToService(dcrs *dcResourceSet, projectName string, svcCo
 		dcrs.resOptions[svcConfig.Name] = options
 	}
 
-	for _, dep := range svcConfig.GetDependencies() {
-		options.resourceDeps = sliceutils.AppendWithoutDupes(options.resourceDeps, dep)
-	}
+	options.resourceDeps = sliceutils.DedupedAndSorted(
+		append(options.resourceDeps, svcConfig.GetDependencies()...))
 
 	svc := dcService{
 		Name:               svcConfig.Name,

--- a/internal/tiltfile/docker_compose_test.go
+++ b/internal/tiltfile/docker_compose_test.go
@@ -39,8 +39,20 @@ services:
 
 	services := f.parse(output)
 	if assert.Len(t, services, 6) {
-		for i, name := range []string{"f", "e", "d", "c", "b", "a"} {
+		serviceOrder := []string{"f", "e", "d", "c", "b", "a"}
+		for i, name := range serviceOrder {
 			assert.Equal(t, name, services[i].Name)
+		}
+		depOrder := [][]string{
+			[]string{},
+			[]string{"f"},
+			[]string{"e", "f"},
+			[]string{"d", "e", "f"},
+			[]string{"c"},
+			[]string{"b"},
+		}
+		for i, deps := range depOrder {
+			assert.Equal(t, deps, services[i].Options.resourceDeps)
 		}
 	}
 }


### PR DESCRIPTION
i don't think this affects anything in practice!
But it mostly helps ensure tests are deterministic.

Signed-off-by: Nick Santos <nick.santos@docker.com>
