### PR TITLE
feat: add build insights and analytics dashboard

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -82,6 +82,7 @@ up-to-date in real-time. Think 'docker build && kubectl apply' or 'docker-compos
 	addCommand(rootCmd, newEnableCmd())
 	addCommand(rootCmd, newDisableCmd())
 	addCommand(rootCmd, newTriggerCmd(streams))
+	addCommand(rootCmd, &insightsCmd{})
 
 	rootCmd.AddCommand(analytics.NewCommand())
 	rootCmd.AddCommand(newDumpCmd(rootCmd, streams))

--- a/internal/cli/insights.go
+++ b/internal/cli/insights.go
@@ -1,0 +1,430 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"sort"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/fatih/color"
+	"github.com/spf13/cobra"
+
+	"github.com/tilt-dev/tilt/internal/analytics"
+	"github.com/tilt-dev/tilt/pkg/model"
+)
+
+type insightsCmd struct {
+	output   string // json, table, summary
+	since    string // duration string like "24h" or "7d"
+	resource string // filter by resource
+	limit    int    // limit results
+}
+
+func (c *insightsCmd) name() model.TiltSubcommand { return "insights" }
+
+func (c *insightsCmd) register() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "insights [resource]",
+		Short: "View build insights and analytics",
+		Long: `Display build performance insights and analytics from the running Tilt instance.
+
+This command shows:
+- Build success/failure rates
+- Average build times per resource
+- Performance recommendations
+- Build history and trends
+
+Examples:
+  # View summary of build insights
+  tilt insights
+
+  # View insights for a specific resource
+  tilt insights frontend
+
+  # View detailed JSON output
+  tilt insights --output json
+
+  # View insights for the last 7 days
+  tilt insights --since 168h
+
+  # View recent builds
+  tilt insights --output builds --limit 20
+`,
+	}
+
+	cmd.Flags().StringVarP(&c.output, "output", "o", "summary", "Output format: summary, table, json, builds")
+	cmd.Flags().StringVar(&c.since, "since", "24h", "Show insights since this duration (e.g., 24h, 168h, 720h)")
+	cmd.Flags().StringVarP(&c.resource, "resource", "r", "", "Filter by resource name")
+	cmd.Flags().IntVarP(&c.limit, "limit", "l", 20, "Limit number of results for builds output")
+
+	addConnectServerFlags(cmd)
+	return cmd
+}
+
+func (c *insightsCmd) run(ctx context.Context, args []string) error {
+	a := analytics.Get(ctx)
+	a.Incr("cmd.insights", map[string]string{"output": c.output})
+	defer a.Flush(time.Second)
+
+	// If a resource is provided as argument, use it
+	if len(args) > 0 {
+		c.resource = args[0]
+	}
+
+	// Build the URL
+	host := provideWebHost()
+	port := provideWebPort()
+	baseURL := fmt.Sprintf("http://%s:%d", host, port)
+
+	switch c.output {
+	case "json":
+		return c.fetchAndPrintJSON(baseURL)
+	case "builds":
+		return c.fetchAndPrintBuilds(baseURL)
+	case "table":
+		return c.fetchAndPrintTable(baseURL)
+	default:
+		return c.fetchAndPrintSummary(baseURL)
+	}
+}
+
+func (c *insightsCmd) fetchAndPrintSummary(baseURL string) error {
+	url := fmt.Sprintf("%s/api/insights?since=%s", baseURL, c.since)
+	if c.resource != "" {
+		url = fmt.Sprintf("%s&resource=%s", url, c.resource)
+	}
+
+	insights, err := c.fetchInsights(url)
+	if err != nil {
+		return err
+	}
+
+	c.printSummary(insights)
+	return nil
+}
+
+func (c *insightsCmd) fetchAndPrintJSON(baseURL string) error {
+	url := fmt.Sprintf("%s/api/insights?since=%s", baseURL, c.since)
+	if c.resource != "" {
+		url = fmt.Sprintf("%s&resource=%s", url, c.resource)
+	}
+
+	resp, err := http.Get(url)
+	if err != nil {
+		return fmt.Errorf("failed to connect to Tilt: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("server error: %s", string(body))
+	}
+
+	_, err = io.Copy(os.Stdout, resp.Body)
+	return err
+}
+
+func (c *insightsCmd) fetchAndPrintBuilds(baseURL string) error {
+	url := fmt.Sprintf("%s/api/insights/builds?limit=%d&since=%s", baseURL, c.limit, c.since)
+	if c.resource != "" {
+		url = fmt.Sprintf("%s&resource=%s", url, c.resource)
+	}
+
+	resp, err := http.Get(url)
+	if err != nil {
+		return fmt.Errorf("failed to connect to Tilt: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("server error: %s", string(body))
+	}
+
+	var builds []model.BuildMetric
+	if err := json.NewDecoder(resp.Body).Decode(&builds); err != nil {
+		return fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	c.printBuilds(builds)
+	return nil
+}
+
+func (c *insightsCmd) fetchAndPrintTable(baseURL string) error {
+	url := fmt.Sprintf("%s/api/insights?since=%s", baseURL, c.since)
+	if c.resource != "" {
+		url = fmt.Sprintf("%s&resource=%s", url, c.resource)
+	}
+
+	insights, err := c.fetchInsights(url)
+	if err != nil {
+		return err
+	}
+
+	c.printTable(insights)
+	return nil
+}
+
+func (c *insightsCmd) fetchInsights(url string) (*model.BuildInsights, error) {
+	resp, err := http.Get(url)
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect to Tilt: %w\nIs Tilt running? Try 'tilt up' first.", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusServiceUnavailable {
+		return nil, fmt.Errorf("build insights not available - this may be a version mismatch")
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("server error (%d): %s", resp.StatusCode, string(body))
+	}
+
+	var insights model.BuildInsights
+	if err := json.NewDecoder(resp.Body).Decode(&insights); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	return &insights, nil
+}
+
+func (c *insightsCmd) printSummary(insights *model.BuildInsights) {
+	bold := color.New(color.Bold)
+	green := color.New(color.FgGreen)
+	red := color.New(color.FgRed)
+	yellow := color.New(color.FgYellow)
+	cyan := color.New(color.FgCyan)
+
+	fmt.Println()
+	bold.Println("═══════════════════════════════════════════════════════════")
+	bold.Println("                    BUILD INSIGHTS DASHBOARD                ")
+	bold.Println("═══════════════════════════════════════════════════════════")
+	fmt.Println()
+
+	// Session Summary
+	s := insights.Session
+	bold.Println("📊 Session Summary")
+	fmt.Println("───────────────────────────────────────────────────────────")
+	fmt.Printf("   Total Builds:       %d\n", s.TotalBuilds)
+
+	successRate := float64(0)
+	if s.TotalBuilds > 0 {
+		successRate = float64(s.SuccessfulBuilds) / float64(s.TotalBuilds) * 100
+	}
+
+	if successRate >= 90 {
+		fmt.Printf("   Success Rate:       ")
+		green.Printf("%.1f%%\n", successRate)
+	} else if successRate >= 70 {
+		fmt.Printf("   Success Rate:       ")
+		yellow.Printf("%.1f%%\n", successRate)
+	} else {
+		fmt.Printf("   Success Rate:       ")
+		red.Printf("%.1f%%\n", successRate)
+	}
+
+	fmt.Printf("   Successful:         ")
+	green.Printf("%d\n", s.SuccessfulBuilds)
+	fmt.Printf("   Failed:             ")
+	if s.FailedBuilds > 0 {
+		red.Printf("%d\n", s.FailedBuilds)
+	} else {
+		fmt.Println("0")
+	}
+
+	fmt.Printf("   Avg Duration:       %s\n", formatDuration(s.AverageDurationMs))
+	fmt.Printf("   Total Duration:     %s\n", formatDuration(s.TotalDurationMs))
+	fmt.Printf("   Live Updates:       %d\n", s.LiveUpdateCount)
+	fmt.Printf("   Full Rebuilds:      %d\n", s.FullRebuildCount)
+	fmt.Printf("   Resources:          %d\n", s.ResourceCount)
+
+	if s.CurrentStreak > 0 {
+		fmt.Printf("   Current Streak:     ")
+		if s.StreakType == "success" {
+			green.Printf("%d successful\n", s.CurrentStreak)
+		} else {
+			red.Printf("%d failed\n", s.CurrentStreak)
+		}
+	}
+	fmt.Println()
+
+	// Top Resources by Build Time
+	if len(insights.Resources) > 0 {
+		bold.Println("🏗️  Resources by Build Count")
+		fmt.Println("───────────────────────────────────────────────────────────")
+
+		// Sort by total builds
+		sorted := make([]model.ResourceStats, len(insights.Resources))
+		copy(sorted, insights.Resources)
+		sort.Slice(sorted, func(i, j int) bool {
+			return sorted[i].TotalBuilds > sorted[j].TotalBuilds
+		})
+
+		// Show top 5
+		limit := 5
+		if len(sorted) < limit {
+			limit = len(sorted)
+		}
+
+		for i := 0; i < limit; i++ {
+			r := sorted[i]
+			status := "✓"
+			statusColor := green
+			if r.SuccessRate < 90 {
+				status = "⚠"
+				statusColor = yellow
+			}
+			if r.SuccessRate < 70 {
+				status = "✗"
+				statusColor = red
+			}
+
+			fmt.Printf("   ")
+			statusColor.Printf("%s ", status)
+			cyan.Printf("%-20s", truncate(string(r.ManifestName), 20))
+			fmt.Printf(" %3d builds  ", r.TotalBuilds)
+			fmt.Printf("avg %s  ", formatDuration(r.AverageDurationMs))
+			statusColor.Printf("%.0f%% success\n", r.SuccessRate)
+		}
+		fmt.Println()
+	}
+
+	// Slowest Builds
+	if len(insights.SlowestBuilds) > 0 {
+		bold.Println("🐢 Slowest Builds")
+		fmt.Println("───────────────────────────────────────────────────────────")
+
+		limit := 5
+		if len(insights.SlowestBuilds) < limit {
+			limit = len(insights.SlowestBuilds)
+		}
+
+		for i := 0; i < limit; i++ {
+			b := insights.SlowestBuilds[i]
+			fmt.Printf("   ")
+			yellow.Printf("%-20s", truncate(string(b.ManifestName), 20))
+			fmt.Printf(" %s  ", formatDuration(b.DurationMs))
+			fmt.Printf("%s\n", b.StartTime.Format("15:04:05"))
+		}
+		fmt.Println()
+	}
+
+	// Recommendations
+	if len(insights.Recommendations) > 0 {
+		bold.Println("💡 Recommendations")
+		fmt.Println("───────────────────────────────────────────────────────────")
+
+		limit := 3
+		if len(insights.Recommendations) < limit {
+			limit = len(insights.Recommendations)
+		}
+
+		for i := 0; i < limit; i++ {
+			rec := insights.Recommendations[i]
+			priority := "  "
+			switch rec.Priority {
+			case model.RecommendationPriorityHigh:
+				priority = "❗"
+			case model.RecommendationPriorityMedium:
+				priority = "⚠️ "
+			case model.RecommendationPriorityLow:
+				priority = "ℹ️ "
+			}
+
+			fmt.Printf("   %s ", priority)
+			bold.Printf("%s\n", rec.Title)
+			fmt.Printf("      %s\n", rec.Description)
+			if rec.PotentialSavingsMs > 0 {
+				green.Printf("      Potential savings: %s per build\n", formatDuration(rec.PotentialSavingsMs))
+			}
+			fmt.Println()
+		}
+	}
+
+	bold.Println("═══════════════════════════════════════════════════════════")
+	fmt.Printf("Generated at: %s\n", insights.GeneratedAt.Format(time.RFC3339))
+	fmt.Println()
+}
+
+func (c *insightsCmd) printTable(insights *model.BuildInsights) {
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+
+	fmt.Fprintln(w, "RESOURCE\tBUILDS\tSUCCESS\tAVG TIME\tP95 TIME\tLIVE UPD\tSTATUS")
+	fmt.Fprintln(w, "--------\t------\t-------\t--------\t--------\t--------\t------")
+
+	for _, r := range insights.Resources {
+		status := "OK"
+		if r.SuccessRate < 90 {
+			status = "WARN"
+		}
+		if r.SuccessRate < 70 {
+			status = "FAIL"
+		}
+
+		fmt.Fprintf(w, "%s\t%d\t%.0f%%\t%s\t%s\t%d\t%s\n",
+			truncate(string(r.ManifestName), 20),
+			r.TotalBuilds,
+			r.SuccessRate,
+			formatDuration(r.AverageDurationMs),
+			formatDuration(r.P95DurationMs),
+			r.LiveUpdateCount,
+			status,
+		)
+	}
+
+	w.Flush()
+}
+
+func (c *insightsCmd) printBuilds(builds []model.BuildMetric) {
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+
+	fmt.Fprintln(w, "TIME\tRESOURCE\tDURATION\tTYPE\tSTATUS")
+	fmt.Fprintln(w, "----\t--------\t--------\t----\t------")
+
+	for _, b := range builds {
+		buildType := "rebuild"
+		if b.LiveUpdate {
+			buildType = "live-upd"
+		}
+
+		status := "OK"
+		if !b.Success {
+			status = "FAIL"
+		}
+
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n",
+			b.StartTime.Format("15:04:05"),
+			truncate(string(b.ManifestName), 20),
+			formatDuration(b.DurationMs),
+			buildType,
+			status,
+		)
+	}
+
+	w.Flush()
+}
+
+func formatDuration(ms int64) string {
+	d := time.Duration(ms) * time.Millisecond
+	if d < time.Second {
+		return fmt.Sprintf("%dms", ms)
+	}
+	if d < time.Minute {
+		return fmt.Sprintf("%.1fs", d.Seconds())
+	}
+	return fmt.Sprintf("%.1fm", d.Minutes())
+}
+
+func truncate(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s + strings.Repeat(" ", maxLen-len(s))
+	}
+	return s[:maxLen-1] + "…"
+}

