### PR TITLE
Debounce transient Kubernetes cluster-health failures

### DIFF
--- a/internal/controllers/core/cluster/monitor.go
+++ b/internal/controllers/core/cluster/monitor.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"sync"
+	"time"
 
 	"github.com/jonboulle/clockwork"
 	"k8s.io/apimachinery/pkg/types"
@@ -96,11 +97,19 @@ func (c *clusterHealthMonitor) run(ctx context.Context, clusterNN types.Namespac
 
 	ticker := c.clock.NewTicker(clientHealthPollInterval)
 	defer ticker.Stop()
+	var unhealthySince time.Time
 	for {
 		err := doKubernetesHealthCheck(ctx, conn.k8sClient)
 		if err != nil {
-			c.UpdateStatus(ctx, clusterNN, err.Error())
+			now := c.clock.Now()
+			if unhealthySince.IsZero() {
+				unhealthySince = now
+			}
+			if now.Sub(unhealthySince) >= clientHealthFailureGracePeriod {
+				c.UpdateStatus(ctx, clusterNN, err.Error())
+			}
 		} else {
+			unhealthySince = time.Time{}
 			c.UpdateStatus(ctx, clusterNN, "")
 		}
 

--- a/internal/controllers/core/cluster/reconciler.go
+++ b/internal/controllers/core/cluster/reconciler.go
@@ -39,6 +39,9 @@ const ArchUnknown string = "unknown"
 const (
 	clientInitBackoff        = 30 * time.Second
 	clientHealthPollInterval = 15 * time.Second
+	// Like Kubernetes probes, require successive health check failures before turning
+	// a point-in-time control-plane error into a terminal CI result.
+	clientHealthFailureGracePeriod = 1 * time.Minute
 )
 
 type Reconciler struct {

--- a/internal/controllers/core/cluster/reconciler_test.go
+++ b/internal/controllers/core/cluster/reconciler_test.go
@@ -282,7 +282,7 @@ users: null
 `, string(contents))
 }
 
-func TestKubernetesMonitor(t *testing.T) {
+func TestKubernetesMonitorReportsSustainedFailure(t *testing.T) {
 	f := newFixture(t)
 	cluster := &v1alpha1.Cluster{
 		ObjectMeta: metav1.ObjectMeta{Name: "default"},
@@ -295,17 +295,62 @@ func TestKubernetesMonitor(t *testing.T) {
 	nn := apis.Key(cluster)
 
 	f.Create(cluster)
+	requireClusterHealthCallCount(t, f.k8sClient, 1)
 	f.MustGet(nn, cluster)
 	connectedAt := *cluster.Status.ConnectedAt
 	f.assertSteadyState(cluster)
 
 	f.k8sClient.ClusterHealthError = errors.New("fake cluster health error")
-	f.clock.Advance(time.Minute)
+	f.clock.Advance(clientHealthPollInterval)
+	requireClusterHealthCallCount(t, f.k8sClient, 2)
+
+	f.MustGet(nn, cluster)
+	assert.Empty(t, cluster.Status.Error)
+
+	f.clock.Advance(clientHealthFailureGracePeriod)
+	requireClusterHealthCallCount(t, f.k8sClient, 3)
 	<-f.requeues
 
 	f.MustGet(nn, cluster)
 	assert.Equal(t, "fake cluster health error", cluster.Status.Error)
 	timecmp.RequireTimeEqual(t, connectedAt, cluster.Status.ConnectedAt)
+}
+
+func TestKubernetesMonitorIgnoresTransientFailure(t *testing.T) {
+	f := newFixture(t)
+	cluster := &v1alpha1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "default"},
+		Spec: v1alpha1.ClusterSpec{
+			Connection: &v1alpha1.ClusterConnection{
+				Kubernetes: &v1alpha1.KubernetesClusterConnection{},
+			},
+		},
+	}
+	nn := apis.Key(cluster)
+
+	f.Create(cluster)
+	requireClusterHealthCallCount(t, f.k8sClient, 1)
+
+	f.k8sClient.ClusterHealthError = errors.New("fake cluster health error")
+	f.clock.Advance(clientHealthPollInterval)
+	requireClusterHealthCallCount(t, f.k8sClient, 2)
+
+	f.MustGet(nn, cluster)
+	assert.Empty(t, cluster.Status.Error)
+
+	f.k8sClient.ClusterHealthError = nil
+	f.clock.Advance(clientHealthPollInterval)
+	requireClusterHealthCallCount(t, f.k8sClient, 3)
+
+	f.MustGet(nn, cluster)
+	assert.Empty(t, cluster.Status.Error)
+}
+
+func requireClusterHealthCallCount(t *testing.T, client *k8s.FakeK8sClient, expected int) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		return client.ClusterHealthCallCount() >= expected
+	}, time.Second, time.Millisecond)
 }
 
 func TestDockerError(t *testing.T) {

--- a/internal/k8s/fake_client.go
+++ b/internal/k8s/fake_client.go
@@ -100,6 +100,7 @@ type FakeK8sClient struct {
 	ExecErrors          []error
 	ClusterHealthStatus *ClusterHealth
 	ClusterHealthError  error
+	clusterHealthCalls  int
 	FakeAPIConfig       *api.Config
 }
 
@@ -542,6 +543,8 @@ func (c *FakeK8sClient) ClusterHealth(_ context.Context, _ bool) (ClusterHealth,
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
+	c.clusterHealthCalls++
+
 	if c.ClusterHealthStatus != nil {
 		return *c.ClusterHealthStatus, nil
 	}
@@ -559,6 +562,13 @@ func (c *FakeK8sClient) ClusterHealth(_ context.Context, _ bool) (ClusterHealth,
 		LiveOutput:  "[+]fake-tilt ok\nlivez check passed\n",
 		ReadyOutput: "[+]fake-tilt ok\nreadyz check passed\n",
 	}, nil
+}
+
+func (c *FakeK8sClient) ClusterHealthCallCount() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return c.clusterHealthCalls
 }
 
 func FakePodStatus(image reference.NamedTagged, phase string) v1.PodStatus {


### PR DESCRIPTION
[#6742](https://github.com/tilt-dev/tilt/pull/6742) changed `tilt ci` so that any cluster error immediately fails the CI session. The cluster error it relies on, however, is produced by a single health-check poll and cleared by the next successful poll.

Kubernetes evaluates health over a series of probes rather than treating one failed check as terminal. Its probe model uses a [`failureThreshold`](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes) and only considers the overall check failed after successive failures. Tilt should apply similar tolerance before turning a point-in-time health observation into an irreversible CI result.

We see this most often on busy clusters with many concurrent CI jobs, where one brief control-plane interruption can cascade into failures across every active Tilt session.

This change requires health checks to fail continuously for one minute—five successive failed polls at the current 15-second interval—before reporting a cluster error. A successful check resets the timer immediately. Sustained failures still terminate CI, but one failed poll no longer amplifies a brief interruption into many permanent job failures.
