### PR TITLE
kubernetesapply: error if kubeconfig has not been resolved

### DIFF
--- a/internal/controllers/core/kubernetesapply/reconciler_test.go
+++ b/internal/controllers/core/kubernetesapply/reconciler_test.go
@@ -179,6 +179,7 @@ func TestApplyCmdWithImages(t *testing.T) {
 		assert.Equal(t, []string{
 			"TILT_IMAGE_MAP_0=image-a",
 			"TILT_IMAGE_0=image-a:my-tag",
+			"KUBECONFIG=/path/to/default/kubeconfig",
 		}, call.Cmd.Env)
 	}
 }
@@ -800,7 +801,8 @@ func newFixture(t *testing.T) *fixture {
 		Status: v1alpha1.ClusterStatus{
 			Connection: &v1alpha1.ClusterConnectionStatus{
 				Kubernetes: &v1alpha1.KubernetesClusterConnectionStatus{
-					Context: "default",
+					Context:    "default",
+					ConfigPath: "/path/to/default/kubeconfig",
 				},
 			},
 		},


### PR DESCRIPTION
in theory, we shouldn't even start going down this
codepath if the cluster connection hasn't been established,
so let's make it a hard error and see what happens.

Signed-off-by: Nick Santos <nick.santos@docker.com>
