### PR TITLE
circleci: update build-macos to use new runners

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,7 +124,6 @@ jobs:
           only_for_branches: master
 
   build-macos:
-    resource_class: "macos.x86.medium.gen2"
     macos:
       xcode: "15.0.0"
 
@@ -191,13 +190,13 @@ workflows:
   build:
     # The linux job is cheaper than the others, so run that first.
     jobs:
-      - build-linux
+      - build-linux:
+          requires:
+            - build-macos
       - build-js:
           requires:
             - build-linux
-      - build-macos:
-          requires:
-            - build-linux
+      - build-macos
       - build-integration:
           requires:
             - build-linux


### PR DESCRIPTION
(the old runners are being deprecated)

Signed-off-by: Nick Santos <nick.santos@docker.com>
