### PR TITLE
Introducing Tilt Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 [![Build Status](https://circleci.com/gh/tilt-dev/tilt/tree/master.svg?style=shield)](https://circleci.com/gh/tilt-dev/tilt)
 [![GoDoc](https://godoc.org/github.com/tilt-dev/tilt?status.svg)](https://pkg.go.dev/github.com/tilt-dev/tilt)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Tilt%20Guru-006BFF)](https://gurubase.io/g/tilt)
 
 Kubernetes for Prod, Tilt for Dev
 


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Tilt Guru](https://gurubase.io/g/tilt) to Gurubase. Tilt Guru uses the data from this repo and data from the [docs](https://docs.tilt.dev) to answer questions by leveraging the LLM.

In this PR, I showcased the "Tilt Guru", which highlights that Tilt now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Tilt Guru in Gurubase, just let me know that's totally fine.