--- a/internal/cli/wire.go
+++ b/internal/cli/wire.go
@@ -57,6 +57,7 @@ import (
 	"github.com/tilt-dev/tilt/internal/token"
 	"github.com/tilt-dev/tilt/internal/tracer"
 	"github.com/tilt-dev/tilt/internal/xdg"
+	"github.com/tilt-dev/tilt/internal/engine/buildinsights"
 	"github.com/tilt-dev/tilt/pkg/logger"
 	"github.com/tilt-dev/tilt/pkg/model"
 )
@@ -153,6 +154,8 @@ var BaseWireSet = wire.NewSet(
 	token.GetOrCreateToken,
 
 	build.NewKINDLoader,
+
+	buildinsights.ProvideInsightsStore,
 
 	wire.Value(feature.MainDefaults),
 )

--- a/internal/engine/buildinsights/collector.go
+++ b/internal/engine/buildinsights/collector.go
@@ -1,0 +1,117 @@
+package buildinsights
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/tilt-dev/tilt/internal/store"
+	"github.com/tilt-dev/tilt/pkg/logger"
+	"github.com/tilt-dev/tilt/pkg/model"
+)
+
+// Collector is a store subscriber that collects build metrics.
+// It listens for BuildCompleteAction events and records them to the insights store.
+type Collector struct {
+	store      model.BuildInsightsStore
+	lastBuilds map[model.ManifestName]time.Time
+}
+
+// NewCollector creates a new build insights collector.
+func NewCollector(store model.BuildInsightsStore) *Collector {
+	return &Collector{
+		store:      store,
+		lastBuilds: make(map[model.ManifestName]time.Time),
+	}
+}
+
+// OnChange implements store.Subscriber.
+// It checks for build completion events and records metrics.
+func (c *Collector) OnChange(ctx context.Context, st store.RStore, summary store.ChangeSummary) error {
+	state := st.RLockState()
+	defer st.RUnlockState()
+
+	// Check each manifest for completed builds
+	for _, mt := range state.ManifestTargets {
+		if mt == nil || mt.State == nil {
+			continue
+		}
+
+		ms := mt.State
+
+		// Get the most recent completed build
+		if len(ms.BuildHistory) == 0 {
+			continue
+		}
+
+		lastBuild := ms.BuildHistory[0]
+		if lastBuild.FinishTime.IsZero() {
+			continue
+		}
+
+		// Check if we've already recorded this build
+		if recorded, ok := c.lastBuilds[mt.Manifest.Name]; ok {
+			if !lastBuild.FinishTime.After(recorded) {
+				continue
+			}
+		}
+
+		// Record this build
+		metric := c.buildRecordToMetric(mt.Manifest.Name, lastBuild)
+		if err := c.store.RecordBuild(metric); err != nil {
+			logger.Get(ctx).Debugf("Failed to record build metric: %v", err)
+			continue
+		}
+
+		c.lastBuilds[mt.Manifest.Name] = lastBuild.FinishTime
+	}
+
+	return nil
+}
+
+// buildRecordToMetric converts a BuildRecord to a BuildMetric.
+func (c *Collector) buildRecordToMetric(name model.ManifestName, br model.BuildRecord) model.BuildMetric {
+	metric := model.BuildMetric{
+		BuildID:      uuid.New().String(),
+		ManifestName: name,
+		BuildTypes:   br.BuildTypes,
+		StartTime:    br.StartTime,
+		FinishTime:   br.FinishTime,
+		DurationMs:   br.Duration().Milliseconds(),
+		Success:      br.Error == nil,
+		WarningCount: br.WarningCount,
+		Reason:       br.Reason,
+		FilesChanged: len(br.Edits),
+	}
+
+	if br.Error != nil {
+		metric.ErrorMessage = br.Error.Error()
+	}
+
+	// Determine if this was a live update
+	for _, bt := range br.BuildTypes {
+		if bt == model.BuildTypeLiveUpdate {
+			metric.LiveUpdate = true
+			break
+		}
+	}
+
+	return metric
+}
+
+// Close cleans up resources.
+func (c *Collector) Close() error {
+	if c.store != nil {
+		return c.store.Close()
+	}
+	return nil
+}
+
+// Store returns the underlying insights store.
+func (c *Collector) Store() model.BuildInsightsStore {
+	return c.store
+}
+
+// Verify Collector implements store.Subscriber.
+var _ store.Subscriber = (*Collector)(nil)

