### PR TITLE
engine: fix a bug in cluster connection checks

### DIFF
--- a/internal/engine/buildcontrol/build_control.go
+++ b/internal/engine/buildcontrol/build_control.go
@@ -254,7 +254,7 @@ func HoldTargetsWaitingOnCluster(state store.EngineState, mts []*store.ManifestT
 		cluster, ok := state.Clusters[clusterName]
 		isClusterOK := ok && cluster.Status.Error == "" && cluster.Status.Arch != ""
 		if isClusterOK {
-			return
+			continue
 		}
 
 		gvk := v1alpha1.SchemeGroupVersion.WithKind("Cluster")

--- a/internal/engine/buildcontrol/build_control_test.go
+++ b/internal/engine/buildcontrol/build_control_test.go
@@ -166,6 +166,31 @@ func TestK8sDependsOnCluster(t *testing.T) {
 	f.assertNextTargetToBuild("k8s1")
 }
 
+func TestK8sDependsOnCluster_TwoClusters(t *testing.T) {
+	f := newTestFixture(t)
+
+	f.st.Clusters["default"].Status.Error = "connection error"
+
+	_ = f.upsertK8sManifest("k8s1")
+	dc1 := f.upsertDCManifest("dc1")
+	f.assertNextTargetToBuild("dc1")
+	dc1.State.AddCompletedBuild(model.BuildRecord{
+		StartTime:  time.Now(),
+		FinishTime: time.Now(),
+	})
+	f.assertNoTargetNextToBuild()
+
+	f.assertHoldOnRefs("k8s1", store.HoldReasonCluster, v1alpha1.UIResourceStateWaitingOnRef{
+		Group:      "tilt.dev",
+		APIVersion: "v1alpha1",
+		Kind:       "Cluster",
+		Name:       "default",
+	})
+
+	f.st.Clusters["default"].Status.Error = ""
+	f.assertNextTargetToBuild("k8s1")
+}
+
 func TestCurrentlyBuildingLocalResourceDisablesK8sScheduling(t *testing.T) {
 	f := newTestFixture(t)
 
@@ -679,6 +704,11 @@ type testFixture struct {
 func newTestFixture(t *testing.T) testFixture {
 	f := tempdir.NewTempDirFixture(t)
 	st := store.NewState()
+	st.Clusters["docker"] = &v1alpha1.Cluster{
+		Status: v1alpha1.ClusterStatus{
+			Arch: "amd64",
+		},
+	}
 	st.Clusters["default"] = &v1alpha1.Cluster{
 		Status: v1alpha1.ClusterStatus{
 			Arch: "amd64",
@@ -740,6 +770,14 @@ func (f *testFixture) upsertK8sManifest(name model.ManifestName, opts ...manifes
 		b = o(b)
 	}
 	return f.upsertManifest(b.WithK8sYAML(testyaml.SanchoYAML).Build())
+}
+
+func (f *testFixture) upsertDCManifest(name model.ManifestName, opts ...manifestOption) *store.ManifestTarget {
+	b := manifestbuilder.New(f, name)
+	for _, o := range opts {
+		b = o(b)
+	}
+	return f.upsertManifest(b.WithDockerCompose().Build())
 }
 
 func (f *testFixture) upsertLocalManifest(name model.ManifestName, opts ...manifestOption) *store.ManifestTarget {


### PR DESCRIPTION
before this change, if you were deploying
to both a DockerCompose engine and a Kube
cluster, we sometimes wouldn't correctly
synchronize the cluster connections.

this led to problems where we would try
to deploy before the connection had been
established properly.

fixes https://github.com/tilt-dev/tilt/issues/6453

Signed-off-by: Nick Santos <nick.santos@docker.com>
