### PR TITLE
Improve error handling during Powershell Tilt installation

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -3,6 +3,9 @@
 # Usage:
 #   iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/tilt-dev/tilt/master/scripts/install.ps1')
 
+& { #enclose in scope to avoid leaking variables when ran through iex
+$ErrorActionPreference = 'Stop'
+try {        
 $version = "0.36.1"
 $url = "https://github.com/tilt-dev/tilt/releases/download/v" + $version + "/tilt." + $version + ".windows.x86_64.zip"
 $zip = "tilt-" + $version + ".zip"
@@ -40,10 +43,13 @@ Expand-Archive $zip -DestinationPath $extractDir
 
 Write-Output "Installing Tilt as $dest"
 New-Item -ItemType Directory -Force -Path $binDir >$null
-Move-Item -Force -Path "$extractDir\tilt.exe" -Destination "$dest"
-
-Remove-Item -Force -Path "$zip"
-Remove-Item -Force -Recurse -Path "$extractDir"
+try {
+    Move-Item -Force -Path "$extractDir\tilt.exe" -Destination "$dest"    
+}
+catch {
+    Write-Host "Unable to install tilt.exe. Is tilt in use?" -ForegroundColor Red
+    throw
+}
 
 iex "$dest version"
 iex "$dest verify-install"
@@ -51,4 +57,13 @@ iex "$dest verify-install"
 Write-Output "Tilt installed!"
 Write-Output "Run '$dest up' to start."
 Write-Output "Or add $binDir to your PATH"
-
+}
+catch {
+    Write-Output $_
+    Write-Host "Tilt installation failed" -ForegroundColor Red
+}
+finally {
+    Remove-Item -Force -Path "$zip" -ErrorAction Ignore
+    Remove-Item -Force -Recurse -Path "$extractDir" -ErrorAction Ignore
+}
+}


### PR DESCRIPTION
Fixed several issues with PowerShell tilt installation.

- Fixed the script continuing and printing "Tilt installed!", even if there was a failure halfway through.
- Enclosed the script in a scope to prevent it leaking variables into the parent scope. (Only happens when using `iex`)
- Clarified a confusing error message when tilt.exe was in use. "`Cannot create a file when that file already exists`" -> "`Unable to install tilt.exe. Is tilt in use?`" [Issue](https://github.com/PowerShell/PowerShell/issues/21251)

Tested with pwsh.exe, powershell.exe, with and without scoop.

Example Error:
<img width="942" height="217" alt="image" src="https://github.com/user-attachments/assets/40fadccb-3ec7-4352-81b6-3af2ad722ede" />

Example Success:
<img width="976" height="180" alt="image" src="https://github.com/user-attachments/assets/57cbf65f-e0a6-4922-8c0e-951aa8e471bd" />



I wasn't sure if I should reindent the whole file and obliterate the git blame.