### PR TITLE
session: don't apply readiness timeout to jobs

### DIFF
--- a/internal/controllers/core/session/status.go
+++ b/internal/controllers/core/session/status.go
@@ -162,6 +162,20 @@ func (r *Reconciler) enforceReadinessTimeout(spec v1alpha1.SessionSpec, status *
 		if target.State.Active == nil || target.State.Active.Ready {
 			continue
 		}
+		if target.Type == v1alpha1.TargetTypeJob {
+			// Readiness is not currently enforced for jobs.
+			//
+			// Two problems:
+			// 1) Tilt resource readiness means "can the next dependency start"
+			// 2) Kubernetes readiness means "is the pod ready to serve traffic"
+			// 3) Tilt does not formally track Job status, and doesn't
+			//    look at job retry policies.
+			//
+			// I think the right thing to do here is to track Job status
+			// and watch that in tilt ci. Readiness timeout would only apply
+			// to kubernetes readiness. But that's a bigger change.
+			continue
+		}
 		var refTime time.Time
 		if !target.State.Active.LastReadyTime.IsZero() {
 			refTime = target.State.Active.LastReadyTime.Time

--- a/internal/tiltfile/api/__init__.py
+++ b/internal/tiltfile/api/__init__.py
@@ -1291,7 +1291,7 @@ def ci_settings(
   Args:
     k8s_grace_period: Grace period given for Kubernetes resources to recover after they start failing. A duration string.
     timeout: Timeout for the whole CI pipeline. A duration string. Defaults to '30m'.
-    readiness_timeout: Timeout for a resource to become ready before the CI pipeline fails. Measured from the time the resource is started. Defaults to '5m'.
+    readiness_timeout: Timeout for an active resource to become ready before the CI pipeline fails. Measured from the time the resource is started. Defaults to '5m'. Does not affect Kubernetes jobs.
   """
 
 def watch_settings(ignore: Union[str, List[str]]) -> None:

--- a/pkg/apis/core/v1alpha1/generated.proto
+++ b/pkg/apis/core/v1alpha1/generated.proto
@@ -2638,9 +2638,10 @@ message SessionCISpec {
   // Timeout for the whole CI pipeline. Defaults to 30m.
   optional k8s.io.apimachinery.pkg.apis.meta.v1.Duration timeout = 2;
 
-  // Timeout for a resource to become ready before the CI pipeline fails.
+  // Timeout for an active resource to become ready before the CI pipeline fails.
   // Measured from the time the resource is started.
   // Defaults to 5m.
+  // Does not affect Kubernetes jobs.
   optional k8s.io.apimachinery.pkg.apis.meta.v1.Duration readinessTimeout = 3;
 }
 

--- a/pkg/apis/core/v1alpha1/session_types.go
+++ b/pkg/apis/core/v1alpha1/session_types.go
@@ -76,9 +76,10 @@ type SessionCISpec struct {
 	// Timeout for the whole CI pipeline. Defaults to 30m.
 	Timeout *metav1.Duration `json:"timeout,omitempty" protobuf:"bytes,2,opt,name=timeout"`
 
-	// Timeout for a resource to become ready before the CI pipeline fails.
+	// Timeout for an active resource to become ready before the CI pipeline fails.
 	// Measured from the time the resource is started.
 	// Defaults to 5m.
+	// Does not affect Kubernetes jobs.
 	ReadinessTimeout *metav1.Duration `json:"readinessTimeout,omitempty" protobuf:"bytes,3,opt,name=readinessTimeout"`
 }
 

--- a/pkg/openapi/zz_generated.openapi.go
+++ b/pkg/openapi/zz_generated.openapi.go
@@ -6217,7 +6217,7 @@ func schema_pkg_apis_core_v1alpha1_SessionCISpec(ref common.ReferenceCallback) c
 					},
 					"readinessTimeout": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Timeout for a resource to become ready before the CI pipeline fails. Measured from the time the resource is started. Defaults to 5m.",
+							Description: "Timeout for an active resource to become ready before the CI pipeline fails. Measured from the time the resource is started. Defaults to 5m. Does not affect Kubernetes jobs.",
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Duration"),
 						},
 					},


### PR DESCRIPTION
fixes https://github.com/tilt-dev/tilt/issues/6664

Signed-off-by: Nick Santos <nick.santos@docker.com>
