### PR TITLE
feat(web): add per-container log filtering to the log pane

### DIFF
--- a/internal/controllers/core/podlogstream/podlogstreamcontroller.go
+++ b/internal/controllers/core/podlogstream/podlogstreamcontroller.go
@@ -353,6 +353,13 @@ func (c *Controller) consumeLogs(watch *podLogWatch, st store.RStore) {
 
 	ns := watch.namespace
 	startReadTime := watch.startWatchTime
+
+	// Stamp every log line with the container name as a structured field so the
+	// frontend can filter by container without parsing log text.
+	ctx = logger.WithLogger(ctx, logger.Get(ctx).WithFields(logger.Fields{
+		logger.FieldNameContainer: string(watch.cName),
+	}))
+
 	if watch.shouldPrefix {
 		prefix := fmt.Sprintf("[%s] ", watch.cName)
 		ctx = logger.WithLogger(ctx, logger.NewPrefixedLogger(prefix, logger.Get(ctx)))

--- a/internal/controllers/core/podlogstream/podlogstreamcontroller_test.go
+++ b/internal/controllers/core/podlogstream/podlogstreamcontroller_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"sync"
 	"testing"
 	"testing/synctest"
 	"time"
@@ -62,6 +63,26 @@ func TestLogs(t *testing.T) {
 	assert.Equal(t, []reconcile.Request{
 		{NamespacedName: streamNN},
 	}, f.plsc.podSource.indexer.EnqueueKey(indexer.Key{Name: podNN, GVK: podGVK}))
+}
+
+func TestLogContainerField(t *testing.T) {
+	f := newPLMFixture(t)
+
+	f.kClient.SetLogsForPodContainer(podID, cName, "hello world!")
+
+	start := f.clock.Now()
+	pb := newPodBuilder(podID).addRunningContainer(cName, cID)
+	f.kClient.UpsertPod(pb.toPod())
+
+	pls := plsFromPod("server", pb, start)
+	f.Create(pls)
+
+	f.triggerPodEvent(podID)
+	f.AssertOutputContains("hello world!")
+
+	actions := f.store.LogActionsContaining("hello world!")
+	require.NotEmpty(t, actions, "expected at least one log action containing 'hello world!'")
+	assert.Equal(t, string(cName), actions[0].Fields()[logger.FieldNameContainer])
 }
 
 func TestLogCleanup(t *testing.T) {
@@ -516,7 +537,9 @@ Error streaming pod-id logs: failed to create fsnotify watcher: too many open fi
 type plmStore struct {
 	t testing.TB
 	*store.TestingStore
-	out *bufsync.ThreadSafeBuffer
+	out        *bufsync.ThreadSafeBuffer
+	mu         sync.Mutex
+	logActions []store.LogAction
 }
 
 func newPLMStore(t testing.TB, out *bufsync.ThreadSafeBuffer) *plmStore {
@@ -533,10 +556,26 @@ func (s *plmStore) Dispatch(action store.Action) {
 		s.t.Errorf("Expected action type LogAction. Actual: %T", action)
 	}
 
+	s.mu.Lock()
+	s.logActions = append(s.logActions, event)
+	s.mu.Unlock()
+
 	_, err := s.out.Write(event.Message())
 	if err != nil {
 		fmt.Printf("error writing event: %v\n", err)
 	}
+}
+
+func (s *plmStore) LogActionsContaining(text string) []store.LogAction {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var result []store.LogAction
+	for _, a := range s.logActions {
+		if strings.Contains(string(a.Message()), text) {
+			result = append(result, a)
+		}
+	}
+	return result
 }
 
 type plmFixture struct {

--- a/pkg/logger/fields.go
+++ b/pkg/logger/fields.go
@@ -7,6 +7,7 @@ type Fields map[string]string
 
 const FieldNameProgressID = "progressID"
 const FieldNameBuildEvent = "buildEvent"
+const FieldNameContainer = "container"
 
 // Most progress lines are optional. For example, if a bunch
 // of little upload updates come in, it's ok to skip some.

--- a/web/src/CopyLogs.test.tsx
+++ b/web/src/CopyLogs.test.tsx
@@ -23,6 +23,7 @@ const DEFAULT_FILTER_SET: FilterSet = {
   source: FilterSource.all,
   level: FilterLevel.all,
   term: EMPTY_FILTER_TERM,
+  containers: [],
 }
 
 describe("CopyLogs", () => {

--- a/web/src/LogStore.test.ts
+++ b/web/src/LogStore.test.ts
@@ -608,4 +608,87 @@ describe("LogStore", () => {
     let patch3 = logs.starredLogPatchSet(["res1", "res2"], patch.checkpoint)
     expect(logLinesToString(patch3.lines, false)).toEqual("build 4\nbuild 5")
   })
+
+  describe("containersForManifest", () => {
+    it("returns empty when no lines have a container field", () => {
+      let logs = new LogStore()
+      logs.append({
+        spans: { "pod:1": { manifestName: "fe" } },
+        segments: [
+          { spanId: "pod:1", text: "line\n", time: new Date().toString() },
+        ],
+      })
+      expect(logs.containersForManifest("fe")).toEqual([])
+    })
+
+    it("returns distinct container names for the manifest", () => {
+      let logs = new LogStore()
+      logs.append({
+        spans: { "pod:1": { manifestName: "fe" } },
+        segments: [
+          {
+            spanId: "pod:1",
+            text: "a\n",
+            time: new Date().toString(),
+            fields: { container: "app" },
+          },
+          {
+            spanId: "pod:1",
+            text: "b\n",
+            time: new Date().toString(),
+            fields: { container: "sidecar" },
+          },
+          {
+            spanId: "pod:1",
+            text: "c\n",
+            time: new Date().toString(),
+            fields: { container: "app" },
+          },
+        ],
+      })
+      expect(logs.containersForManifest("fe")).toEqual(["app", "sidecar"])
+    })
+
+    it("excludes lines from other manifests", () => {
+      let logs = new LogStore()
+      logs.append({
+        spans: {
+          "pod:fe": { manifestName: "fe" },
+          "pod:be": { manifestName: "be" },
+        },
+        segments: [
+          {
+            spanId: "pod:fe",
+            text: "a\n",
+            time: new Date().toString(),
+            fields: { container: "app" },
+          },
+          {
+            spanId: "pod:be",
+            text: "b\n",
+            time: new Date().toString(),
+            fields: { container: "other" },
+          },
+        ],
+      })
+      expect(logs.containersForManifest("fe")).toEqual(["app"])
+    })
+
+    it("excludes lines without a container field", () => {
+      let logs = new LogStore()
+      logs.append({
+        spans: { "pod:1": { manifestName: "fe" } },
+        segments: [
+          { spanId: "pod:1", text: "build\n", time: new Date().toString() },
+          {
+            spanId: "pod:1",
+            text: "runtime\n",
+            time: new Date().toString(),
+            fields: { container: "app" },
+          },
+        ],
+      })
+      expect(logs.containersForManifest("fe")).toEqual(["app"])
+    })
+  })
 })

--- a/web/src/LogStore.ts
+++ b/web/src/LogStore.ts
@@ -418,6 +418,24 @@ class LogStore implements LogAlertIndex {
     return result
   }
 
+  // Returns the distinct container names seen in log lines for the given manifest.
+  // Only includes names from lines that carry a container field (pod logs).
+  // Returns an empty array for resources with no multi-container log data.
+  containersForManifest(mn: string): string[] {
+    const manifestSpans = this.spansForManifest(mn)
+    const seen = new Set<string>()
+    for (const line of this.lines) {
+      if (!manifestSpans[line.spanId]) {
+        continue
+      }
+      const name = line.fields?.container
+      if (name) {
+        seen.add(name)
+      }
+    }
+    return Array.from(seen)
+  }
+
   getOrderedBuildSpanIds(spanId: string): string[] {
     let startSpan = this.spans[spanId]
     if (!startSpan) {
@@ -630,6 +648,7 @@ class LogStore implements LogAlertIndex {
           level: storedLine.level,
           manifestName: span.manifestName,
           buildEvent: storedLine.fields?.buildEvent,
+          containerName: storedLine.fields?.container,
           spanId: spanId,
           storedLineIndex: i,
         }

--- a/web/src/OverviewActionBar.test.tsx
+++ b/web/src/OverviewActionBar.test.tsx
@@ -11,7 +11,12 @@ import { useLocation } from "react-router-dom"
 import { SnackbarProvider } from "notistack"
 import React from "react"
 import { ButtonSet } from "./ApiButton"
-import { EMPTY_FILTER_TERM, FilterLevel, FilterSource } from "./logfilters"
+import {
+  EMPTY_FILTER_TERM,
+  FilterLevel,
+  FilterSet,
+  FilterSource,
+} from "./logfilters"
 import OverviewActionBar, {
   createLogSearch,
   FILTER_INPUT_DEBOUNCE,
@@ -19,10 +24,11 @@ import OverviewActionBar, {
 import { EmptyBar, FullBar } from "./OverviewActionBar.stories"
 import { disableButton, oneResource, oneUIButton } from "./testdata"
 
-const DEFAULT_FILTER_SET = {
+const DEFAULT_FILTER_SET: FilterSet = {
   level: FilterLevel.all,
   source: FilterSource.all,
   term: EMPTY_FILTER_TERM,
+  containers: [],
 }
 
 let location: any = window.location
@@ -257,6 +263,125 @@ describe("OverviewActionBar", () => {
     })
   })
 
+  describe("FilterContainerMenu", () => {
+    const containers = ["app", "istio-proxy", "daprd"]
+
+    it("does not render when no containers are present", () => {
+      customRender(
+        <OverviewActionBar filterSet={DEFAULT_FILTER_SET} logContainers={[]} />
+      )
+      expect(
+        screen.queryByLabelText(/select containers to filter logs/i)
+      ).toBeNull()
+    })
+
+    it("renders as disabled when exactly 1 container is present", () => {
+      customRender(
+        <OverviewActionBar
+          filterSet={DEFAULT_FILTER_SET}
+          logContainers={["app"]}
+        />
+      )
+      expect(
+        screen.getByLabelText(/select containers to filter logs/i)
+      ).toBeDisabled()
+    })
+
+    it("shows the single container name in the right pill when disabled", () => {
+      customRender(
+        <OverviewActionBar
+          filterSet={DEFAULT_FILTER_SET}
+          logContainers={["app"]}
+        />
+      )
+      expect(
+        screen.getByLabelText(/select containers to filter logs/i)
+      ).toHaveTextContent("app")
+    })
+
+    it("renders as enabled when 2 or more containers are present", () => {
+      customRender(
+        <OverviewActionBar
+          filterSet={DEFAULT_FILTER_SET}
+          logContainers={["app", "istio-proxy"]}
+        />
+      )
+      expect(
+        screen.getByLabelText(/select containers to filter logs/i)
+      ).not.toBeDisabled()
+    })
+
+    it("shows the container name in the right pill when 1 container is selected", () => {
+      customRender(
+        <OverviewActionBar
+          filterSet={{ ...DEFAULT_FILTER_SET, containers: ["app"] }}
+          logContainers={containers}
+        />
+      )
+      expect(
+        screen.getByLabelText(/select containers to filter logs/i)
+      ).toHaveTextContent("app")
+    })
+
+    it("shows a count in the right pill when 2+ containers are selected", () => {
+      customRender(
+        <OverviewActionBar
+          filterSet={{
+            ...DEFAULT_FILTER_SET,
+            containers: ["app", "istio-proxy"],
+          }}
+          logContainers={containers}
+        />
+      )
+      expect(
+        screen.getByLabelText(/select containers to filter logs/i)
+      ).toHaveTextContent("2")
+    })
+
+    it("updates the URL when a container is toggled on", () => {
+      customRender(
+        <OverviewActionBar
+          filterSet={DEFAULT_FILTER_SET}
+          logContainers={containers}
+        />
+      )
+      userEvent.click(
+        screen.getByLabelText(/select containers to filter logs/i)
+      )
+      userEvent.click(screen.getByRole("menuitemcheckbox", { name: /app/i }))
+      expect(getSearch()).toContain("containers=")
+      expect(new URLSearchParams(getSearch()).get("containers")).toBe("app")
+    })
+
+    it("removes a container from the URL when it is toggled off", () => {
+      customRender(
+        <OverviewActionBar
+          filterSet={{ ...DEFAULT_FILTER_SET, containers: ["app"] }}
+          logContainers={containers}
+        />
+      )
+      userEvent.click(
+        screen.getByLabelText(/select containers to filter logs/i)
+      )
+      userEvent.click(screen.getByRole("menuitemcheckbox", { name: /app/i }))
+      expect(new URLSearchParams(getSearch()).get("containers")).toBeNull()
+    })
+
+    it("clears the containers filter when 'All Containers' is clicked", () => {
+      customRender(
+        <OverviewActionBar
+          filterSet={{ ...DEFAULT_FILTER_SET, containers: ["app"] }}
+          logContainers={containers}
+        />
+      )
+      userEvent.click(
+        screen.getByLabelText(/select containers to filter logs/i)
+      )
+      userEvent.click(screen.getByRole("menuitem", { name: /all containers/i }))
+      expect(new URLSearchParams(getSearch()).get("containers")).toBeNull()
+    })
+  })
+
   describe("createLogSearch", () => {
     let currentSearch: URLSearchParams
     beforeEach(() => (currentSearch = new URLSearchParams()))
@@ -310,6 +435,32 @@ describe("OverviewActionBar", () => {
           term: "test",
         }).toString()
       ).toBe("source=build&term=test")
+    })
+
+    it("sets the containers param when a non-empty array is passed", () => {
+      expect(
+        createLogSearch(currentSearch.toString(), {
+          containers: ["app", "istio"],
+        }).get("containers")
+      ).toBe("app,istio")
+    })
+
+    it("removes the containers param when an empty array is passed", () => {
+      currentSearch.set("containers", "app,istio")
+      expect(
+        createLogSearch(currentSearch.toString(), { containers: [] }).get(
+          "containers"
+        )
+      ).toBeNull()
+    })
+
+    it("preserves an existing containers param when containers is undefined", () => {
+      currentSearch.set("containers", "app")
+      expect(
+        createLogSearch(currentSearch.toString(), { term: "test" }).get(
+          "containers"
+        )
+      ).toBe("app")
     })
   })
 })

--- a/web/src/OverviewActionBar.tsx
+++ b/web/src/OverviewActionBar.tsx
@@ -62,6 +62,12 @@ type OverviewActionBarProps = {
 
   // buttons for this resource
   buttons?: ButtonSet
+
+  // Distinct container names seen in this resource's logs.
+  // Shown when 1 or more containers are present: disabled at 1, interactive at 2+.
+  // Resources with no container logs (e.g. local_resource) will have an empty
+  // array and will not render the dropdown at all.
+  logContainers?: string[]
 }
 
 type FilterSourceMenuProps = {
@@ -86,6 +92,145 @@ let useMenuStyles = makeStyles((theme: any) => ({
     fontSize: FontSize.smallest,
   },
 }))
+
+type FilterContainerMenuProps = {
+  // The container names observed in the current resource's logs.
+  containers: string[]
+
+  // The currently selected containers from the filter set.
+  selectedContainers: string[]
+}
+
+// Button + dropdown to filter logs by container name.
+// Rendered when 1 or more containers are present; disabled at exactly 1 so the
+// layout is stable once any container logs arrive.
+// Follows the same left/right pill pattern as FilterRadioButton:
+//   left pill: always "Containers" (stable width)
+//   right pill: chevron when unfiltered, name when 1 selected, count when 2+
+function FilterContainerMenu(props: FilterContainerMenuProps) {
+  const { containers, selectedContainers } = props
+  const navigate = useNavigate()
+  const l = useLocation()
+  const classes = useMenuStyles()
+  const [anchorEl, setAnchorEl] = useState<Element | null>(null)
+  const open = !!anchorEl
+  const disabled = containers.length < 2
+
+  const toggle = (name: string) => {
+    const next = selectedContainers.includes(name)
+      ? selectedContainers.filter((c) => c !== name)
+      : [...selectedContainers, name]
+    const search = createLogSearch(l.search, { containers: next })
+    navigate({ pathname: l.pathname, search: search.toString() })
+    setAnchorEl(null)
+  }
+
+  const clearAll = () => {
+    const search = createLogSearch(l.search, { containers: [] })
+    navigate({ pathname: l.pathname, search: search.toString() })
+    setAnchorEl(null)
+  }
+
+  const isActive = selectedContainers.length > 0
+
+  // Left pill is always a non-interactive label (isRadio + isEnabled = pointer-events: none).
+  // The right pill is the only interaction point; it communicates filter state via its content.
+  const leftClass = "isRadio isEnabled"
+  const rightClass = isActive ? "isEnabled" : ""
+
+  let rightContent: JSX.Element | string
+  let rightStyle = { paddingLeft: "4px", paddingRight: "4px" } as any
+  if (selectedContainers.length === 1) {
+    rightContent = (
+      <TruncateText key="right" style={{ maxWidth: "120px" }}>
+        {selectedContainers[0]}
+      </TruncateText>
+    )
+    rightStyle = null
+  } else if (selectedContainers.length > 1) {
+    rightContent = <span key="right">{selectedContainers.length}</span>
+    rightStyle = null
+  } else if (disabled && containers.length === 1) {
+    // Single container: show its name so the user knows what's running
+    rightContent = (
+      <TruncateText key="right" style={{ maxWidth: "120px" }}>
+        {containers[0]}
+      </TruncateText>
+    )
+    rightStyle = null
+  } else {
+    rightContent = (
+      <ExpandMoreIcon
+        style={{ width: "16px", height: "16px" }}
+        key="right"
+        role="presentation"
+      />
+    )
+  }
+
+  const anchorOrigin: PopoverOrigin = {
+    vertical: "bottom",
+    horizontal: "right",
+  }
+  const transformOrigin: PopoverOrigin = {
+    vertical: "top",
+    horizontal: "right",
+  }
+
+  return (
+    <ButtonPill>
+      <ButtonLeftPill className={leftClass}>Containers</ButtonLeftPill>
+      <ButtonRightPill
+        style={rightStyle}
+        className={rightClass}
+        onClick={
+          disabled ? undefined : (e: any) => setAnchorEl(e.currentTarget)
+        }
+        aria-label="Select containers to filter logs"
+        disabled={disabled}
+      >
+        {rightContent}
+      </ButtonRightPill>
+      <Menu
+        anchorEl={anchorEl}
+        open={open}
+        onClose={() => setAnchorEl(null)}
+        disableScrollLock={true}
+        keepMounted={true}
+        anchorOrigin={anchorOrigin}
+        transformOrigin={transformOrigin}
+        getContentAnchorEl={null}
+      >
+        <MenuItem classes={classes} onClick={clearAll}>
+          All Containers
+        </MenuItem>
+        {containers.map((name) => {
+          const selected = selectedContainers.includes(name)
+          return (
+            <MenuItem
+              key={name}
+              classes={classes}
+              onClick={() => toggle(name)}
+              role="menuitemcheckbox"
+              aria-checked={selected}
+            >
+              <CheckmarkSvg
+                width="12"
+                height="12"
+                style={{
+                  marginRight: "4px",
+                  visibility: selected ? "visible" : "hidden",
+                }}
+                role="presentation"
+              />
+              {name}
+            </MenuItem>
+          )
+        })}
+      </Menu>
+    </ButtonPill>
+  )
+}
 
 // Menu to filter logs by source (e.g., build-only, runtime-only).
 function FilterSourceMenu(props: FilterSourceMenuProps) {
@@ -328,7 +473,13 @@ export function createLogSearch(
     level,
     source,
     term,
-  }: { level?: FilterLevel; source?: FilterSource; term?: string }
+    containers,
+  }: {
+    level?: FilterLevel
+    source?: FilterSource
+    term?: string
+    containers?: string[]
+  }
 ) {
   // Start with the existing search params
   const newSearch = new URLSearchParams(currentSearch)
@@ -354,6 +505,14 @@ export function createLogSearch(
       newSearch.set("term", term)
     } else {
       newSearch.delete("term")
+    }
+  }
+
+  if (containers !== undefined) {
+    if (containers.length > 0) {
+      newSearch.set("containers", containers.join(","))
+    } else {
+      newSearch.delete("containers")
     }
   }
 
@@ -708,7 +867,7 @@ function DisableButtonSection(props: { button?: UIButton }) {
 }
 
 export default function OverviewActionBar(props: OverviewActionBarProps) {
-  let { resource, filterSet, alerts, buttons } = props
+  let { resource, filterSet, alerts, buttons, logContainers } = props
   const logStore = useLogStore()
   const isSnapshot = usePathBuilder().isSnapshot()
   const isDisabled = resourceIsDisabled(resource)
@@ -803,6 +962,15 @@ export default function OverviewActionBar(props: OverviewActionBarProps) {
         alerts={alerts}
       />
     )
+    if (logContainers && logContainers.length >= 1) {
+      bottomRow.push(
+        <FilterContainerMenu
+          key="filterContainerMenu"
+          containers={logContainers}
+          selectedContainers={filterSet.containers}
+        />
+      )
+    }
     bottomRow.push(
       <FilterTermField key="filterTermField" termFromUrl={filterSet.term} />
     )

--- a/web/src/OverviewLogPane.stories.tsx
+++ b/web/src/OverviewLogPane.stories.tsx
@@ -36,6 +36,7 @@ let defaultFilter: FilterSet = {
   source: FilterSource.all,
   level: FilterLevel.all,
   term: EMPTY_FILTER_TERM,
+  containers: [],
 }
 
 export const ThreeLines = () => {
@@ -358,6 +359,7 @@ export const BuildLogAndRunLog = (args: any) => {
           source: args.source,
           level: args.level,
           term: args.term || EMPTY_FILTER_TERM,
+          containers: [],
         }}
       />
     </LogStoreProvider>

--- a/web/src/OverviewLogPane.test.tsx
+++ b/web/src/OverviewLogPane.test.tsx
@@ -6,6 +6,7 @@ import {
   createFilterTermState,
   EMPTY_FILTER_TERM,
   FilterLevel,
+  FilterSet,
   FilterSource,
 } from "./logfilters"
 import LogStore, { LogUpdateAction, LogStoreProvider } from "./LogStore"
@@ -63,10 +64,11 @@ describe("OverviewLogPane", () => {
   })
 
   it("properly escapes ansi chars", () => {
-    let defaultFilter = {
+    let defaultFilter: FilterSet = {
       source: FilterSource.all,
       level: FilterLevel.all,
       term: EMPTY_FILTER_TERM,
+      containers: [],
     }
     let logStore = new LogStore()
     appendLines(logStore, "fe", "[32m➜[39m  [1mLocal[22m:   [36mhttp://localhost:[1m5173[22m/[39m\n")

--- a/web/src/OverviewResourceDetails.tsx
+++ b/web/src/OverviewResourceDetails.tsx
@@ -1,10 +1,11 @@
-import React from "react"
+import React, { useEffect, useState } from "react"
 import styled from "styled-components"
 import { Alert } from "./alerts"
 import { ButtonSet } from "./ApiButton"
 import { useFilterSet } from "./logfilters"
 import OverviewActionBar from "./OverviewActionBar"
 import OverviewLogPane from "./OverviewLogPane"
+import { useLogStore } from "./LogStore"
 import { Color } from "./style-helpers"
 import { ResourceName, UIResource } from "./types"
 
@@ -41,6 +42,26 @@ export default function OverviewResourceDetails(
   let notFound = !all && !starred && !manifestName
   let filterSet = useFilterSet()
 
+  const logStore = useLogStore()
+  const logTarget = starred ? name : manifestName
+  const [logContainers, setLogContainers] = useState<string[]>(() =>
+    logStore.containersForManifest(logTarget)
+  )
+
+  useEffect(() => {
+    const onUpdate = () => {
+      const next = logStore.containersForManifest(logTarget)
+      setLogContainers((prev) =>
+        prev.length === next.length && prev.every((c, i) => c === next[i])
+          ? prev
+          : next
+      )
+    }
+    onUpdate()
+    logStore.addUpdateListener(onUpdate)
+    return () => logStore.removeUpdateListener(onUpdate)
+  }, [logStore, logTarget])
+
   return (
     <OverviewResourceDetailsRoot>
       <OverviewActionBar
@@ -48,6 +69,7 @@ export default function OverviewResourceDetails(
         filterSet={filterSet}
         alerts={alerts}
         buttons={buttons}
+        logContainers={logContainers}
       />
       {notFound ? (
         <NotFound>No resource '{name}'</NotFound>

--- a/web/src/logfilters.test.ts
+++ b/web/src/logfilters.test.ts
@@ -2,7 +2,10 @@ import { Location } from "history"
 import {
   EMPTY_FILTER_TERM,
   filterSetFromLocation,
+  filterSetsEqual,
   parseTermInput,
+  FilterLevel,
+  FilterSource,
   TermState,
 } from "./logfilters"
 
@@ -53,6 +56,61 @@ describe("Log filters", () => {
         expect(parsedTerm.input).toEqual("/dock(er?/")
         expect(parsedTerm.hasOwnProperty("regexp")).toBe(false)
         expect(parsedTerm.hasOwnProperty("error")).toBe(true)
+      })
+    })
+
+    describe("for container filter", () => {
+      it("defaults to empty (all containers)", () => {
+        const loc = { search: "" } as Location
+        expect(filterSetFromLocation(loc).containers).toEqual([])
+      })
+
+      it("parses a single container", () => {
+        const loc = { search: "containers=istio-proxy" } as Location
+        expect(filterSetFromLocation(loc).containers).toEqual(["istio-proxy"])
+      })
+
+      it("parses multiple containers", () => {
+        const loc = {
+          search: "containers=istio-proxy%2Cdaprd",
+        } as Location
+        expect(filterSetFromLocation(loc).containers).toEqual([
+          "istio-proxy",
+          "daprd",
+        ])
+      })
+    })
+
+    describe("filterSetsEqual containers", () => {
+      const base = {
+        level: FilterLevel.all,
+        source: FilterSource.all,
+        term: EMPTY_FILTER_TERM,
+        containers: [] as string[],
+      }
+      it("equal when both empty", () => {
+        expect(filterSetsEqual(base, { ...base })).toBe(true)
+      })
+      it("equal when same containers", () => {
+        expect(
+          filterSetsEqual(
+            { ...base, containers: ["a", "b"] },
+            { ...base, containers: ["a", "b"] }
+          )
+        ).toBe(true)
+      })
+      it("not equal when containers differ", () => {
+        expect(
+          filterSetsEqual(
+            { ...base, containers: ["a"] },
+            { ...base, containers: ["b"] }
+          )
+        ).toBe(false)
+      })
+      it("not equal when one has containers and the other doesn't", () => {
+        expect(filterSetsEqual({ ...base, containers: ["a"] }, base)).toBe(
+          false
+        )
       })
     })
 

--- a/web/src/logfilters.ts
+++ b/web/src/logfilters.ts
@@ -50,6 +50,7 @@ export type FilterSet = {
   level: FilterLevel
   source: FilterSource
   term: FilterTerm
+  containers: string[]
 }
 
 export const EMPTY_TERM = ""
@@ -122,6 +123,7 @@ export function filterSetFromLocation(l: Location): FilterSet {
     level: FilterLevel.all,
     source: FilterSource.all,
     term: EMPTY_FILTER_TERM,
+    containers: [],
   }
   switch (params.get("level")) {
     case FilterLevel.warn:
@@ -146,6 +148,11 @@ export function filterSetFromLocation(l: Location): FilterSet {
     filters.term = createFilterTermState(input)
   }
 
+  const containersParam = params.get("containers")
+  if (containersParam) {
+    filters.containers = containersParam.split(",").filter(Boolean)
+  }
+
   return filters
 }
 
@@ -154,5 +161,10 @@ export function filterSetsEqual(a: FilterSet, b: FilterSet): boolean {
   const levelEqual = a.level === b.level
   // Filter terms are case-insensitive, so we can ignore casing when comparing terms
   const termEqual = a.term.input.toLowerCase() === b.term.input.toLowerCase()
-  return sourceEqual && levelEqual && termEqual
+  const sortedA = [...a.containers].sort()
+  const sortedB = [...b.containers].sort()
+  const containersEqual =
+    sortedA.length === sortedB.length &&
+    sortedA.every((c, i) => c === sortedB[i])
+  return sourceEqual && levelEqual && termEqual && containersEqual
 }

--- a/web/src/logs.containerFilter.test.ts
+++ b/web/src/logs.containerFilter.test.ts
@@ -1,0 +1,97 @@
+import { EMPTY_FILTER_TERM, FilterLevel, FilterSource } from "./logfilters"
+import { filterLogLinesForDisplay } from "./logs"
+import { LogLine } from "./types"
+
+function makeLine(overrides: Partial<LogLine> = {}): LogLine {
+  return {
+    text: "some log text\n",
+    manifestName: "my-resource",
+    level: "INFO",
+    spanId: "span1",
+    storedLineIndex: 0,
+    ...overrides,
+  }
+}
+
+const baseFilterSet = {
+  level: FilterLevel.all,
+  source: FilterSource.all,
+  term: EMPTY_FILTER_TERM,
+  containers: [] as string[],
+}
+
+describe("LogDisplay container filter", () => {
+  it("passes all lines through when containers is empty", () => {
+    const lines = [
+      makeLine({ containerName: "app" }),
+      makeLine({ containerName: "istio-proxy" }),
+      makeLine({ containerName: undefined }),
+    ]
+    const result = filterLogLinesForDisplay(lines, {
+      ...baseFilterSet,
+      containers: [],
+    })
+    expect(result).toHaveLength(3)
+  })
+
+  it("filters to only the selected containers", () => {
+    const lines = [
+      makeLine({ text: "app log\n", containerName: "app" }),
+      makeLine({ text: "istio log\n", containerName: "istio-proxy" }),
+      makeLine({ text: "dapr log\n", containerName: "daprd" }),
+    ]
+    const result = filterLogLinesForDisplay(lines, {
+      ...baseFilterSet,
+      containers: ["app"],
+    })
+    expect(result).toHaveLength(1)
+    expect(result[0].text).toBe("app log\n")
+  })
+
+  it("passes through lines with no containerName even when filter is active", () => {
+    const lines = [
+      makeLine({ text: "build log\n", containerName: undefined }),
+      makeLine({ text: "app log\n", containerName: "app" }),
+      makeLine({ text: "istio log\n", containerName: "istio-proxy" }),
+    ]
+    const result = filterLogLinesForDisplay(lines, {
+      ...baseFilterSet,
+      containers: ["app"],
+    })
+    // build log (no container) and app log should both pass through
+    expect(result).toHaveLength(2)
+    expect(result.map((l) => l.text)).toEqual(["build log\n", "app log\n"])
+  })
+
+  it("passes through buildEvent lines even when filter is active", () => {
+    const lines = [
+      makeLine({
+        text: "build event\n",
+        buildEvent: "init",
+        containerName: undefined,
+      }),
+      makeLine({ text: "app log\n", containerName: "app" }),
+      makeLine({ text: "istio log\n", containerName: "istio-proxy" }),
+    ]
+    const result = filterLogLinesForDisplay(lines, {
+      ...baseFilterSet,
+      containers: ["app"],
+    })
+    expect(result).toHaveLength(2)
+    expect(result.map((l) => l.text)).toEqual(["build event\n", "app log\n"])
+  })
+
+  it("supports multiple selected containers", () => {
+    const lines = [
+      makeLine({ text: "app log\n", containerName: "app" }),
+      makeLine({ text: "istio log\n", containerName: "istio-proxy" }),
+      makeLine({ text: "dapr log\n", containerName: "daprd" }),
+    ]
+    const result = filterLogLinesForDisplay(lines, {
+      ...baseFilterSet,
+      containers: ["app", "daprd"],
+    })
+    expect(result).toHaveLength(2)
+    expect(result.map((l) => l.text)).toEqual(["app log\n", "dapr log\n"])
+  })
+})

--- a/web/src/logs.ts
+++ b/web/src/logs.ts
@@ -95,6 +95,15 @@ export class LogDisplay {
     return true
   }
 
+  matchesContainerFilter(line: LogLine): boolean {
+    const { containers } = this.filterSet
+    // Empty selection = show all. Lines without a container field always pass through.
+    if (containers.length === 0 || !line.containerName) {
+      return true
+    }
+    return containers.includes(line.containerName)
+  }
+
   matchesFilter(line: LogLine): boolean {
     if (line.buildEvent) {
       return true
@@ -108,7 +117,11 @@ export class LogDisplay {
       return false
     }
 
-    return this.matchesLevelFilter(line) && this.matchesTermFilter(line)
+    return (
+      this.matchesLevelFilter(line) &&
+      this.matchesTermFilter(line) &&
+      this.matchesContainerFilter(line)
+    )
   }
 
   trackPrologueLine(line: LogLine) {

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -138,6 +138,7 @@ export type LogLine = {
   level: string
   buildEvent?: string
   spanId: string
+  containerName?: string
 
   // The index of this line in the LogStore StoredLine list.
   storedLineIndex: number


### PR DESCRIPTION
Closes #3814

## Summary

- Adds a `container` structured field to every pod log line in the streaming controller, enabling frontend filtering without text parsing
- Adds a container filter dropdown to the log pane action bar, shown when a resource has logs from 1+ distinct containers: disabled at exactly 1 (layout stays stable once any container logs arrive), interactive at 2+
- Resources with no container logs (e.g. `local_resource`) never render the dropdown
- Filter selection is URL-persisted via the existing search param pattern and integrates with the existing `FilterSet` pipeline

### Multi-Container

<img width="1501" height="405" alt="image" src="https://github.com/user-attachments/assets/cd11e859-0053-42e7-8c8e-c14317e2e598" />

### Single Container

<img width="1510" height="537" alt="image" src="https://github.com/user-attachments/assets/b9e07d6a-ba75-4dfd-bbed-d0478a1c7627" />

### No container

<img width="1512" height="543" alt="image" src="https://github.com/user-attachments/assets/13bf68c9-80a4-4cc0-b9a6-ddfa424face7" />


## Test plan

- [x] Run `go test ./internal/controllers/core/podlogstream/...` to verify the new `TestLogContainerField` test passes
- [x] Run `yarn test` in `web/` to verify all frontend tests pass
- [x] Deploy a multi-container resource (e.g. app + sidecar) and confirm the container dropdown appears and is interactive
- [x] Verify selecting a container filters logs correctly and the selection round-trips through the URL
- [x] Verify a single-container resource shows the dropdown disabled with the container name in the right pill
- [x] Verify a resource with no container logs (e.g. `local_resource`) shows no dropdown