### PR TITLE
Ignore the temporary files of flymake

### DIFF
--- a/internal/ignore/ephemeral.go
+++ b/internal/ignore/ephemeral.go
@@ -18,7 +18,7 @@ var EphemeralPathMatcher = initEphemeralPathMatcher()
 
 func initEphemeralPathMatcher() model.PathMatcher {
 	golandPatterns := []string{"**/*___jb_old___", "**/*___jb_tmp___", "**/.idea/**"}
-	emacsPatterns := []string{"**/.#*", "**/#*#"}
+	emacsPatterns := []string{"**/.#*", "**/#*#", "**/flymake_*.*"}
 	// if .swp is taken (presumably because multiple vims are running in that dir),
 	// vim will go with .swo, .swn, etc, and then even .svz, .svy!
 	// https://github.com/vim/vim/blob/ea781459b9617aa47335061fcc78403495260315/src/memline.c#L5076


### PR DESCRIPTION
This PR adds a new element to `emacsPatterns` to ignore the temporary files created by [Flymake](https://www.gnu.org/software/emacs/manual/html_node/flymake/index.html). I had several failed and unnecessary builds because Tilt tried to rebuild when Flymake created its temporary files.

Thank you for maintaining this useful and cool project. <3
