### PR TITLE
adding jsonpath dict filtering

### DIFF
--- a/internal/k8s/jsonpath/jsonpath.go
+++ b/internal/k8s/jsonpath/jsonpath.go
@@ -450,17 +450,30 @@ func (j *JSONPath) evalFilter(input []Value, node *FilterNode) ([]Value, error) 
 		valueInner, _ := template.Indirect(value.Value)
 		value = Wrap(valueInner)
 
-		if value.Kind() != reflect.Array && value.Kind() != reflect.Slice {
-			return input, fmt.Errorf("%v is not array or slice and cannot be filtered", value)
+		var items []reflect.Value
+		switch value.Kind() {
+		case reflect.Array, reflect.Slice:
+			items = make([]reflect.Value, 0, value.Len())
+			for i := 0; i < value.Len(); i++ {
+				items = append(items, value.Index(i))
+			}
+		case reflect.Map:
+			items = make([]reflect.Value, 0, value.Len())
+			for _, key := range value.MapKeys() {
+				items = append(items, value.MapIndex(key))
+			}
+		default:
+			return input, fmt.Errorf("%v is not array, slice or map and cannot be filtered", value)
 		}
-		for i := 0; i < value.Len(); i++ {
-			temp := []Value{Wrap(value.Index(i))}
+
+		for _, item := range items {
+			temp := []Value{Wrap(item)}
 			lefts, err := j.evalList(temp, node.Left)
 
 			// case exists
 			if node.Operator == "exists" {
 				if len(lefts) > 0 {
-					results = append(results, Wrap(value.Index(i)))
+					results = append(results, Wrap(item))
 				}
 				continue
 			}
@@ -511,7 +524,7 @@ func (j *JSONPath) evalFilter(input []Value, node *FilterNode) ([]Value, error) 
 				return results, err
 			}
 			if pass {
-				results = append(results, Wrap(value.Index(i)))
+				results = append(results, Wrap(item))
 			}
 		}
 	}

