### PR TITLE
Docker delete volumes

### DIFF
--- a/internal/cli/down.go
+++ b/internal/cli/down.go
@@ -24,7 +24,7 @@ import (
 type downCmd struct {
 	fileName         string
 	deleteNamespaces bool
-	deleteVolumes bool
+	deleteVolumes    bool
 	downDepsProvider func(ctx context.Context, tiltAnalytics *analytics.TiltAnalytics, subcommand model.TiltSubcommand) (DownDeps, error)
 }
 

--- a/internal/cli/down.go
+++ b/internal/cli/down.go
@@ -24,6 +24,7 @@ import (
 type downCmd struct {
 	fileName         string
 	deleteNamespaces bool
+	deleteVolumes bool
 	downDepsProvider func(ctx context.Context, tiltAnalytics *analytics.TiltAnalytics, subcommand model.TiltSubcommand) (DownDeps, error)
 }
 
@@ -51,6 +52,8 @@ Specify additional flags and arguments to control which resources are deleted.
 
 Namespaces are not deleted by default. Use --delete-namespaces to change that.
 
+Docker Volumes are not deleted by default. Use --delete-volumes to change that.
+
 Kubernetes resources with the annotation 'tilt.dev/down-policy: keep' are not deleted.
 
 For more complex cases, the Tiltfile has APIs to add additional flags and arguments to the Tilt CLI.
@@ -63,6 +66,7 @@ See https://docs.tilt.dev/tiltfile_config.html for examples.
 	addKubeContextFlag(cmd)
 	addNamespaceFlag(cmd)
 	cmd.Flags().BoolVar(&c.deleteNamespaces, "delete-namespaces", false, "delete namespaces defined in the Tiltfile (by default, don't)")
+	cmd.Flags().BoolVar(&c.deleteVolumes, "delete-volumes", false, "delete docker volumes defined in the Tiltfile (by default, don't)")
 
 	return cmd
 }
@@ -106,7 +110,7 @@ func (c *downCmd) down(ctx context.Context, downDeps DownDeps, args []string) er
 
 	for _, dcProject := range dcProjects {
 		dcc := downDeps.dcClient
-		err = dcc.Down(ctx, dcProject, logger.Get(ctx).Writer(logger.InfoLvl), logger.Get(ctx).Writer(logger.InfoLvl))
+		err = dcc.Down(ctx, dcProject, logger.Get(ctx).Writer(logger.InfoLvl), logger.Get(ctx).Writer(logger.InfoLvl), c.deleteVolumes)
 		if err != nil {
 			return errors.Wrap(err, "Running `docker-compose down`")
 		}

--- a/internal/dockercompose/client.go
+++ b/internal/dockercompose/client.go
@@ -42,7 +42,7 @@ var dcProjectOptions = []compose.ProjectOptionsFn{
 
 type DockerComposeClient interface {
 	Up(ctx context.Context, spec v1alpha1.DockerComposeServiceSpec, shouldBuild bool, stdout, stderr io.Writer) error
-	Down(ctx context.Context, spec v1alpha1.DockerComposeProject, stdout, stderr io.Writer) error
+	Down(ctx context.Context, spec v1alpha1.DockerComposeProject, stdout, stderr io.Writer, deleteVolumes bool) error
 	Rm(ctx context.Context, specs []v1alpha1.DockerComposeServiceSpec, stdout, stderr io.Writer) error
 	StreamEvents(ctx context.Context, spec v1alpha1.DockerComposeProject) (<-chan string, error)
 	Project(ctx context.Context, spec v1alpha1.DockerComposeProject) (*types.Project, error)
@@ -146,7 +146,7 @@ func (c *cmdDCClient) Up(ctx context.Context, spec v1alpha1.DockerComposeService
 	return FormatError(cmd, nil, cmd.Run())
 }
 
-func (c *cmdDCClient) Down(ctx context.Context, p v1alpha1.DockerComposeProject, stdout, stderr io.Writer) error {
+func (c *cmdDCClient) Down(ctx context.Context, p v1alpha1.DockerComposeProject, stdout, stderr io.Writer, deleteVolumes bool) error {
 	// To be safe, we try not to run two docker-compose downs in parallel,
 	// because we know docker-compose up is not thread-safe.
 	c.mu.Lock()
@@ -158,6 +158,9 @@ func (c *cmdDCClient) Down(ctx context.Context, p v1alpha1.DockerComposeProject,
 	}
 
 	args = append(args, "down", "--remove-orphans")
+	if deleteVolumes {
+	    args = append(args, "--volumes")
+	}
 	cmd := c.dcCommand(ctx, args)
 	cmd.Stdin = strings.NewReader(p.YAML)
 	cmd.Stdout = stdout

--- a/internal/dockercompose/client.go
+++ b/internal/dockercompose/client.go
@@ -159,7 +159,7 @@ func (c *cmdDCClient) Down(ctx context.Context, p v1alpha1.DockerComposeProject,
 
 	args = append(args, "down", "--remove-orphans")
 	if deleteVolumes {
-	    args = append(args, "--volumes")
+		args = append(args, "--volumes")
 	}
 	cmd := c.dcCommand(ctx, args)
 	cmd.Stdin = strings.NewReader(p.YAML)

--- a/internal/dockercompose/fake_client.go
+++ b/internal/dockercompose/fake_client.go
@@ -72,7 +72,7 @@ func (c *FakeDCClient) Up(ctx context.Context, spec v1alpha1.DockerComposeServic
 	return nil
 }
 
-func (c *FakeDCClient) Down(ctx context.Context, proj v1alpha1.DockerComposeProject, stdout, stderr io.Writer) error {
+func (c *FakeDCClient) Down(ctx context.Context, proj v1alpha1.DockerComposeProject, stdout, stderr io.Writer, deleteVolumes bool) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 


### PR DESCRIPTION
Add '--delete-volumes' option to `tilt down` that removes volumes for docker compose projects only.

`docker compose down` does not remove internal volumes without a '-v|--volumes' option. This change adds that option if `tilt down` is called with an additional '--delete-volumes' option.

Tested and working as expected.