### PR TITLE
cli: reconcile `tilt up` and `tilt logs`

### DIFF
--- a/internal/cli/ci.go
+++ b/internal/cli/ci.go
@@ -49,7 +49,8 @@ See blog post for additional information: https://blog.tilt.dev/2020/04/16/how-t
 	addTiltfileFlag(cmd, &c.fileName)
 	addKubeContextFlag(cmd)
 	addNamespaceFlag(cmd)
-	addLogFilterFlags(cmd)
+	addLogFilterFlags(cmd, "log-")
+	addLogFilterResourcesFlag(cmd)
 
 	cmd.Flags().BoolVar(&logActionsFlag, "logactions", false, "log all actions and state changes")
 	cmd.Flags().Lookup("logactions").Hidden = true

--- a/internal/cli/flags.go
+++ b/internal/cli/flags.go
@@ -81,10 +81,14 @@ func addNamespaceFlag(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&namespaceOverride, "namespace", defaultNamespace, "Default namespace for Kubernetes resources (overrides default namespace from active context in kubeconfig)")
 }
 
-func addLogFilterFlags(cmd *cobra.Command) {
-	cmd.Flags().StringVar(&logLevelFlag, "log-level", defaultLogLevel, `Specify a log level. One of "warn", "error"`)
+func addLogFilterResourcesFlag(cmd *cobra.Command) {
+	cmd.Flags().StringSliceVar(&logResourcesFlag, "log-resource", nil, `Specify one or more resources to print logs for, e.g. "(Tiltfile)", "nginx", etc. If not specified, prints all resources.`)
+}
+
+func addLogFilterFlags(cmd *cobra.Command, prefix string) {
+	cmd.Flags().StringVar(&logLevelFlag, prefix+"level", defaultLogLevel, `Specify a log level. One of "warn", "error"`)
 	_ = cmd.RegisterFlagCompletionFunc(
-		"log-level",
+		prefix+"level",
 		func(_ *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			var completions []string
 			options := []string{"warn", "error"}
@@ -97,10 +101,9 @@ func addLogFilterFlags(cmd *cobra.Command) {
 			return completions, cobra.ShellCompDirectiveNoFileComp
 		},
 	)
-	cmd.Flags().StringSliceVar(&logResourcesFlag, "log-resource", nil, `Specify one or more resources to print logs for, e.g. "(Tiltfile)", "nginx", etc. If not specified, prints all resources.`)
-	cmd.Flags().StringVar(&logSourceFlag, "log-source", defaultLogSource, `Specify a log source. One of "all", "build", "runtime"`)
+	cmd.Flags().StringVar(&logSourceFlag, prefix+"source", defaultLogSource, `Specify a log source. One of "all", "build", "runtime"`)
 	_ = cmd.RegisterFlagCompletionFunc(
-		"log-source",
+		prefix+"source",
 		func(_ *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			var completions []string
 			options := []string{

--- a/internal/cli/logs.go
+++ b/internal/cli/logs.go
@@ -33,8 +33,8 @@ By default, looks for a running Tilt instance on localhost:10350
 
 	cmd.Flags().BoolVarP(&c.follow, "follow", "f", false, "If true, stream the requested logs; otherwise, print the requested logs at the current moment in time, then exit.")
 
-	// TODO: log level flags
 	addConnectServerFlags(cmd)
+	addLogFilterFlags(cmd, "")
 	return cmd
 }
 
@@ -48,10 +48,13 @@ func (c *logsCmd) run(ctx context.Context, args []string) error {
 		log.Printf("Tilt analytics disabled: %s", reason)
 	}
 
+	// For `tilt logs`, the resources are passed as extra args.
+	logResourcesFlag = args
+
 	logDeps, err := wireLogsDeps(ctx, a, "logs")
 	if err != nil {
 		return err
 	}
 
-	return server.StreamLogs(ctx, c.follow, logDeps.url, args, logDeps.printer)
+	return server.StreamLogs(ctx, c.follow, logDeps.url, logDeps.filter, logDeps.printer)
 }

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -89,7 +89,8 @@ local resources--i.e. those using serve_cmd--are terminated when you exit Tilt.
 	addTiltfileFlag(cmd, &c.fileName)
 	addKubeContextFlag(cmd)
 	addNamespaceFlag(cmd)
-	addLogFilterFlags(cmd)
+	addLogFilterFlags(cmd, "log-")
+	addLogFilterResourcesFlag(cmd)
 	cmd.Flags().Lookup("logactions").Hidden = true
 	cmd.Flags().StringVar(&c.outputSnapshotOnExit, "output-snapshot-on-exit", "", "If specified, Tilt will dump a snapshot of its state to the specified path when it exits")
 

--- a/internal/cli/wire.go
+++ b/internal/cli/wire.go
@@ -305,20 +305,15 @@ func ProvideDownDeps(
 }
 
 func wireLogsDeps(ctx context.Context, tiltAnalytics *analytics.TiltAnalytics, subcommand model.TiltSubcommand) (LogsDeps, error) {
-	wire.Build(UpWireSet, ProvideLogsDeps)
+	wire.Build(UpWireSet,
+		wire.Struct(new(LogsDeps), "*"))
 	return LogsDeps{}, nil
 }
 
 type LogsDeps struct {
 	url     model.WebURL
 	printer *hud.IncrementalPrinter
-}
-
-func ProvideLogsDeps(u model.WebURL, p *hud.IncrementalPrinter) LogsDeps {
-	return LogsDeps{
-		url:     u,
-		printer: p,
-	}
+	filter  hud.LogFilter
 }
 
 func provideClock() func() time.Time {

--- a/internal/cli/wire_gen.go
+++ b/internal/cli/wire_gen.go
@@ -991,7 +991,15 @@ func wireLogsDeps(ctx context.Context, tiltAnalytics *analytics.TiltAnalytics, s
 	}
 	stdout := hud.ProvideStdout()
 	incrementalPrinter := hud.NewIncrementalPrinter(stdout)
-	logsDeps := ProvideLogsDeps(webURL, incrementalPrinter)
+	filterSource := provideLogSource()
+	filterResources := provideLogResources()
+	filterLevel := provideLogLevel()
+	logFilter := hud.NewLogFilter(filterSource, filterResources, filterLevel)
+	logsDeps := LogsDeps{
+		url:     webURL,
+		printer: incrementalPrinter,
+		filter:  logFilter,
+	}
 	return logsDeps, nil
 }
 
@@ -1149,13 +1157,7 @@ func ProvideDownDeps(
 type LogsDeps struct {
 	url     model.WebURL
 	printer *hud.IncrementalPrinter
-}
-
-func ProvideLogsDeps(u model.WebURL, p *hud.IncrementalPrinter) LogsDeps {
-	return LogsDeps{
-		url:     u,
-		printer: p,
-	}
+	filter  hud.LogFilter
 }
 
 func provideClock() func() time.Time {

--- a/internal/hud/log_filter.go
+++ b/internal/hud/log_filter.go
@@ -68,6 +68,11 @@ func (f LogFilter) matchesLevelFilter(line logstore.LogLine) bool {
 	return f.level == line.Level
 }
 
+// if printing logs for only one resource, don't need resource name prefix
+func (f LogFilter) SuppressPrefix() bool {
+	return len(f.resources) == 1
+}
+
 // Matches Checks if this line matches the current filter.
 // The implementation is identical to matchesFilter in web/src/OverviewLogPane.tsx.
 // except for term filtering as tools like grep can be used from the CLI.

--- a/internal/hud/server/logs_reader_test.go
+++ b/internal/hud/server/logs_reader_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/tilt-dev/tilt/pkg/logger"
 	"github.com/tilt-dev/tilt/pkg/model"
 
 	"github.com/tilt-dev/tilt/internal/hud"
@@ -141,20 +142,27 @@ type logStreamerFixture struct {
 func newLogStreamerFixture(t *testing.T) *logStreamerFixture {
 	fakeStdout := &bytes.Buffer{}
 	printer := hud.NewIncrementalPrinter(hud.Stdout(fakeStdout))
+	filter := hud.NewLogFilter(
+		hud.FilterSourceAll,
+		hud.FilterResources{},
+		hud.FilterLevel(logger.InfoLvl))
 	return &logStreamerFixture{
 		t:          t,
 		fakeStdout: fakeStdout,
 		printer:    printer,
-		ls:         NewLogStreamer(nil, printer),
+		ls:         NewLogStreamer(filter, printer),
 	}
 }
 
 func (f *logStreamerFixture) withResourceNames(resourceNames ...string) *logStreamerFixture {
-	rns := make(model.ManifestNameSet, len(resourceNames))
+	resources := []model.ManifestName{}
 	for _, rn := range resourceNames {
-		rns[model.ManifestName(rn)] = true
+		resources = append(resources, model.ManifestName(rn))
 	}
-	f.ls.resources = rns
+	f.ls.filter = hud.NewLogFilter(
+		hud.FilterSourceAll,
+		hud.FilterResources(resources),
+		hud.FilterLevel(logger.InfoLvl))
 	return f
 }
 

--- a/internal/hud/terminal_stream.go
+++ b/internal/hud/terminal_stream.go
@@ -52,7 +52,9 @@ func (h *TerminalStream) OnChange(ctx context.Context, st store.RStore, _ store.
 	}
 
 	state := st.RLockState()
-	lines := state.LogStore.ContinuingLines(h.ProcessedLogs)
+	lines := state.LogStore.ContinuingLinesWithOptions(h.ProcessedLogs, logstore.LineOptions{
+		SuppressPrefix: h.filter.SuppressPrefix(),
+	})
 	lines = h.filter.Apply(lines)
 
 	checkpoint := state.LogStore.Checkpoint()


### PR DESCRIPTION
- ensure they both let you filter by level/source
- ensure they both print the prefix when necessary

Signed-off-by: Nick Santos <nick.santos@docker.com>
