### PR TITLE
cli: tweak how new log flags are injected

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,14 +113,8 @@ else
 endif
 
 wire:
-	# run wire in a container, which will then invoke `make wire-dev`
-	toast wire
-
-wire-dev:
-	# run wire directly, both used by Toast job and useful for faster iteration
-	# if you have wire installed (but don't forget to run `make wire` before
-	# committing to generate the authoritative versions!)
 	wire ./internal/engine ./internal/engine/buildcontrol ./internal/cli
+	goimports -w -l $(GOIMPORTS_LOCAL_ARG) internal/
 
 wire-check:
 	wire check ./internal/engine ./internal/engine/buildcontrol ./internal/cli

--- a/internal/cli/ci.go
+++ b/internal/cli/ci.go
@@ -49,7 +49,7 @@ See blog post for additional information: https://blog.tilt.dev/2020/04/16/how-t
 	addTiltfileFlag(cmd, &c.fileName)
 	addKubeContextFlag(cmd)
 	addNamespaceFlag(cmd)
-	addLogFilterFlags(cmd, &logSourceFlag, &logResourceFlag, &logLevelFlag)
+	addLogFilterFlags(cmd)
 
 	cmd.Flags().BoolVar(&logActionsFlag, "logactions", false, "log all actions and state changes")
 	cmd.Flags().Lookup("logactions").Hidden = true

--- a/internal/cli/flags.go
+++ b/internal/cli/flags.go
@@ -19,7 +19,6 @@ var (
 	defaultWebPort       = model.DefaultWebPort
 	defaultNamespace     = ""
 	defaultLogLevel      = ""
-	defaultLogResource   = ""
 	defaultLogSource     = "all"
 	webHostFlag          = ""
 	webPortFlag          = 0
@@ -82,8 +81,8 @@ func addNamespaceFlag(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&namespaceOverride, "namespace", defaultNamespace, "Default namespace for Kubernetes resources (overrides default namespace from active context in kubeconfig)")
 }
 
