### PR TITLE
tiltfile: explicitly mark echo_off as optional

### DIFF
--- a/internal/tiltfile/live_update.go
+++ b/internal/tiltfile/live_update.go
@@ -169,7 +169,7 @@ func (s *tiltfileState) liveUpdateRun(thread *starlark.Thread, fn *starlark.Buil
 	if err := s.unpackArgs(fn.Name(), args, kwargs,
 		"cmd", &commandVal,
 		"trigger?", &triggers,
-		"echo_off", &echoOff); err != nil {
+		"echo_off?", &echoOff); err != nil {
 		return nil, err
 	}
 

--- a/internal/tiltfile/live_update_test.go
+++ b/internal/tiltfile/live_update_test.go
@@ -284,6 +284,7 @@ func TestLiveUpdateRunEchoOff(t *testing.T) {
 		{"echoOff True", `echo_off=True`, true},
 		{"echoOff False", `echo_off=False`, false},
 		{"echoOff default", ``, false},
+		{"echoOff default", `[]`, false},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			f := newFixture(t)


### PR DESCRIPTION
fixes https://github.com/tilt-dev/tilt/issues/6369

i think there's an underlying starlark bug here,
since it's supposed to be marking this as optional
implicitly, and the enforcement of optionality
seems to be buggy.
