### PR TITLE
fix: down-policy not respected when resource is disabled via UI

### DIFF
--- a/internal/controllers/core/kubernetesapply/reconciler.go
+++ b/internal/controllers/core/kubernetesapply/reconciler.go
@@ -806,6 +806,12 @@ func (r *Reconciler) garbageCollect(nn types.NamespacedName, isDeleting bool) de
 	toDelete := make([]k8s.K8sEntity, 0, len(result.DanglingObjects))
 	for k, v := range result.DanglingObjects {
 		delete(result.DanglingObjects, k)
+		// Respect tilt.dev/down-policy: keep — don't delete resources
+		// that the user marked as keep, even when the resource is disabled
+		// (not just during `tilt down`).
+		if ann, ok := v.Annotations()["tilt.dev/down-policy"]; ok && ann == "keep" {
+			continue
+		}
 		toDelete = append(toDelete, v)
 	}
 	if isDeleting {


### PR DESCRIPTION
### Summary

When a Kubernetes resource has tilt.dev/down-policy: keep and is disabled through the Tilt UI, the resource gets deleted anyway.

### Root Cause

tilt down (in internal/cli/down.go) correctly checks for the down-policy annotation. However, when a resource is disabled via the Tilt UI, the KubernetesApply reconciler garbageCollect() method deletes dangling objects without checking for the annotation.

### Fix

In garbageCollect(), skip objects with tilt.dev/down-policy: keep before appending to the delete list. This ensures the annotation is respected during both tilt down and resource disable/delete operations.

Fixes #6645
