### PR TITLE
engine: remove some dead code

### DIFF
--- a/internal/controllers/apis/restarton/restarton.go
+++ b/internal/controllers/apis/restarton/restarton.go
@@ -11,7 +11,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 
 	"github.com/tilt-dev/tilt/internal/controllers/indexer"
-	"github.com/tilt-dev/tilt/internal/sliceutils"
 	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
 )
 
@@ -197,32 +196,6 @@ func LastRestartEvent(restartOn *v1alpha1.RestartOnSpec, triggerObjs Objects) (t
 	}
 
 	return cur, latestButton
-}
-
-// Fetch the set of files that have changed since the given timestamp.
-// We err on the side of undercounting (i.e., skipping files that may have triggered
-// this build but are not sure).
-func FilesChanged(restartOn *v1alpha1.RestartOnSpec, fileWatches map[string]*v1alpha1.FileWatch, lastBuild time.Time) []string {
-	filesChanged := []string{}
-	if restartOn == nil {
-		return filesChanged
-	}
-	for _, fwn := range restartOn.FileWatches {
-		fw, ok := fileWatches[fwn]
-		if !ok {
-			// ignore missing filewatches
-			continue
-		}
-
-		// Add files so that the most recent files are first.
-		for i := len(fw.Status.FileEvents) - 1; i >= 0; i-- {
-			e := fw.Status.FileEvents[i]
-			if e.Time.Time.After(lastBuild) {
-				filesChanged = append(filesChanged, e.SeenFiles...)
-			}
-		}
-	}
-	return sliceutils.DedupedAndSorted(filesChanged)
 }
 
 // registerWatches ensures that reconciliation happens on changes to objects referenced by RestartOnSpec/StartOnSpec.

--- a/internal/controllers/core/tiltfile/reducers.go
+++ b/internal/controllers/core/tiltfile/reducers.go
@@ -3,7 +3,6 @@ package tiltfile
 import (
 	"context"
 
-	"github.com/tilt-dev/tilt/internal/sliceutils"
 	"github.com/tilt-dev/tilt/internal/store"
 	"github.com/tilt-dev/tilt/pkg/logger"
 	"github.com/tilt-dev/tilt/pkg/model"
@@ -29,7 +28,6 @@ func HandleConfigsReloadStarted(
 	}
 	ms.CurrentBuilds[TiltfileBuildSource] = status
 	state.RemoveFromTriggerQueue(event.Name)
-	state.StartedTiltfileLoadCount++
 }
 
 // In the original Tilt architecture, the Tiltfile contained
