### PR TITLE
Fix powershell install crashing when $script:ErrorActionPreference='Stop' and Scoop not installed

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -11,7 +11,7 @@ $binDir = "$HOME\bin"
 $dest = "$binDir\tilt.exe"
 
 $useScoop = ""
-if (Get-Command "scoop" 2>$null) {
+if (Get-Command "scoop" -ErrorAction Ignore) {
    $useScoop = "true"
 }
 


### PR DESCRIPTION
While trying to automate installing tilt, I came across this issue. (I don't have scoop installed)

```powershell
$script:ErrorActionPreference = 'Stop'
iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/tilt-dev/tilt/master/scripts/install.ps1'))
```
throws the error
```
Line |
  14 |  if (Get-Command "scoop" 2>$null) {
     |      ~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | The term 'scoop' is not recognized as a name of a cmdlet, function, script file, or executable program. Check the spelling of the name, or if a path was included, verify that the path is correct and try again.
```

This change prevents the scoop check from throwing an error while also allowing me to stop the installation if it throws a real error.