-func addLogFilterFlags(cmd *cobra.Command, logSource *string, logResource *string, logLevel *string) {
-	cmd.Flags().StringVar(logLevel, "log-level", defaultLogLevel, `Specify a log level. One of "warn", "error"`)
+func addLogFilterFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVar(&logLevelFlag, "log-level", defaultLogLevel, `Specify a log level. One of "warn", "error"`)
 	_ = cmd.RegisterFlagCompletionFunc(
 		"log-level",
 		func(_ *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {
@@ -98,8 +97,8 @@ func addLogFilterFlags(cmd *cobra.Command, logSource *string, logResource *strin
 			return completions, cobra.ShellCompDirectiveNoFileComp
 		},
 	)
-	cmd.Flags().StringVar(logResource, "log-resource", defaultLogResource, `Specify a resource to print logs for, e.g. "(Tiltfile)", "nginx", etc.`)
-	cmd.Flags().StringVar(logSource, "log-source", defaultLogSource, `Specify a log source. One of "all", "build", "runtime"`)
+	cmd.Flags().StringSliceVar(&logResourcesFlag, "log-resource", nil, `Specify one or more resources to print logs for, e.g. "(Tiltfile)", "nginx", etc. If not specified, prints all resources.`)
+	cmd.Flags().StringVar(&logSourceFlag, "log-source", defaultLogSource, `Specify a log source. One of "all", "build", "runtime"`)
 	_ = cmd.RegisterFlagCompletionFunc(
 		"log-source",
 		func(_ *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -31,12 +31,12 @@ var webModeFlag model.WebMode = model.DefaultWebMode
 const DefaultWebDevPort = 46764
 
 var (
-	updateModeFlag  string = string(liveupdates.UpdateModeAuto)
-	webDevPort             = 0
-	logActionsFlag  bool   = false
-	logSourceFlag   string = ""
-	logResourceFlag string = ""
-	logLevelFlag    string = ""
+	updateModeFlag   string   = string(liveupdates.UpdateModeAuto)
+	webDevPort                = 0
+	logActionsFlag   bool     = false
+	logSourceFlag    string   = ""
+	logResourcesFlag []string = nil
+	logLevelFlag     string   = ""
 )
 
 var userExitError = errors.New("user requested Tilt exit")
@@ -89,7 +89,7 @@ local resources--i.e. those using serve_cmd--are terminated when you exit Tilt.
 	addTiltfileFlag(cmd, &c.fileName)
 	addKubeContextFlag(cmd)
 	addNamespaceFlag(cmd)
-	addLogFilterFlags(cmd, &logSourceFlag, &logResourceFlag, &logLevelFlag)
+	addLogFilterFlags(cmd)
 	cmd.Flags().Lookup("logactions").Hidden = true
 	cmd.Flags().StringVar(&c.outputSnapshotOnExit, "output-snapshot-on-exit", "", "If specified, Tilt will dump a snapshot of its state to the specified path when it exits")
 

--- a/internal/cli/wire.go
+++ b/internal/cli/wire.go
@@ -107,7 +107,7 @@ var BaseWireSet = wire.NewSet(
 	build.ProvideClock,
 	provideClock,
 	provideLogSource,
-	provideLogResource,
+	provideLogResources,
 	provideLogLevel,
 	hud.WireSet,
 	prompt.WireSet,
@@ -360,17 +360,21 @@ func provideLogSource() hud.FilterSource {
 	return hud.FilterSource(logSourceFlag)
 }
 
-func provideLogResource() model.ManifestName {
-	return model.ManifestName(logResourceFlag)
+func provideLogResources() hud.FilterResources {
+	result := []model.ManifestName{}
+	for _, r := range logResourcesFlag {
+		result = append(result, model.ManifestName(r))
+	}
+	return hud.FilterResources(result)
 }
 
-func provideLogLevel() logger.Level {
+func provideLogLevel() hud.FilterLevel {
 	switch logLevelFlag {
 	case "warn", "WARN", "warning", "WARNING":
-		return logger.WarnLvl
+		return hud.FilterLevel(logger.WarnLvl)
 	case "error", "ERROR":
-		return logger.ErrorLvl
+		return hud.FilterLevel(logger.ErrorLvl)
 	default:
-		return logger.NoneLvl
+		return hud.FilterLevel(logger.NoneLvl)
 	}
 }

--- a/internal/engine/buildcontrol/wire_gen.go
+++ b/internal/engine/buildcontrol/wire_gen.go
@@ -8,8 +8,11 @@ package buildcontrol
 
 import (
 	"context"
+
 	"github.com/google/wire"
 	"github.com/jonboulle/clockwork"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	"github.com/tilt-dev/clusterid"
 	"github.com/tilt-dev/tilt/internal/analytics"
 	"github.com/tilt-dev/tilt/internal/build"
@@ -29,7 +32,6 @@ import (
 	"github.com/tilt-dev/tilt/internal/tracer"
 	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
 	"github.com/tilt-dev/wmclient/pkg/dirs"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // Injectors from wire.go:

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -3187,7 +3187,7 @@ func newTestFixture(t *testing.T, options ...fixtureOptions) *testFixture {
 	lsc := local.NewServerController(cdc)
 	sr := ctrlsession.NewReconciler(cdc, st, clock)
 	sessionController := session.NewController(sr)
-	ts := hud.NewTerminalStream(hud.NewIncrementalPrinter(log), hud.NewLogFilter(hud.FilterSourceAll, "", logger.NoneLvl), st)
+	ts := hud.NewTerminalStream(hud.NewIncrementalPrinter(log), hud.NewLogFilter(hud.FilterSourceAll, nil, hud.FilterLevel(logger.NoneLvl)), st)
 	tp := prompt.NewTerminalPrompt(ta, prompt.TTYOpen, openurl.BrowserOpen,
 		log, "localhost", model.WebURL{})
 	h := hud.NewFakeHud()

--- a/internal/engine/wire_gen.go
+++ b/internal/engine/wire_gen.go
@@ -8,8 +8,12 @@ package engine
 
 import (
 	"context"
+
 	"github.com/google/wire"
 	"github.com/jonboulle/clockwork"
+	"go.opentelemetry.io/otel/sdk/trace"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	"github.com/tilt-dev/clusterid"
 	"github.com/tilt-dev/tilt/internal/analytics"
 	"github.com/tilt-dev/tilt/internal/build"
@@ -30,8 +34,6 @@ import (
 	"github.com/tilt-dev/tilt/internal/tracer"
 	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
 	"github.com/tilt-dev/wmclient/pkg/dirs"
-	"go.opentelemetry.io/otel/sdk/trace"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // Injectors from wire.go:

--- a/internal/hud/log_filter_test.go
+++ b/internal/hud/log_filter_test.go
@@ -139,19 +139,19 @@ func TestLogFilterMatches(t *testing.T) {
 		},
 		{
 			description: "empty manifest name matches any logs",
-			logFilter:   LogFilter{source: FilterSourceAll, manifestName: ""},
+			logFilter:   LogFilter{source: FilterSourceAll, resources: nil},
 			input:       logstore.LogLine{SpanID: "pod:default:nginx", ManifestName: "nginx"},
 			expected:    true,
 		},
 		{
 			description: "manifest name matches logs with the same manifest name",
-			logFilter:   LogFilter{source: FilterSourceAll, manifestName: "nginx"},
+			logFilter:   LogFilter{source: FilterSourceAll, resources: FilterResources{"nginx"}},
 			input:       logstore.LogLine{SpanID: "pod:default:nginx", ManifestName: "nginx"},
 			expected:    true,
 		},
 		{
 			description: "manifest name does not match logs with a different manifest name",
-			logFilter:   LogFilter{source: FilterSourceAll, manifestName: "test"},
+			logFilter:   LogFilter{source: FilterSourceAll, resources: FilterResources{"test"}},
 			input:       logstore.LogLine{SpanID: "pod:default:nginx", ManifestName: "nginx"},
 			expected:    false,
 		},
@@ -261,7 +261,7 @@ func TestLogFilterApply(t *testing.T) {
 		},
 		{
 			description: "filter with manifest name matches only logs with the same manifest name",
-			logFilter:   LogFilter{source: FilterSourceAll, manifestName: "nginx"},
+			logFilter:   LogFilter{source: FilterSourceAll, resources: FilterResources{"nginx"}},
 			input: []logstore.LogLine{
 				{SpanID: "pod:default:nginx", ManifestName: "nginx"},
 				{SpanID: "build:1", ManifestName: "nginx"},

--- a/pkg/webview/view.pb.go
+++ b/pkg/webview/view.pb.go
@@ -741,12 +741,12 @@ func (x *VersionSettings) GetCheckUpdates() bool {
 
 // Our websocket service has two kinds of View messages:
 //
-// 1) On initialization, we send down the complete view state
-//    (TiltStartTime, UISession, UIResources, and LogList)
+//  1. On initialization, we send down the complete view state
+//     (TiltStartTime, UISession, UIResources, and LogList)
 //
-// 2) On every change, we send down the resources that have
-//    changed since the last send().
-//    (new logs and any updated UISession/UIResource objects).
+//  2. On every change, we send down the resources that have
+//     changed since the last send().
+//     (new logs and any updated UISession/UIResource objects).
 //
 // All other fields are obsolete, but are needed for deserializing
 // old snapshots.
@@ -1268,9 +1268,9 @@ func (x *UploadSnapshotResponse) GetUrl() string {
 // NOTE(nick): This is obsolete.
 //
 // Our websocket service has two kinds of messages:
-// 1) On initialization, we send down the complete view state
-// 2) On every change, we send down the resources that have
-//    changed since the last send().
+//  1. On initialization, we send down the complete view state
+//  2. On every change, we send down the resources that have
+//     changed since the last send().
 type AckWebsocketRequest struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache

--- a/toast.yml
+++ b/toast.yml
@@ -27,7 +27,7 @@ tasks:
        --go_out=. --go_opt=paths=source_relative \
        --go-grpc_out=. --go-grpc_opt=paths=source_relative \
        pkg/webview/*.proto
-      sed -i 's|v1alpha1 "pkg/apis/core/v1alpha1"|v1alpha1 "github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"|g' pkg/webview/*.pb.go 
+      sed -i 's|v1alpha1 "pkg/apis/core/v1alpha1"|v1alpha1 "github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"|g' pkg/webview/*.pb.go
       sed -i 's|"$ref": "#/definitions/v1Time",|"type": "string", "format": "date-time",|g' pkg/webview/view.swagger.json
       sed -i 's|"$ref": "#/definitions/v1MicroTime",|"type": "string", "format": "date-time",|g' pkg/webview/view.swagger.json
       goimports -local github.com/tilt-dev -w pkg/webview/*.pb.go
@@ -45,22 +45,3 @@ tasks:
       declare namespace Proto
       " --output web/src/view.d.ts
       sed -i 's|v1alpha1 "pkg/apis/core/v1alpha1"|v1alpha1 "github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"|g' pkg/webview/*.pb.go
-
-  wire:
-    input_paths:
-      - go.mod
-      - go.sum
-      - cmd
-      - integration
-      - internal
-      - pkg
-      - web/web.go
-      - vendor
-      - Makefile
-    output_paths:
-      - ./internal/cli/wire_gen.go
-      - ./internal/engine/wire_gen.go
-      - ./internal/engine/buildcontrol/wire_gen.go
-    command: |
-      make wire-dev
-      make goimports


### PR DESCRIPTION
- create custom wire types
- allow multiple resource filters
- remove legacy wire gen

Signed-off-by: Nick Santos <nick.santos@docker.com>
