### PR TITLE
store: initialize BuildStatus at startup

### DIFF
--- a/internal/controllers/core/tiltfile/reducers.go
+++ b/internal/controllers/core/tiltfile/reducers.go
@@ -159,7 +159,7 @@ func HandleConfigsReloaded(
 			// Manifest has changed such that the current build is invalid;
 			// ensure we do an image build so that we apply the changes
 			ms := mt.State
-			ms.BuildStatuses = make(map[model.TargetID]*store.BuildStatus)
+			ms.ResetBuildStatus(m)
 			ms.PendingManifestChange = event.FinishTime
 			ms.ConfigFilesThatCausedChange = configFilesThatChanged
 		}

--- a/internal/engine/buildcontrol/build_control.go
+++ b/internal/engine/buildcontrol/build_control.go
@@ -187,7 +187,12 @@ func HoldTargetsWithBuildingComponents(state store.EngineState, mts []*store.Man
 			building[mt.Manifest.ID()] = true
 
 			for _, spec := range mt.Manifest.TargetSpecs() {
-				if canReuseImageTargetHeuristic(spec, mt.State.BuildStatus(spec.ID())) {
+				bs, ok := mt.State.BuildStatus(spec.ID())
+				if !ok {
+					continue
+				}
+
+				if canReuseImageTargetHeuristic(spec, bs) {
 					continue
 				}
 
@@ -207,7 +212,12 @@ func HoldTargetsWithBuildingComponents(state store.EngineState, mts []*store.Man
 		}
 
 		for _, spec := range m.TargetSpecs() {
-			if canReuseImageTargetHeuristic(spec, mt.State.BuildStatus(spec.ID())) {
+			bs, ok := mt.State.BuildStatus(spec.ID())
+			if !ok {
+				continue
+			}
+
+			if canReuseImageTargetHeuristic(spec, bs) {
 				continue
 			}
 

--- a/internal/engine/buildcontroller.go
+++ b/internal/engine/buildcontroller.go
@@ -215,7 +215,11 @@ func buildStateSet(ctx context.Context, manifest model.Manifest,
 
 	for _, spec := range specs {
 		id := spec.ID()
-		status := ms.BuildStatus(id)
+		status, ok := ms.BuildStatus(id)
+		if !ok {
+			continue
+		}
+
 		filesChanged := status.PendingFileChangesSorted()
 
 		var depsChanged []model.TargetID

--- a/internal/hud/view_test.go
+++ b/internal/hud/view_test.go
@@ -47,7 +47,9 @@ func TestStateToViewRelativeEditPaths(t *testing.T) {
 			},
 		},
 	}
-	ms.MutableBuildStatus(m.ImageTargets[0].ID()).FileChanges =
+	bs, ok := ms.BuildStatus(m.ImageTargets[0].ID())
+	require.True(t, ok)
+	bs.FileChanges =
 		map[string]time.Time{
 			f.JoinPath("a", "b", "c", "foo"):    time.Now(),
 			f.JoinPath("a", "b", "c", "d", "e"): time.Now(),

--- a/internal/hud/webview/convert_test.go
+++ b/internal/hud/webview/convert_test.go
@@ -58,7 +58,9 @@ func TestStateToWebViewRelativeEditPaths(t *testing.T) {
 	ms.BuildHistory = []model.BuildRecord{
 		{},
 	}
-	ms.MutableBuildStatus(m.ImageTargets[0].ID()).FileChanges =
+	bs, ok := ms.BuildStatus(m.ImageTargets[0].ID())
+	require.True(t, ok)
+	bs.FileChanges =
 		map[string]time.Time{
 			f.JoinPath("a", "b", "c", "foo"):    time.Now(),
 			f.JoinPath("a", "b", "c", "d", "e"): time.Now(),

--- a/internal/store/buildcontrols/reducers.go
+++ b/internal/store/buildcontrols/reducers.go
@@ -76,7 +76,10 @@ func handleBuildResults(engineState *store.EngineState,
 	ms := mt.State
 	mn := mt.Manifest.Name
 	for id, result := range results {
-		ms.MutableBuildStatus(id).LastResult = result
+		bs, ok := ms.BuildStatus(id)
+		if ok {
+			bs.LastResult = result
+		}
 	}
 
 	// Remove pending file changes that were consumed by this build.
@@ -122,9 +125,11 @@ func handleBuildResults(engineState *store.EngineState,
 				continue
 			}
 
-			currentStatus := currentMS.MutableBuildStatus(id)
-			currentStatus.LastResult = result
-			currentStatus.ConsumeChangesBefore(br.StartTime)
+			currentStatus, ok := currentMS.BuildStatus(id)
+			if ok {
+				currentStatus.LastResult = result
+				currentStatus.ConsumeChangesBefore(br.StartTime)
+			}
 			updatedIDSet[id] = true
 		}
 
@@ -155,7 +160,10 @@ func handleBuildResults(engineState *store.EngineState,
 				}
 
 				// Otherwise, we need to mark it for rebuild to pick up the new image.
-				currentMS.MutableBuildStatus(rDepID).DependencyChanges[updatedID] = br.StartTime
+				bs, ok := currentMS.BuildStatus(rDepID)
+				if ok {
+					bs.DependencyChanges[updatedID] = br.StartTime
+				}
 			}
 		}
 	}

--- a/internal/store/engine_state_test.go
+++ b/internal/store/engine_state_test.go
@@ -61,7 +61,8 @@ func TestNextBuildReason(t *testing.T) {
 	mt := NewManifestTarget(m)
 
 	iTargetID := model.ImageID(container.MustParseSelector("sancho"))
-	status := mt.State.MutableBuildStatus(kTarget.ID())
+	status, ok := mt.State.BuildStatus(kTarget.ID())
+	require.True(t, ok)
 	assert.Equal(t, "Initial Build",
 		mt.NextBuildReason().String())
 

--- a/internal/store/json_test.go
+++ b/internal/store/json_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/tilt-dev/tilt/internal/k8s/testyaml"
 	"github.com/tilt-dev/tilt/internal/store/k8sconv"
@@ -23,7 +24,9 @@ func TestToJSON(t *testing.T) {
 	state := newState([]model.Manifest{m})
 
 	mState, _ := state.ManifestState("fe")
-	mState.MutableBuildStatus(m.K8sTarget().ID()).LastResult = NewK8sDeployResult(
+	bs, ok := mState.BuildStatus(m.K8sTarget().ID())
+	require.True(t, ok)
+	bs.LastResult = NewK8sDeployResult(
 		m.K8sTarget().ID(), &k8sconv.KubernetesApplyFilter{})
 
 	buf := bytes.NewBuffer(nil)

--- a/internal/store/tiltfiles/reducers.go
+++ b/internal/store/tiltfiles/reducers.go
@@ -2,7 +2,6 @@ package tiltfiles
 
 import (
 	"github.com/tilt-dev/tilt/internal/store"
-	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
 	"github.com/tilt-dev/tilt/pkg/model"
 )
 
@@ -13,12 +12,7 @@ func HandleTiltfileUpsertAction(state *store.EngineState, action TiltfileUpsertA
 
 	_, ok := state.TiltfileStates[mn]
 	if !ok {
-		state.TiltfileStates[mn] = &store.ManifestState{
-			Name:          mn,
-			BuildStatuses: make(map[model.TargetID]*store.BuildStatus),
-			DisableState:  v1alpha1.DisableStateEnabled,
-			CurrentBuilds: make(map[string]model.BuildRecord),
-		}
+		state.TiltfileStates[mn] = store.NewTiltfileManifestState(mn)
 	}
 
 	if mn == model.MainTiltfileManifestName {

--- a/internal/store/uiresources/reducers.go
+++ b/internal/store/uiresources/reducers.go
@@ -32,7 +32,6 @@ func HandleUIResourceUpsertAction(state *store.EngineState, action UIResourceUps
 		}
 
 		ms, ok := state.ManifestState(model.ManifestName(n))
-
 		if ok {
 			ms.DisableState = uir.Status.DisableStatus.State
 			if len(uir.Status.DisableStatus.Sources) > 0 {
@@ -40,8 +39,10 @@ func HandleUIResourceUpsertAction(state *store.EngineState, action UIResourceUps
 					// since file watches are disabled while a resource is disabled, we can't
 					// have confidence in any previous build state
 					ms.BuildHistory = nil
-					if len(ms.BuildStatuses) > 0 {
-						ms.BuildStatuses = make(map[model.TargetID]*store.BuildStatus)
+					if mt, ok := state.ManifestTargets[ms.Name]; ok {
+						ms.ResetBuildStatus(mt.Manifest)
+					} else if _, ok := state.TiltfileStates[ms.Name]; ok {
+						ms.ResetTiltfileBuildStatus(ms.Name)
 					}
 					state.RemoveFromTriggerQueue(ms.Name)
 				}


### PR DESCRIPTION
Before this change, the engine would initialize
BuildStatus lazily.

This was leading to race conditions.
The event that consumed a file change
would sometimes appear before the file change event,
and would get ignored because BuildStatus
hadn't been initialized yet.

Signed-off-by: Nick Santos <nick.santos@docker.com>
