### PR TITLE
tiltfile/helm: handle parsing version strings without `v` prefix

### DIFF
--- a/internal/tiltfile/helm.go
+++ b/internal/tiltfile/helm.go
@@ -64,7 +64,7 @@ func parseVersion(versionOutput string) (helmVersion, error) {
 
 	if strings.HasPrefix(version, "v3.0.") {
 		return helmV3_0, nil
-	} else if strings.HasPrefix(version, "v3.") {
+	} else if strings.HasPrefix(version, "v3.") || strings.HasPrefix(version, "3.") {
 		return helmV3_1andAbove, nil
 	} else if strings.HasPrefix(version, "Client: v2") {
 		return helmV2, nil

--- a/internal/tiltfile/helm_test.go
+++ b/internal/tiltfile/helm_test.go
@@ -247,6 +247,7 @@ const exampleHelmV2VersionOutput = `Client: v2.12.3geecf22f`
 const exampleHelmV3_0VersionOutput = `v3.0.0`
 const exampleHelmV3_1VersionOutput = `v3.1.0`
 const exampleHelmV3_2VersionOutput = `v3.2.4`
+const examplePkgxHelmV3_15VersionOutput = `3.15.2`
 
 // see https://github.com/tilt-dev/tilt/issues/3788
 const exampleHelmV3_3VersionOutput = `WARNING: Kubernetes configuration file is group-readable. This is insecure. Location: /Users/someone/.kube/config
@@ -277,6 +278,11 @@ func TestParseHelmV3_2Version(t *testing.T) {
 func TestParseHelmV3_3Version(t *testing.T) {
 	expected := helmV3_1andAbove
 	assertHelmVersion(t, exampleHelmV3_3VersionOutput, expected)
+}
+
+func TestParsePkgxHelmV3_15Version(t *testing.T) {
+	expected := helmV3_1andAbove
+	assertHelmVersion(t, examplePkgxHelmV3_15VersionOutput, expected)
 }
 
 func TestHelmUnknownVersionError(t *testing.T) {


### PR DESCRIPTION
`helm version` doesn't necessarily return a string with `v` in the
prefix, as it depends how it's packaged and bundles. For instance
when running helm with pkgx.sh:

```
$ pkgx helm version --client --short
3.15.2
```

(due to https://github.com/pkgxdev/pantry/blob/main/projects/helm.sh/package.yml#L22)

Without this change, tilt fails to parse the version with error:

```
Error in helm: could not parse Helm version from string: "3.15.2\n"
```

This fixes that.

Signed-off-by: Antoine Grondin <antoinegrondin@gmail.com>
