### PR TITLE
tiltfile: fix a bug where sometimes a base image wasn't pushed

### DIFF
--- a/internal/cli/docker_prune.go
+++ b/internal/cli/docker_prune.go
@@ -100,10 +100,8 @@ func (c *dockerPruneCmd) run(ctx context.Context, args []string) error {
 // with all resources in a "disabled" state and rely on the API, but that's not
 // possible currently.
 func resolveImageSelectors(ctx context.Context, kCli k8s.Client, tlr *tiltfile.TiltfileLoadResult) ([]container.RefSelector, error) {
-	for _, m := range tlr.Manifests {
-		if err := m.InferImageProperties(); err != nil {
-			return nil, err
-		}
+	if err := model.InferImageProperties(tlr.Manifests); err != nil {
+		return nil, err
 	}
 
 	var reg *v1alpha1.RegistryHosting

--- a/internal/controllers/core/tiltfile/api.go
+++ b/internal/controllers/core/tiltfile/api.go
@@ -62,13 +62,13 @@ func updateOwnedObjects(
 	disableSources := toDisableSources(tlr)
 
 	if tlr != nil {
-		for i, m := range tlr.Manifests {
-			// Apply the registry to the image refs.
-			err := m.InferImageProperties()
-			if err != nil {
-				return err
-			}
+		// Apply the registry to the image refs.
+		err := model.InferImageProperties(tlr.Manifests)
+		if err != nil {
+			return err
+		}
 
+		for i, m := range tlr.Manifests {
 			// Assemble the LiveUpdate selectors, connecting objects together.
 			err = m.InferLiveUpdateSelectors()
 			if err != nil {

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -3843,9 +3843,7 @@ func (f *testFixture) setupDCFixture() (redis, server model.Manifest) {
 		f.T().Fatalf("Expected two manifests. Actual: %v", tlr.Manifests)
 	}
 
-	for _, m := range tlr.Manifests {
-		require.NoError(f.t, m.InferImageProperties())
-	}
+	require.NoError(f.t, model.InferImageProperties(tlr.Manifests))
 
 	return tlr.Manifests[0], tlr.Manifests[1]
 }

--- a/internal/testutils/manifestbuilder/manifestbuilder.go
+++ b/internal/testutils/manifestbuilder/manifestbuilder.go
@@ -232,7 +232,7 @@ func (b ManifestBuilder) Build() model.Manifest {
 	}
 	m = m.WithTriggerMode(b.triggerMode)
 
-	err := m.InferImageProperties()
+	err := model.InferImageProperties([]model.Manifest{m})
 	require.NoError(b.f.T(), err)
 
 	err = m.InferLiveUpdateSelectors()

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -5947,11 +5947,7 @@ func (f *fixture) loadAllowWarnings(args ...string) {
 		f.t.Fatal(err)
 	}
 	f.loadResult = tlr
-
-	for _, m := range f.loadResult.Manifests {
-		err := m.InferImageProperties()
-		require.NoError(f.t, err)
-	}
+	require.NoError(f.t, model.InferImageProperties(f.loadResult.Manifests))
 }
 
 func unusedImageWarning(unusedImage string, suggestedImages []string, configType string) string {
@@ -5993,11 +5989,7 @@ func (f *fixture) loadArgsErrString(args []string, msgs ...string) {
 			f.t.Fatalf("error %q does not contain string %q", errText, msg)
 		}
 	}
-
-	for _, m := range f.loadResult.Manifests {
-		err := m.InferImageProperties()
-		require.NoError(f.t, err)
-	}
+	require.NoError(f.t, model.InferImageProperties(tlr.Manifests))
 }
 
 func (f *fixture) gitInit(path string) {


### PR DESCRIPTION
if a base image is used in ANY manifest,
it needs to be pushed in all manifests.
Otherwise the caching system will get confused.

fixes issue #6486

Signed-off-by: Nick Santos <nick.santos@docker.com>
