### PR TITLE
add a one-shot retry for object not found errors

### DIFF
--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -431,7 +431,23 @@ func (k *K8sClient) applyEntity(ctx context.Context, entity K8sEntity, ssa SSAOp
 
 	result, err := k.resourceClient.Apply(resources, ssa)
 	if err != nil {
-		return nil, err
+		if !isNotFoundError(err) {
+			return nil, err
+		}
+
+		// The object might have been deleted between kubectl apply's read
+		// and patch/update steps, e.g. if a previous reload started an async
+		// ForceDelete. Rebuild the resource list so the retry sees the latest
+		// cluster state and can recreate the object if needed.
+		logger.Get(ctx).Infof("Resource %s was not found during apply. Retrying...", entity.Name())
+		resources, retryErr := k.prepareUpdateList(ctx, entity)
+		if retryErr != nil {
+			return nil, errors.Wrap(retryErr, "kubernetes apply retry")
+		}
+		result, err = k.resourceClient.Apply(resources, ssa)
+		if err != nil {
+			return nil, errors.Wrap(err, "kubernetes apply retry")
+		}
 	}
 
 	// Under rare circumstances, an apply() may result in a 3-way merge

--- a/internal/k8s/client_test.go
+++ b/internal/k8s/client_test.go
@@ -160,6 +160,31 @@ func TestUpsertStatefulsetForbidden(t *testing.T) {
 	assert.Equal(t, 4, len(f.resourceClient.updates))
 }
 
+func TestUpsertApplyNotFoundRetries(t *testing.T) {
+	f := newClientTestFixture(t)
+	roleBinding := mustParseYAML(t, `
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: app-worker-discovery
+  namespace: default
+subjects:
+- kind: ServiceAccount
+  name: app-service-account
+roleRef:
+  kind: Role
+  name: app-worker-discovery
+  apiGroup: rbac.authorization.k8s.io
+`)
+
+	f.resourceClient.updateErr = errors.New(`rolebindings.rbac.authorization.k8s.io "app-worker-discovery" not found`)
+
+	_, err := f.k8sUpsert(f.ctx, roleBinding)
+	require.NoError(t, err)
+	require.Len(t, f.resourceClient.updates, 1)
+	assert.Equal(t, "app-worker-discovery", f.resourceClient.updates[0].Name)
+}
+
 func TestUpsertToTerminatingNamespaceForbidden(t *testing.T) {
 	f := newClientTestFixture(t)
 	postgres, err := ParseYAMLFromString(testyaml.SanchoYAML)

--- a/internal/k8s/errors.go
+++ b/internal/k8s/errors.go
@@ -2,6 +2,7 @@ package k8s
 
 import (
 	"net/http"
+	"regexp"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -25,8 +26,11 @@ func isNotFoundError(err error) bool {
 	}
 	return apierrors.IsNotFound(err) ||
 		// Helm has it's own custom not found error.
-		strings.Contains(err.Error(), "object not found")
+		strings.Contains(err.Error(), "object not found") ||
+		kubernetesResourceNotFoundRe.MatchString(err.Error())
 }
+
+var kubernetesResourceNotFoundRe = regexp.MustCompile(`(?m)\b[a-z0-9.]+ "[^"]+" not found\b`)
 
 func isMissingKindError(err error) bool {
 	if err == nil {


### PR DESCRIPTION
## Summary

Fix a rare transient `NotFound` error during Kubernetes apply reloads.

During rapid reloads, Tilt can hit errors like:

`rolebindings.rbac.authorization.k8s.io "..." not found`

The same YAML usually succeeds if applied again manually.

## What was happening

Tilt uses kubectl's apply implementation for Kubernetes upserts. Client-side apply does a read of the current object, computes a patch, then sends the patch/update.

There is a race where the object can be deleted between those steps. For example, a previous reload may have started an async delete, then the next reload begins applying the same object before the API server has fully converged.

Kubectl apply already handles the simple case where the initial read returns `NotFound`: it creates the object. But it does not recover if the read succeeds and the later patch/update returns `NotFound`.

Tilt already had retry handling for a related case where apply returns an object with a deletion timestamp. This change covers the adjacent failure mode where apply fails before returning an updated object.

## Fix

When `Apply` returns a Kubernetes-style `NotFound` error, Tilt now treats it as a transient apply race:

1. Rebuild the resource list so it reflects the latest cluster state.
2. Retry apply once.
3. Return the retry error if the object still cannot be applied.

This keeps the retry narrow:
- only `NotFound` errors are retried
- only one retry is attempted
- non-transient apply errors are still returned immediately

I am not sure that this is the best way to fix this long-term, but it does solve the issue in our environment.

## Why this works

If the object was deleted during kubectl apply's read/patch window, retrying starts a fresh apply operation after the cluster has had another chance to converge. On retry, kubectl either sees that the object no longer exists and creates it, or sees the current object and patches it normally.

## Tests

Added a regression test that simulates a RoleBinding apply returning:

`rolebindings.rbac.authorization.k8s.io "app-worker-discovery" not found`

and verifies that Tilt retries and successfully applies the object.
