### PR TITLE
feat(extensions): support for nested extensions

### DIFF
--- a/pkg/apis/identifiers.go
+++ b/pkg/apis/identifiers.go
@@ -19,8 +19,6 @@ const MaxNameLength = validation.DNS1123SubdomainMaxLength
 
 var invalidLabelCharacters = regexp.MustCompile("[^-A-Za-z0-9_.]")
 
-var invalidPathCharacters = regexp.MustCompile(`[` + strings.Join(path.NameMayNotContain, "") + `]`)
-
 type KeyableObject interface {
 	GetName() string
 	GetNamespace() string

--- a/pkg/apis/identifiers.go
+++ b/pkg/apis/identifiers.go
@@ -3,6 +3,7 @@ package apis
 import (
 	"encoding/hex"
 	"hash/fnv"
+	"net/url"
 	"regexp"
 	"strings"
 
@@ -51,6 +52,7 @@ func SanitizeLabel(name string) string {
 // SanitizeName ensures a value is suitable for usage as an apiserver identifier.
 func SanitizeName(name string) string {
 	sanitized := name
+
 	if len(path.IsValidPathSegmentName(name)) != 0 {
 		for _, invalidName := range path.NameMayNotBe {
 			if name == invalidName {
@@ -58,8 +60,10 @@ func SanitizeName(name string) string {
 				return strings.ReplaceAll(name, ".", "_")
 			}
 		}
-		sanitized = invalidPathCharacters.ReplaceAllString(sanitized, "_")
+
+		sanitized = url.QueryEscape(sanitized)
 	}
+
 	if len(sanitized) > MaxNameLength {
 		var sb strings.Builder
 		sb.Grow(MaxNameLength)


### PR DESCRIPTION
This patch introduces support for nested extensions. You can load a nested extension by supplying the child path in the extension module name at load time. This makes it simpler to namespace your extension without having to define multiple extensions or import every symbol into the main extension.

For instance, given an extension repo like such:

```
- tilt-lib
  - bazel
    - Tiltfile
    - watch
        - Tiltfile
  - helm
    - ...
```

You can load symbols from `tilt-lib/bazel/watch` via:

```
v1alpha1.extension_repo(name='custom', url='git://host/repo')
v1alpha1.extension(name='bazel', repo_name='custom', repo_path='tilt-lib/bazel')

load("ext://bazel/watch", "watch_files")
```

To take it further, given the same extension repo, you could:

```
v1alpha1.extension_repo(name='internal', url='git://host/repo')
v1alpha1.extension(name='internal', repo_name='internal', repo_path='tilt-lib')

load("ext://internal/bazel/watch", "watch_files")
load("ext://internal/helm/...", "...")
```