### PR TITLE
tiltfile: fix ignores if context dir appears later

### DIFF
--- a/internal/tiltfile/docker.go
+++ b/internal/tiltfile/docker.go
@@ -526,10 +526,6 @@ func (s *tiltfileState) dockerignoresFromPathsAndContextFilters(source string, p
 		}
 		dupeSet[path] = true
 
-		if !ospath.IsDir(path) {
-			continue
-		}
-
 		if len(ignorePatterns) != 0 {
 			result = append(result, model.Dockerignore{
 				LocalPath: path,


### PR DESCRIPTION
Consider the following (admittedly somewhat unusual) Tiltfile:

    trigger_mode(TRIGGER_MODE_MANUAL)

    clone_cmd = "test -e tilt-avatars || git clone https://github.com/tilt-dev/tilt-avatars"
    custom_build(
        "x-clone-repo",
        deps = [],
        skips_local_docker = True,
        command = clone_cmd,
    )
    docker_build(
        "x-build-image",
        context = "tilt-avatars",
        dockerfile_contents = "\n".join([
            "FROM x-clone-repo",
            "FROM scratch",
            "COPY ./ /opt/app/",
        ]),
        ignore = [
            "**/.git",
        ],
    )
    k8s_custom_deploy(
        name = "x-dummy-resource",
        apply_cmd = "true",
        delete_cmd = "true",
        deps = [],
        image_deps = ["x-build-image"],
    )

This implements on-demand git cloning — the clone happens during the build phase of the resource, and thus other builds can proceed concurrently and this may speed up overall tilt up (and it does in the quite complex tilt setup that we have).

In current Tilt, however, `ignore` and `only` are completely ignored if the context directory doesn't exist when the Tiltfile is loaded. This is quite a strange and seemingly pointless limitation, as everything else seems to work fine.

The fix is trivial — simply remove the IsDir check from `dockerignoresFromPathsAndContextFilters`. The code that follows the check handles the absence of the dockerignore files just fine, so it seems the IsDir check is simply forgotten there from previous iterations.

Note that a similar issue exists in the `repoIgnoresForPaths` function as well. The Tiltfile to reproduce that problem is the same, just without the `ignore = ["**/.git"]` bit. I'm not entirely sure if that `isGitRepoBase` check serves any real purpose — would there be any harm if ".git" was ignored unconditionally (well, we'd need to check for the empty path like `dockerignoresFromPathsAndContextFilters` does)?

Related: https://github.com/tilt-dev/tilt/issues/3048#issuecomment-836877339
