### PR TITLE
handle duplicate objects in parallel upsert batching

### DIFF
--- a/internal/k8s/client_test.go
+++ b/internal/k8s/client_test.go
@@ -214,6 +214,58 @@ func TestUpsertIsParallelized(t *testing.T) {
 	})
 }
 
+func TestUpsertSerializesDuplicateObjectRefs(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		f := newClientTestFixture(t)
+		entities := mustParseYAML(t, `
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: same
+  namespace: default
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: other
+  namespace: default
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: same
+  namespace: default
+`)
+
+		var mu sync.Mutex
+		inFlight := map[v1.ObjectReference]bool{}
+		applyFn := func(target kube.ResourceList, ssa SSAOptions) (*kube.Result, error) {
+			require.Len(t, target, 1)
+			ref := NewK8sEntity(target[0].Object).ToObjectReference()
+
+			mu.Lock()
+			if inFlight[ref] {
+				mu.Unlock()
+				return nil, fmt.Errorf("%s %q already exists", ref.Kind, ref.Name)
+			}
+			inFlight[ref] = true
+			mu.Unlock()
+
+			time.Sleep(50 * time.Millisecond)
+
+			mu.Lock()
+			delete(inFlight, ref)
+			mu.Unlock()
+
+			return &kube.Result{Updated: target}, nil
+		}
+		f.resourceClient.applyFn = &applyFn
+
+		_, err := f.k8sUpsert(f.ctx, entities)
+		require.NoError(t, err)
+	})
+}
+
 // Even within resource types, objects should be returned in the same order they were provided.
 func TestUpsertMaintainsOrdering(t *testing.T) {
 	f := newClientTestFixture(t)

--- a/internal/k8s/entity.go
+++ b/internal/k8s/entity.go
@@ -57,12 +57,22 @@ func (l entityList) Swap(i, j int) { l[i], l[j] = l[j], l[i] }
 func (l entityList) toParallelizableBatches() [][]K8sEntity {
 	result := make([][]K8sEntity, 0)
 	batch := []K8sEntity{}
+	batchRefs := map[v1.ObjectReference]bool{}
 	for i, e := range l {
-		if i == 0 || l.TypeOrder(i-1) == l.TypeOrder(i) {
+		ref := e.ToObjectReference()
+		// Kubernetes create/update identity ignores server-assigned bookkeeping.
+		ref.UID = ""
+		ref.ResourceVersion = ""
+		ref.FieldPath = ""
+		sameTypeOrder := i == 0 || l.TypeOrder(i-1) == l.TypeOrder(i)
+		_, duplicateInBatch := batchRefs[ref]
+		if sameTypeOrder && !duplicateInBatch {
 			batch = append(batch, e)
+			batchRefs[ref] = true
 		} else {
 			result = append(result, batch)
 			batch = []K8sEntity{e}
+			batchRefs = map[v1.ObjectReference]bool{ref: true}
 		}
 	}
 	if len(batch) > 0 {

--- a/internal/k8s/entity_test.go
+++ b/internal/k8s/entity_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
@@ -256,20 +257,22 @@ spec:
 func entitiesWithKinds(kinds []string) []K8sEntity {
 	entities := make([]K8sEntity, len(kinds))
 	for i, k := range kinds {
-		entities[i] = entityWithKind(k)
+		entities[i] = entityWithKindAndName(k, fmt.Sprintf("%s-%d", k, i))
 	}
 	return entities
 }
 
-func entityWithKind(kind string) K8sEntity {
+func entityWithKindAndName(kind, name string) K8sEntity {
 	return K8sEntity{
-		Obj: fakeObject{
-			kind: fakeKind(kind),
+		Obj: &fakeObject{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+			kind:       fakeKind(kind),
 		},
 	}
 }
 
 type fakeObject struct {
+	metav1.ObjectMeta
 	kind fakeKind
 }
 
@@ -363,6 +366,24 @@ func TestToParallelizableBatches(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestToParallelizableBatchesSplitsDuplicateObjectRefs(t *testing.T) {
+	input := entityList([]K8sEntity{
+		entityWithKindAndName("PodMonitor", "same"),
+		entityWithKindAndName("PodMonitor", "other"),
+		entityWithKindAndName("PodMonitor", "same"),
+		entityWithKindAndName("PodMonitor", "other"),
+	})
+
+	batches := input.toParallelizableBatches()
+	require.Len(t, batches, 2)
+	assertKindOrder(t, []string{"PodMonitor", "PodMonitor"}, batches[0], "batch 0")
+	assertKindOrder(t, []string{"PodMonitor", "PodMonitor"}, batches[1], "batch 1")
+	assert.Equal(t, "same", batches[0][0].Name())
+	assert.Equal(t, "other", batches[0][1].Name())
+	assert.Equal(t, "same", batches[1][0].Name())
+	assert.Equal(t, "other", batches[1][1].Name())
 }
 
 // TestFilterByMatchesPodTemplateSpecNamespace tests that Services are only matched


### PR DESCRIPTION
## Summary

Fix a race in parallel Kubernetes upsert when the input YAML contains duplicate references to the same Kubernetes object.

## Problem

After Kubernetes upserts were parallelized, Tilt could apply duplicate YAML objects concurrently. This shows up with Tiltfiles that use `k8s_yaml(..., allow_duplicates=True)`.

On a reload that performs a force update, Tilt deletes the old objects and then reapplies the target YAML. If the same object appears multiple times in the YAML, two concurrent applies can both observe that the object is missing and attempt to create it. One succeeds, and the other fails with an error like:

```text
podmonitors.monitoring.coreos.com "reddit-service-comments-go-podmonitor" already exists
```

Reapplying the failed resource works because the first attempt has already recreated the object, so later applies become updates instead of competing creates.

## Fix
Keep the parallel upsert behavior for distinct objects, but prevent duplicate Kubernetes object references from being placed in the same parallel batch.

Object identity is based on Kubernetes create/update identity: apiVersion/kind/name/namespace, ignoring server-assigned bookkeeping like UID and resourceVersion.



Fixes https://github.com/tilt-dev/tilt/issues/6756