### PR TITLE
kubernetesdiscovery: fix jobset tracking

### DIFF
--- a/internal/store/k8sconv/resource.go
+++ b/internal/store/k8sconv/resource.go
@@ -171,7 +171,10 @@ func FilterPods(filter *KubernetesApplyFilter, pods []v1alpha1.Pod) []v1alpha1.P
 	for _, pod := range pods {
 		// Ignore pods from an old replicaset.
 		newestOwner := newestOwnerByAncestorUID[pod.AncestorUID]
-		if hasValidOwner(pod) && newestOwner != nil && pod.Owner.Name != newestOwner.Name {
+		if hasValidOwner(pod) &&
+			newestOwner != nil &&
+			pod.Owner.Name != newestOwner.Name &&
+			pod.Owner.Kind == "ReplicaSet" {
 			continue
 		}
 


### PR DESCRIPTION
ensures that if one JobSet
has two jobs, we track all the pods.

fixes https://github.com/tilt-dev/tilt/issues/6383

Signed-off-by: Nick Santos <nick.santos@docker.com>
