### PR TITLE
Rapidly updating a parent image can cause a child image to use stale base

### DIFF
--- a/internal/engine/buildcontrol/image_build_and_deployer.go
+++ b/internal/engine/buildcontrol/image_build_and_deployer.go
@@ -118,7 +118,19 @@ func (ibd *ImageBuildAndDeployer) BuildAndDeploy(ctx context.Context, st store.R
 		if err != nil {
 			return nil, err
 		}
-		imageMapSet[nn] = im.DeepCopy()
+		imageMap := im.DeepCopy()
+
+		// For an image we're reusing (not rebuilding this pass), trust the
+		// engine's result over the ImageMap status from the apiserver. The
+		// apiserver status is flushed asynchronously, so it can lag behind a
+		// base image that was just rebuilt and shared with another manifest,
+		// leaving a child built FROM a stale base tag.
+		// https://github.com/tilt-dev/tilt/issues/6634
+		if reusedResult, ok := reused[iTarget.ID()]; ok {
+			imageMap.Status = reusedResult.ImageMapStatus
+		}
+
+		imageMapSet[nn] = imageMap
 	}
 
 	err = q.RunBuilds(func(target model.TargetSpec, depResults []store.ImageBuildResult) (store.ImageBuildResult, error) {

--- a/internal/engine/buildcontrol/image_build_and_deployer_test.go
+++ b/internal/engine/buildcontrol/image_build_and_deployer_test.go
@@ -402,6 +402,87 @@ ENTRYPOINT /go/bin/sancho
 	testutils.AssertFileInTar(t, tar.NewReader(f.docker.BuildContext), expected)
 }
 
+// Regression test for https://github.com/tilt-dev/tilt/issues/6634: a reused
+// base image must inject the engine's latest tag into a child's FROM, not the
+// (possibly stale) ImageMap status from the apiserver.
+func TestMultiStageDockerBuildReusedBaseWithStaleImageMap(t *testing.T) {
+	f := newIBDFixture(t, clusterid.ProductGKE)
+
+	manifest := NewSanchoDockerBuildMultiStageManifest(f)
+	baseTarget := manifest.ImageTargets[0]
+	childTarget := manifest.ImageTargets[1]
+	baseID := baseTarget.ID()
+	childID := childTarget.ID()
+
+	// The base was just (re)built elsewhere and propagated into this manifest's
+	// state as the latest result. The child depends on it and must rebuild.
+	latestBaseResult := store.NewImageBuildResultSingleRef(
+		baseID, container.MustParseNamedTagged("sancho-base:tilt-latest"))
+	childResult := store.NewImageBuildResultSingleRef(
+		childID, container.MustParseNamedTagged("sancho:tilt-prebuilt2"))
+
+	stateSet := store.BuildStateSet{
+		// Base is clean -> reused (not rebuilt) in this pass.
+		baseID: store.NewBuildState(latestBaseResult, nil, nil),
+		// Child depends on the base, which changed -> rebuilt.
+		childID: store.NewBuildState(childResult, nil, []model.TargetID{baseID}),
+	}
+
+	// Seed the apiserver ImageMap specs.
+	for _, iTarget := range manifest.ImageTargets {
+		im := v1alpha1.ImageMap{
+			ObjectMeta: metav1.ObjectMeta{Name: iTarget.ID().Name.String()},
+			Spec:       iTarget.ImageMapSpec,
+		}
+		f.upsertSpec(&im)
+	}
+
+	// Crucially, the base ImageMap status on the apiserver is STALE: it still
+	// points at an older tag than the latest result in stateSet, simulating the
+	// asynchronous flush lagging behind the engine's propagated result.
+	staleBase := v1alpha1.ImageMap{
+		ObjectMeta: metav1.ObjectMeta{Name: baseID.Name.String()},
+		Spec:       baseTarget.ImageMapSpec,
+		Status: store.NewImageBuildResultSingleRef(
+			baseID, container.MustParseNamedTagged("sancho-base:tilt-stale")).ImageMapStatus,
+	}
+	f.updateStatus(&staleBase)
+
+	// Cluster is normally attached to the build state by the engine.
+	for _, iTarget := range manifest.ImageTargets {
+		s := stateSet[iTarget.ID()]
+		s.Cluster = f.cluster
+		stateSet[iTarget.ID()] = s
+	}
+
+	kTarget := manifest.DeployTarget.(model.K8sTarget)
+	f.upsertSpec(&v1alpha1.KubernetesApply{
+		ObjectMeta: metav1.ObjectMeta{Name: kTarget.ID().Name.String()},
+		Spec:       kTarget.KubernetesApplySpec,
+	})
+
+	_, err := f.ibd.BuildAndDeploy(f.ctx, f.st, BuildTargets(manifest), stateSet)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Only the child is rebuilt; the base is reused.
+	assert.Equal(t, 1, f.docker.BuildCount)
+
+	// The child must be built FROM the latest base tag, not the stale apiserver
+	// one.
+	expected := testutils.ExpectedFile{
+		Path: "Dockerfile",
+		Contents: `
+FROM sancho-base:tilt-latest
+ADD . .
+RUN go install github.com/tilt-dev/sancho
+ENTRYPOINT /go/bin/sancho
+`,
+	}
+	testutils.AssertFileInTar(t, tar.NewReader(f.docker.BuildContext), expected)
+}
+
 func TestK8sUpsertTimeout(t *testing.T) {
 	f := newIBDFixture(t, clusterid.ProductGKE)
 


### PR DESCRIPTION
## Problem

Fixes #6634.

Under concurrent rebuilds of a shared base image, a child image can be built
against a **stale parent base image** and never self-correct. The parent
deployment runs the latest base, but a child keeps an older base baked into its
`FROM`, so files inherited from the base diverge across images. The larger the
project and the more image relations there are, the easier it is to trigger.

## Root Cause

A child image resolves its base (`FROM`) tag from the base `ImageMap`. That tag
is published over two channels with different timing:

- the engine's build result — written **synchronously** when the build completes;
- the apiserver `ImageMap.Status` — flushed **asynchronously** by the
  dockerimage/cmdimage reconcilers.

In `internal/engine/buildcontrol/image_build_and_deployer.go`, `BuildAndDeploy`
builds its `imageMapSet` from the apiserver (`ctrlClient.Get`) for *every* image
target, including ones that are **reused** (not rebuilt) in this pass. Tilt
de-dups redundant base rebuilds across manifests that share a base image, so when
a base is rebuilt in one manifest and reused in another, the second manifest's
child reads its `FROM` from the apiserver `ImageMap` — which can still lag the
propagated result. The engine already considers the child up-to-date, so nothing
re-triggers it and the stale tag becomes permanent.

(Within a single manifest this can't happen: `UpdateImageMap` mutates the shared
`imageMapSet` in place and `RunBuilds` is topologically ordered, so a child
always sees its freshly-built base. The bug is specific to the cross-manifest
reuse path.)

## Solution

When seeding `imageMapSet`, for an image that is reused in this pass, take its
status from the authoritative build result the engine already computed
(`TargetQueue.ReusedResults()`) instead of the asynchronously-flushed apiserver
`ImageMap.Status`. Rebuilt targets are still overwritten by `UpdateImageMap` as
before.

## Changes

- `internal/engine/buildcontrol/image_build_and_deployer.go`: prefer the reused
  build result's status over the apiserver `ImageMap` status when building
  `imageMapSet`.
- `internal/engine/buildcontrol/image_build_and_deployer_test.go`: add
  `TestMultiStageDockerBuildReusedBaseWithStaleImageMap`.

## Testing

- New test reproduces the bug: a base image is reused while the apiserver
  `ImageMap` status is deliberately stale, and the child must be built `FROM` the
  latest base tag. It **fails without the fix** (child built `FROM …:tilt-stale`)
  and passes with it.
- Existing cross-manifest / base-image tests still pass, including
  `TestManifestsWithCommonAncestorAndTrigger`,
  `TestManifestsWithTwoCommonAncestors`, `TestTwoK8sTargetsWithBaseImage*` and
  the multi-stage build tests — dedup and trigger-spillover behavior unchanged.
- No change to the propagation guards in `buildcontrols/reducers.go`, so the
  infinite-build behavior referenced by #3542 is unaffected.