### PR TITLE
test: increase engine test stdTimeout to reduce flakiness

### DIFF
--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -117,7 +117,15 @@ import (
 
 var originalWD string
 
-const stdTimeout = 2 * time.Second
+// stdTimeout is how long "wait until X happens" helpers wait before failing.
+// These helpers return as soon as the condition is met, so a generous timeout
+// is free for passing tests and only buys slack against CI load (the build
+// controller can take >2s to start its first build on a busy machine).
+const stdTimeout = 5 * time.Second
+
+// nonExitTimeout is for "assert X does NOT happen" helpers, which always block
+// for the full duration. Keep it short so those tests stay fast.
+const nonExitTimeout = 2 * time.Second
 
 type buildCompletionChannel chan bool
 
@@ -3494,7 +3502,7 @@ func (f *testFixture) WaitForExit() error {
 
 func (f *testFixture) WaitForNoExit() error {
 	select {
-	case <-time.After(stdTimeout):
+	case <-time.After(nonExitTimeout):
 		return nil
 	case err := <-f.upperInitResult:
 		f.T().Fatalf("upper exited when it shouldn't have")


### PR DESCRIPTION
Bump stdTimeout 2s->5s to give the build controller slack under CI load;
wait-until helpers return as soon as their condition is met, so a longer
timeout is free for passing tests. Add separate nonExitTimeout for
WaitForNoExit, which always blocks the full duration.

Signed-off-by: Nick Sieger <nick@nicksieger.com>
