### PR TITLE
cmd: fix a flaky test

### DIFF
--- a/internal/controllers/core/cmd/execer_test.go
+++ b/internal/controllers/core/cmd/execer_test.go
@@ -72,7 +72,6 @@ func TestShutdownOnCancel(t *testing.T) {
 function cleanup()
 {
   echo "cleanup time!"
-  exit 1
 }
 
 trap cleanup EXIT
@@ -80,8 +79,6 @@ sleep 100
 `
 	f.start(cmd)
 	f.cancel()
-
-	time.Sleep(time.Second)
 	f.waitForStatus(Done)
 	f.assertLogContains("cleanup time")
 }


### PR DESCRIPTION
i think it's technicall incorrect
to exit within a TRAP.

i don't 100% understand why this
fails non-deterministically, but
skipping the exit+sleep should be faster
and more correct.

Signed-off-by: Nick Santos <nick.santos@docker.com>