--- a/internal/k8s/jsonpath/jsonpath_test.go
+++ b/internal/k8s/jsonpath/jsonpath_test.go
@@ -171,6 +171,7 @@ func TestStructInput(t *testing.T) {
 		{"dict/", "{$.Employees.jason}", storeData, "manager", false},
 		{"dict/", "{$.Employees.dan}", storeData, "clerk", false},
 		{"dict-", "{.Labels.k8s-app}", storeData, "20", false},
+		{"dictfilter", "{.Book[?(@.Category == 'reference')].Title}", storeData, "Sayings of the Centurey", false},
 		{"nest", "{.Bicycle[*].Color}", storeData, "red green", false},
 		{"allarray", "{.Book[*].Author}", storeData, "Nigel Rees Evelyn Waugh Herman Melville", false},
 		{"allfileds", "{.Bicycle.*}", storeData, "{red 19.95 true} {green 20.01 false}", false},

--- a/internal/k8s/jsonpath/jsonpath_test.go
+++ b/internal/k8s/jsonpath/jsonpath_test.go
@@ -235,8 +235,7 @@ func TestKubernetes(t *testing.T) {
 		  "status":{
 			"capacity":{"cpu":"4"},
 			"ready": true,
-			"addresses":[{"type": "LegacyHostIP", "address":"127.0.0.1"}],
-			"unique": true
+			"addresses":[{"type": "LegacyHostIP", "address":"127.0.0.1"}]
 		  }
 		},
 		{
@@ -289,8 +288,6 @@ func TestKubernetes(t *testing.T) {
 		{"user password", `{.users[?(@.name=="e2e")].user.password}`, &nodesData, "secret", false},
 		{"hostname", `{.items[0].metadata.labels.kubernetes\.io/hostname}`, &nodesData, "127.0.0.1", false},
 		{"hostname filter", `{.items[?(@.metadata.labels.kubernetes\.io/hostname=="127.0.0.1")].kind}`, &nodesData, "None", false},
-		{"dict filter-found", `{.items[0][?(@.unique)].unique}`, &nodesData, "true", false},
-		{"dict filter-missing", `{.items[1][?(@.unique)].unique}`, &nodesData, "", false},
 		{"bool item", `{.items[?(@..ready==true)].metadata.name}`, &nodesData, "127.0.0.1", false},
 	}
 	testJSONPath(nodesTests, false, t)
@@ -654,4 +651,19 @@ func TestStep(t *testing.T) {
 		false,
 		t,
 	)
+}
+
+func TestDictPropertyFilter(t *testing.T) {
+	var input = []byte(`{
+        "withProp":    {"color": "blue", "size": 10},
+        "withoutProp": {"color": "red"}
+    }`)
+	var data interface{}
+	if err := json.Unmarshal(input, &data); err != nil {
+		t.Fatal(err)
+	}
+	testJSONPath([]jsonpathTest{
+		{"dict filter-found", `{[?(@.size)].color}`, data, "blue", false},
+		{"dict filter-missing", `{[?(@.missing)].color}`, data, "", false},
+	}, false, t)
 }

--- a/internal/k8s/jsonpath/jsonpath_test.go
+++ b/internal/k8s/jsonpath/jsonpath_test.go
@@ -289,7 +289,8 @@ func TestKubernetes(t *testing.T) {
 		{"user password", `{.users[?(@.name=="e2e")].user.password}`, &nodesData, "secret", false},
 		{"hostname", `{.items[0].metadata.labels.kubernetes\.io/hostname}`, &nodesData, "127.0.0.1", false},
 		{"hostname filter", `{.items[?(@.metadata.labels.kubernetes\.io/hostname=="127.0.0.1")].kind}`, &nodesData, "None", false},
-		{"dict filter", `{.items[0][?(@.unique)].unique}`, &nodesData, "true", false},
+		{"dict filter-found", `{.items[0][?(@.unique)].unique}`, &nodesData, "true", false},
+		{"dict filter-missing", `{.items[1][?(@.unique)].unique}`, &nodesData, "", false},
 		{"bool item", `{.items[?(@..ready==true)].metadata.name}`, &nodesData, "127.0.0.1", false},
 	}
 	testJSONPath(nodesTests, false, t)

--- a/internal/k8s/jsonpath/jsonpath_test.go
+++ b/internal/k8s/jsonpath/jsonpath_test.go
@@ -171,7 +171,6 @@ func TestStructInput(t *testing.T) {
 		{"dict/", "{$.Employees.jason}", storeData, "manager", false},
 		{"dict/", "{$.Employees.dan}", storeData, "clerk", false},
 		{"dict-", "{.Labels.k8s-app}", storeData, "20", false},
-		{"dictfilter", "{.Book[?(@.Category == 'reference')].Title}", storeData, "Sayings of the Centurey", false},
 		{"nest", "{.Bicycle[*].Color}", storeData, "red green", false},
 		{"allarray", "{.Book[*].Author}", storeData, "Nigel Rees Evelyn Waugh Herman Melville", false},
 		{"allfileds", "{.Bicycle.*}", storeData, "{red 19.95 true} {green 20.01 false}", false},
@@ -236,7 +235,8 @@ func TestKubernetes(t *testing.T) {
 		  "status":{
 			"capacity":{"cpu":"4"},
 			"ready": true,
-			"addresses":[{"type": "LegacyHostIP", "address":"127.0.0.1"}]
+			"addresses":[{"type": "LegacyHostIP", "address":"127.0.0.1"}],
+			"unique": true
 		  }
 		},
 		{
@@ -289,6 +289,7 @@ func TestKubernetes(t *testing.T) {
 		{"user password", `{.users[?(@.name=="e2e")].user.password}`, &nodesData, "secret", false},
 		{"hostname", `{.items[0].metadata.labels.kubernetes\.io/hostname}`, &nodesData, "127.0.0.1", false},
 		{"hostname filter", `{.items[?(@.metadata.labels.kubernetes\.io/hostname=="127.0.0.1")].kind}`, &nodesData, "None", false},
+		{"dict filter", `{.items[0][?(@.unique)].unique}`, &nodesData, "true", false},
 		{"bool item", `{.items[?(@..ready==true)].metadata.name}`, &nodesData, "127.0.0.1", false},
 	}
 	testJSONPath(nodesTests, false, t)


### PR DESCRIPTION
## What?

Update the JsonPath implementation to support filtering in dicts as well as lists


## Why?

Suppose we have a CRD with this kind of structure:

```yaml
spec:
  sql:
    migrations: sql-hello-migrations
    users:
      - name: writer
        permissions:
          - tables: [greetings]
            grant: [ALL]
      - name: reader
        permissions:
          - tables: [greetings]
            grant: [SELECT]
  functions:
    - name: setup
      module: sql-hello-setup
      sqlUser: writer
      trigger:
        http:
          path: /sql-hello/setup
          methods:
            - POST
    - name: query
      module: sql-hello-query
      sqlUser: reader
      trigger:
        http:
          path: /sql-hello
          methods:
            - GET
    - name: insert-test
      module: sql-hello-insert-test
      sqlUser: reader
      trigger:
        http:
          path: /sql-hello/insert
          methods:
            - POST
```

The `functions` section is required, and has to include at least one executable `module` that tilt needs to track. The `sql` section is optional, there's no database if this section isn't provided. If it is provided, you can also include a `migrations` property, which the operator will interpret as an image containing migrations data.

We could construct a k8s_kind to represent this CRD like this:

```starlark
    k8s_kind('Application',
             image_json_path = ['{.spec.functions[*].module}', '{.spec[?(@.migrations)].migrations}'],
             pod_readiness = 'ignore')
```

The `.spec.functions[*].module` jsonpath query covers the easy case, but  `.spec[?(@.migrations)].migrations` uses a filter to optionally select the migrations image if it exists. JsonPath supports this, but tilt currently doesn't.