--- a/internal/engine/buildinsights/collector_test.go
+++ b/internal/engine/buildinsights/collector_test.go
@@ -1,0 +1,298 @@
+package buildinsights
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tilt-dev/tilt/internal/store"
+	"github.com/tilt-dev/tilt/pkg/model"
+)
+
+// mockStore implements model.BuildInsightsStore for testing.
+type mockStore struct {
+	mu      sync.Mutex
+	metrics []model.BuildMetric
+}
+
+func newMockStore() *mockStore {
+	return &mockStore{
+		metrics: make([]model.BuildMetric, 0),
+	}
+}
+
+func (m *mockStore) RecordBuild(metric model.BuildMetric) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.metrics = append(m.metrics, metric)
+	return nil
+}
+
+func (m *mockStore) GetInsights(since time.Time) (*model.BuildInsights, error) {
+	return &model.BuildInsights{}, nil
+}
+
+func (m *mockStore) GetResourceStats(name model.ManifestName) (*model.ResourceStats, error) {
+	return &model.ResourceStats{ManifestName: name}, nil
+}
+
+func (m *mockStore) GetRecentBuilds(n int) ([]model.BuildMetric, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if n > len(m.metrics) {
+		n = len(m.metrics)
+	}
+	return m.metrics[:n], nil
+}
+
+func (m *mockStore) GetBuildHistory(name model.ManifestName, since time.Time) ([]model.BuildMetric, error) {
+	return nil, nil
+}
+
+func (m *mockStore) ClearOlderThan(t time.Time) error {
+	return nil
+}
+
+func (m *mockStore) Close() error {
+	return nil
+}
+
+func (m *mockStore) getMetrics() []model.BuildMetric {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	result := make([]model.BuildMetric, len(m.metrics))
+	copy(result, m.metrics)
+	return result
+}
+
+// fakeRStore implements store.RStore for testing.
+type fakeRStore struct {
+	state    store.EngineState
+	stateMu  sync.RWMutex
+	unlocked bool
+}
+
+func newFakeRStore() *fakeRStore {
+	return &fakeRStore{
+		state: *store.NewState(),
+	}
+}
+
+func (f *fakeRStore) Dispatch(action store.Action) {}
+
+func (f *fakeRStore) RLockState() store.EngineState {
+	f.stateMu.RLock()
+	return f.state
+}
+
+func (f *fakeRStore) RUnlockState() {
+	f.stateMu.RUnlock()
+}
+
+func (f *fakeRStore) StateMutex() *sync.RWMutex {
+	return &f.stateMu
+}
+
+func (f *fakeRStore) SetManifestTarget(mt *store.ManifestTarget) {
+	f.stateMu.Lock()
+	defer f.stateMu.Unlock()
+	if f.state.ManifestTargets == nil {
+		f.state.ManifestTargets = make(map[model.ManifestName]*store.ManifestTarget)
+	}
+	f.state.ManifestTargets[mt.Manifest.Name] = mt
+}
+
+func TestCollector_OnChange_RecordsBuild(t *testing.T) {
+	mockSt := newMockStore()
+	collector := NewCollector(mockSt)
+
+	rs := newFakeRStore()
+
+	// Create a manifest with a completed build
+	m := model.Manifest{Name: "test-service"}
+	mt := store.NewManifestTarget(m)
+	mt.State.BuildHistory = []model.BuildRecord{
+		{
+			StartTime:    time.Now().Add(-10 * time.Second),
+			FinishTime:   time.Now(),
+			Reason:       model.BuildReasonFlagChangedFiles,
+			Error:        nil,
+			WarningCount: 0,
+			BuildTypes:   []model.BuildType{model.BuildTypeImage},
+		},
+	}
+	rs.SetManifestTarget(mt)
+
+	// Call OnChange
+	ctx := context.Background()
+	err := collector.OnChange(ctx, rs, store.ChangeSummary{})
+	require.NoError(t, err)
+
+	// Verify metric was recorded
+	metrics := mockSt.getMetrics()
+	require.Len(t, metrics, 1)
+	assert.Equal(t, model.ManifestName("test-service"), metrics[0].ManifestName)
+	assert.True(t, metrics[0].Success)
+}
+
+func TestCollector_OnChange_SkipsDuplicates(t *testing.T) {
+	mockSt := newMockStore()
+	collector := NewCollector(mockSt)
+
+	rs := newFakeRStore()
+
+	finishTime := time.Now()
+
+	// Create a manifest with a completed build
+	m := model.Manifest{Name: "test-service"}
+	mt := store.NewManifestTarget(m)
+	mt.State.BuildHistory = []model.BuildRecord{
+		{
+			StartTime:  finishTime.Add(-10 * time.Second),
+			FinishTime: finishTime,
+			Reason:     model.BuildReasonFlagChangedFiles,
+		},
+	}
+	rs.SetManifestTarget(mt)
+
+	ctx := context.Background()
+
+	// Call OnChange multiple times with the same build
+	for i := 0; i < 5; i++ {
+		err := collector.OnChange(ctx, rs, store.ChangeSummary{})
+		require.NoError(t, err)
+	}
+
+	// Should only have one metric recorded
+	metrics := mockSt.getMetrics()
+	assert.Len(t, metrics, 1)
+}
+
+func TestCollector_OnChange_RecordsNewBuilds(t *testing.T) {
+	mockSt := newMockStore()
+	collector := NewCollector(mockSt)
+
+	rs := newFakeRStore()
+	ctx := context.Background()
+
+	m := model.Manifest{Name: "test-service"}
+	mt := store.NewManifestTarget(m)
+	rs.SetManifestTarget(mt)
+
+	// First build
+	firstFinish := time.Now()
+	mt.State.BuildHistory = []model.BuildRecord{
+		{
+			StartTime:  firstFinish.Add(-10 * time.Second),
+			FinishTime: firstFinish,
+		},
+	}
+	err := collector.OnChange(ctx, rs, store.ChangeSummary{})
+	require.NoError(t, err)
+
+	// Second build (newer)
+	secondFinish := firstFinish.Add(30 * time.Second)
+	mt.State.BuildHistory = []model.BuildRecord{
+		{
+			StartTime:  secondFinish.Add(-5 * time.Second),
+			FinishTime: secondFinish,
+		},
+	}
+	err = collector.OnChange(ctx, rs, store.ChangeSummary{})
+	require.NoError(t, err)
+
+	// Should have two metrics
+	metrics := mockSt.getMetrics()
+	assert.Len(t, metrics, 2)
+}
+
+func TestCollector_OnChange_HandlesFailedBuilds(t *testing.T) {
+	mockSt := newMockStore()
+	collector := NewCollector(mockSt)
+
+	rs := newFakeRStore()
+
+	// Create a manifest with a failed build
+	m := model.Manifest{Name: "failing-service"}
+	mt := store.NewManifestTarget(m)
+	mt.State.BuildHistory = []model.BuildRecord{
+		{
+			StartTime:  time.Now().Add(-10 * time.Second),
+			FinishTime: time.Now(),
+			Error:      assert.AnError,
+		},
+	}
+	rs.SetManifestTarget(mt)
+
+	ctx := context.Background()
+	err := collector.OnChange(ctx, rs, store.ChangeSummary{})
+	require.NoError(t, err)
+
+	metrics := mockSt.getMetrics()
+	require.Len(t, metrics, 1)
+	assert.False(t, metrics[0].Success)
+	assert.NotEmpty(t, metrics[0].ErrorMessage)
+}
+
+func TestCollector_OnChange_DetectsLiveUpdate(t *testing.T) {
+	mockSt := newMockStore()
+	collector := NewCollector(mockSt)
+
+	rs := newFakeRStore()
+
+	// Create a manifest with a live update build
+	m := model.Manifest{Name: "live-update-service"}
+	mt := store.NewManifestTarget(m)
+	mt.State.BuildHistory = []model.BuildRecord{
+		{
+			StartTime:  time.Now().Add(-2 * time.Second),
+			FinishTime: time.Now(),
+			BuildTypes: []model.BuildType{model.BuildTypeLiveUpdate},
+		},
+	}
+	rs.SetManifestTarget(mt)
+
+	ctx := context.Background()
+	err := collector.OnChange(ctx, rs, store.ChangeSummary{})
+	require.NoError(t, err)
+
+	metrics := mockSt.getMetrics()
+	require.Len(t, metrics, 1)
+	assert.True(t, metrics[0].LiveUpdate)
+}
+
+func TestCollector_Close(t *testing.T) {
+	mockSt := newMockStore()
+	collector := NewCollector(mockSt)
+
+	err := collector.Close()
+	require.NoError(t, err)
+}
+
+func TestBuildRecordToMetric(t *testing.T) {
+	collector := NewCollector(nil)
+
+	br := model.BuildRecord{
+		StartTime:    time.Now().Add(-30 * time.Second),
+		FinishTime:   time.Now(),
+		Error:        nil,
+		WarningCount: 2,
+		Reason:       model.BuildReasonFlagChangedFiles,
+		BuildTypes:   []model.BuildType{model.BuildTypeImage, model.BuildTypeK8s},
+		Edits:        []string{"file1.go", "file2.go", "file3.go"},
+	}
+
+	metric := collector.buildRecordToMetric("my-service", br)
+
+	assert.Equal(t, model.ManifestName("my-service"), metric.ManifestName)
+	assert.True(t, metric.Success)
+	assert.Equal(t, 2, metric.WarningCount)
+	assert.Equal(t, 3, metric.FilesChanged)
+	assert.False(t, metric.LiveUpdate)
+	assert.Equal(t, model.BuildReasonFlagChangedFiles, metric.Reason)
+	assert.InDelta(t, 30000, metric.DurationMs, 100)
+}

