### PR TITLE
circleci: upgrade compose to 2.25

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -7,7 +7,7 @@ RUN curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-c
     && chmod +x /usr/local/bin/docker-compose-v1
 
 # NOTE: cimg/go already includes Docker Compose v2, but it's not always up-to-date
-ARG COMPOSE_V2_VERSION="2.24.5"
+ARG COMPOSE_V2_VERSION="2.25.0"
 RUN mkdir -p "${HOME}/.docker/cli-plugins" \
     && curl -sSL "https://github.com/docker/compose/releases/download/v${COMPOSE_V2_VERSION}/docker-compose-linux-$(uname -m)" -o "${HOME}/.docker/cli-plugins/docker-compose" \
     && chmod +x "${HOME}/.docker/cli-plugins/docker-compose" \

--- a/.circleci/Dockerfile.integration
+++ b/.circleci/Dockerfile.integration
@@ -3,19 +3,18 @@ FROM cimg/go:1.21-node
 USER root
 
 # Install dependencies from OS package manager sources
-RUN apt update && apt install -y --no-install-recommends apt-transport-https \
-  && curl -fsS https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - \
-  && touch /etc/apt/sources.list.d/kubernetes.list \
-  && echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | tee -a /etc/apt/sources.list.d/kubernetes.list \
-  && apt update \
-  && apt install -y --no-install-recommends \
+RUN apt update && apt install -y --no-install-recommends \
     ca-certificates \
     jq \
-    kubectl \
     liblz4-tool \
     rsync \
     socat \
-  && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/*
+
+# Install kubectl
+RUN curl -sSL -o /usr/local/bin/kubectl "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" \
+    && chmod +x /usr/local/bin/kubectl \
+    && kubectl version --client
 
 # Install docker
 # Adapted from https://github.com/circleci/circleci-images/blob/staging/shared/images/Dockerfile-basic.template
@@ -39,7 +38,7 @@ RUN curl -fL "https://github.com/docker/compose/releases/download/${DOCKER_COMPO
   && docker-compose-v1 version
 
 # docker-compose v2
-ARG DOCKER_COMPOSE_V2_VERSION=v2.24.5
+ARG DOCKER_COMPOSE_V2_VERSION=v2.25.0
 RUN curl -fL "https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_V2_VERSION}/docker-compose-$(uname -s | tr '[A-Z]' '[a-z]')-$(uname -m)" -o /usr/local/bin/docker-compose \
   && chmod a+x /usr/local/bin/docker-compose \
   && docker-compose version

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
   build-linux:
     resource_class: medium+
     docker:
-      - image: docker/tilt-ci@sha256:dc3b3adf081a326a0b5a036e2490acecb1643412f0bdbe0e6ed5ce13521b7f93
+      - image: docker/tilt-ci@sha256:f75cdf45493ed211e052b49ab019616d9cae8ec7dc232aed1cfba583299e4da7
     # apiserver code generation scripts require being in GOPATH
     working_directory: /home/circleci/go/src/github.com/tilt-dev/tilt
 
@@ -50,7 +50,7 @@ jobs:
 
   check-docs:
     docker:
-      - image: docker/tilt-ci@sha256:dc3b3adf081a326a0b5a036e2490acecb1643412f0bdbe0e6ed5ce13521b7f93
+      - image: docker/tilt-ci@sha256:f75cdf45493ed211e052b49ab019616d9cae8ec7dc232aed1cfba583299e4da7
     steps:
       - checkout
       - setup_remote_docker
@@ -100,7 +100,7 @@ jobs:
   build-integration:
     resource_class: medium+
     docker:
-      - image: docker/tilt-integration-ci@sha256:b90db4d6acee12436e2e407737d3fc177a81d3e2dd3934e4054e1f19b0a2cc1c
+      - image: docker/tilt-integration-ci@sha256:ecb852844519c18dac9256105c4b388301ba11e4845062a7b054e2fa6ae9992b
     steps:
       - checkout
       - run: echo 'export PATH=/go/bin:$PATH' >> $BASH_ENV


### PR DESCRIPTION
compose 2.24 had some network flakyness
problems; our ci is also having network
flakyness problems; i'm hoping this will
fix them.

Signed-off-by: Nick Santos <nick.santos@docker.com>
