### PR TITLE
scripts: fix release scripts for go 1.25

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,7 +146,7 @@ jobs:
     resource_class: medium+
     docker:
       # keep image in sync with build.toast.yml
-      - image: "docker/tilt-releaser@sha256:bac805cc7f100d9b53b1bfca780c864120f3326eb7528943a67c741dc39ed494"
+      - image: "docker/tilt-releaser@sha256:304fa435c4b18d71d1aeae4578762625fc43ab69bc24656e20d150ee23dc2b2b"
     steps:
       - setup_remote_docker
       # https://discuss.circleci.com/t/arm-version-of-remote-docker/41624
@@ -162,7 +162,7 @@ jobs:
     resource_class: medium+
     docker:
       # keep image in sync with build.toast.yml
-      - image: "docker/tilt-releaser@sha256:bac805cc7f100d9b53b1bfca780c864120f3326eb7528943a67c741dc39ed494"
+      - image: "docker/tilt-releaser@sha256:304fa435c4b18d71d1aeae4578762625fc43ab69bc24656e20d150ee23dc2b2b"
     environment:
       DOCKER_CLI_EXPERIMENTAL: enabled
     steps:

--- a/build.toast.yml
+++ b/build.toast.yml
@@ -1,5 +1,5 @@
 # keep image in sync with .circleci/config.yml
-image: "docker/tilt-releaser@sha256:bac805cc7f100d9b53b1bfca780c864120f3326eb7528943a67c741dc39ed494"
+image: "docker/tilt-releaser@sha256:304fa435c4b18d71d1aeae4578762625fc43ab69bc24656e20d150ee23dc2b2b"
 location: /go/src/github.com/tilt-dev/tilt
 command_prefix: set -euo pipefail
 tasks:

--- a/scripts/release.Dockerfile
+++ b/scripts/release.Dockerfile
@@ -5,7 +5,7 @@
 # 2) Be able to do releases from a CI job
 
 # osxcross contains the MacOSX cross toolchain for xx
-FROM crazymax/osxcross:11.3-debian AS osxcross
+FROM crazymax/osxcross:12.3-debian AS osxcross
 
 FROM golang:1.25-trixie AS musl-cross
 WORKDIR /musl
@@ -30,6 +30,8 @@ RUN apt-get update && \
     zlib1g-dev \
     g++-aarch64-linux-gnu \
     gcc-aarch64-linux-gnu \
+    binutils-aarch64-linux-gnu \
+    binutils-gold-aarch64-linux-gnu \
     g++-arm-linux-gnueabi \
     gcc-arm-linux-gnueabi \
     g++-mingw-w64 \


### PR DESCRIPTION
- add the gold linker so we can cross compile linux arm on trixie
- add some macos headers

Signed-off-by: Nick Santos <nick.santos@docker.com>
