### PR TITLE
controllers: ensure all sources implement fmt.Stringer

### DIFF
--- a/internal/controllers/core/podlogstream/podsource.go
+++ b/internal/controllers/core/podlogstream/podsource.go
@@ -48,6 +48,7 @@ type podWatch struct {
 }
 
 var _ source.Source = &PodSource{}
+var _ fmt.Stringer = &PodSource{}
 
 func NewPodSource(ctx context.Context, kClient k8s.Client, scheme *runtime.Scheme, clock clockwork.Clock) *PodSource {
 	return &PodSource{
@@ -57,6 +58,10 @@ func NewPodSource(ctx context.Context, kClient k8s.Client, scheme *runtime.Schem
 		watchesByNamespace: make(map[string]*podWatch),
 		clock:              clock,
 	}
+}
+
+func (s *PodSource) String() string {
+	return "pod-source"
 }
 
 func (s *PodSource) Start(ctx context.Context, q workqueue.TypedRateLimitingInterface[reconcile.Request]) error {

--- a/internal/controllers/indexer/requeuer.go
+++ b/internal/controllers/indexer/requeuer.go
@@ -2,6 +2,7 @@ package indexer
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
@@ -18,9 +19,14 @@ type Requeuer struct {
 }
 
 var _ source.Source = &Requeuer{}
+var _ fmt.Stringer = &Requeuer{}
 
 func NewRequeuer() *Requeuer {
 	return &Requeuer{}
+}
+
+func (s *Requeuer) String() string {
+	return "requeuer"
 }
 
 func (s *Requeuer) Start(ctx context.Context, q workqueue.TypedRateLimitingInterface[reconcile.Request]) error {


### PR DESCRIPTION
prevents race conditions that cause a panic

for more info, see
https://github.com/kubernetes-sigs/controller-runtime/issues/3057

Signed-off-by: Nick Santos <nick.santos@docker.com>
