### PR TITLE
chore: use --fork-org=tilt-dev for homebrew core updates

### DIFF
--- a/scripts/release-ci.sh
+++ b/scripts/release-ci.sh
@@ -45,8 +45,5 @@ goreleaser --clean
 ./scripts/release-update-tilt-repo.sh "$VERSION"
 ./scripts/release-update-tilt-docs-repo.sh "$VERSION"
 ./scripts/record-release.sh "$VERSION"
-
-# No longer works with our release process - run this manually.
-#./scripts/release-update-homebrew-core.sh "$VERSION"
-
+./scripts/release-update-homebrew-core.sh "$VERSION"
 ./scripts/release-update-extension-repo.sh "$VERSION"

--- a/scripts/release-ci.sh
+++ b/scripts/release-ci.sh
@@ -45,5 +45,5 @@ goreleaser --clean
 ./scripts/release-update-tilt-repo.sh "$VERSION"
 ./scripts/release-update-tilt-docs-repo.sh "$VERSION"
 ./scripts/record-release.sh "$VERSION"
-./scripts/release-update-homebrew-core.sh "$VERSION"
 ./scripts/release-update-extension-repo.sh "$VERSION"
+./scripts/release-update-homebrew-core.sh "$VERSION"

--- a/scripts/release-update-homebrew-core.sh
+++ b/scripts/release-update-homebrew-core.sh
@@ -28,4 +28,5 @@ if ! [[ $VERSION =~ $VERSION_PATTERN ]]; then
 fi
 
 # send the brew team a PR to upgrade homebrew-core
-brew bump-formula-pr --no-browse --no-fork --force --version="$VERSION" tilt
+brew bump-formula-pr --verbose --debug --no-browse --force \
+     --fork-org=tilt-dev --version="$VERSION" --tag="v$VERSION" tilt


### PR DESCRIPTION
I noticed that I couldn't manually run `scripts/release-update-homebrew-core.sh` without removing `--no-fork` from the args. Maybe this will allow the app to create homebrew update PRs?
