### PR TITLE
feat(magic): add python's magic variable __name__

### DIFF
--- a/internal/tiltfile/api/__init__.py
+++ b/internal/tiltfile/api/__init__.py
@@ -5,6 +5,9 @@ from typing import Dict, Union, List, Callable, Any, Optional
 file__: str = ""
 """The path of the Tiltfile. Set as a local variable in each Tiltfile as it loads.
 """
+__name__: str = ""
+"""Equivalent to the Python __name__ variable, except set to "__main__" in the Tiltfile context. (In other words, if you check whether __name__ == "__main__", it will be True in your Tiltfile, and False in any modules you import.)
+"""
 
 class Blob:
   """The result of executing a command on your local system.

--- a/internal/tiltfile/starkit/environment.go
+++ b/internal/tiltfile/starkit/environment.go
@@ -301,6 +301,12 @@ func (e *Environment) doLoad(t *starlark.Thread, localPath string) (starlark.Str
 	}
 	predeclared["__file__"] = starlark.String(localPath)
 
+	if e.startTf != nil && e.startTf.Spec.Path == localPath {
+		predeclared["__name__"] = starlark.String("__main__")
+	} else {
+		predeclared["__name__"] = starlark.String(filepath.Base(localPath))
+	}
+
 	return starlark.ExecFileOptions(fileOptions, t, localPath, bytes, predeclared)
 }
 

--- a/internal/tiltfile/starkit/environment_test.go
+++ b/internal/tiltfile/starkit/environment_test.go
@@ -234,6 +234,28 @@ print_mypath()
 	require.Equal(t, "Tiltfile2", filepath.Base(paths[1]))
 }
 
+// Tiltfile loads Tiltfile2
+// 1 prints its __name__ and calls a method in 2 to do the same
+func TestUseMagicNameVar(t *testing.T) {
+	f := NewFixture(t, PwdPlugin{})
+	f.File("Tiltfile2", `
+def print_mypath():
+  print(__name__)
+`)
+	f.File("Tiltfile", `
+load('Tiltfile2', 'print_mypath')
+print(__name__)
+print_mypath()
+`)
+
+	_, err := f.ExecFile("Tiltfile")
+	require.NoError(t, err)
+
+	paths := strings.Split(strings.TrimSpace(f.out.String()), "\n")
+	require.Equal(t, "__main__", paths[0])
+	require.Equal(t, "Tiltfile2", filepath.Base(paths[1]))
+}
+
 func TestSupportsSet(t *testing.T) {
 	f := NewFixture(t, PwdPlugin{})
 	f.File("Tiltfile", `


### PR DESCRIPTION
Technically this is already replicable with the following : 

```py
if __file__ = config.main_path:
  main()
```

But since Starlark is really welcoming for Python users, I feel like having `__name__` be either `__main__` or the name of the Tiltfile makes the entry really easy.

(To be honest, I've been using Tilt for quite a bit now, and only discovered `__file__` while trying to add `__name__` 😅)

This PR would allow such patterns : 


```py
def main():
  do_something()

if __name__ = "__main__":
  main()
```

Not sure what the workflow is for the documentation but if this is accepted I'd also need to [tilt.build](https://github.com/tilt-dev/tilt.build) in order to add __name__ workaround like __file__ ?