@@ -121,9 +119,6 @@ func HandleConfigsReloaded(
 		// and introduce a syntax error.  You don't want partial results to wipe out
 		// your "good" state.
 
-		// Watch any new config files in the partial state.
-		state.TiltfileConfigPaths[event.Name] = sliceutils.AppendWithoutDupes(state.TiltfileConfigPaths[event.Name], event.ConfigFiles...)
-
 		if isMainTiltfile {
 			// Enable any new features in the partial state.
 			if len(state.Features) == 0 {
@@ -183,8 +178,6 @@ func HandleConfigsReloaded(
 			continue
 		}
 	}
-
-	state.TiltfileConfigPaths[event.Name] = event.ConfigFiles
 
 	// Global state that's only configurable from the main manifest.
 	if isMainTiltfile {

--- a/internal/engine/actions.go
+++ b/internal/engine/actions.go
@@ -19,7 +19,6 @@ func NewErrorAction(err error) store.ErrorAction {
 
 type InitAction struct {
 	TiltfilePath string
-	ConfigFiles  []string
 	UserArgs     []string
 
 	TiltBuild model.TiltBuild

--- a/internal/engine/upper.go
+++ b/internal/engine/upper.go
@@ -85,12 +85,8 @@ func (u Upper) Start(
 	if err != nil {
 		return err
 	}
-
-	configFiles := []string{absTfPath}
-
 	return u.Init(ctx, InitAction{
 		TiltfilePath:     absTfPath,
-		ConfigFiles:      configFiles,
 		UserArgs:         args,
 		TiltBuild:        b,
 		StartTime:        startTime,
@@ -282,7 +278,6 @@ func handleInitAction(ctx context.Context, engineState *store.EngineState, actio
 	engineState.TiltBuildInfo = action.TiltBuild
 	engineState.TiltStartTime = action.StartTime
 	engineState.DesiredTiltfilePath = action.TiltfilePath
-	engineState.TiltfileConfigPaths[model.MainTiltfileManifestName] = action.ConfigFiles
 	engineState.UserConfigState = model.NewUserConfigState(action.UserArgs)
 	engineState.AnalyticsUserOpt = action.AnalyticsUserOpt
 	engineState.CloudAddress = action.CloudAddress

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -1955,22 +1955,6 @@ func TestHudExitWithError(t *testing.T) {
 	_ = f.WaitForNoExit()
 }
 
-func TestNewConfigsAreWatchedAfterFailure(t *testing.T) {
-	f := newTestFixture(t)
-	f.useRealTiltfileLoader()
-	f.loadAndStart()
-
-	f.WriteConfigFiles("Tiltfile", "read_file('foo.txt')")
-	f.WaitUntil("foo.txt is a config file", func(state store.EngineState) bool {
-		for _, s := range state.MainConfigPaths() {
-			if s == f.JoinPath("foo.txt") {
-				return true
-			}
-		}
-		return false
-	})
-}
-
 func TestDockerComposeUp(t *testing.T) {
 	f := newTestFixture(t)
 	redis, server := f.setupDCFixture()
@@ -3413,7 +3397,7 @@ func (f *testFixture) Init(action InitAction) {
 	expectedFileWatches := ctrltiltfile.ToFileWatchObjects(ctrltiltfile.WatchInputs{
 		TiltfileManifestName: model.MainTiltfileManifestName,
 		Manifests:            state.Manifests(),
-		ConfigFiles:          state.MainConfigPaths(),
+		ConfigFiles:          []string{action.TiltfilePath},
 		TiltfilePath:         action.TiltfilePath,
 	}, make(map[model.ManifestName]*v1alpha1.DisableSource))
 	if f.overrideMaxParallelUpdates > 0 {

--- a/internal/store/engine_state.go
+++ b/internal/store/engine_state.go
@@ -41,10 +41,6 @@ type EngineState struct {
 	// How many builds have been completed (pass or fail) since starting tilt
 	CompletedBuildCount int
 
-	// For synchronizing ConfigsController -- wait until engine records all builds started
-	// so far before starting another build
-	StartedTiltfileLoadCount int
-
 	UpdateSettings model.UpdateSettings
 
 	FatalError error
@@ -74,10 +70,6 @@ type EngineState struct {
 
 	TiltfileDefinitionOrder []model.ManifestName
 	TiltfileStates          map[model.ManifestName]*ManifestState
-
-	// Files and directories read during tiltfile execution,
-	// which we listen to for reload.
-	TiltfileConfigPaths map[model.ManifestName][]string
 
 	SuggestedTiltVersion string
 	VersionSettings      model.VersionSettings
@@ -375,10 +367,6 @@ func (e *EngineState) MainTiltfileState() *ManifestState {
 	return e.TiltfileStates[model.MainTiltfileManifestName]
 }
 
-func (e *EngineState) MainConfigPaths() []string {
-	return e.TiltfileConfigPaths[model.MainTiltfileManifestName]
-}
-
 func (e *EngineState) HasBuild() bool {
 	for _, m := range e.Manifests() {
 		for _, targ := range m.ImageTargets {
@@ -515,7 +503,6 @@ func NewState() *EngineState {
 			CurrentBuilds: make(map[string]model.BuildRecord),
 		},
 	}
-	ret.TiltfileConfigPaths = map[model.ManifestName][]string{}
 
 	if ok, _ := tiltanalytics.IsAnalyticsDisabledFromEnv(); ok {
 		ret.AnalyticsEnvOpt = analytics.OptOut


### PR DESCRIPTION
noticed this when i was poking around
at tiltfile reload logic.

now that tiltfile reload is entirely handled
by the reconciler, there's no reason for the
engine to track this state at all.

Signed-off-by: Nick Santos <nick.santos@docker.com>
