### PR TITLE
k8s: fix port-forward wedges when the pod connection or API server hangs

### DIFF
--- a/internal/k8s/portforward/portforward.go
+++ b/internal/k8s/portforward/portforward.go
@@ -26,6 +26,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/httpstream"
@@ -44,6 +45,11 @@ var (
 	networkClosedError = "use of closed network connection"
 )
 
+const (
+	defaultDialTimeout     = 30 * time.Second
+	streamConnCloseTimeout = 5 * time.Second
+)
+
 // PortForwarder knows how to listen for local connections and forward them to
 // a remote pod via an upgraded HTTP request.
 type PortForwarder struct {
@@ -51,10 +57,15 @@ type PortForwarder struct {
 	ports     []ForwardedPort
 	stopChan  <-chan struct{}
 
-	dialer        httpstream.Dialer
-	streamConn    httpstream.Connection
-	errorHandler  *errorHandler
+	dialer       httpstream.Dialer
+	dialTimeout  time.Duration
+	streamConn   httpstream.Connection
+	errorHandler *errorHandler
+
+	// listenersLock guards listeners.
+	listenersLock sync.Mutex
 	listeners     []io.Closer
+
 	Ready         chan struct{}
 	requestIDLock sync.Mutex
 	requestID     int
@@ -181,13 +192,14 @@ func NewOnAddresses(dialer httpstream.Dialer, addresses []string, ports []string
 		return nil, err
 	}
 	return &PortForwarder{
-		dialer:    dialer,
-		addresses: parsedAddresses,
-		ports:     parsedPorts,
-		stopChan:  stopChan,
-		Ready:     readyChan,
-		out:       out,
-		errOut:    errOut,
+		dialer:      dialer,
+		dialTimeout: defaultDialTimeout,
+		addresses:   parsedAddresses,
+		ports:       parsedPorts,
+		stopChan:    stopChan,
+		Ready:       readyChan,
+		out:         out,
+		errOut:      errOut,
 	}, nil
 }
 
@@ -202,20 +214,81 @@ func (pf *PortForwarder) Addresses() []string {
 // ForwardPorts formats and executes a port forwarding request. The connection will remain
 // open until stopChan is closed.
 func (pf *PortForwarder) ForwardPorts() error {
-	defer pf.Close()
-
-	var err error
-	var protocol string
-	pf.streamConn, protocol, err = pf.dialer.Dial(PortForwardProtocolV1Name)
+	streamConn, err := pf.dial()
 	if err != nil {
-		return fmt.Errorf("error upgrading connection: %s", err)
+		return err
 	}
-	defer pf.streamConn.Close()
-	if protocol != PortForwardProtocolV1Name {
-		return fmt.Errorf("unable to negotiate protocol: client supports %q, server returned %q", PortForwardProtocolV1Name, protocol)
-	}
+	pf.streamConn = streamConn
+	defer func() {
+		// Release the local ports before touching the stream connection:
+		// closing it can stall on a dead peer (see closeStreamConn), and a
+		// stalled teardown must not keep the ports bound.
+		pf.Close()
+		pf.closeStreamConn()
+	}()
 
 	return pf.forward()
+}
+
+// dial upgrades a connection to the pod, giving up after dialTimeout or when
+// stopChan is closed. The dialer itself has no deadline, so an unresponsive
+// API server would otherwise block the forwarder — and the reconciler's retry
+// loop above it — indefinitely.
+func (pf *PortForwarder) dial() (httpstream.Connection, error) {
+	type dialResult struct {
+		conn     httpstream.Connection
+		protocol string
+		err      error
+	}
+	resultCh := make(chan dialResult, 1)
+	go func() {
+		conn, protocol, err := pf.dialer.Dial(PortForwardProtocolV1Name)
+		resultCh <- dialResult{conn: conn, protocol: protocol, err: err}
+	}()
+
+	abandon := func() {
+		go func() {
+			if res := <-resultCh; res.conn != nil {
+				res.conn.Close()
+			}
+		}()
+	}
+
+	select {
+	case res := <-resultCh:
+		if res.err != nil {
+			return nil, fmt.Errorf("error upgrading connection: %s", res.err)
+		}
+		if res.protocol != PortForwardProtocolV1Name {
+			res.conn.Close()
+			return nil, fmt.Errorf("unable to negotiate protocol: client supports %q, server returned %q", PortForwardProtocolV1Name, res.protocol)
+		}
+		return res.conn, nil
+	case <-pf.stopChan:
+		abandon()
+		return nil, errors.New("error upgrading connection: stop requested while dialing")
+	case <-time.After(pf.dialTimeout):
+		abandon()
+		return nil, fmt.Errorf("error upgrading connection: timed out dialing after %s", pf.dialTimeout)
+	}
+}
+
+// closeStreamConn closes the stream connection, giving up after
+// streamConnCloseTimeout: spdystream's Close writes a GOAWAY frame with no
+// deadline, so closing a half-open connection with a saturated send buffer
+// blocks forever. The abandoned close goroutine is harmless — the connection
+// it holds is already dead.
+func (pf *PortForwarder) closeStreamConn() {
+	done := make(chan struct{})
+	go func() {
+		_ = pf.streamConn.Close()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(streamConnCloseTimeout):
+		_, _ = fmt.Fprintf(pf.out, "timed out closing connection to pod (dead peer?); abandoning it")
+	}
 }
 
 // forward dials the remote host specific in req, upgrades the request, starts
@@ -283,7 +356,9 @@ func (pf *PortForwarder) listenOnPortAndAddress(port *ForwardedPort, protocol st
 	if err != nil {
 		return err
 	}
+	pf.listenersLock.Lock()
 	pf.listeners = append(pf.listeners, listener)
+	pf.listenersLock.Unlock()
 	go pf.waitForConnection(listener, *port)
 	return nil
 }
@@ -428,14 +503,18 @@ func (pf *PortForwarder) handleConnection(conn net.Conn, port ForwardedPort) {
 	}
 }
 
-// Close stops all listeners of PortForwarder.
+// Close stops all listeners of PortForwarder. It is idempotent.
 func (pf *PortForwarder) Close() {
+	pf.listenersLock.Lock()
+	defer pf.listenersLock.Unlock()
+
 	// stop all listeners
 	for _, l := range pf.listeners {
 		if err := l.Close(); err != nil {
 			_, _ = fmt.Fprintf(pf.out, "error closing listener: %v", err)
 		}
 	}
+	pf.listeners = nil
 }
 
 // GetPorts will return the ports that were forwarded; this can be used to

--- a/internal/k8s/portforward/portforward_test.go
+++ b/internal/k8s/portforward/portforward_test.go
@@ -627,3 +627,130 @@ func TestForwardPortsReturnsNilWhenStopChanIsClosed(t *testing.T) {
 		t.Fatalf("unexpected error from pf.ForwardPorts(): %s", err)
 	}
 }
