### PR TITLE
store: update how we model file changes

### DIFF
--- a/internal/controllers/core/tiltfile/reducers.go
+++ b/internal/controllers/core/tiltfile/reducers.go
@@ -73,7 +73,7 @@ func HandleConfigsReloaded(
 
 	// Remove pending file changes that were consumed by this build.
 	for _, status := range ms.BuildStatuses {
-		status.ClearPendingChangesBefore(b.StartTime)
+		status.ConsumeChangesBefore(b.StartTime)
 	}
 
 	// Track the new secrets and go back to scrub them.

--- a/internal/engine/buildcontroller.go
+++ b/internal/engine/buildcontroller.go
@@ -218,13 +218,13 @@ func buildStateSet(ctx context.Context, manifest model.Manifest,
 		id := spec.ID()
 		status := ms.BuildStatus(id)
 		var filesChanged []string
-		for file := range status.PendingFileChanges {
+		for file := range status.PendingFileChanges() {
 			filesChanged = append(filesChanged, file)
 		}
 		sort.Strings(filesChanged)
 
 		var depsChanged []model.TargetID
-		for dep := range status.PendingDependencyChanges {
+		for dep := range status.PendingDependencyChanges() {
 			depsChanged = append(depsChanged, dep)
 		}
 

--- a/internal/engine/buildcontroller_test.go
+++ b/internal/engine/buildcontroller_test.go
@@ -113,7 +113,7 @@ func TestTriggerModes(t *testing.T) {
 
 			f.fsWatcher.Events <- watch.NewFileEvent(f.JoinPath("main.go"))
 			f.WaitUntil("pending change appears", func(st store.EngineState) bool {
-				return len(st.BuildStatus(manifest.ImageTargetAt(0).ID()).PendingFileChanges) >= 1
+				return st.BuildStatus(manifest.ImageTargetAt(0).ID()).CountPendingFileChanges() >= 1
 			})
 
 			if !tc.expectBuildWhenFilesChange {
@@ -161,7 +161,7 @@ func TestBuildControllerImageBuildTrigger(t *testing.T) {
 				f.fsWatcher.Events <- watch.NewFileEvent(f.JoinPath("main.go"))
 			}
 			f.WaitUntil("pending change appears", func(st store.EngineState) bool {
-				return len(st.BuildStatus(manifest.ImageTargetAt(0).ID()).PendingFileChanges) >= len(expectedFiles)
+				return st.BuildStatus(manifest.ImageTargetAt(0).ID()).CountPendingFileChanges() >= len(expectedFiles)
 			})
 
 			if manifest.TriggerMode.AutoOnChange() {
@@ -214,10 +214,10 @@ func TestBuildQueueOrdering(t *testing.T) {
 
 	f.fsWatcher.Events <- watch.NewFileEvent(f.JoinPath("main.go"))
 	f.WaitUntil("pending change appears", func(st store.EngineState) bool {
-		return len(st.BuildStatus(m1.ImageTargetAt(0).ID()).PendingFileChanges) > 0 &&
-			len(st.BuildStatus(m2.ImageTargetAt(0).ID()).PendingFileChanges) > 0 &&
-			len(st.BuildStatus(m3.ImageTargetAt(0).ID()).PendingFileChanges) > 0 &&
-			len(st.BuildStatus(m4.ImageTargetAt(0).ID()).PendingFileChanges) > 0
+		return st.BuildStatus(m1.ImageTargetAt(0).ID()).HasPendingFileChanges() &&
+			st.BuildStatus(m2.ImageTargetAt(0).ID()).HasPendingFileChanges() &&
+			st.BuildStatus(m3.ImageTargetAt(0).ID()).HasPendingFileChanges() &&
+			st.BuildStatus(m4.ImageTargetAt(0).ID()).HasPendingFileChanges()
 	})
 	f.assertNoCall("even tho there are pending changes, manual manifest shouldn't build w/o explicit trigger")
 
@@ -270,10 +270,10 @@ func TestBuildQueueAndAutobuildOrdering(t *testing.T) {
 
 	f.fsWatcher.Events <- watch.NewFileEvent(f.JoinPath("dirManual/main.go"))
 	f.WaitUntil("pending change appears", func(st store.EngineState) bool {
-		return len(st.BuildStatus(m1.ImageTargetAt(0).ID()).PendingFileChanges) > 0 &&
-			len(st.BuildStatus(m2.ImageTargetAt(0).ID()).PendingFileChanges) > 0 &&
-			len(st.BuildStatus(m3.ImageTargetAt(0).ID()).PendingFileChanges) > 0 &&
-			len(st.BuildStatus(m4.ImageTargetAt(0).ID()).PendingFileChanges) > 0
+		return st.BuildStatus(m1.ImageTargetAt(0).ID()).HasPendingFileChanges() &&
+			st.BuildStatus(m2.ImageTargetAt(0).ID()).HasPendingFileChanges() &&
+			st.BuildStatus(m3.ImageTargetAt(0).ID()).HasPendingFileChanges() &&
+			st.BuildStatus(m4.ImageTargetAt(0).ID()).HasPendingFileChanges()
 	})
 	f.assertNoCall("even tho there are pending changes, manual manifest shouldn't build w/o explicit trigger")
 

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -1093,7 +1093,7 @@ k8s_yaml('snack.yaml')`
 
 	f.fsWatcher.Events <- watch.NewFileEvent(f.JoinPath("src/main.go"))
 	f.WaitUntil("pending change appears", func(st store.EngineState) bool {
-		return len(st.BuildStatus(imageTargetID).PendingFileChanges) > 0
+		return st.BuildStatus(imageTargetID).HasPendingFileChanges()
 	})
 	f.assertNoCall("even tho there are pending changes, manual manifest shouldn't build w/o explicit trigger")
 

--- a/internal/hud/view.go
+++ b/internal/hud/view.go
@@ -51,7 +51,7 @@ func StateToTerminalView(s store.EngineState, mu *sync.RWMutex) view.View {
 
 		var pendingBuildEdits []string
 		for _, status := range ms.BuildStatuses {
-			for f := range status.PendingFileChanges {
+			for f := range status.PendingFileChanges() {
 				pendingBuildEdits = append(pendingBuildEdits, f)
 			}
 		}

--- a/internal/hud/view_test.go
+++ b/internal/hud/view_test.go
@@ -47,7 +47,7 @@ func TestStateToViewRelativeEditPaths(t *testing.T) {
 			},
 		},
 	}
-	ms.MutableBuildStatus(m.ImageTargets[0].ID()).PendingFileChanges =
+	ms.MutableBuildStatus(m.ImageTargets[0].ID()).FileChanges =
 		map[string]time.Time{
 			f.JoinPath("a", "b", "c", "foo"):    time.Now(),
 			f.JoinPath("a", "b", "c", "d", "e"): time.Now(),

--- a/internal/hud/webview/convert_test.go
+++ b/internal/hud/webview/convert_test.go
@@ -58,7 +58,7 @@ func TestStateToWebViewRelativeEditPaths(t *testing.T) {
 	ms.BuildHistory = []model.BuildRecord{
 		{},
 	}
-	ms.MutableBuildStatus(m.ImageTargets[0].ID()).PendingFileChanges =
+	ms.MutableBuildStatus(m.ImageTargets[0].ID()).FileChanges =
 		map[string]time.Time{
 			f.JoinPath("a", "b", "c", "foo"):    time.Now(),
 			f.JoinPath("a", "b", "c", "d", "e"): time.Now(),

--- a/internal/store/buildcontrols/reducers.go
+++ b/internal/store/buildcontrols/reducers.go
@@ -81,7 +81,7 @@ func handleBuildResults(engineState *store.EngineState,
 
 	// Remove pending file changes that were consumed by this build.
 	for _, status := range ms.BuildStatuses {
-		status.ClearPendingChangesBefore(br.StartTime)
+		status.ConsumeChangesBefore(br.StartTime)
 	}
 
 	if isBuildSuccess {
@@ -124,7 +124,7 @@ func handleBuildResults(engineState *store.EngineState,
 
 			currentStatus := currentMS.MutableBuildStatus(id)
 			currentStatus.LastResult = result
-			currentStatus.ClearPendingChangesBefore(br.StartTime)
+			currentStatus.ConsumeChangesBefore(br.StartTime)
 			updatedIDSet[id] = true
 		}
 
@@ -155,7 +155,7 @@ func handleBuildResults(engineState *store.EngineState,
 				}
 
 				// Otherwise, we need to mark it for rebuild to pick up the new image.
-				currentMS.MutableBuildStatus(rDepID).PendingDependencyChanges[updatedID] = br.StartTime
+				currentMS.MutableBuildStatus(rDepID).DependencyChanges[updatedID] = br.StartTime
 			}
 		}
 	}


### PR DESCRIPTION
before this PR, we kept a map of recent file changes,
and deleted from the map when the changes were consumed.

this creates race conditions if the events are processed
in a different order than the changes, e.g.,
if a "consumed" event at 12:02 is processed before
the file change event at 12:01.

after this PR, we record both the file change time
and the consumed time, then compare them to determine
if the file change is still pending.

Signed-off-by: Nick Santos <nick.santos@docker.com>