--- a/internal/engine/buildinsights/store.go
+++ b/internal/engine/buildinsights/store.go
@@ -1,0 +1,599 @@
+package buildinsights
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/tilt-dev/tilt/internal/xdg"
+	"github.com/tilt-dev/tilt/pkg/model"
+)
+
+const (
+	// insightsDir is the directory within XDG data directory for insights storage
+	insightsDir = "insights"
+
+	// metricsFileName is the name of the metrics database file
+	metricsFileName = "build_metrics.json"
+
+	// maxMetricsAge is the default maximum age for stored metrics (30 days)
+	maxMetricsAge = 30 * 24 * time.Hour
+
+	// maxRecentBuilds is the maximum number of recent builds to return
+	maxRecentBuilds = 100
+
+	// maxSlowestBuilds is the number of slowest builds to track
+	maxSlowestBuilds = 10
+)
+
+// FileStore implements BuildInsightsStore using local file storage.
+// It persists metrics to a JSON file in the XDG data directory.
+type FileStore struct {
+	mu        sync.RWMutex
+	xdgBase   xdg.Base
+	sessionID string
+	startTime time.Time
+
+	// In-memory cache of metrics
+	metrics   []model.BuildMetric
+	filePath  string
+	dirty     bool
+	lastFlush time.Time
+}
+
+// NewFileStore creates a new file-based insights store.
+func NewFileStore(xdgBase xdg.Base) (*FileStore, error) {
+	filePath, err := xdgBase.DataFile(filepath.Join(insightsDir, metricsFileName))
+	if err != nil {
+		return nil, fmt.Errorf("failed to get insights data path: %w", err)
+	}
+
+	store := &FileStore{
+		xdgBase:   xdgBase,
+		sessionID: uuid.New().String(),
+		startTime: time.Now(),
+		metrics:   make([]model.BuildMetric, 0),
+		filePath:  filePath,
+		lastFlush: time.Now(),
+	}
+
+	// Load existing metrics
+	if err := store.load(); err != nil {
+		// If file doesn't exist, that's OK - we'll create it on first write
+		if !os.IsNotExist(err) {
+			return nil, fmt.Errorf("failed to load existing metrics: %w", err)
+		}
+	}
+
+	return store, nil
+}
+
+// metricsFile represents the on-disk format of the metrics database.
+type metricsFile struct {
+	Version int                 `json:"version"`
+	Metrics []model.BuildMetric `json:"metrics"`
+}
+
+// load reads metrics from the file system.
+func (fs *FileStore) load() error {
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
+
+	data, err := os.ReadFile(fs.filePath)
+	if err != nil {
+		return err
+	}
+
+	var mf metricsFile
+	if err := json.Unmarshal(data, &mf); err != nil {
+		return fmt.Errorf("failed to unmarshal metrics file: %w", err)
+	}
+
+	// Handle version migrations if needed
+	if mf.Version != model.BuildInsightsVersion {
+		// For now, just accept older versions as-is
+		// In future, add migration logic here
+	}
+
+	fs.metrics = mf.Metrics
+	return nil
+}
+
+// flush writes metrics to the file system.
+func (fs *FileStore) flush() error {
+	if !fs.dirty {
+		return nil
+	}
+
+	mf := metricsFile{
+		Version: model.BuildInsightsVersion,
+		Metrics: fs.metrics,
+	}
+
+	data, err := json.MarshalIndent(mf, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal metrics: %w", err)
+	}
+
+	// Ensure directory exists
+	dir := filepath.Dir(fs.filePath)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return fmt.Errorf("failed to create insights directory: %w", err)
+	}
+
+	// Write atomically using temp file
+	tmpPath := fs.filePath + ".tmp"
+	if err := os.WriteFile(tmpPath, data, 0644); err != nil {
+		return fmt.Errorf("failed to write metrics file: %w", err)
+	}
+
+	if err := os.Rename(tmpPath, fs.filePath); err != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("failed to rename temp metrics file: %w", err)
+	}
+
+	fs.dirty = false
+	fs.lastFlush = time.Now()
+	return nil
+}
+
+// RecordBuild stores a new build metric.
+func (fs *FileStore) RecordBuild(metric model.BuildMetric) error {
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
+
+	// Generate ID if not set
+	if metric.BuildID == "" {
+		metric.BuildID = uuid.New().String()
+	}
+
+	fs.metrics = append(fs.metrics, metric)
+	fs.dirty = true
+
+	// Auto-flush periodically to avoid losing data
+	if time.Since(fs.lastFlush) > time.Minute {
+		return fs.flush()
+	}
+
+	return nil
+}
+
+// GetInsights returns computed insights for the specified time range.
+func (fs *FileStore) GetInsights(since time.Time) (*model.BuildInsights, error) {
+	fs.mu.RLock()
+	defer fs.mu.RUnlock()
+
+	// Filter metrics by time range
+	var filtered []model.BuildMetric
+	for _, m := range fs.metrics {
+		if m.StartTime.After(since) || m.StartTime.Equal(since) {
+			filtered = append(filtered, m)
+		}
+	}
+
+	// Compute per-resource stats
+	resourceMetrics := make(map[model.ManifestName][]model.BuildMetric)
+	for _, m := range filtered {
+		resourceMetrics[m.ManifestName] = append(resourceMetrics[m.ManifestName], m)
+	}
+
+	var resourceStats []model.ResourceStats
+	for name, metrics := range resourceMetrics {
+		stats := fs.computeResourceStats(name, metrics)
+		resourceStats = append(resourceStats, stats)
+	}
+
+	// Sort by total builds descending
+	sort.Slice(resourceStats, func(i, j int) bool {
+		return resourceStats[i].TotalBuilds > resourceStats[j].TotalBuilds
+	})
+
+	// Get recent builds
+	recentBuilds := fs.getRecentBuildsLocked(maxRecentBuilds, filtered)
+
+	// Get slowest builds
+	slowestBuilds := fs.getSlowestBuildsLocked(maxSlowestBuilds, filtered)
+
+	// Get most failed resources
+	mostFailed := fs.getMostFailedResources(resourceStats, 5)
+
+	// Compute session stats
+	sessionStats := fs.computeSessionStats(filtered)
+
+	// Generate recommendations
+	recommendations := fs.generateRecommendations(resourceStats, filtered)
+
+	return &model.BuildInsights{
+		Version:             model.BuildInsightsVersion,
+		GeneratedAt:         time.Now(),
+		Session:             sessionStats,
+		Resources:           resourceStats,
+		RecentBuilds:        recentBuilds,
+		SlowestBuilds:       slowestBuilds,
+		MostFailedResources: mostFailed,
+		Recommendations:     recommendations,
+	}, nil
+}
+
+// computeResourceStats calculates statistics for a single resource.
+func (fs *FileStore) computeResourceStats(name model.ManifestName, metrics []model.BuildMetric) model.ResourceStats {
+	if len(metrics) == 0 {
+		return model.ResourceStats{ManifestName: name}
+	}
+
+	var (
+		totalDuration   int64
+		successCount    int
+		failedCount     int
+		liveUpdateCount int
+		cacheHitCount   int
+		totalWarnings   int
+		totalFiles      int
+		durations       []int64
+		lastBuild       model.BuildMetric
+	)
+
+	for _, m := range metrics {
+		durations = append(durations, m.DurationMs)
+		totalDuration += m.DurationMs
+		totalWarnings += m.WarningCount
+		totalFiles += m.FilesChanged
+
+		if m.Success {
+			successCount++
+		} else {
+			failedCount++
+		}
+
+		if m.LiveUpdate {
+			liveUpdateCount++
+		}
+
+		if m.CacheHit {
+			cacheHitCount++
+		}
+
+		if m.StartTime.After(lastBuild.StartTime) {
+			lastBuild = m
+		}
+	}
+
+	sort.Slice(durations, func(i, j int) bool {
+		return durations[i] < durations[j]
+	})
+
+	total := len(metrics)
+	avgDuration := totalDuration / int64(total)
+	avgFiles := float64(totalFiles) / float64(total)
+
+	successRate := float64(0)
+	if total > 0 {
+		successRate = float64(successCount) / float64(total) * 100
+	}
+
+	cacheHitRate := float64(0)
+	if total > 0 {
+		cacheHitRate = float64(cacheHitCount) / float64(total) * 100
+	}
+
+	return model.ResourceStats{
+		ManifestName:        name,
+		TotalBuilds:         total,
+		SuccessfulBuilds:    successCount,
+		FailedBuilds:        failedCount,
+		SuccessRate:         successRate,
+		TotalDurationMs:     totalDuration,
+		AverageDurationMs:   avgDuration,
+		MinDurationMs:       durations[0],
+		MaxDurationMs:       durations[len(durations)-1],
+		P50DurationMs:       percentile(durations, 50),
+		P95DurationMs:       percentile(durations, 95),
+		P99DurationMs:       percentile(durations, 99),
+		LiveUpdateCount:     liveUpdateCount,
+		FullRebuildCount:    total - liveUpdateCount,
+		CacheHitRate:        cacheHitRate,
+		TotalWarnings:       totalWarnings,
+		LastBuildTime:       lastBuild.StartTime,
+		LastBuildSuccess:    lastBuild.Success,
+		AverageFilesChanged: avgFiles,
+	}
+}
+
+// percentile calculates the nth percentile from a sorted slice.
+func percentile(sorted []int64, n int) int64 {
+	if len(sorted) == 0 {
+		return 0
+	}
+	idx := (n * len(sorted)) / 100
+	if idx >= len(sorted) {
+		idx = len(sorted) - 1
+	}
+	return sorted[idx]
+}
+
+// computeSessionStats calculates statistics for the current session.
+func (fs *FileStore) computeSessionStats(metrics []model.BuildMetric) model.SessionStats {
+	var (
+		totalDuration    int64
+		successCount     int
+		failedCount      int
+		liveUpdateCount  int
+		resourceSet      = make(map[model.ManifestName]bool)
+		currentStreak    int
+		streakType       string
+		lastSuccess      *bool
+	)
+
+	// Sort by time to calculate streaks
+	sorted := make([]model.BuildMetric, len(metrics))
+	copy(sorted, metrics)
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].StartTime.Before(sorted[j].StartTime)
+	})
+
+	for _, m := range sorted {
+		totalDuration += m.DurationMs
+		resourceSet[m.ManifestName] = true
+
+		if m.Success {
+			successCount++
+		} else {
+			failedCount++
+		}
+
+		if m.LiveUpdate {
+			liveUpdateCount++
+		}
+
+		// Calculate streak
+		if lastSuccess == nil {
+			currentStreak = 1
+			if m.Success {
+				streakType = "success"
+			} else {
+				streakType = "failure"
+			}
+		} else if *lastSuccess == m.Success {
+			currentStreak++
+		} else {
+			currentStreak = 1
+			if m.Success {
+				streakType = "success"
+			} else {
+				streakType = "failure"
+			}
+		}
+		s := m.Success
+		lastSuccess = &s
+	}
+
+	total := len(metrics)
+	avgDuration := int64(0)
+	if total > 0 {
+		avgDuration = totalDuration / int64(total)
+	}
+
+	return model.SessionStats{
+		SessionID:         fs.sessionID,
+		StartTime:         fs.startTime,
+		TotalBuilds:       total,
+		SuccessfulBuilds:  successCount,
+		FailedBuilds:      failedCount,
+		TotalDurationMs:   totalDuration,
+		AverageDurationMs: avgDuration,
+		LiveUpdateCount:   liveUpdateCount,
+		FullRebuildCount:  total - liveUpdateCount,
+		ResourceCount:     len(resourceSet),
+		CurrentStreak:     currentStreak,
+		StreakType:        streakType,
+	}
+}
+
+// getRecentBuildsLocked returns the most recent n builds.
+func (fs *FileStore) getRecentBuildsLocked(n int, metrics []model.BuildMetric) []model.BuildMetric {
+	sorted := make([]model.BuildMetric, len(metrics))
+	copy(sorted, metrics)
+
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].StartTime.After(sorted[j].StartTime)
+	})
+
+	if len(sorted) > n {
+		sorted = sorted[:n]
+	}
+	return sorted
+}
+
+// getSlowestBuildsLocked returns the n slowest builds.
+func (fs *FileStore) getSlowestBuildsLocked(n int, metrics []model.BuildMetric) []model.BuildMetric {
+	sorted := make([]model.BuildMetric, len(metrics))
+	copy(sorted, metrics)
+
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].DurationMs > sorted[j].DurationMs
+	})
+
+	if len(sorted) > n {
+		sorted = sorted[:n]
+	}
+	return sorted
+}
+
+// getMostFailedResources returns resources with most failures.
+func (fs *FileStore) getMostFailedResources(stats []model.ResourceStats, n int) []model.ResourceStats {
+	sorted := make([]model.ResourceStats, len(stats))
+	copy(sorted, stats)
+
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].FailedBuilds > sorted[j].FailedBuilds
+	})
+
+	// Filter to only resources with failures
+	var withFailures []model.ResourceStats
+	for _, s := range sorted {
+		if s.FailedBuilds > 0 {
+			withFailures = append(withFailures, s)
+		}
+	}
+
+	if len(withFailures) > n {
+		withFailures = withFailures[:n]
+	}
+	return withFailures
+}
+
+// generateRecommendations creates actionable insights from the data.
+func (fs *FileStore) generateRecommendations(stats []model.ResourceStats, metrics []model.BuildMetric) []model.BuildRecommendation {
+	var recommendations []model.BuildRecommendation
+
+	for _, s := range stats {
+		// Slow builds recommendation
+		if s.AverageDurationMs > 30000 && s.LiveUpdateCount < s.FullRebuildCount {
+			recommendations = append(recommendations, model.BuildRecommendation{
+				Type:               model.RecommendationTypePerformance,
+				Priority:           model.RecommendationPriorityHigh,
+				Title:              "Consider enabling Live Update",
+				Description:        fmt.Sprintf("Resource '%s' has slow builds (avg %.1fs) with mostly full rebuilds. Live Update could significantly reduce iteration time.", s.ManifestName, float64(s.AverageDurationMs)/1000),
+				AffectedResources:  []model.ManifestName{s.ManifestName},
+				PotentialSavingsMs: s.AverageDurationMs / 2,
+			})
+		}
+
+		// High failure rate recommendation
+		if s.TotalBuilds >= 5 && s.SuccessRate < 70 {
+			recommendations = append(recommendations, model.BuildRecommendation{
+				Type:              model.RecommendationTypeReliability,
+				Priority:          model.RecommendationPriorityHigh,
+				Title:             "High build failure rate detected",
+				Description:       fmt.Sprintf("Resource '%s' has a %.0f%% success rate. Review build configuration and error logs.", s.ManifestName, s.SuccessRate),
+				AffectedResources: []model.ManifestName{s.ManifestName},
+			})
+		}
+
+		// Low cache hit rate recommendation
+		if s.TotalBuilds >= 5 && s.CacheHitRate < 50 {
+			recommendations = append(recommendations, model.BuildRecommendation{
+				Type:               model.RecommendationTypeCaching,
+				Priority:           model.RecommendationPriorityMedium,
+				Title:              "Improve Docker layer caching",
+				Description:        fmt.Sprintf("Resource '%s' has low cache hit rate (%.0f%%). Consider reordering Dockerfile instructions to maximize cache reuse.", s.ManifestName, s.CacheHitRate),
+				AffectedResources:  []model.ManifestName{s.ManifestName},
+				PotentialSavingsMs: s.AverageDurationMs / 3,
+			})
+		}
+
+		// High variance recommendation
+		if s.TotalBuilds >= 10 && s.MaxDurationMs > s.AverageDurationMs*3 {
+			recommendations = append(recommendations, model.BuildRecommendation{
+				Type:              model.RecommendationTypePerformance,
+				Priority:          model.RecommendationPriorityLow,
+				Title:             "Build time variance is high",
+				Description:       fmt.Sprintf("Resource '%s' shows high variance in build times (max: %.1fs, avg: %.1fs). This may indicate intermittent issues or resource contention.", s.ManifestName, float64(s.MaxDurationMs)/1000, float64(s.AverageDurationMs)/1000),
+				AffectedResources: []model.ManifestName{s.ManifestName},
+			})
+		}
+	}
+
+	// Sort by priority
+	priorityOrder := map[model.RecommendationPriority]int{
+		model.RecommendationPriorityHigh:   0,
+		model.RecommendationPriorityMedium: 1,
+		model.RecommendationPriorityLow:    2,
+	}
+	sort.Slice(recommendations, func(i, j int) bool {
+		return priorityOrder[recommendations[i].Priority] < priorityOrder[recommendations[j].Priority]
+	})
+
+	return recommendations
+}
+
+// GetResourceStats returns statistics for a specific resource.
+func (fs *FileStore) GetResourceStats(name model.ManifestName) (*model.ResourceStats, error) {
+	fs.mu.RLock()
+	defer fs.mu.RUnlock()
+
+	var metrics []model.BuildMetric
+	for _, m := range fs.metrics {
+		if m.ManifestName == name {
+			metrics = append(metrics, m)
+		}
+	}
+
+	if len(metrics) == 0 {
+		return nil, fmt.Errorf("no metrics found for resource: %s", name)
+	}
+
+	stats := fs.computeResourceStats(name, metrics)
+	return &stats, nil
+}
+
+// GetRecentBuilds returns the most recent n builds.
+func (fs *FileStore) GetRecentBuilds(n int) ([]model.BuildMetric, error) {
+	fs.mu.RLock()
+	defer fs.mu.RUnlock()
+
+	return fs.getRecentBuildsLocked(n, fs.metrics), nil
+}
+
+// GetBuildHistory returns all builds for a resource within a time range.
+func (fs *FileStore) GetBuildHistory(name model.ManifestName, since time.Time) ([]model.BuildMetric, error) {
+	fs.mu.RLock()
+	defer fs.mu.RUnlock()
+
+	var results []model.BuildMetric
+	for _, m := range fs.metrics {
+		if m.ManifestName == name && (m.StartTime.After(since) || m.StartTime.Equal(since)) {
+			results = append(results, m)
+		}
+	}
+
+	// Sort by time descending
+	sort.Slice(results, func(i, j int) bool {
+		return results[i].StartTime.After(results[j].StartTime)
+	})
+
+	return results, nil
+}
+
+// ClearOlderThan removes metrics older than the specified time.
+func (fs *FileStore) ClearOlderThan(t time.Time) error {
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
+
+	var kept []model.BuildMetric
+	for _, m := range fs.metrics {
+		if m.StartTime.After(t) || m.StartTime.Equal(t) {
+			kept = append(kept, m)
+		}
+	}
+
+	if len(kept) != len(fs.metrics) {
+		fs.metrics = kept
+		fs.dirty = true
+		return fs.flush()
+	}
+
+	return nil
+}
+
+// Close releases resources and flushes pending writes.
+func (fs *FileStore) Close() error {
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
+
+	return fs.flush()
+}
+
+// SessionID returns the current session ID.
+func (fs *FileStore) SessionID() string {
+	return fs.sessionID
+}
+
+// Verify FileStore implements BuildInsightsStore.
+var _ model.BuildInsightsStore = (*FileStore)(nil)

