### PR TITLE
Fix service grouping across namespaces

### DIFF
--- a/internal/k8s/entity.go
+++ b/internal/k8s/entity.go
@@ -232,10 +232,6 @@ func FilterByImage(entities []K8sEntity, img container.RefSelector, locators []I
 	return Filter(entities, func(e K8sEntity) (bool, error) { return e.HasImage(img, locators, inEnvVars) })
 }
 
-func FilterBySelectorMatchesLabels(entities []K8sEntity, labels map[string]string) (passing, rest []K8sEntity, err error) {
-	return Filter(entities, func(e K8sEntity) (bool, error) { return e.SelectorMatchesLabels(labels), nil })
-}
-
 func FilterByMetadataLabels(entities []K8sEntity, labels map[string]string) (passing, rest []K8sEntity, err error) {
 	return Filter(entities, func(e K8sEntity) (bool, error) { return e.MatchesMetadataLabels(labels) })
 }


### PR DESCRIPTION
  ## Summary

  Fix service grouping across namespaces (#6311)

  ## Problem

  When multiple namespaces contain same-named Services and Deployments (e.g., `shop-phoenix` in both `local` and `upfit` namespaces), Tilt incorrectly groups all Services under one workload, leaving other workloads without their Services deployed.

  **Root Cause:** `FilterByMatchesPodTemplateSpec` in `internal/k8s/entity.go` only checks if selector labels match, without considering namespace boundaries.

  ## Solution

  Modified `FilterByMatchesPodTemplateSpec` to also check that entities are in the same namespace before associating them:

  ```go
  // Before: only checks selector labels
  match, rest, err := FilterBySelectorMatchesLabels(remaining, template.Labels)

  // After: checks both selector labels AND same namespace
  match, rest, err := filterBySelectorMatchesLabelsAndNamespace(remaining, template.Labels, workloadNamespace)

  Testing

  - Tested with multiple namespaces containing same-named resources
  - Verified Services are now correctly associated with their respective Deployments in each namespace
  - HTTPRoute correctly resolves Service references after the fix

  Fixes #6311
