### PR TITLE
test: resolve symlinks in tempdirs

### DIFF
--- a/internal/testutils/tempdir/temp_dir_fixture.go
+++ b/internal/testutils/tempdir/temp_dir_fixture.go
@@ -6,6 +6,8 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 type TempDirFixture struct {
@@ -22,9 +24,14 @@ func SanitizeFileName(name string) string {
 }
 
 func NewTempDirFixture(t testing.TB) *TempDirFixture {
+	dir := t.TempDir()
+
+	dir, err := filepath.EvalSymlinks(dir)
+	require.NoError(t, err)
+
 	f := &TempDirFixture{
 		t:   t,
-		dir: t.TempDir(),
+		dir: dir,
 	}
 	t.Cleanup(f.tearDown)
 	return f


### PR DESCRIPTION
fixes the watch tests on macos, which
are sensitive to symlinks in directories.

Signed-off-by: Nick Santos <nick.santos@docker.com>
