### PR TITLE
Add disable-port-forwards flag

### DIFF
--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -50,6 +50,7 @@ var starterTiltfile []byte
 type upCmd struct {
 	fileName             string
 	outputSnapshotOnExit string
+	disablePortForwards  bool
 
 	legacy bool
 	stream bool
@@ -86,6 +87,8 @@ local resources--i.e. those using serve_cmd--are terminated when you exit Tilt.
 		fmt.Sprintf("Control the strategy Tilt uses for updating instances. Possible values: %v", liveupdates.AllUpdateModes))
 	cmd.Flags().BoolVar(&c.legacy, "legacy", false, "If true, tilt will open in legacy terminal mode.")
 	cmd.Flags().BoolVar(&c.stream, "stream", false, "If true, tilt will stream logs in the terminal.")
+	cmd.Flags().BoolVar(&c.disablePortForwards, "disable-port-forwards", false,
+		"Disable all Kubernetes port-forwards to the local machine.")
 	cmd.Flags().BoolVar(&logActionsFlag, "logactions", false, "log all actions and state changes")
 	addStartServerFlags(cmd)
 	addDevServerFlags(cmd)
@@ -128,8 +131,9 @@ func (c *upCmd) run(ctx context.Context, args []string) error {
 	termMode := c.initialTermMode(isTTY)
 
 	cmdUpTags := engineanalytics.CmdTags(map[string]string{
-		"update_mode": updateModeFlag, // before 7/8/20 this was just called "mode"
-		"term_mode":   strconv.Itoa(int(termMode)),
+		"update_mode":           updateModeFlag, // before 7/8/20 this was just called "mode"
+		"term_mode":             strconv.Itoa(int(termMode)),
+		"disable_port_forwards": strconv.FormatBool(c.disablePortForwards),
 	})
 
 	generateTiltfileResult, err := maybeGenerateTiltfile(c.fileName)
@@ -155,7 +159,7 @@ func (c *upCmd) run(ctx context.Context, args []string) error {
 		log.Printf("Tilt analytics disabled: %s", reason)
 	}
 
-	cmdUpDeps, err := wireCmdUp(ctx, a, cmdUpTags, "up")
+	cmdUpDeps, err := wireCmdUp(ctx, a, cmdUpTags, "up", c.disablePortForwards)
 	if err != nil {
 		deferred.SetOutput(deferred.Original())
 		return err

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -18,6 +18,7 @@ import (
 	"github.com/tilt-dev/tilt/internal/controllers"
 	engineanalytics "github.com/tilt-dev/tilt/internal/engine/analytics"
 	"github.com/tilt-dev/tilt/internal/hud/prompt"
+	"github.com/tilt-dev/tilt/internal/k8s"
 	"github.com/tilt-dev/tilt/internal/store"
 	"github.com/tilt-dev/tilt/internal/store/liveupdates"
 	"github.com/tilt-dev/tilt/pkg/assets"
@@ -159,7 +160,7 @@ func (c *upCmd) run(ctx context.Context, args []string) error {
 		log.Printf("Tilt analytics disabled: %s", reason)
 	}
 
-	cmdUpDeps, err := wireCmdUp(ctx, a, cmdUpTags, "up", c.disablePortForwards)
+	cmdUpDeps, err := wireCmdUp(ctx, a, cmdUpTags, "up", k8s.DisablePortForwardsFlag(c.disablePortForwards))
 	if err != nil {
 		deferred.SetOutput(deferred.Original())
 		return err

--- a/internal/cli/wire.go
+++ b/internal/cli/wire.go
@@ -185,7 +185,8 @@ func wireDockerPrune(ctx context.Context, analytics *analytics.TiltAnalytics, su
 	return dpDeps{}, nil
 }
 
-func wireCmdUp(ctx context.Context, analytics *analytics.TiltAnalytics, cmdTags engineanalytics.CmdTags, subcommand model.TiltSubcommand) (CmdUpDeps, error) {
+func wireCmdUp(ctx context.Context, analytics *analytics.TiltAnalytics, cmdTags engineanalytics.CmdTags, subcommand model.TiltSubcommand,
+	disablePortForwards bool) (CmdUpDeps, error) {
 	wire.Build(UpWireSet,
 		cloud.NewSnapshotter,
 		wire.Value(store.EngineModeUp),
@@ -206,6 +207,7 @@ func wireCmdCI(ctx context.Context, analytics *analytics.TiltAnalytics, subcomma
 	wire.Build(UpWireSet,
 		cloud.NewSnapshotter,
 		wire.Value(store.EngineModeCI),
+		wire.Value(false),
 		wire.Value(engineanalytics.CmdTags(map[string]string{})),
 		wire.Struct(new(CmdCIDeps), "*"),
 	)
@@ -230,6 +232,7 @@ func wireCmdUpdog(ctx context.Context,
 		provideUpdogSubscriber,
 		provideUpdogCmdSubscribers,
 		wire.Value(store.EngineModeCI),
+		wire.Value(false),
 		wire.Struct(new(CmdUpdogDeps), "*"))
 	return CmdUpdogDeps{}, nil
 }

--- a/internal/cli/wire.go
+++ b/internal/cli/wire.go
@@ -186,7 +186,7 @@ func wireDockerPrune(ctx context.Context, analytics *analytics.TiltAnalytics, su
 }
 
 func wireCmdUp(ctx context.Context, analytics *analytics.TiltAnalytics, cmdTags engineanalytics.CmdTags, subcommand model.TiltSubcommand,
-	disablePortForwards bool) (CmdUpDeps, error) {
+	disablePortForwards k8s.DisablePortForwardsFlag) (CmdUpDeps, error) {
 	wire.Build(UpWireSet,
 		cloud.NewSnapshotter,
 		wire.Value(store.EngineModeUp),
@@ -207,7 +207,7 @@ func wireCmdCI(ctx context.Context, analytics *analytics.TiltAnalytics, subcomma
 	wire.Build(UpWireSet,
 		cloud.NewSnapshotter,
 		wire.Value(store.EngineModeCI),
-		wire.Value(false),
+		wire.Value(k8s.DisablePortForwardsFlag(false)),
 		wire.Value(engineanalytics.CmdTags(map[string]string{})),
 		wire.Struct(new(CmdCIDeps), "*"),
 	)
@@ -232,7 +232,7 @@ func wireCmdUpdog(ctx context.Context,
 		provideUpdogSubscriber,
 		provideUpdogCmdSubscribers,
 		wire.Value(store.EngineModeCI),
-		wire.Value(false),
+		wire.Value(k8s.DisablePortForwardsFlag(false)),
 		wire.Struct(new(CmdUpdogDeps), "*"))
 	return CmdUpdogDeps{}, nil
 }

--- a/internal/cli/wire_gen.go
+++ b/internal/cli/wire_gen.go
@@ -208,7 +208,7 @@ func wireDockerPrune(ctx context.Context, analytics2 *analytics.TiltAnalytics, s
 	return cliDpDeps, nil
 }
 
-func wireCmdUp(ctx context.Context, analytics3 *analytics.TiltAnalytics, cmdTags analytics2.CmdTags, subcommand model.TiltSubcommand) (CmdUpDeps, error) {
+func wireCmdUp(ctx context.Context, analytics3 *analytics.TiltAnalytics, cmdTags analytics2.CmdTags, subcommand model.TiltSubcommand, disablePortForwards bool) (CmdUpDeps, error) {
 	reducer := _wireReducerValue
 	storeLogActionsFlag := provideLogActions()
 	storeStore := store.NewStore(reducer, storeLogActionsFlag)
@@ -303,7 +303,7 @@ func wireCmdUp(ctx context.Context, analytics3 *analytics.TiltAnalytics, cmdTags
 	uisessionReconciler := uisession.NewReconciler(deferredClient, websocketList)
 	uiresourceReconciler := uiresource.NewReconciler(deferredClient, websocketList, storeStore)
 	uibuttonReconciler := uibutton.NewReconciler(deferredClient, websocketList, storeStore)
-	portforwardReconciler := portforward.NewReconciler(deferredClient, scheme, storeStore, connectionManager)
+	portforwardReconciler := portforward.NewReconciler(deferredClient, scheme, storeStore, connectionManager, disablePortForwards)
 	plugin := k8scontext.NewPlugin(kubeContext, namespace, product)
 	versionPlugin := version.NewPlugin(tiltBuild)
 	configPlugin := config.NewPlugin(subcommand)
@@ -328,7 +328,7 @@ func wireCmdUp(ctx context.Context, analytics3 *analytics.TiltAnalytics, cmdTags
 	}
 	compositeClient := docker.ProvideSwitchCli(clusterClient, localClient)
 	engineMode := _wireEngineModeValue
-	tiltfileReconciler := tiltfile2.NewReconciler(storeStore, tiltfileLoader, compositeClient, deferredClient, scheme, engineMode, k8sKubeContextOverride, k8sNamespaceOverride, ciTimeoutFlag)
+	tiltfileReconciler := tiltfile2.NewReconciler(storeStore, tiltfileLoader, compositeClient, deferredClient, scheme, engineMode, k8sKubeContextOverride, k8sNamespaceOverride, ciTimeoutFlag, disablePortForwards)
 	togglebuttonReconciler := togglebutton.NewReconciler(deferredClient, scheme)
 	dockerUpdater := containerupdate.NewDockerUpdater(compositeClient)
 	execUpdater := containerupdate.NewExecUpdater(k8sClient)
@@ -528,7 +528,8 @@ func wireCmdCI(ctx context.Context, analytics3 *analytics.TiltAnalytics, subcomm
 	uisessionReconciler := uisession.NewReconciler(deferredClient, websocketList)
 	uiresourceReconciler := uiresource.NewReconciler(deferredClient, websocketList, storeStore)
 	uibuttonReconciler := uibutton.NewReconciler(deferredClient, websocketList, storeStore)
-	portforwardReconciler := portforward.NewReconciler(deferredClient, scheme, storeStore, connectionManager)
+	bool2 := _wireBoolValue
+	portforwardReconciler := portforward.NewReconciler(deferredClient, scheme, storeStore, connectionManager, bool2)
 	plugin := k8scontext.NewPlugin(kubeContext, namespace, product)
 	versionPlugin := version.NewPlugin(tiltBuild)
 	configPlugin := config.NewPlugin(subcommand)
@@ -553,7 +554,7 @@ func wireCmdCI(ctx context.Context, analytics3 *analytics.TiltAnalytics, subcomm
 	}
 	compositeClient := docker.ProvideSwitchCli(clusterClient, localClient)
 	engineMode := _wireStoreEngineModeValue
-	tiltfileReconciler := tiltfile2.NewReconciler(storeStore, tiltfileLoader, compositeClient, deferredClient, scheme, engineMode, k8sKubeContextOverride, k8sNamespaceOverride, ciTimeoutFlag)
+	tiltfileReconciler := tiltfile2.NewReconciler(storeStore, tiltfileLoader, compositeClient, deferredClient, scheme, engineMode, k8sKubeContextOverride, k8sNamespaceOverride, ciTimeoutFlag, bool2)
 	togglebuttonReconciler := togglebutton.NewReconciler(deferredClient, scheme)
 	dockerUpdater := containerupdate.NewDockerUpdater(compositeClient)
 	execUpdater := containerupdate.NewExecUpdater(k8sClient)
@@ -650,6 +651,7 @@ func wireCmdCI(ctx context.Context, analytics3 *analytics.TiltAnalytics, subcomm
 }
 
 var (
+	_wireBoolValue            = false
 	_wireStoreEngineModeValue = store.EngineModeCI
 	_wireCmdTagsValue         = analytics2.CmdTags(map[string]string{})
 )
@@ -749,7 +751,8 @@ func wireCmdUpdog(ctx context.Context, analytics3 *analytics.TiltAnalytics, cmdT
 	uisessionReconciler := uisession.NewReconciler(deferredClient, websocketList)
 	uiresourceReconciler := uiresource.NewReconciler(deferredClient, websocketList, storeStore)
 	uibuttonReconciler := uibutton.NewReconciler(deferredClient, websocketList, storeStore)
-	portforwardReconciler := portforward.NewReconciler(deferredClient, scheme, storeStore, connectionManager)
+	bool2 := _wireBoolValue2
+	portforwardReconciler := portforward.NewReconciler(deferredClient, scheme, storeStore, connectionManager, bool2)
 	plugin := k8scontext.NewPlugin(kubeContext, namespace, product)
 	versionPlugin := version.NewPlugin(tiltBuild)
 	configPlugin := config.NewPlugin(subcommand)
@@ -774,7 +777,7 @@ func wireCmdUpdog(ctx context.Context, analytics3 *analytics.TiltAnalytics, cmdT
 	}
 	compositeClient := docker.ProvideSwitchCli(clusterClient, localClient)
 	engineMode := _wireEngineModeValue2
-	tiltfileReconciler := tiltfile2.NewReconciler(storeStore, tiltfileLoader, compositeClient, deferredClient, scheme, engineMode, k8sKubeContextOverride, k8sNamespaceOverride, ciTimeoutFlag)
+	tiltfileReconciler := tiltfile2.NewReconciler(storeStore, tiltfileLoader, compositeClient, deferredClient, scheme, engineMode, k8sKubeContextOverride, k8sNamespaceOverride, ciTimeoutFlag, bool2)
 	togglebuttonReconciler := togglebutton.NewReconciler(deferredClient, scheme)
 	dockerUpdater := containerupdate.NewDockerUpdater(compositeClient)
 	execUpdater := containerupdate.NewExecUpdater(k8sClient)
@@ -841,6 +844,7 @@ func wireCmdUpdog(ctx context.Context, analytics3 *analytics.TiltAnalytics, cmdT
 }
 
 var (
+	_wireBoolValue2       = false
 	_wireEngineModeValue2 = store.EngineModeCI
 )
 

--- a/internal/cli/wire_gen.go
+++ b/internal/cli/wire_gen.go
@@ -208,7 +208,7 @@ func wireDockerPrune(ctx context.Context, analytics2 *analytics.TiltAnalytics, s
 	return cliDpDeps, nil
 }
 
-func wireCmdUp(ctx context.Context, analytics3 *analytics.TiltAnalytics, cmdTags analytics2.CmdTags, subcommand model.TiltSubcommand, disablePortForwards bool) (CmdUpDeps, error) {
+func wireCmdUp(ctx context.Context, analytics3 *analytics.TiltAnalytics, cmdTags analytics2.CmdTags, subcommand model.TiltSubcommand, disablePortForwards k8s.DisablePortForwardsFlag) (CmdUpDeps, error) {
 	reducer := _wireReducerValue
 	storeLogActionsFlag := provideLogActions()
 	storeStore := store.NewStore(reducer, storeLogActionsFlag)
@@ -528,8 +528,8 @@ func wireCmdCI(ctx context.Context, analytics3 *analytics.TiltAnalytics, subcomm
 	uisessionReconciler := uisession.NewReconciler(deferredClient, websocketList)
 	uiresourceReconciler := uiresource.NewReconciler(deferredClient, websocketList, storeStore)
 	uibuttonReconciler := uibutton.NewReconciler(deferredClient, websocketList, storeStore)
-	bool2 := _wireBoolValue
-	portforwardReconciler := portforward.NewReconciler(deferredClient, scheme, storeStore, connectionManager, bool2)
+	disablePortForwardsFlag := _wireDisablePortForwardsFlagValue
+	portforwardReconciler := portforward.NewReconciler(deferredClient, scheme, storeStore, connectionManager, disablePortForwardsFlag)
 	plugin := k8scontext.NewPlugin(kubeContext, namespace, product)
 	versionPlugin := version.NewPlugin(tiltBuild)
 	configPlugin := config.NewPlugin(subcommand)
@@ -554,7 +554,7 @@ func wireCmdCI(ctx context.Context, analytics3 *analytics.TiltAnalytics, subcomm
 	}
 	compositeClient := docker.ProvideSwitchCli(clusterClient, localClient)
 	engineMode := _wireStoreEngineModeValue
-	tiltfileReconciler := tiltfile2.NewReconciler(storeStore, tiltfileLoader, compositeClient, deferredClient, scheme, engineMode, k8sKubeContextOverride, k8sNamespaceOverride, ciTimeoutFlag, bool2)
+	tiltfileReconciler := tiltfile2.NewReconciler(storeStore, tiltfileLoader, compositeClient, deferredClient, scheme, engineMode, k8sKubeContextOverride, k8sNamespaceOverride, ciTimeoutFlag, disablePortForwardsFlag)
 	togglebuttonReconciler := togglebutton.NewReconciler(deferredClient, scheme)
 	dockerUpdater := containerupdate.NewDockerUpdater(compositeClient)
 	execUpdater := containerupdate.NewExecUpdater(k8sClient)
@@ -651,9 +651,9 @@ func wireCmdCI(ctx context.Context, analytics3 *analytics.TiltAnalytics, subcomm
 }
 
 var (
-	_wireBoolValue            = false
-	_wireStoreEngineModeValue = store.EngineModeCI
-	_wireCmdTagsValue         = analytics2.CmdTags(map[string]string{})
+	_wireDisablePortForwardsFlagValue = k8s.DisablePortForwardsFlag(false)
+	_wireStoreEngineModeValue         = store.EngineModeCI
+	_wireCmdTagsValue                 = analytics2.CmdTags(map[string]string{})
 )
 
 func wireCmdUpdog(ctx context.Context, analytics3 *analytics.TiltAnalytics, cmdTags analytics2.CmdTags, subcommand model.TiltSubcommand, objects []client2.Object) (CmdUpdogDeps, error) {
@@ -751,8 +751,8 @@ func wireCmdUpdog(ctx context.Context, analytics3 *analytics.TiltAnalytics, cmdT
 	uisessionReconciler := uisession.NewReconciler(deferredClient, websocketList)
 	uiresourceReconciler := uiresource.NewReconciler(deferredClient, websocketList, storeStore)
 	uibuttonReconciler := uibutton.NewReconciler(deferredClient, websocketList, storeStore)
-	bool2 := _wireBoolValue2
-	portforwardReconciler := portforward.NewReconciler(deferredClient, scheme, storeStore, connectionManager, bool2)
+	disablePortForwardsFlag := _wireK8sDisablePortForwardsFlagValue
+	portforwardReconciler := portforward.NewReconciler(deferredClient, scheme, storeStore, connectionManager, disablePortForwardsFlag)
 	plugin := k8scontext.NewPlugin(kubeContext, namespace, product)
 	versionPlugin := version.NewPlugin(tiltBuild)
 	configPlugin := config.NewPlugin(subcommand)
@@ -777,7 +777,7 @@ func wireCmdUpdog(ctx context.Context, analytics3 *analytics.TiltAnalytics, cmdT
 	}
 	compositeClient := docker.ProvideSwitchCli(clusterClient, localClient)
 	engineMode := _wireEngineModeValue2
-	tiltfileReconciler := tiltfile2.NewReconciler(storeStore, tiltfileLoader, compositeClient, deferredClient, scheme, engineMode, k8sKubeContextOverride, k8sNamespaceOverride, ciTimeoutFlag, bool2)
+	tiltfileReconciler := tiltfile2.NewReconciler(storeStore, tiltfileLoader, compositeClient, deferredClient, scheme, engineMode, k8sKubeContextOverride, k8sNamespaceOverride, ciTimeoutFlag, disablePortForwardsFlag)
 	togglebuttonReconciler := togglebutton.NewReconciler(deferredClient, scheme)
 	dockerUpdater := containerupdate.NewDockerUpdater(compositeClient)
 	execUpdater := containerupdate.NewExecUpdater(k8sClient)
@@ -844,8 +844,8 @@ func wireCmdUpdog(ctx context.Context, analytics3 *analytics.TiltAnalytics, cmdT
 }
 
 var (
-	_wireBoolValue2       = false
-	_wireEngineModeValue2 = store.EngineModeCI
+	_wireK8sDisablePortForwardsFlagValue = k8s.DisablePortForwardsFlag(false)
+	_wireEngineModeValue2                = store.EngineModeCI
 )
 
 func wireKubeContext(ctx context.Context) (k8s.KubeContext, error) {

--- a/internal/controllers/core/portforward/reconciler.go
+++ b/internal/controllers/core/portforward/reconciler.go
@@ -41,7 +41,7 @@ type Reconciler struct {
 	clients             *cluster.ClientManager
 	requeuer            *indexer.Requeuer
 	indexer             *indexer.Indexer
-	disablePortForwards bool
+	disablePortForwards k8s.DisablePortForwardsFlag
 
 	// map of PortForward object name --> running forward(s)
 	activeForwards map[types.NamespacedName]*portForwardEntry
@@ -55,7 +55,7 @@ func NewReconciler(
 	scheme *runtime.Scheme,
 	store store.RStore,
 	clients cluster.ClientProvider,
-	disablePortForwards bool,
+	disablePortForwards k8s.DisablePortForwardsFlag,
 ) *Reconciler {
 	return &Reconciler{
 		store:               store,

--- a/internal/controllers/core/portforward/reconciler.go
+++ b/internal/controllers/core/portforward/reconciler.go
@@ -36,11 +36,12 @@ import (
 var clusterGVK = v1alpha1.SchemeGroupVersion.WithKind("Cluster")
 
 type Reconciler struct {
-	store      store.RStore
-	ctrlClient ctrlclient.Client
-	clients    *cluster.ClientManager
-	requeuer   *indexer.Requeuer
-	indexer    *indexer.Indexer
+	store               store.RStore
+	ctrlClient          ctrlclient.Client
+	clients             *cluster.ClientManager
+	requeuer            *indexer.Requeuer
+	indexer             *indexer.Indexer
+	disablePortForwards bool
 
 	// map of PortForward object name --> running forward(s)
 	activeForwards map[types.NamespacedName]*portForwardEntry
@@ -54,14 +55,16 @@ func NewReconciler(
 	scheme *runtime.Scheme,
 	store store.RStore,
 	clients cluster.ClientProvider,
+	disablePortForwards bool,
 ) *Reconciler {
 	return &Reconciler{
-		store:          store,
-		ctrlClient:     ctrlClient,
-		clients:        cluster.NewClientManager(clients),
-		requeuer:       indexer.NewRequeuer(),
-		indexer:        indexer.NewIndexer(scheme, indexPortForward),
-		activeForwards: make(map[types.NamespacedName]*portForwardEntry),
+		store:               store,
+		ctrlClient:          ctrlClient,
+		clients:             cluster.NewClientManager(clients),
+		requeuer:            indexer.NewRequeuer(),
+		indexer:             indexer.NewIndexer(scheme, indexPortForward),
+		disablePortForwards: disablePortForwards,
+		activeForwards:      make(map[types.NamespacedName]*portForwardEntry),
 	}
 }
 
@@ -88,6 +91,11 @@ func (r *Reconciler) reconcile(ctx context.Context, name types.NamespacedName) e
 	r.indexer.OnReconcile(name, pf)
 	if apierrors.IsNotFound(err) || pf.ObjectMeta.DeletionTimestamp != nil {
 		// PortForward deleted in API server -- stop and remove it
+		r.stop(name)
+		return nil
+	}
+
+	if r.disablePortForwards {
 		r.stop(name)
 		return nil
 	}

--- a/internal/controllers/core/portforward/reconciler.go
+++ b/internal/controllers/core/portforward/reconciler.go
@@ -82,6 +82,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 }
 
 func (r *Reconciler) reconcile(ctx context.Context, name types.NamespacedName) error {
+	if r.disablePortForwards {
+		return nil
+	}
+
 	pf := &PortForward{}
 	err := r.ctrlClient.Get(ctx, name, pf)
 	if err != nil && !apierrors.IsNotFound(err) {
@@ -91,11 +95,6 @@ func (r *Reconciler) reconcile(ctx context.Context, name types.NamespacedName) e
 	r.indexer.OnReconcile(name, pf)
 	if apierrors.IsNotFound(err) || pf.ObjectMeta.DeletionTimestamp != nil {
 		// PortForward deleted in API server -- stop and remove it
-		r.stop(name)
-		return nil
-	}
-
-	if r.disablePortForwards {
 		r.stop(name)
 		return nil
 	}

--- a/internal/controllers/core/portforward/reconciler_test.go
+++ b/internal/controllers/core/portforward/reconciler_test.go
@@ -363,7 +363,7 @@ func newPFRFixture(t *testing.T) *pfrFixture {
 	return newPFRFixtureWithFlag(t, false)
 }
 
-func newPFRFixtureWithFlag(t *testing.T, disablePortForwards bool) *pfrFixture {
+func newPFRFixtureWithFlag(t *testing.T, disablePortForwards k8s.DisablePortForwardsFlag) *pfrFixture {
 	cfb := fake.NewControllerFixtureBuilder(t)
 	clients := cluster.NewFakeClientProvider(t, cfb.Client)
 	r := NewReconciler(cfb.Client, cfb.Scheme(), cfb.Store, clients, disablePortForwards)

--- a/internal/controllers/core/portforward/reconciler_test.go
+++ b/internal/controllers/core/portforward/reconciler_test.go
@@ -51,6 +51,17 @@ func TestCreatePortForward(t *testing.T) {
 	assert.Equal(t, 8080, kCli.LastForwardPortRemotePort())
 }
 
+func TestCreatePortForwardDisabled(t *testing.T) {
+	f := newPFRFixtureWithFlag(t, true)
+
+	pf := f.makeSimplePF(pfFooName, 8000, 8080)
+	f.Create(pf)
+	kCli := f.clients.MustK8sClient(clusterNN(pf))
+
+	require.Empty(t, f.r.activeForwards)
+	require.Zero(t, kCli.CreatePortForwardCallCount())
+}
+
 func TestDeletePortForward(t *testing.T) {
 	f := newPFRFixture(t)
 
@@ -349,9 +360,13 @@ type pfrFixture struct {
 }
 
 func newPFRFixture(t *testing.T) *pfrFixture {
+	return newPFRFixtureWithFlag(t, false)
+}
+
+func newPFRFixtureWithFlag(t *testing.T, disablePortForwards bool) *pfrFixture {
 	cfb := fake.NewControllerFixtureBuilder(t)
 	clients := cluster.NewFakeClientProvider(t, cfb.Client)
-	r := NewReconciler(cfb.Client, cfb.Scheme(), cfb.Store, clients)
+	r := NewReconciler(cfb.Client, cfb.Scheme(), cfb.Store, clients, disablePortForwards)
 
 	return &pfrFixture{
 		ControllerFixture: cfb.WithRequeuer(r.requeuer).Build(r),

--- a/internal/controllers/core/tiltfile/reconciler.go
+++ b/internal/controllers/core/tiltfile/reconciler.go
@@ -22,6 +22,7 @@ import (
 	"github.com/tilt-dev/tilt/internal/controllers/apicmp"
 	"github.com/tilt-dev/tilt/internal/controllers/apis/configmap"
 	"github.com/tilt-dev/tilt/internal/controllers/apis/trigger"
+	"github.com/tilt-dev/tilt/internal/controllers/apiset"
 	"github.com/tilt-dev/tilt/internal/controllers/indexer"
 	"github.com/tilt-dev/tilt/internal/docker"
 	"github.com/tilt-dev/tilt/internal/k8s"
@@ -50,6 +51,7 @@ type Reconciler struct {
 	engineMode           store.EngineMode
 	loadCount            int // used to differentiate spans
 	ciTimeoutFlag        model.CITimeoutFlag
+	disablePortForwards  bool
 
 	runs map[types.NamespacedName]*runStatus
 
@@ -89,6 +91,7 @@ func NewReconciler(
 	k8sContextOverride k8s.KubeContextOverride,
 	k8sNamespaceOverride k8s.NamespaceOverride,
 	ciTimeoutFlag model.CITimeoutFlag,
+	disablePortForwards bool,
 ) *Reconciler {
 	return &Reconciler{
 		st:                   st,
@@ -102,6 +105,7 @@ func NewReconciler(
 		k8sContextOverride:   k8sContextOverride,
 		k8sNamespaceOverride: k8sNamespaceOverride,
 		ciTimeoutFlag:        ciTimeoutFlag,
+		disablePortForwards:  disablePortForwards,
 	}
 }
 
@@ -362,6 +366,10 @@ func (r *Reconciler) handleLoaded(
 	tf *v1alpha1.Tiltfile,
 	entry *BuildEntry,
 	tlr *tiltfile.TiltfileLoadResult) error {
+	if r.disablePortForwards {
+		tlr = tiltfileResultWithoutPortForwards(tlr)
+	}
+
 	// TODO(nick): Rewrite to handle multiple tiltfiles.
 	changeEnabledResources := entry.ArgsChanged && tlr != nil && tlr.Error == nil
 	err := updateOwnedObjects(ctx, r.ctrlClient, nn, tf, tlr, changeEnabledResources, r.ciTimeoutFlag, r.engineMode,
@@ -406,6 +414,51 @@ func (r *Reconciler) handleLoaded(
 	r.requeuer.Add(nn)
 
 	return nil
+}
+
+// tiltfileResultWithoutPortForwards returns a copy with port-forward templates
+// removed from both high-level manifests and v1alpha1 API objects. Keeping the
+// original result intact ensures later Tiltfile reloads still receive the
+// unmodified previous result.
+func tiltfileResultWithoutPortForwards(tlr *tiltfile.TiltfileLoadResult) *tiltfile.TiltfileLoadResult {
+	if tlr == nil {
+		return nil
+	}
+
+	result := *tlr
+	result.Manifests = make([]model.Manifest, len(tlr.Manifests))
+	for i, manifest := range tlr.Manifests {
+		if manifest.IsK8s() {
+			target := manifest.K8sTarget()
+			target.PortForwardTemplateSpec = nil
+			manifest = manifest.WithDeployTarget(target)
+		}
+		result.Manifests[i] = manifest
+	}
+
+	if tlr.ObjectSet != nil {
+		result.ObjectSet = make(apiset.ObjectSet, len(tlr.ObjectSet))
+		for gvr, objectSet := range tlr.ObjectSet {
+			newObjectSet := make(apiset.TypedObjectSet, len(objectSet))
+			for name, object := range objectSet {
+				switch object := object.(type) {
+				case *v1alpha1.KubernetesApply:
+					copy := object.DeepCopy()
+					copy.Spec.PortForwardTemplateSpec = nil
+					newObjectSet[name] = copy
+				case *v1alpha1.KubernetesDiscovery:
+					copy := object.DeepCopy()
+					copy.Spec.PortForwardTemplateSpec = nil
+					newObjectSet[name] = copy
+				default:
+					newObjectSet[name] = object
+				}
+			}
+			result.ObjectSet[gvr] = newObjectSet
+		}
+	}
+
+	return &result
 }
 
 // Cancel execution of a running tiltfile and delete all record of it.

--- a/internal/controllers/core/tiltfile/reconciler.go
+++ b/internal/controllers/core/tiltfile/reconciler.go
@@ -51,7 +51,7 @@ type Reconciler struct {
 	engineMode           store.EngineMode
 	loadCount            int // used to differentiate spans
 	ciTimeoutFlag        model.CITimeoutFlag
-	disablePortForwards  bool
+	disablePortForwards  k8s.DisablePortForwardsFlag
 
 	runs map[types.NamespacedName]*runStatus
 
@@ -91,7 +91,7 @@ func NewReconciler(
 	k8sContextOverride k8s.KubeContextOverride,
 	k8sNamespaceOverride k8s.NamespaceOverride,
 	ciTimeoutFlag model.CITimeoutFlag,
-	disablePortForwards bool,
+	disablePortForwards k8s.DisablePortForwardsFlag,
 ) *Reconciler {
 	return &Reconciler{
 		st:                   st,

--- a/internal/controllers/core/tiltfile/reconciler_test.go
+++ b/internal/controllers/core/tiltfile/reconciler_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/tilt-dev/tilt/internal/container"
 	configmap2 "github.com/tilt-dev/tilt/internal/controllers/apis/configmap"
 	"github.com/tilt-dev/tilt/internal/controllers/apis/uibutton"
+	"github.com/tilt-dev/tilt/internal/controllers/apiset"
 	"github.com/tilt-dev/tilt/internal/controllers/fake"
 	"github.com/tilt-dev/tilt/internal/docker"
 	"github.com/tilt-dev/tilt/internal/k8s/testyaml"
@@ -35,6 +36,48 @@ import (
 	"github.com/tilt-dev/tilt/pkg/model"
 	"github.com/tilt-dev/wmclient/pkg/analytics"
 )
+
+func TestTiltfileResultWithoutPortForwards(t *testing.T) {
+	portForwardTemplate := &v1alpha1.PortForwardTemplateSpec{
+		Forwards: []v1alpha1.Forward{{LocalPort: 8000, ContainerPort: 8080}},
+	}
+	tf := tempdir.NewTempDirFixture(t)
+	manifest := manifestbuilder.New(tf, "sancho").WithK8sYAML(testyaml.SanchoYAML).Build()
+	target := manifest.K8sTarget()
+	target.PortForwardTemplateSpec = portForwardTemplate.DeepCopy()
+	manifest = manifest.WithDeployTarget(target)
+
+	kubernetesApply := &v1alpha1.KubernetesApply{
+		ObjectMeta: metav1.ObjectMeta{Name: "apply"},
+		Spec: v1alpha1.KubernetesApplySpec{
+			PortForwardTemplateSpec: portForwardTemplate.DeepCopy(),
+		},
+	}
+	kubernetesDiscovery := &v1alpha1.KubernetesDiscovery{
+		ObjectMeta: metav1.ObjectMeta{Name: "discovery"},
+		Spec: v1alpha1.KubernetesDiscoverySpec{
+			PortForwardTemplateSpec: portForwardTemplate.DeepCopy(),
+		},
+	}
+	objectSet := apiset.ObjectSet{}
+	objectSet.Add(kubernetesApply)
+	objectSet.Add(kubernetesDiscovery)
+
+	input := &tiltfile.TiltfileLoadResult{
+		Manifests: []model.Manifest{manifest},
+		ObjectSet: objectSet,
+	}
+	result := tiltfileResultWithoutPortForwards(input)
+
+	require.Nil(t, result.Manifests[0].K8sTarget().PortForwardTemplateSpec)
+	require.Nil(t, result.ObjectSet.GetSetForType(&v1alpha1.KubernetesApply{})["apply"].(*v1alpha1.KubernetesApply).Spec.PortForwardTemplateSpec)
+	require.Nil(t, result.ObjectSet.GetSetForType(&v1alpha1.KubernetesDiscovery{})["discovery"].(*v1alpha1.KubernetesDiscovery).Spec.PortForwardTemplateSpec)
+
+	// Filtering a load result must not affect the previous result supplied to a later reload.
+	require.NotNil(t, input.Manifests[0].K8sTarget().PortForwardTemplateSpec)
+	require.NotNil(t, kubernetesApply.Spec.PortForwardTemplateSpec)
+	require.NotNil(t, kubernetesDiscovery.Spec.PortForwardTemplateSpec)
+}
 
 func TestDefault(t *testing.T) {
 	f := newFixture(t)
@@ -542,7 +585,7 @@ func newFixture(t *testing.T) *fixture {
 	st := NewTestingStore()
 	tfl := tiltfile.NewFakeTiltfileLoader()
 	d := docker.NewFakeClient()
-	r := NewReconciler(st, tfl, d, cfb.Client, v1alpha1.NewScheme(), store.EngineModeUp, "", "", 0)
+	r := NewReconciler(st, tfl, d, cfb.Client, v1alpha1.NewScheme(), store.EngineModeUp, "", "", 0, false)
 	q := workqueue.NewTypedRateLimitingQueue[reconcile.Request](
 		workqueue.NewTypedItemExponentialFailureRateLimiter[reconcile.Request](time.Millisecond, time.Millisecond))
 	_ = r.requeuer.Start(context.Background(), q)

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -3314,7 +3314,7 @@ func newTestFixture(t *testing.T, options ...fixtureOptions) *testFixture {
 		cdc,
 		uncached)
 	require.NoError(t, err, "Failed to create Tilt API server controller manager")
-	pfr := apiportforward.NewReconciler(cdc, sch, st, clusterClients)
+	pfr := apiportforward.NewReconciler(cdc, sch, st, clusterClients, false)
 
 	wsl := server.NewWebsocketList()
 
@@ -3322,7 +3322,7 @@ func newTestFixture(t *testing.T, options ...fixtureOptions) *testFixture {
 	dcds := dockercomposeservice.NewDisableSubscriber(ctx, fakeDcc, clock)
 	dcr := dockercomposeservice.NewReconciler(cdc, fakeDcc, dockerClient, st, sch, dcds)
 
-	tfr := ctrltiltfile.NewReconciler(st, tfl, dockerClient, cdc, sch, engineMode, "", "", 0)
+	tfr := ctrltiltfile.NewReconciler(st, tfl, dockerClient, cdc, sch, engineMode, "", "", 0, false)
 	tbr := togglebutton.NewReconciler(cdc, sch)
 	extr := extension.NewReconciler(cdc, sch, ta)
 	extrr, err := extensionrepo.NewReconciler(cdc, st, base)

--- a/internal/k8s/portforward_flag.go
+++ b/internal/k8s/portforward_flag.go
@@ -1,0 +1,4 @@
+package k8s
+
+// DisablePortForwardsFlag controls whether Tilt starts Kubernetes port-forwards.
+type DisablePortForwardsFlag bool


### PR DESCRIPTION
We have started running multiple `tilt up` instances per host. While this works well, we run into lots of port-forward conflict warnings that spam the logs and result in an uncertain set of port-forwards.

This adds a flag to `tilt up --disable-port-forwards` that prevents these port forwards from being created, allowing us to control which instance can use port-forwards.

I have not used wire before, so I wasn't sure if I should just use a bare bool, or the typed one I added here.