### PR TITLE
engine: speed up the tests

### DIFF
--- a/internal/engine/buildcontroller_test.go
+++ b/internal/engine/buildcontroller_test.go
@@ -27,6 +27,7 @@ import (
 )
 
 func TestBuildControllerLocalResource(t *testing.T) {
+	t.Parallel()
 	f := newTestFixture(t)
 
 	dep := f.JoinPath("stuff.json")
@@ -55,6 +56,7 @@ func TestBuildControllerLocalResource(t *testing.T) {
 }
 
 func TestBuildControllerManualTriggerBuildReasonInit(t *testing.T) {
+	t.Parallel()
 	for _, tc := range []struct {
 		name        string
 		triggerMode model.TriggerMode
@@ -63,6 +65,7 @@ func TestBuildControllerManualTriggerBuildReasonInit(t *testing.T) {
 		{"manual with auto init", model.TriggerModeManualWithAutoInit},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			f := newTestFixture(t)
 			mName := model.ManifestName("foobar")
 			manifest := f.newManifest(mName.String()).WithTriggerMode(tc.triggerMode)
@@ -84,6 +87,7 @@ func TestBuildControllerManualTriggerBuildReasonInit(t *testing.T) {
 }
 
 func TestTriggerModes(t *testing.T) {
+	t.Parallel()
 	for _, tc := range []struct {
 		name                       string
 		triggerMode                model.TriggerMode
@@ -96,6 +100,7 @@ func TestTriggerModes(t *testing.T) {
 		{name: "fully manual", triggerMode: model.TriggerModeManual, expectInitialBuild: false, expectBuildWhenFilesChange: false},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			f := newTestFixture(t)
 
 			manifest := f.simpleManifestWithTriggerMode("foobar", tc.triggerMode)
@@ -129,6 +134,7 @@ func TestTriggerModes(t *testing.T) {
 }
 
 func TestBuildControllerImageBuildTrigger(t *testing.T) {
+	t.Parallel()
 	for _, tc := range []struct {
 		name               string
 		triggerMode        model.TriggerMode
@@ -143,6 +149,7 @@ func TestBuildControllerImageBuildTrigger(t *testing.T) {
 		{name: "auto with manual init without change", triggerMode: model.TriggerModeAutoWithManualInit, filesChanged: false, expectedImageBuild: true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			f := newTestFixture(t)
 			mName := model.ManifestName("foobar")
 
@@ -187,6 +194,7 @@ func TestBuildControllerImageBuildTrigger(t *testing.T) {
 }
 
 func TestBuildQueueOrdering(t *testing.T) {
+	t.Parallel()
 	f := newTestFixture(t)
 
 	m1 := f.newManifestWithRef("manifest1", container.MustParseNamed("manifest1")).
@@ -241,6 +249,7 @@ func TestBuildQueueOrdering(t *testing.T) {
 }
 
 func TestBuildQueueAndAutobuildOrdering(t *testing.T) {
+	t.Parallel()
 	f := newTestFixture(t)
 
 	// changes to this dir. will register with our manual manifests
@@ -303,6 +312,7 @@ func TestBuildQueueAndAutobuildOrdering(t *testing.T) {
 
 // any manifests without image targets should be deployed before any manifests WITH image targets
 func TestBuildControllerNoBuildManifestsFirst(t *testing.T) {
+	t.Parallel()
 	f := newTestFixture(t)
 
 	manifests := make([]model.Manifest, 10)
@@ -341,6 +351,7 @@ func TestBuildControllerNoBuildManifestsFirst(t *testing.T) {
 }
 
 func TestBuildControllerUnresourcedYAMLFirst(t *testing.T) {
+	t.Parallel()
 	f := newTestFixture(t)
 
 	manifests := []model.Manifest{
@@ -371,6 +382,7 @@ func TestBuildControllerUnresourcedYAMLFirst(t *testing.T) {
 }
 
 func TestBuildControllerRespectDockerComposeOrder(t *testing.T) {
+	t.Parallel()
 	f := newTestFixture(t)
 
 	sancho := NewSanchoLiveUpdateDCManifest(f)
@@ -399,6 +411,7 @@ func TestBuildControllerRespectDockerComposeOrder(t *testing.T) {
 }
 
 func TestBuildControllerLocalResourcesBeforeClusterResources(t *testing.T) {
+	t.Parallel()
 	f := newTestFixture(t)
 
 	manifests := []model.Manifest{
@@ -440,6 +453,7 @@ func TestBuildControllerLocalResourcesBeforeClusterResources(t *testing.T) {
 }
 
 func TestBuildControllerResourceDeps(t *testing.T) {
+	t.Parallel()
 	f := newTestFixture(t)
 
 	depGraph := map[string][]string{
@@ -497,6 +511,7 @@ func TestBuildControllerResourceDeps(t *testing.T) {
 // normally, local builds go before k8s builds
 // if the local build depends on the k8s build, the k8s build should go first
 func TestBuildControllerResourceDepTrumpsLocalResourcePriority(t *testing.T) {
+	t.Parallel()
 	f := newTestFixture(t)
 
 	k8sManifest := f.newManifest("foo")
@@ -525,6 +540,7 @@ func TestBuildControllerResourceDepTrumpsLocalResourcePriority(t *testing.T) {
 
 // bar depends on foo, we build foo three times before marking it ready, and make sure bar waits
 func TestBuildControllerResourceDepTrumpsInitialBuild(t *testing.T) {
+	t.Parallel()
 	if runtime.GOOS == "windows" {
 		t.Skip("flaky on windows")
 	}
@@ -560,6 +576,7 @@ func TestBuildControllerResourceDepTrumpsInitialBuild(t *testing.T) {
 
 // bar depends on foo. make sure bar waits on foo even as foo fails
 func TestBuildControllerResourceDepTrumpsPendingBuild(t *testing.T) {
+	t.Parallel()
 	if runtime.GOOS == "windows" {
 		t.Skip("flaky on windows")
 	}
@@ -593,6 +610,7 @@ func TestBuildControllerResourceDepTrumpsPendingBuild(t *testing.T) {
 }
 
 func TestBuildControllerWontBuildManifestIfNoSlotsAvailable(t *testing.T) {
+	t.Parallel()
 	f := newTestFixture(t)
 	f.b.completeBuildsManually = true
 	f.setMaxParallelUpdates(2)
@@ -628,6 +646,7 @@ func TestBuildControllerWontBuildManifestIfNoSlotsAvailable(t *testing.T) {
 // are in progress (e.g. if there are 5 builds in progress and user sets
 // maxParallelUpdates=3, nothing should explode.)
 func TestCurrentlyBuildingMayExceedMaxParallelUpdates(t *testing.T) {
+	t.Parallel()
 	f := newTestFixture(t)
 	f.b.completeBuildsManually = true
 	f.setMaxParallelUpdates(3)
@@ -682,6 +701,7 @@ func TestCurrentlyBuildingMayExceedMaxParallelUpdates(t *testing.T) {
 }
 
 func TestDontStartBuildIfControllerAndEngineUnsynced(t *testing.T) {
+	t.Parallel()
 	f := newTestFixture(t)
 
 	f.b.completeBuildsManually = true
@@ -719,6 +739,7 @@ func TestDontStartBuildIfControllerAndEngineUnsynced(t *testing.T) {
 }
 
 func TestErrorHandlingWithMultipleBuilds(t *testing.T) {
+	t.Parallel()
 	if runtime.GOOS == "windows" {
 		t.Skip("TODO(nick): fix this")
 	}
@@ -768,6 +789,7 @@ func TestErrorHandlingWithMultipleBuilds(t *testing.T) {
 }
 
 func TestManifestsWithSameTwoImages(t *testing.T) {
+	t.Parallel()
 	f := newTestFixture(t)
 	m1, m2 := NewManifestsWithSameTwoImages(f)
 	f.Start([]model.Manifest{m1, m2})
@@ -815,6 +837,7 @@ func TestManifestsWithSameTwoImages(t *testing.T) {
 }
 
 func TestManifestsWithTwoCommonAncestors(t *testing.T) {
+	t.Parallel()
 	f := newTestFixture(t)
 	m1, m2 := NewManifestsWithTwoCommonAncestors(f)
 	f.Start([]model.Manifest{m1, m2})
@@ -871,6 +894,7 @@ func TestManifestsWithTwoCommonAncestors(t *testing.T) {
 }
 
 func TestLocalDependsOnNonWorkloadK8s(t *testing.T) {
+	t.Parallel()
 	f := newTestFixture(t)
 
 	local1 := manifestbuilder.New(f, "local").
@@ -897,6 +921,7 @@ func TestLocalDependsOnNonWorkloadK8s(t *testing.T) {
 }
 
 func TestManifestsWithCommonAncestorAndTrigger(t *testing.T) {
+	t.Parallel()
 	f := newTestFixture(t)
 	m1, m2 := NewManifestsWithCommonAncestor(f)
 	f.Start([]model.Manifest{m1, m2})
@@ -924,6 +949,7 @@ func TestManifestsWithCommonAncestorAndTrigger(t *testing.T) {
 }
 
 func TestDisablingCancelsBuild(t *testing.T) {
+	t.Parallel()
 	f := newTestFixture(t)
 	manifest := manifestbuilder.New(f, "local").
 		WithLocalResource("sleep 10000", nil).
@@ -948,6 +974,7 @@ func TestDisablingCancelsBuild(t *testing.T) {
 }
 
 func TestCancelButton(t *testing.T) {
+	t.Parallel()
 	f := newTestFixture(t)
 	f.b.completeBuildsManually = true
 	f.useRealTiltfileLoader()
@@ -975,6 +1002,7 @@ local_resource('local', 'sleep 10000')
 }
 
 func TestCancelButtonClickedBeforeBuild(t *testing.T) {
+	t.Parallel()
 	f := newTestFixture(t)
 	f.b.completeBuildsManually = true
 	f.useRealTiltfileLoader()
@@ -1014,6 +1042,7 @@ local_resource('local', 'sleep 10000')
 }
 
 func TestBuildControllerK8sFileDependencies(t *testing.T) {
+	t.Parallel()
 	f := newTestFixture(t)
 
 	kt := k8s.MustTarget("fe", testyaml.SanchoYAML).

--- a/internal/engine/main_test.go
+++ b/internal/engine/main_test.go
@@ -1,0 +1,14 @@
+package engine
+
+import (
+	"io"
+	"os"
+	"testing"
+
+	"github.com/tilt-dev/tilt/internal/controllers"
+)
+
+func TestMain(m *testing.M) {
+	controllers.InitKlog(io.Discard)
+	os.Exit(m.Run())
+}

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"log"
 	"os"
 	"path"
@@ -586,6 +585,7 @@ func (b *fakeBuildAndDeployer) completeBuild(key string) {
 }
 
 func TestUpper_Up(t *testing.T) {
+	t.Parallel()
 	f := newTestFixture(t)
 	manifest := f.newManifest("foobar")
 
@@ -619,6 +619,7 @@ func TestUpper_Up(t *testing.T) {
 }
 
 func TestUpper_UpK8sEntityOrdering(t *testing.T) {
+	t.Parallel()
 	f := newTestFixture(t, fixtureOptions{engineMode: &store.EngineModeCI})
 	f.useRealTiltfileLoader()
 
@@ -653,6 +654,7 @@ func TestUpper_UpK8sEntityOrdering(t *testing.T) {
 }
 
 func TestUpper_CI(t *testing.T) {
+	t.Parallel()
 	f := newTestFixture(t, fixtureOptions{engineMode: &store.EngineModeCI})
 
 	manifest := f.newManifest("foobar")
@@ -677,6 +679,7 @@ func TestUpper_CI(t *testing.T) {
 }
 
 func TestFirstBuildFails_Up(t *testing.T) {
+	t.Parallel()
 	if runtime.GOOS == "windows" {
 		t.Skip("flaky on windows")
 	}
@@ -702,6 +705,7 @@ func TestFirstBuildFails_Up(t *testing.T) {
 }
 
 func TestFirstBuildCancels_Up(t *testing.T) {
+	t.Parallel()
 	f := newTestFixture(t)
 	manifest := f.newManifest("foobar")
 	f.SetNextBuildError(context.Canceled)
@@ -717,6 +721,7 @@ func TestFirstBuildCancels_Up(t *testing.T) {
 }
 
 func TestFirstBuildFails_CI(t *testing.T) {
+	t.Parallel()
 	f := newTestFixture(t, fixtureOptions{engineMode: &store.EngineModeCI})
 	manifest := f.newManifest("foobar")
 	buildFailedToken := errors.New("doesn't compile")
@@ -747,6 +752,7 @@ func TestFirstBuildFails_CI(t *testing.T) {
 }
 
 func TestCIIgnoresDisabledResources(t *testing.T) {
+	t.Parallel()
 	f := newTestFixture(t, fixtureOptions{engineMode: &store.EngineModeCI})
 
 	m1 := f.newManifest("m1")
@@ -772,6 +778,7 @@ func TestCIIgnoresDisabledResources(t *testing.T) {
 }
 
 func TestConfigFileChangeClearsBuildStateToForceImageBuild(t *testing.T) {
+	t.Parallel()
 	f := newTestFixture(t)
 	f.useRealTiltfileLoader()
 
@@ -805,6 +812,7 @@ k8s_yaml('snack.yaml')
 }
 
 func TestMultipleChangesOnlyDeployOneManifest(t *testing.T) {
+	t.Parallel()
 	f := newTestFixture(t)
 	f.useRealTiltfileLoader()
 
@@ -868,6 +876,7 @@ k8s_resource('doggos', new_name='quux')
 }
 
 func TestSecondResourceIsBuilt(t *testing.T) {
+	t.Parallel()
 	f := newTestFixture(t)
 	f.useRealTiltfileLoader()
 
@@ -910,6 +919,7 @@ k8s_resource('doggos', new_name='quux')  # rename "doggos" --> "quux"
 }
 
 func TestConfigChange_NoOpChange(t *testing.T) {
+	t.Parallel()
 	f := newTestFixture(t)
 	f.useRealTiltfileLoader()
 
@@ -951,6 +961,7 @@ k8s_yaml('snack.yaml')`)
 }
 
 func TestConfigChange_TiltfileErrorAndFixWithNoChanges(t *testing.T) {
+	t.Parallel()
 	f := newTestFixture(t)
 	f.useRealTiltfileLoader()
 
@@ -985,6 +996,7 @@ k8s_yaml('snack.yaml')`
 }
 
 func TestConfigChange_TiltfileErrorAndFixWithFileChange(t *testing.T) {
+	t.Parallel()
 	f := newTestFixture(t)
 	f.useRealTiltfileLoader()
 
@@ -1041,6 +1053,7 @@ k8s_yaml('snack.yaml')
 }
 
 func TestConfigChange_TriggerModeChangePropagatesButDoesntInvalidateBuild(t *testing.T) {
+	t.Parallel()
 	f := newTestFixture(t)
 	f.useRealTiltfileLoader()
 
@@ -1075,6 +1088,7 @@ trigger_mode(TRIGGER_MODE_MANUAL)`, origTiltfile)
 }
 
 func TestConfigChange_ManifestWithPendingChangesBuildsIfTriggerModeChangedToAuto(t *testing.T) {
+	t.Parallel()
 	f := newTestFixture(t)
 	f.useRealTiltfileLoader()
 
@@ -1122,6 +1136,7 @@ k8s_yaml('snack.yaml')`
 }
 
 func TestConfigChange_ManifestIncludingInitialBuildsIfTriggerModeChangedToManualAfterInitial(t *testing.T) {
+	t.Parallel()
 	f := newTestFixture(t)
 
 	foo := f.newManifest("foo").WithTriggerMode(model.TriggerModeManual)
@@ -1159,6 +1174,7 @@ func TestConfigChange_ManifestIncludingInitialBuildsIfTriggerModeChangedToManual
 }
 
 func TestConfigChange_FilenamesLoggedInManifestBuild(t *testing.T) {
+	t.Parallel()
 	f := newTestFixture(t)
 	f.useRealTiltfileLoader()
 
@@ -1194,6 +1210,7 @@ docker_build('gcr.io/windmill-public-containers/servantes/snack', './src', ignor
 }
 
 func TestConfigChange_LocalResourceChange(t *testing.T) {
+	t.Parallel()
 	f := newTestFixture(t)
 	f.useRealTiltfileLoader()
 
@@ -1219,6 +1236,7 @@ local_resource('local', 'echo red fish blue fish', deps='foo.bar')`)
 }
 
 func TestDockerRebuildWithChangedFiles(t *testing.T) {
+	t.Parallel()
 	f := newTestFixture(t)
 	df := `FROM golang
 ADD ./ ./
@@ -1252,6 +1270,7 @@ go build ./...
 }
 
 func TestHudUpdated(t *testing.T) {
+	t.Parallel()
 	f := newTestFixture(t)
 
 	manifest := f.newManifest("foobar")
@@ -1275,6 +1294,7 @@ func TestHudUpdated(t *testing.T) {
 }
 
 func TestDisabledHudUpdated(t *testing.T) {
+	t.Parallel()
 	if runtime.GOOS == "windows" {
 		t.Skip("TODO(nick): Investigate")
 	}
@@ -1315,6 +1335,7 @@ func TestDisabledHudUpdated(t *testing.T) {
 }
 
 func TestPodEvent(t *testing.T) {
+	t.Parallel()
 	f := newTestFixture(t)
 	manifest := f.newManifest("foobar")
 	pb := f.registerForDeployer(manifest)
@@ -1339,6 +1360,7 @@ func TestPodEvent(t *testing.T) {
 }
 
 func TestPodEventContainerStatus(t *testing.T) {
+	t.Parallel()
 	f := newTestFixture(t)
 	manifest := f.newManifest("foobar")
 	pb := f.registerForDeployer(manifest)
@@ -1378,6 +1400,7 @@ func TestPodEventContainerStatus(t *testing.T) {
 }
 
 func TestPodEventContainerStatusWithoutImage(t *testing.T) {
+	t.Parallel()
 	f := newTestFixture(t)
 	manifest := model.Manifest{
 		Name: model.ManifestName("foobar"),
@@ -1433,6 +1456,7 @@ func TestPodEventContainerStatusWithoutImage(t *testing.T) {
 }
 
 func TestPodEventUpdateByTimestamp(t *testing.T) {
+	t.Parallel()
 	f := newTestFixture(t)
 	manifest := f.newManifest("foobar")
 	pb := f.registerForDeployer(manifest)
@@ -1469,6 +1493,7 @@ func TestPodEventUpdateByTimestamp(t *testing.T) {
 }
 
 func TestPodForgottenOnDisable(t *testing.T) {
+	t.Parallel()
 	f := newTestFixture(t)
 	manifest := f.newManifest("foobar")
 	pb := f.registerForDeployer(manifest)
@@ -1495,6 +1520,7 @@ func TestPodForgottenOnDisable(t *testing.T) {
 }
 
 func TestPodEventUpdateByPodName(t *testing.T) {
+	t.Parallel()
 	f := newTestFixture(t)
 	manifest := f.newManifest("foobar")
 	pb := f.registerForDeployer(manifest)
@@ -1532,6 +1558,7 @@ func TestPodEventUpdateByPodName(t *testing.T) {
 }
 
 func TestPodEventIgnoreOlderPod(t *testing.T) {
+	t.Parallel()
 	f := newTestFixture(t)
 	manifest := f.newManifest("foobar")
 	pb := f.registerForDeployer(manifest)
@@ -1565,6 +1592,7 @@ func TestPodEventIgnoreOlderPod(t *testing.T) {
 }
 
 func TestPodContainerStatus(t *testing.T) {
+	t.Parallel()
 	f := newTestFixture(t)
 	manifest := f.newManifest("fe")
 	pb := f.registerForDeployer(manifest)
@@ -1608,6 +1636,7 @@ func TestPodContainerStatus(t *testing.T) {
 }
 
 func TestUpper_WatchDockerIgnoredFiles(t *testing.T) {
+	t.Parallel()
 	f := newTestFixture(t)
 	manifest := f.newManifest("foobar")
 	manifest = manifest.WithImageTarget(manifest.ImageTargetAt(0).
@@ -1632,6 +1661,7 @@ func TestUpper_WatchDockerIgnoredFiles(t *testing.T) {
 }
 
 func TestUpper_ShowErrorPodLog(t *testing.T) {
+	t.Parallel()
 	f := newTestFixture(t)
 
 	name := model.ManifestName("foobar")
@@ -1661,6 +1691,7 @@ func TestUpper_ShowErrorPodLog(t *testing.T) {
 }
 
 func TestUpperPodLogInCrashLoopThirdInstanceStillUp(t *testing.T) {
+	t.Parallel()
 	f := newTestFixture(t)
 
 	name := model.ManifestName("foobar")
@@ -1694,6 +1725,7 @@ func TestUpperPodLogInCrashLoopThirdInstanceStillUp(t *testing.T) {
 }
 
 func TestUpperPodLogInCrashLoopPodCurrentlyDown(t *testing.T) {
+	t.Parallel()
 	f := newTestFixture(t)
 
 	name := model.ManifestName("foobar")
@@ -1726,6 +1758,7 @@ func TestUpperPodLogInCrashLoopPodCurrentlyDown(t *testing.T) {
 }
 
 func TestUpperRecordPodWithMultipleContainers(t *testing.T) {
+	t.Parallel()
 	f := newTestFixture(t)
 
 	name := model.ManifestName("foobar")
@@ -1767,6 +1800,7 @@ func TestUpperRecordPodWithMultipleContainers(t *testing.T) {
 }
 
 func TestUpperProcessOtherContainersIfOneErrors(t *testing.T) {
+	t.Parallel()
 	f := newTestFixture(t)
 
 	name := model.ManifestName("foobar")
@@ -1808,6 +1842,7 @@ func TestUpperProcessOtherContainersIfOneErrors(t *testing.T) {
 }
 
 func TestUpper_ServiceEvent(t *testing.T) {
+	t.Parallel()
 	f := newTestFixture(t)
 
 	manifest := f.newManifest("foobar")
@@ -1840,6 +1875,7 @@ func TestUpper_ServiceEvent(t *testing.T) {
 }
 
 func TestUpper_ServiceEventRemovesURL(t *testing.T) {
+	t.Parallel()
 	f := newTestFixture(t)
 
 	manifest := f.newManifest("foobar")
@@ -1876,6 +1912,7 @@ func TestUpper_ServiceEventRemovesURL(t *testing.T) {
 }
 
 func TestUpper_PodLogs(t *testing.T) {
+	t.Parallel()
 	f := newTestFixture(t)
 
 	name := model.ManifestName("fe")
@@ -1894,6 +1931,7 @@ func TestUpper_PodLogs(t *testing.T) {
 }
 
 func TestK8sEventGlobalLogAndManifestLog(t *testing.T) {
+	t.Parallel()
 	f := newTestFixture(t)
 
 	name := model.ManifestName("fe")
@@ -1927,6 +1965,7 @@ func TestK8sEventGlobalLogAndManifestLog(t *testing.T) {
 }
 
 func TestK8sEventNotLoggedIfNoManifestForUID(t *testing.T) {
+	t.Parallel()
 	f := newTestFixture(t)
 
 	name := model.ManifestName("fe")
@@ -1953,6 +1992,7 @@ func TestK8sEventNotLoggedIfNoManifestForUID(t *testing.T) {
 }
 
 func TestHudExitNoError(t *testing.T) {
+	t.Parallel()
 	f := newTestFixture(t)
 	f.Start([]model.Manifest{})
 	f.store.Dispatch(hud.NewExitAction(nil))
@@ -1961,6 +2001,7 @@ func TestHudExitNoError(t *testing.T) {
 }
 
 func TestHudExitWithError(t *testing.T) {
+	t.Parallel()
 	f := newTestFixture(t)
 	f.Start([]model.Manifest{})
 	e := errors.New("helllllo")
@@ -1969,6 +2010,7 @@ func TestHudExitWithError(t *testing.T) {
 }
 
 func TestDockerComposeUp(t *testing.T) {
+	t.Parallel()
 	f := newTestFixture(t)
 	redis, server := f.setupDCFixture()
 
@@ -1984,6 +2026,7 @@ func TestDockerComposeUp(t *testing.T) {
 }
 
 func TestDockerComposeRedeployFromFileChange(t *testing.T) {
+	t.Parallel()
 	if runtime.GOOS == "windows" {
 		t.Skip("flaky on windows")
 	}
@@ -2001,6 +2044,7 @@ func TestDockerComposeRedeployFromFileChange(t *testing.T) {
 }
 
 func TestDockerComposeRecordsBuildLogs(t *testing.T) {
+	t.Parallel()
 	f := newTestFixture(t)
 	f.useRealTiltfileLoader()
 
@@ -2022,6 +2066,7 @@ func TestDockerComposeRecordsBuildLogs(t *testing.T) {
 }
 
 func TestDockerComposeBuildCompletedSetsStatusToUpIfSuccessful(t *testing.T) {
+	t.Parallel()
 	f := newTestFixture(t)
 	f.useRealTiltfileLoader()
 
@@ -2048,6 +2093,7 @@ func TestDockerComposeBuildCompletedSetsStatusToUpIfSuccessful(t *testing.T) {
 }
 
 func TestDockerComposeStopOnDisable(t *testing.T) {
+	t.Parallel()
 	f := newTestFixture(t)
 	f.useRealTiltfileLoader()
 
@@ -2075,6 +2121,7 @@ func TestDockerComposeStopOnDisable(t *testing.T) {
 }
 
 func TestDockerComposeStartOnReenable(t *testing.T) {
+	t.Parallel()
 	f := newTestFixture(t)
 	f.useRealTiltfileLoader()
 
@@ -2102,6 +2149,7 @@ func TestDockerComposeStartOnReenable(t *testing.T) {
 }
 
 func TestEmptyTiltfile(t *testing.T) {
+	t.Parallel()
 	f := newTestFixture(t)
 	f.useRealTiltfileLoader()
 	f.WriteFile("Tiltfile", "")
@@ -2133,6 +2181,7 @@ func TestEmptyTiltfile(t *testing.T) {
 }
 
 func TestUpperStart(t *testing.T) {
+	t.Parallel()
 	f := newTestFixture(t)
 	f.useRealTiltfileLoader()
 
@@ -2167,6 +2216,7 @@ func TestUpperStart(t *testing.T) {
 }
 
 func TestWatchManifestsWithCommonAncestor(t *testing.T) {
+	t.Parallel()
 	f := newTestFixture(t)
 	m1, m2 := NewManifestsWithCommonAncestor(f)
 	f.Start([]model.Manifest{m1, m2})
@@ -2219,6 +2269,7 @@ func TestWatchManifestsWithCommonAncestor(t *testing.T) {
 }
 
 func TestConfigChangeThatChangesManifestIsIncludedInManifestsChangedFile(t *testing.T) {
+	t.Parallel()
 	// https://app.clubhouse.io/windmill/story/5701/test-testconfigchangethatchangesmanifestisincludedinmanifestschangedfile-is-flaky
 	t.Skip("TODO(nick): fix this")
 
@@ -2256,6 +2307,7 @@ k8s_yaml('snack.yaml')`
 }
 
 func TestSetAnalyticsOpt(t *testing.T) {
+	t.Parallel()
 	f := newTestFixture(t)
 
 	opt := func(ia InitAction) InitAction {
@@ -2288,6 +2340,7 @@ func TestSetAnalyticsOpt(t *testing.T) {
 }
 
 func TestFeatureFlagsStoredOnState(t *testing.T) {
+	t.Parallel()
 	f := newTestFixture(t)
 
 	f.Start([]model.Manifest{})
@@ -2315,6 +2368,7 @@ func TestFeatureFlagsStoredOnState(t *testing.T) {
 }
 
 func TestTeamIDStoredOnState(t *testing.T) {
+	t.Parallel()
 	f := newTestFixture(t)
 
 	f.Start([]model.Manifest{})
@@ -2342,6 +2396,7 @@ func TestTeamIDStoredOnState(t *testing.T) {
 }
 
 func TestBuildLogAction(t *testing.T) {
+	t.Parallel()
 	f := newTestFixture(t)
 	f.bc.DisableForTesting()
 
@@ -2378,6 +2433,7 @@ alert-injest… │ ghij`)
 }
 
 func TestBuildErrorLoggedOnceByUpper(t *testing.T) {
+	t.Parallel()
 	f := newTestFixture(t)
 
 	manifest := f.newManifest("alert-injester")
@@ -2395,6 +2451,7 @@ func TestBuildErrorLoggedOnceByUpper(t *testing.T) {
 }
 
 func TestTiltfileChangedFilesOnlyLoggedAfterFirstBuild(t *testing.T) {
+	t.Parallel()
 	f := newTestFixture(t)
 	f.useRealTiltfileLoader()
 
@@ -2434,6 +2491,7 @@ k8s_yaml('snack.yaml')`)
 }
 
 func TestDeployUIDsInEngineState(t *testing.T) {
+	t.Parallel()
 	f := newTestFixture(t)
 
 	uid := types.UID("fake-uid")
@@ -2453,6 +2511,7 @@ func TestDeployUIDsInEngineState(t *testing.T) {
 }
 
 func TestEnableFeatureOnFail(t *testing.T) {
+	t.Parallel()
 	f := newTestFixture(t)
 	f.useRealTiltfileLoader()
 
@@ -2472,6 +2531,7 @@ fail('goodnight moon')
 }
 
 func TestSecretScrubbed(t *testing.T) {
+	t.Parallel()
 	f := newTestFixture(t)
 	f.useRealTiltfileLoader()
 
@@ -2502,6 +2562,7 @@ data:
 }
 
 func TestShortSecretNotScrubbed(t *testing.T) {
+	t.Parallel()
 	f := newTestFixture(t)
 	f.useRealTiltfileLoader()
 
@@ -2530,6 +2591,7 @@ stringData:
 }
 
 func TestDisableDockerPrune(t *testing.T) {
+	t.Parallel()
 	f := newTestFixture(t)
 	f.useRealTiltfileLoader()
 
@@ -2551,6 +2613,7 @@ docker_prune_settings(disable=True)
 }
 
 func TestDockerPruneEnabledByDefault(t *testing.T) {
+	t.Parallel()
 	f := newTestFixture(t)
 	f.useRealTiltfileLoader()
 
@@ -2571,6 +2634,7 @@ func TestDockerPruneEnabledByDefault(t *testing.T) {
 }
 
 func TestHasEverBeenReadyK8s(t *testing.T) {
+	t.Parallel()
 	f := newTestFixture(t)
 
 	m := f.newManifest("foobar")
@@ -2589,6 +2653,7 @@ func TestHasEverBeenReadyK8s(t *testing.T) {
 }
 
 func TestHasEverBeenCompleteK8s(t *testing.T) {
+	t.Parallel()
 	f := newTestFixture(t)
 
 	m := f.newManifest("foobar")
@@ -2607,6 +2672,7 @@ func TestHasEverBeenCompleteK8s(t *testing.T) {
 }
 
 func TestHasEverBeenReadyLocal(t *testing.T) {
+	t.Parallel()
 	if runtime.GOOS == "windows" {
 		t.Skip("flaky on windows")
 	}
@@ -2631,6 +2697,7 @@ func TestHasEverBeenReadyLocal(t *testing.T) {
 }
 
 func TestVersionSettingsStoredOnState(t *testing.T) {
+	t.Parallel()
 	f := newTestFixture(t)
 
 	f.Start([]model.Manifest{})
@@ -2656,6 +2723,7 @@ func TestVersionSettingsStoredOnState(t *testing.T) {
 }
 
 func TestAnalyticsTiltfileOpt(t *testing.T) {
+	t.Parallel()
 	f := newTestFixture(t)
 
 	f.Start([]model.Manifest{})
@@ -2681,6 +2749,7 @@ func TestAnalyticsTiltfileOpt(t *testing.T) {
 }
 
 func TestConfigArgsChangeCausesTiltfileRerun(t *testing.T) {
+	t.Parallel()
 	f := newTestFixture(t)
 	f.useRealTiltfileLoader()
 
@@ -2725,6 +2794,7 @@ print('foo=', cfg['foo'])`)
 }
 
 func TestTelemetryLogAction(t *testing.T) {
+	t.Parallel()
 	f := newTestFixture(t)
 
 	f.Start([]model.Manifest{})
@@ -2738,6 +2808,7 @@ func TestTelemetryLogAction(t *testing.T) {
 }
 
 func TestLocalResourceServeChangeCmd(t *testing.T) {
+	t.Parallel()
 	f := newTestFixture(t)
 	f.useRealTiltfileLoader()
 
@@ -2763,6 +2834,7 @@ func TestLocalResourceServeChangeCmd(t *testing.T) {
 }
 
 func TestDefaultUpdateSettings(t *testing.T) {
+	t.Parallel()
 	f := newTestFixture(t)
 	f.useRealTiltfileLoader()
 
@@ -2782,6 +2854,7 @@ func TestDefaultUpdateSettings(t *testing.T) {
 }
 
 func TestSetK8sUpsertTimeout(t *testing.T) {
+	t.Parallel()
 	f := newTestFixture(t)
 	f.useRealTiltfileLoader()
 
@@ -2802,6 +2875,7 @@ update_settings(k8s_upsert_timeout_secs=123)
 }
 
 func TestSetMaxBuildSlots(t *testing.T) {
+	t.Parallel()
 	f := newTestFixture(t)
 	f.useRealTiltfileLoader()
 
@@ -2823,6 +2897,7 @@ update_settings(max_parallel_updates=123)
 
 // https://github.com/tilt-dev/tilt/issues/3514
 func TestTiltignoreRespectedOnError(t *testing.T) {
+	t.Parallel()
 	f := newTestFixture(t)
 	f.useRealTiltfileLoader()
 
@@ -2863,6 +2938,7 @@ fail('x')`)
 }
 
 func TestHandleTiltfileTriggerQueue(t *testing.T) {
+	t.Parallel()
 	f := newTestFixture(t)
 	f.useRealTiltfileLoader()
 
@@ -2905,6 +2981,7 @@ func TestHandleTiltfileTriggerQueue(t *testing.T) {
 }
 
 func TestOverrideTriggerModeEvent(t *testing.T) {
+	t.Parallel()
 	f := newTestFixture(t)
 
 	manifest := f.newManifest("foo")
@@ -2930,6 +3007,7 @@ func TestOverrideTriggerModeEvent(t *testing.T) {
 }
 
 func TestOverrideTriggerModeBadManifestLogsError(t *testing.T) {
+	t.Parallel()
 	f := newTestFixture(t)
 
 	manifest := f.newManifest("foo")
@@ -2953,6 +3031,7 @@ func TestOverrideTriggerModeBadManifestLogsError(t *testing.T) {
 }
 
 func TestOverrideTriggerModeBadTriggerModeLogsError(t *testing.T) {
+	t.Parallel()
 	f := newTestFixture(t)
 
 	manifest := f.newManifest("foo")
@@ -2976,6 +3055,7 @@ func TestOverrideTriggerModeBadTriggerModeLogsError(t *testing.T) {
 }
 
 func TestDisableButtonIsCreated(t *testing.T) {
+	t.Parallel()
 	f := newTestFixture(t)
 	f.useRealTiltfileLoader()
 
@@ -3004,6 +3084,7 @@ local_resource('foo', 'echo hi')
 }
 
 func TestCmdServerDoesntStartWhenDisabled(t *testing.T) {
+	t.Parallel()
 	f := newTestFixture(t)
 	f.useRealTiltfileLoader()
 
@@ -3029,6 +3110,7 @@ config.set_enabled_resources(['bar'])
 }
 
 func TestDisabledResourceRemovedFromTriggerQueue(t *testing.T) {
+	t.Parallel()
 	f := newTestFixture(t)
 
 	m := manifestbuilder.New(f, "foo").WithLocalResource("foo", []string{f.Path()}).Build()
@@ -3053,6 +3135,7 @@ func TestDisabledResourceRemovedFromTriggerQueue(t *testing.T) {
 }
 
 func TestLocalResourceNoServeCmdDeps(t *testing.T) {
+	t.Parallel()
 	if runtime.GOOS == "windows" {
 		t.Skip("TODO(nick): fix this")
 	}
@@ -3128,7 +3211,6 @@ type fixtureOptions struct {
 }
 
 func newTestFixture(t *testing.T, options ...fixtureOptions) *testFixture {
-	controllers.InitKlog(io.Discard)
 	f := tempdir.NewTempDirFixture(t)
 
 	engineMode := store.EngineModeUp
@@ -3677,7 +3759,7 @@ func (f *testFixture) assertNoCall(msgAndArgs ...interface{}) {
 		select {
 		case call := <-f.b.calls:
 			f.T().Fatalf("%s\ncall:\n%s", msg, spew.Sdump(call))
-		case <-time.After(200 * time.Millisecond):
+		case <-time.After(50 * time.Millisecond):
 			return
 		}
 	}


### PR DESCRIPTION
these tests are covering a lot of subtle async interactions on a main event loop.

we can parallelize them to run that event loop multiple times!

on my old mac, the tests went from ~35s to ~6s