### PR TITLE
fix(dockercompose): respect health check status in RuntimeStatus

### DIFF
--- a/internal/dockercompose/state_test.go
+++ b/internal/dockercompose/state_test.go
@@ -1,0 +1,129 @@
+package dockercompose
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
+)
+
+func TestRuntimeStatus_NoHealthCheck(t *testing.T) {
+	// Container running without health check should be OK
+	s := State{
+		ContainerState: v1alpha1.DockerContainerState{
+			Running: true,
+			Status:  ContainerStatusRunning,
+		},
+	}
+	assert.Equal(t, v1alpha1.RuntimeStatusOK, s.RuntimeStatus())
+}
+
+func TestRuntimeStatus_HealthCheckStarting(t *testing.T) {
+	// Container running but health check still starting should be Pending
+	s := State{
+		ContainerState: v1alpha1.DockerContainerState{
+			Running:      true,
+			Status:       ContainerStatusRunning,
+			HealthStatus: "starting",
+		},
+	}
+	assert.Equal(t, v1alpha1.RuntimeStatusPending, s.RuntimeStatus())
+}
+
+func TestRuntimeStatus_HealthCheckHealthy(t *testing.T) {
+	// Container running and health check healthy should be OK
+	s := State{
+		ContainerState: v1alpha1.DockerContainerState{
+			Running:      true,
+			Status:       ContainerStatusRunning,
+			HealthStatus: "healthy",
+		},
+	}
+	assert.Equal(t, v1alpha1.RuntimeStatusOK, s.RuntimeStatus())
+}
+
+func TestRuntimeStatus_HealthCheckUnhealthy(t *testing.T) {
+	// Container running but health check unhealthy should be Error
+	s := State{
+		ContainerState: v1alpha1.DockerContainerState{
+			Running:      true,
+			Status:       ContainerStatusRunning,
+			HealthStatus: "unhealthy",
+		},
+	}
+	assert.Equal(t, v1alpha1.RuntimeStatusError, s.RuntimeStatus())
+}
+
+func TestRuntimeStatus_ContainerError(t *testing.T) {
+	// Container with error should be Error regardless of health
+	s := State{
+		ContainerState: v1alpha1.DockerContainerState{
+			Running:      false,
+			Status:       ContainerStatusExited,
+			Error:        "some error",
+			HealthStatus: "healthy",
+		},
+	}
+	assert.Equal(t, v1alpha1.RuntimeStatusError, s.RuntimeStatus())
+}
+
+func TestRuntimeStatus_NonZeroExitCode(t *testing.T) {
+	// Container with non-zero exit code should be Error
+	s := State{
+		ContainerState: v1alpha1.DockerContainerState{
+			Running:  false,
+			Status:   ContainerStatusExited,
+			ExitCode: 1,
+		},
+	}
+	assert.Equal(t, v1alpha1.RuntimeStatusError, s.RuntimeStatus())
+}
+
+func TestRuntimeStatus_ExitedSuccessfully(t *testing.T) {
+	// Container exited with code 0 and no health check should be OK
+	s := State{
+		ContainerState: v1alpha1.DockerContainerState{
+			Running:  false,
+			Status:   ContainerStatusExited,
+			ExitCode: 0,
+		},
+	}
+	assert.Equal(t, v1alpha1.RuntimeStatusOK, s.RuntimeStatus())
+}
+
+func TestRuntimeStatus_EmptyStatus(t *testing.T) {
+	// Container with empty status should be Unknown
+	s := State{
+		ContainerState: v1alpha1.DockerContainerState{
+			Status: "",
+		},
+	}
+	assert.Equal(t, v1alpha1.RuntimeStatusUnknown, s.RuntimeStatus())
+}
+
+func TestRuntimeStatus_CreatedStatus(t *testing.T) {
+	// Container in created state should be Pending
+	s := State{
+		ContainerState: v1alpha1.DockerContainerState{
+			Status: ContainerStatusCreated,
+		},
+	}
+	assert.Equal(t, v1alpha1.RuntimeStatusPending, s.RuntimeStatus())
+}
+
+func TestRuntimeStatusError_UnhealthyContainer(t *testing.T) {
+	// RuntimeStatusError should return appropriate message for unhealthy container
+	s := State{
+		ContainerID: "abc123",
+		ContainerState: v1alpha1.DockerContainerState{
+			Running:      true,
+			Status:       ContainerStatusRunning,
+			HealthStatus: "unhealthy",
+		},
+	}
+	err := s.RuntimeStatusError()
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "health check failed")
+	assert.Contains(t, err.Error(), "abc123")
+}


### PR DESCRIPTION
## Summary

- Fix RuntimeStatus() to consider Docker health check status before reporting container as OK
- Return RuntimeStatusPending when health check is "starting"
- Return RuntimeStatusError when health check is "unhealthy"
- Add comprehensive tests for health check status handling

## Problem

When using Tilt with docker-compose services that have health checks configured, Tilt would mark containers as "OK" (green in the Tilt UI) as soon as they entered the "running" state, without waiting for the health check to pass.

This caused issues with docker-compose's `depends_on` with `condition: service_healthy`:

```yaml
services:
  db:
    healthcheck:
      test: ["CMD", "pg_isready"]
      
  app:
    depends_on:
      db:
        condition: service_healthy
```

Even though docker-compose was configured to wait for health checks, Tilt's `resource_deps` would not honor this because Tilt only looks at whether the container is "running", not whether it's "healthy".

## Solution

Modified `RuntimeStatus()` in `internal/dockercompose/state.go` to check `HealthStatus`:

- If `HealthStatus` is empty (no health check configured): behavior unchanged
- If `HealthStatus` is "starting": return `RuntimeStatusPending` 
- If `HealthStatus` is "healthy": return `RuntimeStatusOK`
- If `HealthStatus` is "unhealthy": return `RuntimeStatusError`

The `HealthStatus` field was already being captured and stored in `DockerContainerState` (via `ToContainerState()`), it just wasn't being used in the status determination.

## Test plan

- [x] Added unit tests for all health check status scenarios
- [x] All existing tests pass
- [ ] Manual testing with docker-compose services that have health checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)