### PR TITLE
cluster: bug fixes to kubeconfig gen

### DIFF
--- a/internal/xdg/fake.go
+++ b/internal/xdg/fake.go
@@ -13,7 +13,7 @@ type FakeBase struct {
 var _ Base = FakeBase{}
 
 func (b FakeBase) createPath(prefix, relPath string) (string, error) {
-	p := filepath.Join(b.Dir, "cache", relPath)
+	p := filepath.Join(b.Dir, prefix, relPath)
 	dir := filepath.Dir(p)
 	err := os.MkdirAll(dir, os.ModeDir|0700)
 	if err != nil {


### PR DESCRIPTION
- treat failure to write kubeconfigs as a cluster
  connection failure
- if runtime dir is not available, write
  kubeconfigs in a state dir instead
  (spec says that if the runtime dir doesn't exist,
  it's up to the implementer to find a better dir,
  but isn't opinionated about what dir we use)

Signed-off-by: Nick Santos <nick.santos@docker.com>