+
+// blockingCloseConnection simulates spdystream's Close on a half-open
+// connection with a saturated send buffer: the GOAWAY frame write never
+// returns.
+type blockingCloseConnection struct {
+	*fakeConnection
+	block chan struct{}
+}
+
+func (c *blockingCloseConnection) Close() error {
+	<-c.block
+	return c.fakeConnection.Close()
+}
+
+// blockingDialer simulates dialing an API server that accepts TCP but never
+// completes the upgrade.
+type blockingDialer struct {
+	block chan struct{}
+}
+
+func (d *blockingDialer) Dial(protocols ...string) (httpstream.Connection, string, error) {
+	<-d.block
+	return nil, "", fmt.Errorf("dialer unblocked")
+}
+
+func TestForwardPortsReleasesListenersWhenStreamConnCloseHangs(t *testing.T) {
+	conn := &blockingCloseConnection{
+		fakeConnection: newFakeConnection(),
+		block:          make(chan struct{}),
+	}
+	defer close(conn.block)
+	dialer := &fakeDialer{
+		conn:               conn,
+		negotiatedProtocol: PortForwardProtocolV1Name,
+	}
+
+	stopChan := make(chan struct{})
+	readyChan := make(chan struct{})
+	errChan := make(chan error)
+
+	pf, err := New(dialer, []string{":5000"}, stopChan, readyChan, os.Stdout, os.Stderr)
+	if err != nil {
+		t.Fatalf("failed to create new PortForwarder: %s", err)
+	}
+
+	go func() {
+		errChan <- pf.ForwardPorts()
+	}()
+
+	<-pf.Ready
+
+	ports, err := pf.GetPorts()
+	if err != nil {
+		t.Fatalf("failed to get ports: %s", err)
+	}
+	localPort := ports[0].Local
+
+	close(stopChan)
+
+	// The port must be released even while the stream connection's Close is
+	// still hung, or a successor forward would fail with EADDRINUSE.
+	addr := fmt.Sprintf("127.0.0.1:%d", localPort)
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		l, err := net.Listen("tcp4", addr)
+		if err == nil {
+			_ = l.Close()
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("port %d still bound while streamConn.Close is hung: %s", localPort, err)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func TestForwardPortsTimesOutWhenDialHangs(t *testing.T) {
+	dialer := &blockingDialer{block: make(chan struct{})}
+	defer close(dialer.block)
+
+	stopChan := make(chan struct{})
+	readyChan := make(chan struct{})
+
+	pf, err := New(dialer, []string{":5000"}, stopChan, readyChan, os.Stdout, os.Stderr)
+	if err != nil {
+		t.Fatalf("failed to create new PortForwarder: %s", err)
+	}
+	pf.dialTimeout = 20 * time.Millisecond
+
+	err = pf.ForwardPorts()
+	if err == nil {
+		t.Fatalf("unexpected non-error from pf.ForwardPorts()")
+	} else if !strings.Contains(err.Error(), "timed out dialing") {
+		t.Fatalf("unexpected error from pf.ForwardPorts(): %s", err)
+	}
+}
+
+func TestForwardPortsAbortsDialWhenStopChanIsClosed(t *testing.T) {
+	dialer := &blockingDialer{block: make(chan struct{})}
+	defer close(dialer.block)
+
+	stopChan := make(chan struct{})
+	readyChan := make(chan struct{})
+	errChan := make(chan error)
+
+	pf, err := New(dialer, []string{":5000"}, stopChan, readyChan, os.Stdout, os.Stderr)
+	if err != nil {
+		t.Fatalf("failed to create new PortForwarder: %s", err)
+	}
+
+	go func() {
+		errChan <- pf.ForwardPorts()
+	}()
+
+	close(stopChan)
+
+	select {
+	case err = <-errChan:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("pf.ForwardPorts() did not return after stopChan was closed mid-dial")
+	}
+	if err == nil {
+		t.Fatalf("unexpected non-error from pf.ForwardPorts()")
+	} else if !strings.Contains(err.Error(), "stop requested") {
+		t.Fatalf("unexpected error from pf.ForwardPorts(): %s", err)
+	}
+}


### PR DESCRIPTION
## Problem

Two failure modes leave a PortForward permanently broken while its resource stays green in the Tilt UI, and both survive the reconciler's infinite retry loop (added for #4801):

**1. A hung `streamConn.Close()` leaks the local port forever.**

`ForwardPorts` defers `pf.streamConn.Close()` *after* `pf.Close()` (LIFO: the stream conn closes first, listeners last). spdystream's `Connection.Close()` synchronously writes a GOAWAY frame with no write deadline ([connection.go#L785](https://github.com/moby/spdystream/blob/v0.5.0/connection.go#L785)). On a half-open connection whose kernel send buffer is already saturated — the peer died mid-traffic — that write never returns, so the listeners are never closed:

- the local port stays bound with nobody accepting (connects hang on SYN until timeout), and
- when the pod is recreated, the successor PortForward fails every retry with `bind: address already in use` — we observed one stuck like this for **5 hours**, while `tilt get uiresources` showed the resource healthy. Only restarting Tilt cleared it.

**2. The dial has no deadline.**

`pf.dialer.Dial(...)` performs the SPDY/websocket upgrade with no timeout anywhere in the chain (the `http.Client` built in `ProvidePortForwardClient` has no `Timeout`). Against an API server that accepts TCP but never answers — overloaded, or its VM is unhealthy — `Dial` blocks forever. The reconciler's retry loop is wedged *inside* `onePortForward`, so the forward never recovers **even after the API server does**. Observed as a forward stuck on `lost connection to pod` (status never updated again) after an API-server brownout.

Both were hit in the wild against a kind cluster whose API server degraded under host disk pressure; the diagnosis above is from reading the wedged state live (`tilt get portforwards` error statuses, SYN-timeout behavior on the leaked port, nothing else bound to the port).

## Fix

- `ForwardPorts` now releases the local listeners **before** touching the stream connection, and bounds the stream-conn close with a 5s timeout (`closeStreamConn`). A wedged close abandons the already-dead connection instead of holding the port and the retry loop hostage.
- `Close()` takes a mutex and is idempotent; listener registration locks the same mutex.
- Dialing moved to `dial()`: runs the dialer in a goroutine, gives up after 30s or when `stopChan` closes, and reaps a late-arriving connection.

## Tests

- `TestForwardPortsReleasesListenersWhenStreamConnCloseHangs` — stream conn whose `Close` blocks forever; asserts the local port becomes bindable after stop anyway (fails on master).
- `TestForwardPortsTimesOutWhenDialHangs` — dialer that never returns; `ForwardPorts` errors with a timeout (hangs forever on master).
- `TestForwardPortsAbortsDialWhenStopChanIsClosed` — stop mid-dial returns promptly (hangs forever on master).

`go test ./internal/k8s/... ./internal/controllers/core/portforward/ -race` passes.

Related: #4801 (same symptom family; its `tilt delete portforwards` workaround is what we'd been running as an external watchdog), #4816.