### PR TITLE
Fix tilt logs -f to respect resource filtering

### DIFF
--- a/internal/hud/client/log_filter.go
+++ b/internal/hud/client/log_filter.go
@@ -109,14 +109,15 @@ func (f LogFilter) matchesSinceFilter(line logstore.LogLine) bool {
 // The implementation is identical to matchesFilter in web/src/OverviewLogPane.tsx.
 // except for term filtering as tools like grep can be used from the CLI.
 func (f LogFilter) Matches(line logstore.LogLine) bool {
-	if line.BuildEvent != "" {
-		// Always leave in build event logs.
-		// This makes it easier to see which logs belong to which builds.
-		return true
-	}
-
+	// Check resource filter first - build events should also respect resource filtering
 	if !f.resources.Matches(line.ManifestName) {
 		return false
+	}
+
+	if line.BuildEvent != "" {
+		// Include build event logs that match the resource filter.
+		// This makes it easier to see which logs belong to which builds.
+		return true
 	}
 
 	isBuild := isBuildSpanID(line.SpanID)


### PR DESCRIPTION
## Problem
When running `tilt logs -f <resource>`, build event logs from other resources were incorrectly shown in the output. This included:
- Initial Build messages from all resources
- Files Changed messages from unrelated services

## Root Cause
In `internal/hud/client/log_filter.go`, the `LogFilter.Matches()` function was checking if a log line is a BuildEvent BEFORE checking if it matches the resource filter. This caused all build event logs to bypass the resource filtering.

## Solution
Reorder the filter checks in `LogFilter.Matches()` to apply the resource filter FIRST, before checking for build events. This ensures all logs, including build events, respect the resource filter.

## Changes
- File: `internal/hud/client/log_filter.go` (lines 111-121)
- Moved resource filter check BEFORE BuildEvent check
- Minimal change: 6 lines added, 5 removed

## Testing
The fix has been:
- ✅ Verified to compile successfully (v0.37.0-dev)
- ✅ Tested with the binary
- ✅ Code reviewed for logic correctness

Fixes #6663