### PR TITLE
docker: remove support for building to microk8s docker socket

### DIFF
--- a/internal/docker/client.go
+++ b/internal/docker/client.go
@@ -69,10 +69,6 @@ var minDockerVersionExperimentalBuildkit = semver.MustParse("1.38.0")
 
 var versionTimeout = 5 * time.Second
 
-// microk8s exposes its own docker socket
-// https://github.com/ubuntu/microk8s/blob/master/docs/dockerd.md
-const microK8sDockerHost = "unix:///var/snap/microk8s/current/docker.sock"
-
 // Create an interface so this can be mocked out.
 type Client interface {
 	CheckConnected() error

--- a/internal/docker/client_test.go
+++ b/internal/docker/client_test.go
@@ -152,18 +152,6 @@ func TestProvideClusterProduct(t *testing.T) {
 		},
 		{
 			env:     clusterid.ProductMicroK8s,
-			runtime: container.RuntimeDocker,
-			expectedCluster: Env{
-				Client:              hostClient{Host: "unix:///var/snap/microk8s/current/docker.sock"},
-				Environ:             []string{"DOCKER_HOST=unix:///var/snap/microk8s/current/docker.sock"},
-				BuildToKubeContexts: []string{"microk8s-me"},
-			},
-			expectedLocal: Env{
-				Client: hostClient{Host: "unix:///var/run/docker.sock"},
-			},
-		},
-		{
-			env:     clusterid.ProductMicroK8s,
 			runtime: container.RuntimeCrio,
 			expectedCluster: Env{
 				Client: hostClient{Host: "unix:///var/run/docker.sock"},

--- a/internal/docker/env.go
+++ b/internal/docker/env.go
@@ -246,21 +246,6 @@ func ProvideClusterEnv(
 		}
 	}
 
-	if product == clusterid.ProductMicroK8s && kClient.ContainerRuntime(ctx) == container.RuntimeDocker {
-		// If we're running Microk8s with a docker runtime, talk to Microk8s's docker socket.
-		d, err := creator.FromEnvMap(map[string]string{"DOCKER_HOST": microK8sDockerHost})
-		if err != nil {
-			return ClusterEnv{Error: fmt.Errorf("connecting to microk8s: %v", err)}
-		}
-
-		// Handle the case where people manually set DOCKER_HOST to microk8s.
-		if hostOverride == "" || hostOverride == d.DaemonHost() {
-			env.Client = d
-			env.Environ = append(env.Environ, fmt.Sprintf("DOCKER_HOST=%s", microK8sDockerHost))
-			env.BuildToKubeContexts = append(env.BuildToKubeContexts, string(kubeContext))
-		}
-	}
-
 	if env.Client == nil {
 		client, err := creator.FromCLI(ctx)
 		env.Client = client
@@ -274,8 +259,7 @@ func ProvideClusterEnv(
 	// images)
 	//
 	// currently, we handle this by inspecting the Docker + K8s configs to see
-	// if they're matched up, but with the exception of microk8s (handled above),
-	// we don't override the environmental Docker config
+	// if they're matched up, but we don't override the environmental Docker config
 	if willBuildToKubeContext(ctx, product, kubeContext, env) &&
 		kClient.ContainerRuntime(ctx) == container.RuntimeDocker {
 		env.BuildToKubeContexts = append(env.BuildToKubeContexts, string(kubeContext))


### PR DESCRIPTION
i think this feature was removed from microk8s
years ago and we no longer need to support it.

fixes https://github.com/tilt-dev/tilt/issues/6494

Signed-off-by: Nick Santos <nick.santos@docker.com>
