### PR TITLE
fix (Tiltfile) stuck in pending state

### DIFF
--- a/internal/controllers/core/filewatch/controller.go
+++ b/internal/controllers/core/filewatch/controller.go
@@ -190,6 +190,10 @@ func (c *Controller) addOrReplace(ctx context.Context, name types.NamespacedName
 		w.restartBackoff = existing.restartBackoff
 		status.Error = existing.status.Error
 	}
+	if hasExisting {
+		status.FileEvents = existing.status.FileEvents
+		status.LastEventTime = existing.status.LastEventTime
+	}
 
 	ignoreMatcher := ignore.CreateFileChangeFilter(fw.Spec.Ignores)
 	startFileChangeLoop := false

--- a/internal/controllers/core/filewatch/controller_test.go
+++ b/internal/controllers/core/filewatch/controller_test.go
@@ -324,13 +324,14 @@ func TestController_Reconcile_Watches(t *testing.T) {
 	assert.Truef(t, updatedStart.After(originalStart),
 		"Monitor start time should be more recent after update, (original: %s, updated: %s)",
 		originalStart, updatedStart)
-	if assert.Equal(t, 2, len(updated.Status.FileEvents)) {
+	if assert.Equal(t, 3, len(updated.Status.FileEvents)) {
 		// ensure ONLY the expected files were seen
 		assert.NotZero(t, updated.Status.FileEvents[0].Time.Time)
-		mostRecentEventTime := updated.Status.FileEvents[1].Time.Time
+		mostRecentEventTime := updated.Status.FileEvents[2].Time.Time
 		assert.NotZero(t, mostRecentEventTime)
-		assert.Equal(t, []string{f.tmpdir.JoinPath("d", "1")}, updated.Status.FileEvents[0].SeenFiles)
-		assert.Equal(t, []string{f.tmpdir.JoinPath("d", "2")}, updated.Status.FileEvents[1].SeenFiles)
+		assert.Equal(t, []string{f.tmpdir.JoinPath("a", "1")}, updated.Status.FileEvents[0].SeenFiles)
+		assert.Equal(t, []string{f.tmpdir.JoinPath("d", "1")}, updated.Status.FileEvents[1].SeenFiles)
+		assert.Equal(t, []string{f.tmpdir.JoinPath("d", "2")}, updated.Status.FileEvents[2].SeenFiles)
 		assert.Equal(t, mostRecentEventTime, updated.Status.LastEventTime.Time)
 	}
 }


### PR DESCRIPTION
Fixes #5902 

I was having the same issue described in #5902 where when using filesystem triggers to add or remove resources, it would sometimes race and leave the Tiltfile in the pending status without the most recent state.

I believe I successfully tracked this down to the filewatch controller when reconciled can replace the watcher object with a new configuration, but doesn't preserve previous file events when doing so. This can then race with the Reconcile on the tiltfile to miss that there is a pending filesystem change and instead see an empty list of filesystem changes (https://github.com/tilt-dev/tilt/blob/59f9aa24c86dc5302772c61905275fd90675596f/internal/controllers/core/tiltfile/reconciler.go#L235-L240). The Tiltfile reconciler then does not trigger a subsequent build.
