### PR TITLE
Consider cronjob resources to be immediately ready

### DIFF
--- a/internal/tiltfile/k8s/resource.go
+++ b/internal/tiltfile/k8s/resource.go
@@ -11,11 +11,16 @@ type KindInfo struct {
 }
 
 func InitialKinds() map[k8s.ObjectSelector]*KindInfo {
-	sel, err := k8s.NewPartialMatchObjectSelector("batch/v1", "Job", "", "")
+	jobSel, err := k8s.NewPartialMatchObjectSelector("batch/v1", "Job", "", "")
+	if err != nil {
+		panic(err)
+	}
+	cronJobSel, err := k8s.NewPartialMatchObjectSelector("batch/v1", "CronJob", "", "")
 	if err != nil {
 		panic(err)
 	}
 	return map[k8s.ObjectSelector]*KindInfo{
-		sel: {PodReadinessMode: model.PodReadinessSucceeded},
+		jobSel:     {PodReadinessMode: model.PodReadinessSucceeded},
+		cronJobSel: {PodReadinessMode: model.PodReadinessIgnore},
 	}
 }

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -1856,6 +1856,24 @@ k8s_yaml('job.yaml')
 	)
 }
 
+func TestCronJobReadiness(t *testing.T) {
+	f := newFixture(t)
+
+	f.file("cronjob.yaml", `apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: mycronjob
+`)
+	f.file("Tiltfile", `
+k8s_yaml('cronjob.yaml')
+`)
+
+	f.load("mycronjob")
+	f.assertNextManifest("mycronjob",
+		podReadiness(model.PodReadinessIgnore),
+	)
+}
+
 func TestK8sDiscoveryStrategy(t *testing.T) {
 	f := newFixture(t)
 


### PR DESCRIPTION
Fixes #2136                                                                                                                                                                                                                                                                                                                                                                                                                                                                            
   
CronJobs were stuck in a pending state indefinitely after deployment because Tilt waited for pods to appear before marking them healthy. Since cronJobs run on a schedule, it might take hours, days, etc. for pods to be created. 

It is not enough to set `pod_readiness='ignore'` since it's not about pods being ready, but about them existing in the first place.                                                                                                                                                                                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       
CronJobs are now marked as healthy (`RuntimeStatusOK`) as soon as the manifest is successfully applied to the cluster, consistent with the expectation that Tilt's responsibility ends at deployment and not at execution time.                                                                                                                                                                                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       
### Changes                                                                                                                                                                                                                                                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       
- Added `CronJob` to `InitialKinds()` with `PodReadinessIgnore` mode, so Tilt considers a CronJob ready once the resource is created, without waiting for any scheduled pod to run.                                                                                                                                                                                                                                                                                                                                                                                                                                                        
- Added `TestCronJobReadiness` to cover this behavior