### PR TITLE
release: only release to tiltdev docker hub namespace

### DIFF
--- a/.circleci/Dockerfile.integration
+++ b/.circleci/Dockerfile.integration
@@ -53,4 +53,4 @@ RUN go install gotest.tools/gotestsum@latest \
     && gotestsum --version
 
 # install ctlptl from the ctlptl release image
-COPY --from=docker/tilt-ctlptl /usr/local/bin/ctlptl /usr/local/bin/
+COPY --from=tiltdev/ctlptl /usr/local/bin/ctlptl /usr/local/bin/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
   build-linux:
     resource_class: medium+
     docker:
-      - image: docker/tilt-ci@sha256:3b83314ab36d9a529f5af8ca788b00d0926d16ed981a929317aab62696a88d77
+      - image: tiltdev/tilt-ci@sha256:fb737aaed8f1d44d56d4797c1c96046ec940cf2a238d76be29527da2784e8f1e
     # apiserver code generation scripts require being in GOPATH
     working_directory: /home/circleci/go/src/github.com/tilt-dev/tilt
     steps:
@@ -46,7 +46,7 @@ jobs:
           only_for_branches: master
   check-docs:
     docker:
-      - image: docker/tilt-ci@sha256:3b83314ab36d9a529f5af8ca788b00d0926d16ed981a929317aab62696a88d77
+      - image: tiltdev/tilt-ci@sha256:fb737aaed8f1d44d56d4797c1c96046ec940cf2a238d76be29527da2784e8f1e
     steps:
       - checkout
       - run: scripts/ci-has-go-changes.sh || circleci-agent step halt
@@ -99,7 +99,7 @@ jobs:
   build-integration:
     resource_class: medium+
     docker:
-      - image: docker/tilt-integration-ci@sha256:9821f02b3304ede7a09ec0564e0a68abea9375bf596b64f34aa683c613db69f4
+      - image: tiltdev/tilt-integration-ci@sha256:d0dd2ae941a5d67d8c194ce0f72feae4018c88b40ef5cbba89f98c1bf44e9e9c
     steps:
       - checkout
       - run: scripts/ci-has-go-changes.sh || circleci-agent step halt
@@ -153,7 +153,7 @@ jobs:
     resource_class: medium+
     docker:
       # keep image in sync with build.toast.yml
-      - image: "docker/tilt-releaser@sha256:304fa435c4b18d71d1aeae4578762625fc43ab69bc24656e20d150ee23dc2b2b"
+      - image: "tiltdev/tilt-releaser@sha256:8e9de835faefee4934c7a50271f927c410084bb4955d294c260418b09ade6cff"
     steps:
       - setup_remote_docker
       # https://discuss.circleci.com/t/arm-version-of-remote-docker/41624
@@ -169,7 +169,7 @@ jobs:
     resource_class: medium+
     docker:
       # keep image in sync with build.toast.yml
-      - image: "docker/tilt-releaser@sha256:304fa435c4b18d71d1aeae4578762625fc43ab69bc24656e20d150ee23dc2b2b"
+      - image: "tiltdev/tilt-releaser@sha256:8e9de835faefee4934c7a50271f927c410084bb4955d294c260418b09ade6cff"
     steps:
       - setup_remote_docker
       # https://discuss.circleci.com/t/arm-version-of-remote-docker/41624

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -186,7 +186,6 @@ dockers:
     - tilt-linux-amd64
   image_templates:
     - "tiltdev/tilt:{{ .Tag }}-amd64"
-    - "docker/tilt:{{ .Tag }}-amd64"
   dockerfile: scripts/tilt.Dockerfile
   use: buildx
   build_flag_templates:
@@ -206,7 +205,6 @@ dockers:
     - tilt-linux-arm64
   image_templates:
     - "tiltdev/tilt:{{ .Tag }}-arm64"
-    - "docker/tilt:{{ .Tag }}-arm64"
   dockerfile: scripts/tilt.Dockerfile
   use: buildx
   build_flag_templates:
@@ -228,14 +226,6 @@ docker_manifests:
   image_templates:
   - tiltdev/{{ .ProjectName }}:{{ .Tag }}-amd64
   - tiltdev/{{ .ProjectName }}:{{ .Tag }}-arm64
-- name_template: docker/{{ .ProjectName }}:{{ .Tag }}
-  image_templates:
-  - docker/{{ .ProjectName }}:{{ .Tag }}-amd64
-  - docker/{{ .ProjectName }}:{{ .Tag }}-arm64
-- name_template: docker/{{ .ProjectName }}:latest
-  image_templates:
-  - docker/{{ .ProjectName }}:{{ .Tag }}-amd64
-  - docker/{{ .ProjectName }}:{{ .Tag }}-arm64
 scoops:
 - url_template: "https://github.com/tilt-dev/tilt/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
   repository:

--- a/build.toast.yml
+++ b/build.toast.yml
@@ -1,5 +1,5 @@
 # keep image in sync with .circleci/config.yml
