### PR TITLE
cluster: treat Docker Desktop misconfiguration as a cluster error

### DIFF
--- a/internal/controllers/core/cluster/reconciler.go
+++ b/internal/controllers/core/cluster/reconciler.go
@@ -16,6 +16,7 @@ import (
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	"github.com/tilt-dev/clusterid"
 	"github.com/tilt-dev/tilt/internal/analytics"
 	"github.com/tilt-dev/tilt/internal/container"
 	"github.com/tilt-dev/tilt/internal/controllers/apicmp"
@@ -353,9 +354,19 @@ func (r *Reconciler) populateK8sMetadata(ctx context.Context, clusterNN types.Na
 
 	if conn.connStatus == nil {
 		apiConfig := conn.k8sClient.APIConfig()
+		product := k8s.ClusterProductFromAPIConfig(apiConfig)
+
+		if product == clusterid.ProductDockerDesktop &&
+			conn.k8sClient.ContainerRuntime(ctx) == container.RuntimeContainerd {
+			if err := r.checkDockerDesktopContainerdSnapshotter(ctx); err != nil {
+				conn.initError = err.Error()
+				return
+			}
+		}
+
 		k8sStatus := &v1alpha1.KubernetesClusterConnectionStatus{
 			Context: apiConfig.CurrentContext,
-			Product: string(k8s.ClusterProductFromAPIConfig(apiConfig)),
+			Product: string(product),
 		}
 		context, ok := apiConfig.Contexts[apiConfig.CurrentContext]
 		if ok {
@@ -409,6 +420,33 @@ func (r *Reconciler) populateDockerMetadata(ctx context.Context, conn *connectio
 			conn.serverVersion = versionInfo.Version
 		}
 	}
+}
+
+// checkDockerDesktopContainerdSnapshotter checks that Docker Desktop has the containerd
+// image snapshotter enabled when using a Docker Desktop Kubernetes cluster with containerd runtime.
+// If the snapshotter is disabled, image loading will not work correctly.
+// Returns nil if the check passes or cannot be performed.
+func (r *Reconciler) checkDockerDesktopContainerdSnapshotter(ctx context.Context) error {
+	dockerClient, err := r.dockerClientFactory.New(ctx, docker.Env(r.localDockerEnv))
+	if err != nil {
+		return nil // can't connect to Docker, skip check
+	}
+
+	info, err := dockerClient.DaemonInfo(ctx)
+	if err != nil {
+		return nil // can't get info, skip check
+	}
+
+	for _, kv := range info.DriverStatus {
+		if kv[0] == "driver-type" && kv[1] == "io.containerd.snapshotter.v1" {
+			return nil // containerd snapshotter is enabled
+		}
+	}
+
+	return fmt.Errorf(
+		"Your Docker Desktop Kubernetes cluster uses containerd, but the containerd image snapshotter is disabled.\n\t" +
+			"Enable 'Use containerd for pulling and storing images' in Docker Desktop settings,\n\t" +
+			"then recreate the cluster.")
 }
 
 func (r *Reconciler) cleanup(clusterNN types.NamespacedName) {

--- a/internal/controllers/core/cluster/reconciler_test.go
+++ b/internal/controllers/core/cluster/reconciler_test.go
@@ -15,7 +15,11 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 
+	"github.com/moby/moby/api/types/system"
+
+	"github.com/tilt-dev/tilt/internal/container"
 	"github.com/tilt-dev/tilt/internal/hud/server"
 	"github.com/tilt-dev/tilt/internal/k8s/kubeconfig"
 	"github.com/tilt-dev/tilt/internal/localexec"
@@ -81,6 +85,88 @@ func TestKubernetesError(t *testing.T) {
 	if assert.NotNil(t, cluster.Status.ConnectedAt, "ConnectedAt should be populated") {
 		assert.NotZero(t, cluster.Status.ConnectedAt.Time, "ConnectedAt should not be zero time")
 	}
+}
+
+func TestDockerDesktopContainerdWithoutSnapshotter(t *testing.T) {
+	f := newFixture(t)
+
+	// Set up the fake K8s client to look like a Docker Desktop cluster with containerd runtime.
+	f.k8sClient.FakeAPIConfig = &clientcmdapi.Config{
+		CurrentContext: "docker-desktop",
+		Contexts: map[string]*clientcmdapi.Context{
+			"docker-desktop": {
+				Cluster:   "docker-desktop",
+				Namespace: "default",
+			},
+		},
+		Clusters: map[string]*clientcmdapi.Cluster{
+			"docker-desktop": {},
+		},
+	}
+	f.k8sClient.Runtime = container.RuntimeContainerd
+
+	// Simulate Docker Desktop without containerd image snapshotter (no io.containerd.snapshotter.v1).
+	f.dockerClient.FakeDaemonInfo = system.Info{
+		DriverStatus: [][2]string{
+			{"Backing Filesystem", "extfs"},
+		},
+	}
+
+	cluster := &v1alpha1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "default"},
+		Spec: v1alpha1.ClusterSpec{
+			Connection: &v1alpha1.ClusterConnection{
+				Kubernetes: &v1alpha1.KubernetesClusterConnection{},
+			},
+		},
+	}
+	nn := apis.Key(cluster)
+
+	f.Create(cluster)
+	f.MustGet(nn, cluster)
+	assert.Contains(t, cluster.Status.Error, "containerd image snapshotter is disabled")
+	assert.Nil(t, cluster.Status.ConnectedAt, "ConnectedAt should be empty on error")
+}
+
+func TestDockerDesktopContainerdWithSnapshotter(t *testing.T) {
+	f := newFixture(t)
+
+	// Set up the fake K8s client to look like a Docker Desktop cluster with containerd runtime.
+	f.k8sClient.FakeAPIConfig = &clientcmdapi.Config{
+		CurrentContext: "docker-desktop",
+		Contexts: map[string]*clientcmdapi.Context{
+			"docker-desktop": {
+				Cluster:   "docker-desktop",
+				Namespace: "default",
+			},
+		},
+		Clusters: map[string]*clientcmdapi.Cluster{
+			"docker-desktop": {},
+		},
+	}
+	f.k8sClient.Runtime = container.RuntimeContainerd
+
+	// Simulate Docker Desktop with containerd image snapshotter enabled.
+	f.dockerClient.FakeDaemonInfo = system.Info{
+		DriverStatus: [][2]string{
+			{"driver-type", "io.containerd.snapshotter.v1"},
+		},
+	}
+
+	cluster := &v1alpha1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "default"},
+		Spec: v1alpha1.ClusterSpec{
+			Connection: &v1alpha1.ClusterConnection{
+				Kubernetes: &v1alpha1.KubernetesClusterConnection{},
+			},
+		},
+	}
+	nn := apis.Key(cluster)
+
+	f.Create(cluster)
+	f.MustGet(nn, cluster)
+	assert.Empty(t, cluster.Status.Error, "No error when containerd snapshotter is enabled")
+	assert.NotNil(t, cluster.Status.ConnectedAt, "ConnectedAt should be populated")
 }
 
 func TestKubernetesDelete(t *testing.T) {

--- a/internal/docker/client.go
+++ b/internal/docker/client.go
@@ -27,6 +27,7 @@ import (
 	typesbuild "github.com/moby/moby/api/types/build"
 	typescontainer "github.com/moby/moby/api/types/container"
 	typesregistry "github.com/moby/moby/api/types/registry"
+	"github.com/moby/moby/api/types/system"
 	"github.com/moby/moby/client"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
@@ -111,6 +112,9 @@ type Client interface {
 	NewVersionError(ctx context.Context, APIrequired, feature string) error
 	BuildCachePrune(ctx context.Context, opts client.BuildCachePruneOptions) (client.BuildCachePruneResult, error)
 	ContainerPrune(ctx context.Context, opts client.ContainerPruneOptions) (client.ContainerPruneResult, error)
+
+	// Returns information about the docker daemon.
+	DaemonInfo(ctx context.Context) (system.Info, error)
 }
 
 // Add-on interface for a client that manages multiple clients transparently.
@@ -394,6 +398,14 @@ func (c *Cli) BuilderVersion(ctx context.Context) (typesbuild.BuilderVersion, er
 func (c *Cli) ServerVersion(ctx context.Context) (client.ServerVersionResult, error) {
 	c.initVersion(ctx)
 	return c.serverVersion, c.versionError
+}
+
+func (c *Cli) DaemonInfo(ctx context.Context) (system.Info, error) {
+	result, err := c.Client.Info(ctx, client.InfoOptions{})
+	if err != nil {
+		return system.Info{}, err
+	}
+	return result.Info, nil
 }
 
 type encodedAuth string

--- a/internal/docker/exploding.go
+++ b/internal/docker/exploding.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/distribution/reference"
 	typesbuild "github.com/moby/moby/api/types/build"
+	"github.com/moby/moby/api/types/system"
 	"github.com/moby/moby/client"
 	"golang.org/x/sync/errgroup"
 
@@ -89,6 +90,9 @@ func (c explodingClient) BuildCachePrune(ctx context.Context, opts client.BuildC
 }
 func (c explodingClient) ContainerPrune(ctx context.Context, opts client.ContainerPruneOptions) (client.ContainerPruneResult, error) {
 	return client.ContainerPruneResult{}, c.err
+}
+func (c explodingClient) DaemonInfo(ctx context.Context) (system.Info, error) {
+	return system.Info{}, c.err
 }
 
 var _ Client = &explodingClient{}

--- a/internal/docker/fake_client.go
+++ b/internal/docker/fake_client.go
@@ -21,6 +21,7 @@ import (
 	typesbuild "github.com/moby/moby/api/types/build"
 	typescontainer "github.com/moby/moby/api/types/container"
 	typesimage "github.com/moby/moby/api/types/image"
+	"github.com/moby/moby/api/types/system"
 	"github.com/moby/moby/client"
 
 	"github.com/tilt-dev/tilt/internal/container"
@@ -142,6 +143,8 @@ type FakeClient struct {
 	ContainersPruneErr     error
 	ContainersPruneFilters client.Filters
 	ContainersPruned       []string
+
+	FakeDaemonInfo system.Info
 }
 
 var _ Client = &FakeClient{}
@@ -178,6 +181,10 @@ func (c *FakeClient) ServerVersion(ctx context.Context) (client.ServerVersionRes
 		Arch:    "amd64",
 		Version: "20.10.11",
 	}, nil
+}
+
+func (c *FakeClient) DaemonInfo(ctx context.Context) (system.Info, error) {
+	return c.FakeDaemonInfo, nil
 }
 
 func (c *FakeClient) SetExecError(err error) {

--- a/internal/docker/switch.go
+++ b/internal/docker/switch.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/distribution/reference"
 	typesbuild "github.com/moby/moby/api/types/build"
+	"github.com/moby/moby/api/types/system"
 	"github.com/moby/moby/client"
 	"golang.org/x/sync/errgroup"
 
@@ -124,6 +125,9 @@ func (c *switchCli) BuildCachePrune(ctx context.Context, opts client.BuildCacheP
 }
 func (c *switchCli) ContainerPrune(ctx context.Context, opts client.ContainerPruneOptions) (client.ContainerPruneResult, error) {
 	return c.client(ctx).ContainerPrune(ctx, opts)
+}
+func (c *switchCli) DaemonInfo(ctx context.Context) (system.Info, error) {
+	return c.client(ctx).DaemonInfo(ctx)
 }
 
 // CompositeClient


### PR DESCRIPTION
fixes
https://github.com/tilt-dev/tilt/issues/6608

Docker Desktop has a more where:
- the user has turned KIND-powered clusters on
- the user has turned the containerd image snapshotter off

which means that Docker Desktop will be running a Kubernetes cluster
that doesn't have access to Docker Desktop's image store.

We're making a change to Docker Desktop to forbid this
configuration. But for now, update tilt to treat this
state as an error and tell the user how to fix it.

Signed-off-by: Nick Santos <nicholas.j.santos@gmail.com>