--- a/internal/engine/buildinsights/store_test.go
+++ b/internal/engine/buildinsights/store_test.go
@@ -1,0 +1,378 @@
+package buildinsights
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tilt-dev/tilt/pkg/model"
+)
+
+// fakeXDGBase implements xdg.Base for testing.
+type fakeXDGBase struct {
+	dir string
+}
+
+func newFakeXDGBase(t *testing.T) *fakeXDGBase {
+	dir := t.TempDir()
+	return &fakeXDGBase{dir: dir}
+}
+
+func (f *fakeXDGBase) CacheFile(relPath string) (string, error) {
+	return filepath.Join(f.dir, "cache", relPath), nil
+}
+
+func (f *fakeXDGBase) ConfigFile(relPath string) (string, error) {
+	return filepath.Join(f.dir, "config", relPath), nil
+}
+
+func (f *fakeXDGBase) DataFile(relPath string) (string, error) {
+	path := filepath.Join(f.dir, "data", relPath)
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return "", err
+	}
+	return path, nil
+}
+
+func (f *fakeXDGBase) StateFile(relPath string) (string, error) {
+	return filepath.Join(f.dir, "state", relPath), nil
+}
+
+func (f *fakeXDGBase) RuntimeFile(relPath string) (string, error) {
+	return filepath.Join(f.dir, "runtime", relPath), nil
+}
+
+func TestFileStore_RecordAndRetrieve(t *testing.T) {
+	xdg := newFakeXDGBase(t)
+	store, err := NewFileStore(xdg)
+	require.NoError(t, err)
+	defer store.Close()
+
+	// Record a build
+	metric := model.BuildMetric{
+		BuildID:      "test-build-1",
+		ManifestName: "frontend",
+		BuildTypes:   []model.BuildType{model.BuildTypeImage},
+		StartTime:    time.Now().Add(-5 * time.Second),
+		FinishTime:   time.Now(),
+		DurationMs:   5000,
+		Success:      true,
+		Reason:       model.BuildReasonFlagChangedFiles,
+		FilesChanged: 3,
+	}
+
+	err = store.RecordBuild(metric)
+	require.NoError(t, err)
+
+	// Retrieve recent builds
+	builds, err := store.GetRecentBuilds(10)
+	require.NoError(t, err)
+	assert.Len(t, builds, 1)
+	assert.Equal(t, "frontend", string(builds[0].ManifestName))
+}
+
+func TestFileStore_GetInsights(t *testing.T) {
+	xdg := newFakeXDGBase(t)
+	store, err := NewFileStore(xdg)
+	require.NoError(t, err)
+	defer store.Close()
+
+	now := time.Now()
+
+	// Record multiple builds for different resources
+	builds := []model.BuildMetric{
+		{
+			ManifestName: "frontend",
+			StartTime:    now.Add(-10 * time.Minute),
+			FinishTime:   now.Add(-9 * time.Minute),
+			DurationMs:   60000,
+			Success:      true,
+			LiveUpdate:   false,
+		},
+		{
+			ManifestName: "frontend",
+			StartTime:    now.Add(-5 * time.Minute),
+			FinishTime:   now.Add(-4*time.Minute - 30*time.Second),
+			DurationMs:   30000,
+			Success:      true,
+			LiveUpdate:   true,
+		},
+		{
+			ManifestName: "backend",
+			StartTime:    now.Add(-3 * time.Minute),
+			FinishTime:   now.Add(-2 * time.Minute),
+			DurationMs:   60000,
+			Success:      false,
+		},
+		{
+			ManifestName: "backend",
+			StartTime:    now.Add(-1 * time.Minute),
+			FinishTime:   now,
+			DurationMs:   45000,
+			Success:      true,
+		},
+	}
+
+	for _, b := range builds {
+		err := store.RecordBuild(b)
+		require.NoError(t, err)
+	}
+
+	// Get insights
+	insights, err := store.GetInsights(now.Add(-1 * time.Hour))
+	require.NoError(t, err)
+
+	// Verify session stats
+	assert.Equal(t, 4, insights.Session.TotalBuilds)
+	assert.Equal(t, 3, insights.Session.SuccessfulBuilds)
+	assert.Equal(t, 1, insights.Session.FailedBuilds)
+	assert.Equal(t, 2, insights.Session.ResourceCount)
+
+	// Verify resource stats
+	assert.Len(t, insights.Resources, 2)
+
+	// Find frontend stats
+	var frontendStats *model.ResourceStats
+	for _, rs := range insights.Resources {
+		if rs.ManifestName == "frontend" {
+			frontendStats = &rs
+			break
+		}
+	}
+
+	require.NotNil(t, frontendStats)
+	assert.Equal(t, 2, frontendStats.TotalBuilds)
+	assert.Equal(t, 2, frontendStats.SuccessfulBuilds)
+	assert.Equal(t, float64(100), frontendStats.SuccessRate)
+	assert.Equal(t, 1, frontendStats.LiveUpdateCount)
+}
+
+func TestFileStore_GetResourceStats(t *testing.T) {
+	xdg := newFakeXDGBase(t)
+	store, err := NewFileStore(xdg)
+	require.NoError(t, err)
+	defer store.Close()
+
+	now := time.Now()
+
+	// Record builds for one resource
+	for i := 0; i < 10; i++ {
+		metric := model.BuildMetric{
+			ManifestName: "api-server",
+			StartTime:    now.Add(time.Duration(-i) * time.Minute),
+			FinishTime:   now.Add(time.Duration(-i)*time.Minute + 30*time.Second),
+			DurationMs:   30000 + int64(i*1000), // Varying durations
+			Success:      i%3 != 0,              // 60% success rate (i=0,3,6,9 are failures)
+		}
+		err := store.RecordBuild(metric)
+		require.NoError(t, err)
+	}
+
+	// Get stats for this resource
+	stats, err := store.GetResourceStats("api-server")
+	require.NoError(t, err)
+
+	assert.Equal(t, model.ManifestName("api-server"), stats.ManifestName)
+	assert.Equal(t, 10, stats.TotalBuilds)
+	assert.Equal(t, 6, stats.SuccessfulBuilds) // i=1,2,4,5,7,8 are successes
+	assert.Equal(t, 4, stats.FailedBuilds)     // i=0,3,6,9 are failures
+	assert.InDelta(t, 60.0, stats.SuccessRate, 0.1)
+
+	// Verify duration statistics
+	assert.Equal(t, int64(30000), stats.MinDurationMs)
+	assert.Equal(t, int64(39000), stats.MaxDurationMs)
+}
+
+func TestFileStore_Recommendations(t *testing.T) {
+	xdg := newFakeXDGBase(t)
+	store, err := NewFileStore(xdg)
+	require.NoError(t, err)
+	defer store.Close()
+
+	now := time.Now()
+
+	// Create a resource with slow builds that should trigger recommendations
+	for i := 0; i < 10; i++ {
+		metric := model.BuildMetric{
+			ManifestName: "slow-service",
+			StartTime:    now.Add(time.Duration(-i) * time.Minute),
+			FinishTime:   now.Add(time.Duration(-i)*time.Minute + 45*time.Second),
+			DurationMs:   45000, // 45 seconds - slow enough to trigger recommendation
+			Success:      true,
+			LiveUpdate:   false, // All full rebuilds
+		}
+		err := store.RecordBuild(metric)
+		require.NoError(t, err)
+	}
+
+	insights, err := store.GetInsights(now.Add(-1 * time.Hour))
+	require.NoError(t, err)
+
+	// Should have a recommendation for slow builds
+	hasPerformanceRec := false
+	for _, rec := range insights.Recommendations {
+		if rec.Type == model.RecommendationTypePerformance {
+			hasPerformanceRec = true
+			assert.Contains(t, rec.Description, "slow-service")
+			break
+		}
+	}
+	assert.True(t, hasPerformanceRec, "Expected a performance recommendation for slow builds")
+}
+
+func TestFileStore_HighFailureRateRecommendation(t *testing.T) {
+	xdg := newFakeXDGBase(t)
+	store, err := NewFileStore(xdg)
+	require.NoError(t, err)
+	defer store.Close()
+
+	now := time.Now()
+
+	// Create a resource with high failure rate
+	for i := 0; i < 10; i++ {
+		metric := model.BuildMetric{
+			ManifestName: "flaky-service",
+			StartTime:    now.Add(time.Duration(-i) * time.Minute),
+			FinishTime:   now.Add(time.Duration(-i)*time.Minute + 10*time.Second),
+			DurationMs:   10000,
+			Success:      i < 3, // Only 30% success rate
+		}
+		err := store.RecordBuild(metric)
+		require.NoError(t, err)
+	}
+
+	insights, err := store.GetInsights(now.Add(-1 * time.Hour))
+	require.NoError(t, err)
+
+	// Should have a reliability recommendation
+	hasReliabilityRec := false
+	for _, rec := range insights.Recommendations {
+		if rec.Type == model.RecommendationTypeReliability {
+			hasReliabilityRec = true
+			assert.Contains(t, rec.Description, "flaky-service")
+			break
+		}
+	}
+	assert.True(t, hasReliabilityRec, "Expected a reliability recommendation for high failure rate")
+}
+
+func TestFileStore_Persistence(t *testing.T) {
+	xdg := newFakeXDGBase(t)
+
+	// Create store and add data
+	store1, err := NewFileStore(xdg)
+	require.NoError(t, err)
+
+	metric := model.BuildMetric{
+		ManifestName: "persistent-service",
+		StartTime:    time.Now().Add(-5 * time.Minute),
+		FinishTime:   time.Now(),
+		DurationMs:   300000,
+		Success:      true,
+	}
+	err = store1.RecordBuild(metric)
+	require.NoError(t, err)
+
+	// Close and reopen
+	err = store1.Close()
+	require.NoError(t, err)
+
+	store2, err := NewFileStore(xdg)
+	require.NoError(t, err)
+	defer store2.Close()
+
+	// Data should still be there
+	builds, err := store2.GetRecentBuilds(10)
+	require.NoError(t, err)
+	assert.Len(t, builds, 1)
+	assert.Equal(t, "persistent-service", string(builds[0].ManifestName))
+}
+
+func TestFileStore_ClearOlderThan(t *testing.T) {
+	xdg := newFakeXDGBase(t)
+	store, err := NewFileStore(xdg)
+	require.NoError(t, err)
+	defer store.Close()
+
+	now := time.Now()
+
+	// Add old and new builds
+	oldBuild := model.BuildMetric{
+		ManifestName: "old-build",
+		StartTime:    now.Add(-48 * time.Hour),
+		FinishTime:   now.Add(-48*time.Hour + 10*time.Second),
+		DurationMs:   10000,
+		Success:      true,
+	}
+	newBuild := model.BuildMetric{
+		ManifestName: "new-build",
+		StartTime:    now.Add(-1 * time.Hour),
+		FinishTime:   now.Add(-1*time.Hour + 10*time.Second),
+		DurationMs:   10000,
+		Success:      true,
+	}
+
+	require.NoError(t, store.RecordBuild(oldBuild))
+	require.NoError(t, store.RecordBuild(newBuild))
+
+	// Clear old builds
+	err = store.ClearOlderThan(now.Add(-24 * time.Hour))
+	require.NoError(t, err)
+
+	// Only new build should remain
+	builds, err := store.GetRecentBuilds(10)
+	require.NoError(t, err)
+	assert.Len(t, builds, 1)
+	assert.Equal(t, "new-build", string(builds[0].ManifestName))
+}
+
+func TestPercentile(t *testing.T) {
+	testCases := []struct {
+		name     string
+		values   []int64
+		n        int
+		expected int64
+	}{
+		{
+			name:     "empty slice",
+			values:   []int64{},
+			n:        50,
+			expected: 0,
+		},
+		{
+			name:     "single value",
+			values:   []int64{100},
+			n:        50,
+			expected: 100,
+		},
+		{
+			name:     "p50 of sorted values",
+			values:   []int64{10, 20, 30, 40, 50, 60, 70, 80, 90, 100},
+			n:        50,
+			expected: 60, // idx = (50 * 10) / 100 = 5 -> values[5] = 60
+		},
+		{
+			name:     "p95 of sorted values",
+			values:   []int64{10, 20, 30, 40, 50, 60, 70, 80, 90, 100},
+			n:        95,
+			expected: 100,
+		},
+		{
+			name:     "p99 of sorted values",
+			values:   []int64{10, 20, 30, 40, 50, 60, 70, 80, 90, 100},
+			n:        99,
+			expected: 100,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := percentile(tc.values, tc.n)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}

--- a/internal/engine/buildinsights/wire.go
+++ b/internal/engine/buildinsights/wire.go
@@ -1,0 +1,18 @@
+package buildinsights
+
+import (
+	"github.com/tilt-dev/tilt/internal/xdg"
+	"github.com/tilt-dev/tilt/pkg/model"
+)
+
+// ProvideInsightsStore creates a new build insights store.
+// This is used for dependency injection via Wire.
+func ProvideInsightsStore(xdgBase xdg.Base) (model.BuildInsightsStore, error) {
+	return NewFileStore(xdgBase)
+}
+
+// ProvideCollector creates a new build insights collector.
+// This is used for dependency injection via Wire.
+func ProvideCollector(store model.BuildInsightsStore) *Collector {
+	return NewCollector(store)
+}

--- a/internal/hud/server/insights_handler.go
+++ b/internal/hud/server/insights_handler.go
@@ -1,0 +1,229 @@
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/tilt-dev/tilt/pkg/model"
+)
+
+// InsightsHandler handles HTTP requests for build insights.
+type InsightsHandler struct {
+	store model.BuildInsightsStore
+}
+
+// NewInsightsHandler creates a new insights HTTP handler.
+func NewInsightsHandler(store model.BuildInsightsStore) *InsightsHandler {
+	return &InsightsHandler{store: store}
+}
+
+// insightsQueryParams represents query parameters for insights requests.
+type insightsQueryParams struct {
+	Since    time.Time
+	Resource string
+	Limit    int
+}
+
+// parseQueryParams extracts query parameters from the request.
+func parseQueryParams(r *http.Request) insightsQueryParams {
+	params := insightsQueryParams{
+		Since: time.Now().Add(-24 * time.Hour), // Default to last 24 hours
+		Limit: 100,
+	}
+
+	if sinceStr := r.URL.Query().Get("since"); sinceStr != "" {
+		// Try parsing as duration (e.g., "24h", "7d")
+		if d, err := time.ParseDuration(sinceStr); err == nil {
+			params.Since = time.Now().Add(-d)
+		} else if t, err := time.Parse(time.RFC3339, sinceStr); err == nil {
+			// Try parsing as RFC3339 timestamp
+			params.Since = t
+		}
+	}
+
+	// Handle special "days" format
+	if daysStr := r.URL.Query().Get("days"); daysStr != "" {
+		if days, err := strconv.Atoi(daysStr); err == nil && days > 0 {
+			params.Since = time.Now().Add(-time.Duration(days) * 24 * time.Hour)
+		}
+	}
+
+	if resource := r.URL.Query().Get("resource"); resource != "" {
+		params.Resource = resource
+	}
+
+	if limitStr := r.URL.Query().Get("limit"); limitStr != "" {
+		if limit, err := strconv.Atoi(limitStr); err == nil && limit > 0 {
+			params.Limit = limit
+		}
+	}
+
+	return params
+}
+
+// HandleInsights returns comprehensive build insights.
+// GET /api/insights
+// Query params:
+//   - since: RFC3339 timestamp or duration (e.g., "24h", "168h")
+//   - days: number of days to look back (alternative to since)
+func (h *InsightsHandler) HandleInsights(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "must be GET request", http.StatusMethodNotAllowed)
+		return
+	}
+
+	if h.store == nil {
+		http.Error(w, "insights not available", http.StatusServiceUnavailable)
+		return
+	}
+
+	params := parseQueryParams(r)
+
+	insights, err := h.store.GetInsights(params.Since)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("failed to get insights: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(insights); err != nil {
+		http.Error(w, fmt.Sprintf("failed to encode response: %v", err), http.StatusInternalServerError)
+	}
+}
+
+// HandleResourceStats returns statistics for a specific resource.
+// GET /api/insights/resource/{name}
+func (h *InsightsHandler) HandleResourceStats(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "must be GET request", http.StatusMethodNotAllowed)
+		return
+	}
+
+	if h.store == nil {
+		http.Error(w, "insights not available", http.StatusServiceUnavailable)
+		return
+	}
+
+	// Extract resource name from URL path
+	// Expected path: /api/insights/resource/{name}
+	resourceName := r.URL.Query().Get("name")
+	if resourceName == "" {
+		http.Error(w, "resource name is required (use ?name=<resource>)", http.StatusBadRequest)
+		return
+	}
+
+	stats, err := h.store.GetResourceStats(model.ManifestName(resourceName))
+	if err != nil {
+		http.Error(w, fmt.Sprintf("failed to get resource stats: %v", err), http.StatusNotFound)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(stats); err != nil {
+		http.Error(w, fmt.Sprintf("failed to encode response: %v", err), http.StatusInternalServerError)
+	}
+}
+
+// HandleRecentBuilds returns the most recent builds.
+// GET /api/insights/builds
+// Query params:
+//   - limit: number of builds to return (default: 100)
+//   - resource: filter by resource name (optional)
+func (h *InsightsHandler) HandleRecentBuilds(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "must be GET request", http.StatusMethodNotAllowed)
+		return
+	}
+
+	if h.store == nil {
+		http.Error(w, "insights not available", http.StatusServiceUnavailable)
+		return
+	}
+
+	params := parseQueryParams(r)
+
+	var builds []model.BuildMetric
+	var err error
+
+	if params.Resource != "" {
+		builds, err = h.store.GetBuildHistory(model.ManifestName(params.Resource), params.Since)
+	} else {
+		builds, err = h.store.GetRecentBuilds(params.Limit)
+	}
+
+	if err != nil {
+		http.Error(w, fmt.Sprintf("failed to get builds: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	// Apply limit
+	if len(builds) > params.Limit {
+		builds = builds[:params.Limit]
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(builds); err != nil {
+		http.Error(w, fmt.Sprintf("failed to encode response: %v", err), http.StatusInternalServerError)
+	}
+}
+
+// HandleSummary returns a brief summary suitable for CLI output.
+// GET /api/insights/summary
+func (h *InsightsHandler) HandleSummary(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "must be GET request", http.StatusMethodNotAllowed)
+		return
+	}
+
+	if h.store == nil {
+		http.Error(w, "insights not available", http.StatusServiceUnavailable)
+		return
+	}
+
+	params := parseQueryParams(r)
+
+	insights, err := h.store.GetInsights(params.Since)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("failed to get insights: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	// Create a condensed summary
+	summary := map[string]interface{}{
+		"session": map[string]interface{}{
+			"total_builds":      insights.Session.TotalBuilds,
+			"success_rate":      calculateSuccessRate(insights.Session.SuccessfulBuilds, insights.Session.TotalBuilds),
+			"avg_duration_ms":   insights.Session.AverageDurationMs,
+			"total_duration_ms": insights.Session.TotalDurationMs,
+			"live_updates":      insights.Session.LiveUpdateCount,
+			"full_rebuilds":     insights.Session.FullRebuildCount,
+			"resource_count":    insights.Session.ResourceCount,
+		},
+		"recommendations_count": len(insights.Recommendations),
+		"failed_resources":      len(insights.MostFailedResources),
+	}
+
+	// Add top recommendations
+	if len(insights.Recommendations) > 0 {
+		topRecs := insights.Recommendations
+		if len(topRecs) > 3 {
+			topRecs = topRecs[:3]
+		}
+		summary["top_recommendations"] = topRecs
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(summary); err != nil {
+		http.Error(w, fmt.Sprintf("failed to encode response: %v", err), http.StatusInternalServerError)
+	}
+}
+
+func calculateSuccessRate(successful, total int) float64 {
+	if total == 0 {
+		return 0
+	}
+	return float64(successful) / float64(total) * 100
+}

--- a/internal/hud/server/insights_handler_test.go
+++ b/internal/hud/server/insights_handler_test.go
@@ -1,0 +1,283 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tilt-dev/tilt/pkg/model"
+)
+
+// mockInsightsStore implements model.BuildInsightsStore for testing.
+type mockInsightsStore struct {
+	insights *model.BuildInsights
+	stats    *model.ResourceStats
+	builds   []model.BuildMetric
+	err      error
+}
+
+func (m *mockInsightsStore) RecordBuild(metric model.BuildMetric) error {
+	return m.err
+}
+
+func (m *mockInsightsStore) GetInsights(since time.Time) (*model.BuildInsights, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.insights, nil
+}
+
+func (m *mockInsightsStore) GetResourceStats(name model.ManifestName) (*model.ResourceStats, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.stats, nil
+}
+
+func (m *mockInsightsStore) GetRecentBuilds(n int) ([]model.BuildMetric, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.builds, nil
+}
+
+func (m *mockInsightsStore) GetBuildHistory(name model.ManifestName, since time.Time) ([]model.BuildMetric, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.builds, nil
+}
+
+func (m *mockInsightsStore) ClearOlderThan(t time.Time) error {
+	return m.err
+}
+
+func (m *mockInsightsStore) Close() error {
+	return m.err
+}
+
+func TestInsightsHandler_HandleInsights(t *testing.T) {
+	store := &mockInsightsStore{
+		insights: &model.BuildInsights{
+			Version:     1,
+			GeneratedAt: time.Now(),
+			Session: model.SessionStats{
+				TotalBuilds:      10,
+				SuccessfulBuilds: 9,
+				FailedBuilds:     1,
+			},
+			Resources: []model.ResourceStats{
+				{
+					ManifestName: "frontend",
+					TotalBuilds:  5,
+					SuccessRate:  100,
+				},
+			},
+		},
+	}
+
+	handler := NewInsightsHandler(store)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/insights", nil)
+	w := httptest.NewRecorder()
+
+	handler.HandleInsights(w, req)
+
+	resp := w.Result()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "application/json", resp.Header.Get("Content-Type"))
+
+	var insights model.BuildInsights
+	err := json.NewDecoder(resp.Body).Decode(&insights)
+	require.NoError(t, err)
+
+	assert.Equal(t, 10, insights.Session.TotalBuilds)
+	assert.Len(t, insights.Resources, 1)
+	assert.Equal(t, model.ManifestName("frontend"), insights.Resources[0].ManifestName)
+}
+
+func TestInsightsHandler_HandleInsights_MethodNotAllowed(t *testing.T) {
+	handler := NewInsightsHandler(&mockInsightsStore{})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/insights", nil)
+	w := httptest.NewRecorder()
+
+	handler.HandleInsights(w, req)
+
+	resp := w.Result()
+	assert.Equal(t, http.StatusMethodNotAllowed, resp.StatusCode)
+}
+
+func TestInsightsHandler_HandleInsights_NilStore(t *testing.T) {
+	handler := NewInsightsHandler(nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/insights", nil)
+	w := httptest.NewRecorder()
+
+	handler.HandleInsights(w, req)
+
+	resp := w.Result()
+	assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+}
+
+func TestInsightsHandler_HandleResourceStats(t *testing.T) {
+	store := &mockInsightsStore{
+		stats: &model.ResourceStats{
+			ManifestName:      "backend",
+			TotalBuilds:       20,
+			SuccessfulBuilds:  18,
+			AverageDurationMs: 5000,
+		},
+	}
+
+	handler := NewInsightsHandler(store)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/insights/resource?name=backend", nil)
+	w := httptest.NewRecorder()
+
+	handler.HandleResourceStats(w, req)
+
+	resp := w.Result()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var stats model.ResourceStats
+	err := json.NewDecoder(resp.Body).Decode(&stats)
+	require.NoError(t, err)
+
+	assert.Equal(t, model.ManifestName("backend"), stats.ManifestName)
+	assert.Equal(t, 20, stats.TotalBuilds)
+}
+
+func TestInsightsHandler_HandleResourceStats_MissingName(t *testing.T) {
+	handler := NewInsightsHandler(&mockInsightsStore{})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/insights/resource", nil)
+	w := httptest.NewRecorder()
+
+	handler.HandleResourceStats(w, req)
+
+	resp := w.Result()
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}
+
+func TestInsightsHandler_HandleRecentBuilds(t *testing.T) {
+	store := &mockInsightsStore{
+		builds: []model.BuildMetric{
+			{
+				ManifestName: "service-1",
+				DurationMs:   5000,
+				Success:      true,
+			},
+			{
+				ManifestName: "service-2",
+				DurationMs:   3000,
+				Success:      false,
+			},
+		},
+	}
+
+	handler := NewInsightsHandler(store)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/insights/builds?limit=10", nil)
+	w := httptest.NewRecorder()
+
+	handler.HandleRecentBuilds(w, req)
+
+	resp := w.Result()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var builds []model.BuildMetric
+	err := json.NewDecoder(resp.Body).Decode(&builds)
+	require.NoError(t, err)
+
+	assert.Len(t, builds, 2)
+}
+
+func TestInsightsHandler_HandleSummary(t *testing.T) {
+	store := &mockInsightsStore{
+		insights: &model.BuildInsights{
+			Session: model.SessionStats{
+				TotalBuilds:       50,
+				SuccessfulBuilds:  45,
+				AverageDurationMs: 10000,
+			},
+			Recommendations: []model.BuildRecommendation{
+				{
+					Type:     model.RecommendationTypePerformance,
+					Priority: model.RecommendationPriorityHigh,
+					Title:    "Test recommendation",
+				},
+			},
+		},
+	}
+
+	handler := NewInsightsHandler(store)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/insights/summary", nil)
+	w := httptest.NewRecorder()
+
+	handler.HandleSummary(w, req)
+
+	resp := w.Result()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var summary map[string]interface{}
+	err := json.NewDecoder(resp.Body).Decode(&summary)
+	require.NoError(t, err)
+
+	session := summary["session"].(map[string]interface{})
+	assert.Equal(t, float64(50), session["total_builds"])
+	assert.Equal(t, float64(1), summary["recommendations_count"])
+}
+
+func TestParseQueryParams(t *testing.T) {
+	testCases := []struct {
+		name          string
+		url           string
+		expectedSince time.Duration // approximate time ago
+		expectedLimit int
+	}{
+		{
+			name:          "default values",
+			url:           "/api/insights",
+			expectedSince: 24 * time.Hour,
+			expectedLimit: 100,
+		},
+		{
+			name:          "custom since duration",
+			url:           "/api/insights?since=48h",
+			expectedSince: 48 * time.Hour,
+			expectedLimit: 100,
+		},
+		{
+			name:          "days parameter",
+			url:           "/api/insights?days=7",
+			expectedSince: 7 * 24 * time.Hour,
+			expectedLimit: 100,
+		},
+		{
+			name:          "custom limit",
+			url:           "/api/insights?limit=50",
+			expectedSince: 24 * time.Hour,
+			expectedLimit: 50,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, tc.url, nil)
+			params := parseQueryParams(req)
+
+			// Check that since is approximately correct (within 1 second tolerance)
+			expectedSince := time.Now().Add(-tc.expectedSince)
+			assert.WithinDuration(t, expectedSince, params.Since, time.Second)
+
+			assert.Equal(t, tc.expectedLimit, params.Limit)
+		})
+	}
+}

