### PR TITLE
When calculating Kustomize dependencies, include components

### DIFF
--- a/internal/kustomize/dependencies.go
+++ b/internal/kustomize/dependencies.go
@@ -86,6 +86,7 @@ func dependenciesForKustomization(dir string) ([]string, error) {
 	}
 
 	paths := append([]string{}, content.Bases...)
+	paths = append(paths, content.Components...)
 	paths = append(paths, content.Resources...)
 
 	for _, p := range paths {

--- a/internal/kustomize/dependencies_test.go
+++ b/internal/kustomize/dependencies_test.go
@@ -86,6 +86,8 @@ func TestRecursive(t *testing.T) {
 	// https://github.com/tilt-dev/tilt/blob/15d0c94ccc08230d3a528b14cb0a3455b947d13c/vendor/sigs.k8s.io/kustomize/api/types/kustomization.go#L102
 	kustomize := `bases:
 - ./dev
+components:
+- ./component
 resources:
 - ./staging
 - ./production
@@ -114,6 +116,11 @@ namePrefix: cluster-a-`
 namePrefix: dev-`
 	f.writeBaseKustomize("dev", dev)
 
+	component := `labels:
+  - pairs:
+      instance: myapp`
+	f.writeBaseKustomize("component", component)
+
 	staging := `bases:
 - ./../base
 namePrefix: stag-`
@@ -127,6 +134,7 @@ namePrefix: prod-`
 	expected := []string{
 		"base/kustomization.yaml",
 		"base/pod.yaml",
+		"component/kustomization.yaml",
 		"dev/kustomization.yaml",
 		"staging/kustomization.yaml",
 		"production/kustomization.yaml",


### PR DESCRIPTION
When calling `kustomize(<directory>)` in a Tiltfile, the directory is watched as well as any paths the Kustomization includes. This doesn't currently include components, so Kustomizations that include [components](https://github.com/kubernetes-sigs/kustomize/blob/master/examples/components.md) don't trigger a reload of the Tiltfile and the Kustomization when files in those components change.

This PR adds the `components:` field of a Kustomization to the list of paths `dependenciesForKustomization` will inspect.