-image: "docker/tilt-releaser@sha256:304fa435c4b18d71d1aeae4578762625fc43ab69bc24656e20d150ee23dc2b2b"
+image: "tiltdev/tilt-releaser@sha256:8e9de835faefee4934c7a50271f927c410084bb4955d294c260418b09ade6cff"
 location: /go/src/github.com/tilt-dev/tilt
 command_prefix: set -euo pipefail
 tasks:

--- a/scripts/build-tilt-ci.sh
+++ b/scripts/build-tilt-ci.sh
@@ -7,11 +7,11 @@ set -ex
 DIR=$(dirname "$0")
 cd "$DIR/.."
  
-docker buildx build --push --pull --platform linux/amd64 -t docker/tilt-ci -f .circleci/Dockerfile .circleci
+docker buildx build --push --pull --platform linux/amd64 -t tiltdev/tilt-ci -f .circleci/Dockerfile .circleci
 
 # add some bash code to pull the image and pull out the tag
-docker pull --platform linux/amd64 docker/tilt-ci
-DIGEST="$(docker inspect --format '{{.RepoDigests}}' docker/tilt-ci | tr -d '[]')"
+docker pull --platform linux/amd64 tiltdev/tilt-ci
+DIGEST="$(docker inspect --format '{{.RepoDigests}}' tiltdev/tilt-ci | tr -d '[]')"
 
 yq eval -i ".jobs.build-linux.docker[0].image = \"$DIGEST\"" .circleci/config.yml
 yq eval -i ".jobs.check-docs.docker[0].image = \"$DIGEST\"" .circleci/config.yml

--- a/scripts/build-tilt-integration-ci.sh
+++ b/scripts/build-tilt-integration-ci.sh
@@ -7,10 +7,10 @@ set -ex
 DIR=$(dirname "$0")
 cd "$DIR/.."
  
-docker buildx build --push --pull --platform linux/amd64 -t docker/tilt-integration-ci -f .circleci/Dockerfile.integration .circleci
+docker buildx build --push --pull --platform linux/amd64 -t tiltdev/tilt-integration-ci -f .circleci/Dockerfile.integration .circleci
 
 # add some bash code to pull the image and pull out the tag
-docker pull --platform linux/amd64 docker/tilt-integration-ci
-DIGEST="$(docker inspect --format '{{.RepoDigests}}' docker/tilt-integration-ci | tr -d '[]')"
+docker pull --platform linux/amd64 tiltdev/tilt-integration-ci
+DIGEST="$(docker inspect --format '{{.RepoDigests}}' tiltdev/tilt-integration-ci | tr -d '[]')"
 
 yq eval -i ".jobs.build-integration.docker[0].image = \"$DIGEST\"" .circleci/config.yml

--- a/scripts/build-tilt-releaser.sh
+++ b/scripts/build-tilt-releaser.sh
@@ -8,11 +8,11 @@ set -ex
 DIR=$(dirname "$0")
 cd "$DIR/.."
 
-docker buildx build --push --platform linux/amd64 -t docker/tilt-releaser -f scripts/release.Dockerfile scripts
+docker buildx build --push --platform linux/amd64 -t tiltdev/tilt-releaser -f scripts/release.Dockerfile scripts
 
 # add some bash code to pull the image and pull out the tag
-docker pull --platform linux/amd64 docker/tilt-releaser
-DIGEST="$(docker inspect --format '{{.RepoDigests}}' docker/tilt-releaser | tr -d '[]')"
+docker pull --platform linux/amd64 tiltdev/tilt-releaser
+DIGEST="$(docker inspect --format '{{.RepoDigests}}' tiltdev/tilt-releaser | tr -d '[]')"
 
 yq eval -i ".jobs.release-dry-run.docker[0].image = \"$DIGEST\"" .circleci/config.yml
 yq eval -i ".jobs.release.docker[0].image = \"$DIGEST\"" .circleci/config.yml

--- a/scripts/goreleaser.sh
+++ b/scripts/goreleaser.sh
@@ -14,7 +14,7 @@ DIR=$(dirname "$0")
 cd "$DIR/.."
 
 docker login
-docker pull docker/tilt-releaser
+docker pull tiltdev/tilt-releaser
 mkdir -p ~/.cache/tilt/release/go-build
 
 docker run --rm --privileged \
@@ -24,5 +24,5 @@ docker run --rm --privileged \
        -v ~/.cache/tilt/release/go-build:/root/.cache/go-build \
        -v "$PWD:/src/tilt:delegated" \
        -v /var/run/docker.sock:/var/run/docker.sock \
-       docker/tilt-releaser \
+       tiltdev/tilt-releaser \
        --clean

--- a/scripts/tilt.Dockerfile
+++ b/scripts/tilt.Dockerfile
@@ -12,7 +12,7 @@
 #
 # Built with goreleaser.
 
-FROM docker/tilt-ctlptl
+FROM tiltdev/ctlptl
 
 # Tilt's extension downloader requires git
 RUN apt update && apt install -y git


### PR DESCRIPTION
docker hub auth is moving towards systems
where auth is scoped by org (e.g., OATs).

this makes it hard to publish to two orgs
at once (docker and tiltdev).

i think the simpler solution is to keep the tiltdev
images in their own org rather than mixing them
with the docker org

Signed-off-by: Nick Santos <nick.santos@docker.com>
