### PR TITLE
fix(k8s): include entity kind/name in kubectl timeout error message

### DIFF
--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -313,8 +313,8 @@ func ServiceURL(service *v1.Service, ip NodeIP) (*url.URL, error) {
 	return nil, nil
 }
 
-func timeoutError(timeout time.Duration) error {
-	return errors.New(fmt.Sprintf("Killed kubectl. Hit timeout of %v.", timeout))
+func timeoutError(timeout time.Duration, entity K8sEntity) error {
+	return errors.New(fmt.Sprintf("Killed kubectl. Hit timeout of %v applying %s/%s.", timeout, entity.GVK().Kind, entity.Name()))
 }
 
 func (k *K8sClient) ToRESTConfig() (*rest.Config, error) {
@@ -378,8 +378,8 @@ func (k *K8sClient) upsertParallel(ctx context.Context, entities []K8sEntity, ti
 
 			newEntityList, err := k.escalatingUpdate(innerCtx, entity, ssa)
 			if err != nil {
-				if errors.Is(wgCtx.Err(), context.DeadlineExceeded) {
-					return timeoutError(timeout)
+				if errors.Is(err, context.DeadlineExceeded) {
+					return timeoutError(timeout, entity)
 				}
 				return err
 			}

--- a/internal/k8s/client_test.go
+++ b/internal/k8s/client_test.go
@@ -49,6 +49,13 @@ func TestNotEmptyNamespace(t *testing.T) {
 	assert.Equal(t, "x", ns.String())
 }
 
+func TestTimeoutErrorMessage(t *testing.T) {
+	entities := MustParseYAMLFromString(t, testyaml.SanchoYAML)
+	err := timeoutError(10*time.Second, entities[0])
+	assert.Contains(t, err.Error(), "10s")
+	assert.Contains(t, err.Error(), "Deployment/sancho")
+}
+
 func TestUpsert(t *testing.T) {
 	f := newClientTestFixture(t)
 	postgres, err := ParseYAMLFromString(testyaml.PostgresYAML)


### PR DESCRIPTION
Fixes #3686

## Problem

When `kubectl apply` timed out, the error message only reported the duration:

```
Killed kubectl. Hit timeout of 10s.
```

This gave no indication of which resource caused the timeout, making it hard to diagnose in deployments with many resources.

Additionally, the condition that triggered this error path was checking `wgCtx.Err()` for `context.DeadlineExceeded`, but `wgCtx` is an errgroup context that only ever emits `context.Canceled` — never `context.DeadlineExceeded`. This made the timeout error message completely unreachable.

## Fix

1. Fix the condition to check `err` instead of `wgCtx.Err()`, so the timeout error is actually returned when `escalatingUpdate` times out
2. Include the entity's kind and name in the error message

The message now reads:
```
Killed kubectl. Hit timeout of 10s applying Deployment/my-app.
```

## Test

Added `TestTimeoutErrorMessage` to verify the error message includes the timeout duration and the entity kind/name.