### PR TITLE
session: adjust 'tilt ci' exit conditions

### DIFF
--- a/internal/controllers/core/session/reconciler_test.go
+++ b/internal/controllers/core/session/reconciler_test.go
@@ -60,6 +60,25 @@ func TestExitControlIdempotent(t *testing.T) {
 	assert.Equal(t, s1.ObjectMeta, s2.ObjectMeta)
 }
 
+func TestExitControlCI_ClusterError(t *testing.T) {
+	f := newFixture(t, store.EngineModeCI)
+
+	m := manifestbuilder.New(f, "fe").WithK8sYAML(testyaml.SanchoYAML).Build()
+	f.upsertManifest(m)
+
+	f.Store.WithState(func(state *store.EngineState) {
+		state.Clusters["default"] = &v1alpha1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{Name: "default"},
+			Status: v1alpha1.ClusterStatus{
+				Error: "connection refused",
+			},
+		}
+	})
+
+	f.MustReconcile(sessionKey)
+	f.requireDoneWithError(`cluster connection failed`)
+}
+
 func TestExitControlCI_FirstBuildFailure(t *testing.T) {
 	f := newFixture(t, store.EngineModeCI)
 

--- a/internal/controllers/core/session/status.go
+++ b/internal/controllers/core/session/status.go
@@ -48,6 +48,30 @@ func (r *Reconciler) makeLatestStatus(session *v1alpha1.Session, result *ctrl.Re
 	return status
 }
 
+// If the default cluster has an error, and we have enabled kubernetes resources, exit immediately.
+// No resources will be able to run.
+func (r *Reconciler) hasClusterError(state *store.EngineState) bool {
+	hasKubernetesResource := false
+	for _, mt := range state.ManifestTargets {
+		if mt.Manifest.IsK8s() &&
+			mt.State != nil && mt.State.DisableState == v1alpha1.DisableStateEnabled {
+			hasKubernetesResource = true
+			break
+		}
+	}
+
+	if !hasKubernetesResource {
+		return false
+	}
+
+	if defaultCluster, ok := state.Clusters[v1alpha1.ClusterNameDefault]; ok {
+		if errMsg := defaultCluster.Status.Error; errMsg != "" {
+			return true
+		}
+	}
+	return false
+}
+
 func (r *Reconciler) processExitCondition(spec v1alpha1.SessionSpec, state *store.EngineState, status *v1alpha1.SessionStatus, result *ctrl.Result) {
 	exitCondition := spec.ExitCondition
 	if exitCondition == v1alpha1.ExitConditionManual {
@@ -55,6 +79,13 @@ func (r *Reconciler) processExitCondition(spec v1alpha1.SessionSpec, state *stor
 	} else if exitCondition != v1alpha1.ExitConditionCI {
 		status.Done = true
 		status.Error = fmt.Sprintf("unsupported exit condition: %s", exitCondition)
+	}
+
+	if r.hasClusterError(state) {
+		// Assume the cluster error has already printed.
+		status.Done = true
+		status.Error = "cluster connection failed"
+		return
 	}
 
 	var waiting []string


### PR DESCRIPTION
if you have:
- kubernetes resources
- a cluster error
then tilt ci should exit immediately

Signed-off-by: Nick Santos <nicholas.j.santos@gmail.com>
