### PR TITLE
Update `metadata:annotations: Too long` error string detection

### DIFF
--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -621,7 +621,7 @@ func maybeImmutableFieldStderr(stderr string) bool {
 		strings.Contains(stderr, ForbiddenFieldsPrefix)
 }
 
-var MetadataAnnotationsTooLongRe = regexp.MustCompile(`metadata.annotations: Too long: must have at most \d+ bytes.*`)
+var MetadataAnnotationsTooLongRe = regexp.MustCompile(`metadata.annotations: Too long: .* \d+ bytes.*`)
 
 // kubectl apply sets an annotation containing the object's previous configuration.
 // However, annotations have a max size of 256k. Large objects such as configmaps can exceed 256k, which makes


### PR DESCRIPTION
Update the regular expression used to match the Kubernetes `metadata.annotations: Too long` API error returned when a resource annotation exceeds a maximum size.

The error message changed in Kubernetes `v1.32`: https://github.com/kubernetes/kubernetes/pull/128553

The change of error string caused Tilt's logic to fall back to create or replace the resource to fail:

https://github.com/tilt-dev/tilt/blob/875606fb003e208c3c3fc4e013317c6254258198/internal/k8s/client.go#L574-L583

Updating the regular expression ensures that resources with annotations exceeding the maximum size can still be applied in Kubernetes >= `v1.32`.

## Verification

Take a large CRD, such as the one in [this Gist](https://gist.github.com/andrew-farries/14f3332ae4bb7d50bc37c71804421ddc) and save it as `install.yaml`.

Create the following `Tiltfile`:

```
k8s_yaml('install.yaml')
```

Run `tilt up` against a Kubernetes `v1.32` cluster, such as one created by `kind` `v0.26.0`.

On `master` `tilt up` fails:

```
uncategorized │ Initial Build
uncategorized │ STEP 1/1 — Deploying
uncategorized │      Applying YAML to cluster
uncategorized │      Tried to apply objects to cluster:
uncategorized │        → envoyproxies.gateway.envoyproxy.io:customresourcedefinition
uncategorized │
uncategorized │ ERROR: Build Failed: CustomResourceDefinition.apiextensions.k8s.io "envoyproxies.gateway.envoyproxy.io" is invalid: metadata.annotations: Too long: may not be more than 262144 bytes
```

With the changes from this PR `tilt up` succeeds:

```
uncategorized │ Initial Build
uncategorized │ STEP 1/1 — Deploying
uncategorized │      Applying YAML to cluster
uncategorized │      Updating "envoyproxies.gateway.envoyproxy.io" failed: CustomResourceDefinition.apiextensions.k8s.io "envoyproxies.gateway.envoyproxy.io" is invalid: metadata.annotations: Too long: may not be more than 262144 bytes
uncategorized │      Attempting to create or replace
uncategorized │      Updating "envoyproxies.gateway.envoyproxy.io" succeeded!
```