### PR TITLE
feat: enable image discovery for image volumes

### DIFF
--- a/internal/k8s/extract.go
+++ b/internal/k8s/extract.go
@@ -124,6 +124,23 @@ func extractEnvVars(obj interface{}) ([]*v1.EnvVar, error) {
 	return result, nil
 }
 
+func extractImageVolumeSources(obj interface{}) ([]*v1.ImageVolumeSource, error) {
+	extracted, err := newExtractor(reflect.TypeOf(v1.ImageVolumeSource{})).extractPointersFrom(obj)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]*v1.ImageVolumeSource, len(extracted))
+	for i, e := range extracted {
+		iv, ok := e.(*v1.ImageVolumeSource)
+		if !ok {
+			return nil, fmt.Errorf("extractImageVolumeSources: expected ImageVolumeSource, actual %T", e)
+		}
+		result[i] = iv
+	}
+	return result, nil
+}
+
 func extractContainers(obj interface{}) ([]*v1.Container, error) {
 	extracted, err := newExtractor(reflect.TypeOf(v1.Container{})).extractPointersFrom(obj)
 	if err != nil {

--- a/internal/k8s/image.go
+++ b/internal/k8s/image.go
@@ -64,6 +64,14 @@ func InjectImageDigest(entity K8sEntity, selector container.RefSelector, injectR
 		replaced = true
 	}
 
+	entity, r, err = injectImageDigestInImageVolumes(entity, selector, injectRef, policy)
+	if err != nil {
+		return K8sEntity{}, false, err
+	}
+	if r {
+		replaced = true
+	}
+
 	if matchInEnvVars {
 		entity, r, err = injectImageDigestInEnvVars(entity, selector, injectRef)
 		if err != nil {
@@ -125,6 +133,32 @@ func injectImageDigestInEnvVars(entity K8sEntity, selector container.RefSelector
 
 		if selector.Matches(existingRef) {
 			envVar.Value = container.FamiliarString(injectRef)
+			replaced = true
+		}
+	}
+
+	return entity, replaced, nil
+}
+
+func injectImageDigestInImageVolumes(entity K8sEntity, selector container.RefSelector, injectRef reference.Named, policy v1.PullPolicy) (K8sEntity, bool, error) {
+	imageVolumes, err := extractImageVolumeSources(&entity)
+	if err != nil {
+		return K8sEntity{}, false, err
+	}
+
+	replaced := false
+	for _, iv := range imageVolumes {
+		if iv.Reference == "" {
+			continue
+		}
+		existingRef, err := container.ParseNamed(iv.Reference)
+		if err != nil {
+			return K8sEntity{}, false, err
+		}
+
+		if selector.Matches(existingRef) {
+			iv.Reference = container.FamiliarString(injectRef)
+			iv.PullPolicy = policy
 			replaced = true
 		}
 	}
@@ -218,6 +252,22 @@ func (e K8sEntity) FindImages(locators []ImageLocator, envVarImages []container.
 			return nil, errors.Wrapf(err, "parsing %s", c.Image)
 		}
 
+		result = append(result, ref)
+	}
+
+	// Look for images in image volume sources
+	imageVolumes, err := extractImageVolumeSources(&e)
+	if err != nil {
+		return nil, err
+	}
+	for _, iv := range imageVolumes {
+		if iv.Reference == "" {
+			continue
+		}
+		ref, err := container.ParseNamed(iv.Reference)
+		if err != nil {
+			return nil, errors.Wrapf(err, "parsing image volume reference %s", iv.Reference)
+		}
 		result = append(result, ref)
 	}
 

--- a/internal/k8s/image_test.go
+++ b/internal/k8s/image_test.go
@@ -463,3 +463,139 @@ func TestMatchInEnvVarsTrue(t *testing.T) {
 	assert.Equal(t, namedTagged.String(), c.Image)
 	assert.Contains(t, c.Env, v1.EnvVar{Name: "bar", Value: namedTagged.String()})
 }
+
+func TestImageVolumeFindImages(t *testing.T) {
+	entity := parseOneEntity(t, testyaml.ImageVolumeYAML)
+	images, err := entity.FindImages(nil, nil)
+	require.NoError(t, err)
+
+	// Should find both the container image (nginx:latest) and the volume image
+	refStrs := make([]string, len(images))
+	for i, ref := range images {
+		refStrs[i] = ref.String()
+	}
+	assert.Contains(t, refStrs, "docker.io/library/nginx:latest")
+	assert.Contains(t, refStrs, "ghcr.io/example-user/website-dist:latest")
+}
+
+func TestImageVolumeHasImage(t *testing.T) {
+	entity := parseOneEntity(t, testyaml.ImageVolumeYAML)
+
+	volImg := container.MustParseSelector("ghcr.io/example-user/website-dist")
+	match, err := entity.HasImage(volImg, nil, false)
+	require.NoError(t, err)
+	assert.True(t, match, "entity should match volume image")
+
+	wrongImg := container.MustParseSelector("ghcr.io/example-user/wrong-image")
+	match, err = entity.HasImage(wrongImg, nil, false)
+	require.NoError(t, err)
+	assert.False(t, match, "entity should not match wrong image")
+}
+
+func TestImageVolumeInjectDigest(t *testing.T) {
+	entity := parseOneEntity(t, testyaml.ImageVolumeYAML)
+
+	name := "ghcr.io/example-user/website-dist"
+	digest := "sha256:2baf1f40105d9501fe319a8ec463fdf4325a2a5df445adf3f572f626253678c9"
+	newEntity, replaced, err := InjectImageDigestWithStrings(entity, name, digest, nil, v1.PullIfNotPresent)
+	require.NoError(t, err)
+	assert.True(t, replaced)
+
+	result, err := SerializeSpecYAML([]K8sEntity{newEntity})
+	require.NoError(t, err)
+
+	assert.Contains(t, result, fmt.Sprintf("reference: %s@%s", name, digest))
+}
+
+func TestImageVolumeInjectPullPolicy(t *testing.T) {
+	entity := parseOneEntity(t, testyaml.ImageVolumeYAML)
+
+	name := "ghcr.io/example-user/website-dist"
+	namedTagged, err := reference.ParseNamed(fmt.Sprintf("%s:my-tag", name))
+	require.NoError(t, err)
+
+	newEntity, replaced, err := InjectImageDigest(entity, container.NameSelector(namedTagged), namedTagged, nil, false, v1.PullNever)
+	require.NoError(t, err)
+	assert.True(t, replaced)
+
+	result, err := SerializeSpecYAML([]K8sEntity{newEntity})
+	require.NoError(t, err)
+
+	assert.Contains(t, result, "pullPolicy: Never")
+}
+
+func TestImageVolumeInjectDoesNotMutateOriginal(t *testing.T) {
+	entity := parseOneEntity(t, testyaml.ImageVolumeYAML)
+
+	name := "ghcr.io/example-user/website-dist"
+	digest := "sha256:2baf1f40105d9501fe319a8ec463fdf4325a2a5df445adf3f572f626253678c9"
+	_, replaced, err := InjectImageDigestWithStrings(entity, name, digest, nil, v1.PullIfNotPresent)
+	require.NoError(t, err)
+	assert.True(t, replaced)
+
+	// Original should be untouched
+	result, err := SerializeSpecYAML([]K8sEntity{entity})
+	require.NoError(t, err)
+	assert.NotContains(t, result, digest)
+	assert.Contains(t, result, "reference: ghcr.io/example-user/website-dist:latest")
+}
+
+func TestImageVolumeAndContainerBothReplaced(t *testing.T) {
+	// Use a YAML where the same image appears in both a container and a volume
+	yaml := `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: dual-image
+spec:
+  containers:
+  - name: app
+    image: ghcr.io/example-user/website-dist:latest
+  volumes:
+  - name: vol
+    image:
+      reference: ghcr.io/example-user/website-dist:latest
+`
+	entity := parseOneEntity(t, yaml)
+
+	name := "ghcr.io/example-user/website-dist"
+	digest := "sha256:2baf1f40105d9501fe319a8ec463fdf4325a2a5df445adf3f572f626253678c9"
+	newEntity, replaced, err := InjectImageDigestWithStrings(entity, name, digest, nil, v1.PullIfNotPresent)
+	require.NoError(t, err)
+	assert.True(t, replaced)
+
+	result, err := SerializeSpecYAML([]K8sEntity{newEntity})
+	require.NoError(t, err)
+
+	expected := fmt.Sprintf("%s@%s", name, digest)
+	assert.Contains(t, result, fmt.Sprintf("image: %s", expected))
+	assert.Contains(t, result, fmt.Sprintf("reference: %s", expected))
+}
+
+func TestImageVolumeInDeployment(t *testing.T) {
+	entity := parseOneEntity(t, testyaml.ImageVolumeDeploymentYAML)
+
+	name := "ghcr.io/example-user/website-dist"
+	digest := "sha256:2baf1f40105d9501fe319a8ec463fdf4325a2a5df445adf3f572f626253678c9"
+	newEntity, replaced, err := InjectImageDigestWithStrings(entity, name, digest, nil, v1.PullIfNotPresent)
+	require.NoError(t, err)
+	assert.True(t, replaced)
+
+	result, err := SerializeSpecYAML([]K8sEntity{newEntity})
+	require.NoError(t, err)
+	assert.Contains(t, result, fmt.Sprintf("reference: %s@%s", name, digest))
+}
+
+func TestImageVolumeInStatefulSet(t *testing.T) {
+	entity := parseOneEntity(t, testyaml.ImageVolumeStatefulSetYAML)
+
+	name := "ghcr.io/example-user/website-dist"
+	digest := "sha256:2baf1f40105d9501fe319a8ec463fdf4325a2a5df445adf3f572f626253678c9"
+	newEntity, replaced, err := InjectImageDigestWithStrings(entity, name, digest, nil, v1.PullIfNotPresent)
+	require.NoError(t, err)
+	assert.True(t, replaced)
+
+	result, err := SerializeSpecYAML([]K8sEntity{newEntity})
+	require.NoError(t, err)
+	assert.Contains(t, result, fmt.Sprintf("reference: %s@%s", name, digest))
+}

--- a/internal/k8s/testyaml/testyaml.go
+++ b/internal/k8s/testyaml/testyaml.go
@@ -1712,3 +1712,95 @@ metadata:
 spec:
   group: metrics.k8s.io
 `
+
+const ImageVolumeYAML = `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: oci-volume-example
+spec:
+  containers:
+  - name: web-server
+    image: nginx:latest
+    volumeMounts:
+    - name: my-oci-volume
+      mountPath: /usr/share/nginx/html/data
+  volumes:
+  - name: my-oci-volume
+    image:
+      reference: ghcr.io/example-user/website-dist:latest
+      pullPolicy: IfNotPresent
+`
+
+const ImageVolumeDeploymentYAML = `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: oci-volume-deploy
+spec:
+  selector:
+    matchLabels:
+      app: oci-vol
+  template:
+    metadata:
+      labels:
+        app: oci-vol
+    spec:
+      containers:
+      - name: web-server
+        image: nginx:latest
+        volumeMounts:
+        - name: my-oci-volume
+          mountPath: /data
+      volumes:
+      - name: my-oci-volume
+        image:
+          reference: ghcr.io/example-user/website-dist:latest
+          pullPolicy: IfNotPresent
+`
+
+const ImageVolumeStatefulSetYAML = `
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: oci-volume-sts
+spec:
+  serviceName: oci-vol
+  selector:
+    matchLabels:
+      app: oci-vol
+  template:
+    metadata:
+      labels:
+        app: oci-vol
+    spec:
+      containers:
+      - name: web-server
+        image: nginx:latest
+        volumeMounts:
+        - name: my-oci-volume
+          mountPath: /data
+      volumes:
+      - name: my-oci-volume
+        image:
+          reference: ghcr.io/example-user/website-dist:latest
+          pullPolicy: IfNotPresent
+`
+
+const ImageVolumeOnlyYAML = `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: oci-volume-only
+spec:
+  containers:
+  - name: web-server
+    image: nginx:latest
+  volumes:
+  - name: my-oci-volume
+    image:
+      reference: ghcr.io/example-user/website-dist:latest
+  - name: config-vol
+    configMap:
+      name: my-config
+`


### PR DESCRIPTION
Enables discovery and replacement of image volumes which have been stabilized in Kubernetes v1.33.

In revisions prior to this the behavior can be had with
```
k8s_image_json_path('{.spec.volumes[*].image.reference}', kind='Pod')
k8s_image_json_path('{.spec.template.spec.volumes[*].image.reference}', kind='Deployment')
k8s_image_json_path('{.spec.template.spec.volumes[*].image.reference}', kind='StatefulSet')
```
