### PR TITLE
liveupdate: always update k8s clusters with kubectl exec

### DIFF
--- a/internal/controllers/core/liveupdate/reconciler.go
+++ b/internal/controllers/core/liveupdate/reconciler.go
@@ -1005,11 +1005,6 @@ func (r *Reconciler) containerUpdater(input Input) containerupdate.ContainerUpda
 		return r.ExecUpdater
 	}
 
-	dcu, ok := r.DockerUpdater.(*containerupdate.DockerUpdater)
-	if ok && dcu.WillBuildToKubeContext(r.kubeContext) {
-		return r.DockerUpdater
-	}
-
 	return r.ExecUpdater
 }
 


### PR DESCRIPTION
this is a fun deep dive into the history of Tilt
and Kubernetes file-syncing

When Tilt was first written, there weren't well-established
conventions for how to sync a file to a cluster. There
were disagreements about whether this was a "user-space"
operation or a "privileged" operation, and what permissions
a file should get when it's written.

Over the years, all that's settled down: the k8s community
has invested a lot in having a robust, streaming exec
endpoint, and using that for all file copying.

(a similar convergence has happened on the container runtime
side -- everything has consolidated on the docker exec
endpoint, rather than separate file-copying endpoints)

with that in mind, let's simplify things even more
and use kubectl exec endpoint, even when we have direct
access to the container runtime.

this fixes the case when Docker Desktop is using
separate container runtimes that share an image store.

fixes https://github.com/tilt-dev/tilt/issues/6533

Signed-off-by: Nick Santos <nick.santos@docker.com>
