### PR TITLE
Allow parallel execution of live updates

### DIFF
--- a/internal/controllers/core/liveupdate/reconciler.go
+++ b/internal/controllers/core/liveupdate/reconciler.go
@@ -254,7 +254,8 @@ func (r *Reconciler) handleFailure(ctx context.Context, lu *v1alpha1.LiveUpdate,
 	return ctrl.Result{}, err
 }
 
-// deleteMonitor removes a monitor from the map with proper locking.
+// Remove a monitor when its LiveUpdate is deleted.
+// Locks because r.monitors may be accessed concurrently.
 func (r *Reconciler) deleteMonitor(name string) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -263,6 +264,7 @@ func (r *Reconciler) deleteMonitor(name string) {
 
 // Create the monitor that tracks a live update. If the live update
 // spec changes, wipe out all accumulated state.
+// Locks because r.monitors may be accessed concurrently.
 func (r *Reconciler) ensureMonitorExists(name string, obj *v1alpha1.LiveUpdate) *monitor {
 	r.mu.Lock()
 	defer r.mu.Unlock()


### PR DESCRIPTION
related to: 
- #4511
- #6659 

summary:
- removed the lock from `Reconcile` so we can run live updates in parallel
- added some descriptions around the newly added locks... 
  - used basically for functions where maps are used
  - locks those whose had to be moved to the functions instead, since now `Reconcile` doesn't have them anymore