### PR TITLE
web: use dark color scheme to match UI

### DIFF
--- a/web/src/index.scss
+++ b/web/src/index.scss
@@ -3,6 +3,7 @@
 html {
   width: 100%;
   height: 100%;
+  color-scheme: dark;
 }
 body {
   margin: 0;


### PR DESCRIPTION
I use Tilt daily.

This is an unsolicited suggestion for the web UI styling. Because the Tilt UI is a dark theme, https://developer.mozilla.org/en-US/docs/Web/CSS/color-scheme hints to browsers to apply similar adjustments to the interface. In this case, the change is most notable with the scrollbars.

## Before

By default, scrollbars rendered by Chrome for overflowing content are light-themed.

<img width="2128" alt="tilt-before" src="https://github.com/user-attachments/assets/c9c387cd-39e5-43e2-93f5-8547cc3ec641">

## After

By applying the declaration on the `html` root element, the browser applies a dark theme to the scrollbars on the `body` and the components list.

<img width="2128" alt="tilt-after" src="https://github.com/user-attachments/assets/61514164-88a3-4603-935b-a510d8c6703d">
