### PR TITLE
docs: cleanup

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -156,7 +156,7 @@ brews:
     name: homebrew-tap
   commit_author:
     name: Tilt Dev
-    email: hi@tilt.dev
+    email: it@tilt.dev
   ids:
     - default
   url_template: "https://github.com/tilt-dev/tilt/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
@@ -243,7 +243,7 @@ scoops:
     name: scoop-bucket
   commit_author:
     name: Tilt Dev
-    email: hi@tilt.dev
+    email: it@tilt.dev
   commit_msg_template: "Scoop update for {{ .ProjectName }} version {{ .Tag }}"
   homepage: "https://tilt.dev/"
   description: "A dev environment as code for microservice apps"

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -4,7 +4,6 @@
 * Treat everyone with respect and kindness
 * Be thoughtful in how you communicate
 * Don’t be destructive or inflammatory
-* If you encounter an issue, please email [**conduct@tilt.dev**](mailto:conduct@tilt.dev)
 
 ## Goals of This Document
 The Tilt project is committed to providing a friendly, safe, and welcoming environment for all of our users, contributors, followers, and Fans, regardless of: gender identity or expression; sexual orientation; disability; neurodivergence; physical appearance; body size; ethnicity; nationality; race; age; religion; level of technical experience; education; socio-economic status; or similar personal characteristics.
@@ -65,7 +64,7 @@ We do not believe that all conflict is bad; healthy debate and disagreement ofte
 
 If you see someone violating the Code of Conduct, you are encouraged to address the behavior directly with those involved. Many issues can be resolved quickly and easily, and this gives people more control over the outcome of their dispute. If you are unable to resolve the matter for any reason, or if the behavior is threatening or harassing, report it. We are dedicated to providing an environment where participants feel welcome and safe.
 
-Reports should be directed to **conduct@tilt.dev**.
+Reports should be directed to **it@tilt.dev**.
 
 We will investigate every complaint, but you may not receive a direct response. We will use our discretion in determining when and how to follow up on reported incidents, which may range from not taking action to permanent expulsion from the project and project-sponsored spaces. We will notify the accused of the report and provide them an opportunity to discuss it before any action is taken. The identity of the reporter will be omitted from the details of the report supplied to the accused. In potentially harmful situations, such as ongoing harassment or threats to anyone’s safety, we may take action without notice.
 

--- a/README.md
+++ b/README.md
@@ -63,10 +63,6 @@ and [C#](https://docs.tilt.dev/example_csharp.html).
 
 **Contribute:** Check out our [guidelines](CONTRIBUTING.md) to contribute to Tilt's source code. To extend the capabilities of Tilt via new Tiltfile functionality, read more about [Extensions](https://docs.tilt.dev/extensions.html).
 
-**Follow along:** [@tilt_dev](https://twitter.com/tilt_dev) on Twitter. For updates
-and announcements, follow [the blog](https://blog.tilt.dev) or subscribe to 
-[the newsletter](https://tilt.dev/subscribe).
-
 **Help us make Tilt even better:** Tilt sends anonymized usage data, so we can
 improve Tilt on every platform. Details in ["What does Tilt
 send?"](http://docs.tilt.dev/telemetry_faq.html).

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -112,7 +112,6 @@ function version_check() {
     exit 1
   else
     echo "Tilt installed!"
-    echo "For the latest Tilt news, subscribe: https://tilt.dev/subscribe"
     echo "Run \`tilt up\` to start."
   fi
 }


### PR DESCRIPTION
- remove references to the newsletter, which hasn't existed for a while
- use it@tilt.dev for contact info

Signed-off-by: Nick Santos <nicholas.j.santos@gmail.com>