--- a/internal/hud/server/server_test.go
+++ b/internal/hud/server/server_test.go
@@ -341,7 +341,10 @@ func newTestFixture(t *testing.T) *serverFixture {
 
 	ctx := context.Background()
 
-	serv, err := server.ProvideHeadsUpServer(ctx, st, assets.NewFakeServer(), ta, wsl, ctrlClient)
+	// Create a nil InsightsHandler for tests that don't need insights
+	var insightsHandler *server.InsightsHandler
+
+	serv, err := server.ProvideHeadsUpServer(ctx, st, assets.NewFakeServer(), ta, wsl, ctrlClient, insightsHandler)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/hud/server/wire.go
+++ b/internal/hud/server/wire.go
@@ -18,4 +18,11 @@ var WireSet = wire.NewSet(
 	ProvideHeadsUpServer,
 	ProvideHeadsUpServerController,
 	NewWebsocketList,
+	ProvideInsightsHandler,
 )
+
+// ProvideInsightsHandler creates an InsightsHandler.
+// If store is nil, the handler will return appropriate errors.
+func ProvideInsightsHandler(store model.BuildInsightsStore) *InsightsHandler {
+	return NewInsightsHandler(store)
+}

--- a/pkg/model/build_insights.go
+++ b/pkg/model/build_insights.go
@@ -1,0 +1,260 @@
+package model
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// BuildInsightsVersion is the current version of the insights data format.
+// Increment this when making breaking changes to the data structure.
+const BuildInsightsVersion = 1
+
+// BuildMetric represents a single build execution with all relevant metrics.
+type BuildMetric struct {
+	// Unique identifier for this build
+	BuildID string `json:"build_id"`
+
+	// ManifestName is the name of the manifest that was built
+	ManifestName ManifestName `json:"manifest_name"`
+
+	// BuildTypes indicates what kind of build was performed
+	BuildTypes []BuildType `json:"build_types"`
+
+	// StartTime is when the build started
+	StartTime time.Time `json:"start_time"`
+
+	// FinishTime is when the build completed
+	FinishTime time.Time `json:"finish_time"`
+
+	// Duration in milliseconds for easier aggregation
+	DurationMs int64 `json:"duration_ms"`
+
+	// Success indicates whether the build succeeded
+	Success bool `json:"success"`
+
+	// ErrorMessage contains the error if the build failed
+	ErrorMessage string `json:"error_message,omitempty"`
+
+	// WarningCount is the number of warnings during the build
+	WarningCount int `json:"warning_count"`
+
+	// Reason indicates why this build was triggered
+	Reason BuildReason `json:"reason"`
+
+	// CacheHit indicates if the build used cached layers (for image builds)
+	CacheHit bool `json:"cache_hit"`
+
+	// ImageSize in bytes (for image builds)
+	ImageSize int64 `json:"image_size,omitempty"`
+
+	// LiveUpdate indicates if this was a live update instead of full rebuild
+	LiveUpdate bool `json:"live_update"`
+
+	// FilesChanged is the count of files that triggered this build
+	FilesChanged int `json:"files_changed"`
+}
+
+// Duration returns the build duration as a time.Duration.
+func (bm BuildMetric) Duration() time.Duration {
+	return time.Duration(bm.DurationMs) * time.Millisecond
+}
+
+// ResourceStats aggregates statistics for a single resource/manifest.
+type ResourceStats struct {
+	// ManifestName is the name of the resource
+	ManifestName ManifestName `json:"manifest_name"`
+
+	// TotalBuilds is the total number of builds
+	TotalBuilds int `json:"total_builds"`
+
+	// SuccessfulBuilds is the count of successful builds
+	SuccessfulBuilds int `json:"successful_builds"`
+
+	// FailedBuilds is the count of failed builds
+	FailedBuilds int `json:"failed_builds"`
+
+	// SuccessRate as a percentage (0-100)
+	SuccessRate float64 `json:"success_rate"`
+
+	// TotalDurationMs is the sum of all build durations
+	TotalDurationMs int64 `json:"total_duration_ms"`
+
+	// AverageDurationMs is the mean build duration
+	AverageDurationMs int64 `json:"average_duration_ms"`
+
+	// MinDurationMs is the fastest build time
+	MinDurationMs int64 `json:"min_duration_ms"`
+
+	// MaxDurationMs is the slowest build time
+	MaxDurationMs int64 `json:"max_duration_ms"`
+
+	// P50DurationMs is the median build time
+	P50DurationMs int64 `json:"p50_duration_ms"`
+
+	// P95DurationMs is the 95th percentile build time
+	P95DurationMs int64 `json:"p95_duration_ms"`
+
+	// P99DurationMs is the 99th percentile build time
+	P99DurationMs int64 `json:"p99_duration_ms"`
+
+	// LiveUpdateCount is the number of live updates
+	LiveUpdateCount int `json:"live_update_count"`
+
+	// FullRebuildCount is the number of full rebuilds
+	FullRebuildCount int `json:"full_rebuild_count"`
+
+	// CacheHitRate as a percentage (0-100)
+	CacheHitRate float64 `json:"cache_hit_rate"`
+
+	// TotalWarnings across all builds
+	TotalWarnings int `json:"total_warnings"`
+
+	// LastBuildTime is the timestamp of the most recent build
+	LastBuildTime time.Time `json:"last_build_time"`
+
+	// LastBuildSuccess indicates if the last build was successful
+	LastBuildSuccess bool `json:"last_build_success"`
+
+	// AverageFilesChanged is the mean number of files triggering builds
+	AverageFilesChanged float64 `json:"average_files_changed"`
+}
+
+// SessionStats aggregates statistics for the current Tilt session.
+type SessionStats struct {
+	// SessionID uniquely identifies this Tilt session
+	SessionID string `json:"session_id"`
+
+	// StartTime is when this Tilt session started
+	StartTime time.Time `json:"start_time"`
+
+	// TotalBuilds is the total number of builds in this session
+	TotalBuilds int `json:"total_builds"`
+
+	// SuccessfulBuilds count
+	SuccessfulBuilds int `json:"successful_builds"`
+
+	// FailedBuilds count
+	FailedBuilds int `json:"failed_builds"`
+
+	// TotalDurationMs is the sum of all build times
+	TotalDurationMs int64 `json:"total_duration_ms"`
+
+	// AverageDurationMs is the mean build time
+	AverageDurationMs int64 `json:"average_duration_ms"`
+
+	// LiveUpdateCount is the number of live updates
+	LiveUpdateCount int `json:"live_update_count"`
+
+	// FullRebuildCount is the number of full rebuilds
+	FullRebuildCount int `json:"full_rebuild_count"`
+
+	// ResourceCount is the number of unique resources that have been built
+	ResourceCount int `json:"resource_count"`
+
+	// CurrentStreak is the current consecutive success/failure streak
+	CurrentStreak int `json:"current_streak"`
+
+	// StreakType is "success" or "failure"
+	StreakType string `json:"streak_type"`
+}
+
+// BuildInsights contains comprehensive build analytics data.
+type BuildInsights struct {
+	// Version is the data format version
+	Version int `json:"version"`
+
+	// GeneratedAt is when this insights report was generated
+	GeneratedAt time.Time `json:"generated_at"`
+
+	// Session contains current session statistics
+	Session SessionStats `json:"session"`
+
+	// Resources contains per-resource statistics
+	Resources []ResourceStats `json:"resources"`
+
+	// RecentBuilds contains the most recent build metrics
+	RecentBuilds []BuildMetric `json:"recent_builds"`
+
+	// SlowestBuilds contains the slowest builds for analysis
+	SlowestBuilds []BuildMetric `json:"slowest_builds"`
+
+	// MostFailedResources is ordered by failure count
+	MostFailedResources []ResourceStats `json:"most_failed_resources"`
+
+	// Recommendations contains actionable insights
+	Recommendations []BuildRecommendation `json:"recommendations"`
+}
+
+// RecommendationType categorizes the type of recommendation.
+type RecommendationType string
+
+const (
+	RecommendationTypePerformance RecommendationType = "performance"
+	RecommendationTypeReliability RecommendationType = "reliability"
+	RecommendationTypeCaching     RecommendationType = "caching"
+	RecommendationTypeGeneral     RecommendationType = "general"
+)
+
+// RecommendationPriority indicates the urgency of a recommendation.
+type RecommendationPriority string
+
+const (
+	RecommendationPriorityHigh   RecommendationPriority = "high"
+	RecommendationPriorityMedium RecommendationPriority = "medium"
+	RecommendationPriorityLow    RecommendationPriority = "low"
+)
+
+// BuildRecommendation represents an actionable insight for improving builds.
+type BuildRecommendation struct {
+	// Type categorizes this recommendation
+	Type RecommendationType `json:"type"`
+
+	// Priority indicates urgency
+	Priority RecommendationPriority `json:"priority"`
+
+	// Title is a short description
+	Title string `json:"title"`
+
+	// Description provides detailed explanation
+	Description string `json:"description"`
+
+	// AffectedResources lists resources this applies to
+	AffectedResources []ManifestName `json:"affected_resources,omitempty"`
+
+	// PotentialSavingsMs is the estimated time savings if implemented
+	PotentialSavingsMs int64 `json:"potential_savings_ms,omitempty"`
+}
+
+// BuildInsightsStore defines the interface for persisting build insights.
+type BuildInsightsStore interface {
+	// RecordBuild stores a new build metric
+	RecordBuild(metric BuildMetric) error
+
+	// GetInsights returns computed insights for the specified time range
+	GetInsights(since time.Time) (*BuildInsights, error)
+
+	// GetResourceStats returns statistics for a specific resource
+	GetResourceStats(name ManifestName) (*ResourceStats, error)
+
+	// GetRecentBuilds returns the most recent n builds
+	GetRecentBuilds(n int) ([]BuildMetric, error)
+
+	// GetBuildHistory returns all builds for a resource within a time range
+	GetBuildHistory(name ManifestName, since time.Time) ([]BuildMetric, error)
+
+	// ClearOlderThan removes metrics older than the specified time
+	ClearOlderThan(t time.Time) error
+
+	// Close releases any resources held by the store
+	Close() error
+}
+
+// MarshalJSON implements custom JSON marshaling for BuildInsights.
+func (bi BuildInsights) MarshalJSON() ([]byte, error) {
+	type Alias BuildInsights
+	return json.Marshal(&struct {
+		Alias
+	}{
+		Alias: (Alias)(bi),
+	})
+}


### PR DESCRIPTION
# Build Insights & Analytics Dashboard

## Summary

This PR introduces a new **Build Insights & Analytics Dashboard** feature that provides developers with comprehensive visibility into their build performance, historical metrics, and actionable recommendations.

## Motivation

Currently, Tilt users lack visibility into:
- How long their builds typically take
- Which resources have the highest failure rates
- Historical trends in build performance
- Whether they could benefit from Live Update adoption

This feature addresses these gaps by collecting build metrics automatically and presenting them through both CLI and API interfaces.

## Features

### CLI Command: `tilt insights`

```bash
# Show summary dashboard (default)
tilt insights

# Show detailed table by resource
tilt insights --format table

# Output as JSON for integration with other tools
tilt insights --format json

# Show recent builds
tilt insights --format builds --limit 20

# Filter by time range
tilt insights --since 24h

# Filter by resource
tilt insights --resource frontend
```

**Example Output (Summary):**
```
╔══════════════════════════════════════════════════════════════╗
║                    BUILD INSIGHTS DASHBOARD                   ║
╚══════════════════════════════════════════════════════════════╝

📊 Session Statistics
────────────────────────────────────────────────────────────────
  Total Builds:     42          Success Rate:   85.7%
  Successful:       36          Failed:         6
  Live Updates:     18          Resources:      5
  Avg Duration:     12.5s       Current Streak: 8 successes

💡 Recommendations
────────────────────────────────────────────────────────────────
  ⚠️  [HIGH] api-server has slow builds (avg 45.2s). Consider...
  ℹ️  [MEDIUM] frontend has 0 live updates out of 15 builds...
```

### REST API Endpoints

| Endpoint | Description |
|----------|-------------|
| `GET /api/insights` | Full insights with session stats, resource stats, and recommendations |
| `GET /api/insights/summary` | Quick summary of current session |
| `GET /api/insights/builds?limit=N` | Recent build history |
| `GET /api/insights/resource?name=X` | Detailed stats for a specific resource |

### Smart Recommendations

The system automatically generates recommendations based on:

1. **Slow Builds**: Resources with average build time > 30 seconds
2. **High Failure Rate**: Resources with > 20% failure rate
3. **Live Update Opportunities**: Resources with many full rebuilds that could use Live Update

## Architecture

```
┌─────────────────┐     ┌──────────────┐     ┌─────────────────┐
│   BuildRecord   │────▶│  Collector   │────▶│   FileStore     │
│   (from Store)  │     │ (Subscriber) │     │ (~/.local/share │
└─────────────────┘     └──────────────┘     │  /tilt-dev/     │
                                              │  insights/)     │
                                              └────────┬────────┘
                                                       │
                        ┌──────────────────────────────┼───────┐
                        │                              │       │
                        ▼                              ▼       ▼
               ┌────────────────┐            ┌─────────────────────┐
               │  CLI Command   │            │   HTTP Handlers     │
               │ (tilt insights)│            │ (/api/insights/*)   │
               └────────────────┘            └─────────────────────┘
```

## Files Changed

### New Files (9)

| File | Lines | Description |
|------|-------|-------------|
| `pkg/model/build_insights.go` | ~200 | Core data models and interfaces |
| `internal/engine/buildinsights/store.go` | ~600 | Persistent JSON file storage |
| `internal/engine/buildinsights/collector.go` | ~120 | Store subscriber for metric collection |
| `internal/engine/buildinsights/wire.go` | ~20 | Wire dependency injection providers |
| `internal/engine/buildinsights/store_test.go` | ~380 | Unit tests for FileStore |
| `internal/engine/buildinsights/collector_test.go` | ~250 | Unit tests for Collector |
| `internal/hud/server/insights_handler.go` | ~180 | HTTP API handlers |
| `internal/hud/server/insights_handler_test.go` | ~200 | Unit tests for handlers |
| `internal/cli/insights.go` | ~400 | CLI command implementation |

### Modified Files (6)

| File | Description |
|------|-------------|
| `internal/hud/server/server.go` | Added InsightsHandler field and API routes |
| `internal/hud/server/wire.go` | Added ProvideInsightsHandler to WireSet |
| `internal/hud/server/server_test.go` | Updated test fixture for new parameter |
| `internal/cli/cli.go` | Registered insights command |
| `internal/cli/wire.go` | Added buildinsights.ProvideInsightsStore |
| `internal/cli/wire_gen.go` | Regenerated by Wire |

## Testing

All new code includes comprehensive unit tests:

```bash
$ go test ./internal/engine/buildinsights/... ./internal/hud/server/... ./pkg/model/...
ok  github.com/tilt-dev/tilt/internal/engine/buildinsights  0.076s
ok  github.com/tilt-dev/tilt/internal/hud/server           1.761s
ok  github.com/tilt-dev/tilt/pkg/model                     0.046s
```

## Data Storage

Build metrics are persisted to `~/.local/share/tilt-dev/insights/metrics.json` following XDG Base Directory specification. The file format is versioned for future compatibility.

## Future Enhancements

Potential future improvements (not included in this PR):
- [ ] Web UI dashboard visualization
- [ ] Export metrics to Prometheus/Grafana
- [ ] Build comparison between branches
- [ ] Team-wide metrics aggregation
- [ ] Slack/webhook notifications for insights

## Checklist

- [x] Code compiles without errors
- [x] All new code has unit tests
- [x] All tests pass
- [x] Wire providers are properly integrated
- [x] CLI follows existing command patterns
- [x] API follows existing endpoint patterns
- [x] Code follows project style guidelines
