### PR TITLE
fix: search bar target url

### DIFF
--- a/web/src/HelpSearchBar.tsx
+++ b/web/src/HelpSearchBar.tsx
@@ -17,7 +17,7 @@ import {
 } from "./style-helpers"
 
 export function searchDocs(query: string) {
-  const docsSearchUrl = new URL("https://docs.tilt.dev/search")
+  const docsSearchUrl = new URL("https://docs.tilt.dev/search.html")
   docsSearchUrl.searchParams.set("q", query)
   docsSearchUrl.searchParams.set("utm_source", "tiltui")
   window.open(docsSearchUrl)


### PR DESCRIPTION
When using the "Search Tilt docs..." search bar in the Tilt UI, the target URL was incorrect. It navigates users to <https://docs.tilt.dev/search?q=search&utm_source=tiltui> instead of <https://docs.tilt.dev/search.html?q=search&utm_source=tiltui>. Notice that ".html" is missing on the first link.


