### PR TITLE
procutil: use setsid instead of setpgid

### DIFF
--- a/pkg/procutil/procutil_unix.go
+++ b/pkg/procutil/procutil_unix.go
@@ -10,7 +10,7 @@ import (
 )
 
 func SetOptNewProcessGroup(attrs *syscall.SysProcAttr) {
-	attrs.Setpgid = true
+	attrs.Setsid = true
 }
 
 func KillProcessGroup(cmd *exec.Cmd) {


### PR DESCRIPTION
this starts to stretch my knowledge
of low-level unix process apis, but
my current understanding is:
- every process has a process group id and a session id
- all processes in a group belong to the same session
- setpgid creates a new process group id in the same session
- setsid creates a new sessions and new process group
- process groups are used to send signals to sets of processes
- sessions are used to attach a process to a controlling terminal

using a new session here ensures
that the subprocess can't run something
that closes the terminal controlling tilt,
or put tilt in the background.

fixes https://github.com/tilt-dev/tilt/issues/6378
fixes https://github.com/tilt-dev/tilt/issues/6387

Signed-off-by: Nick Santos <nick.santos@docker.com>
