### PR TITLE
engine: skip exact log-only store notifications in PodMonitor

### DIFF
--- a/internal/engine/k8srollout/podmonitor.go
+++ b/internal/engine/k8srollout/podmonitor.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/jonboulle/clockwork"
 	v1 "k8s.io/api/core/v1"
 
@@ -72,7 +71,13 @@ func (m *PodMonitor) diff(st store.RStore) []podStatus {
 	return updates
 }
 
-func (m *PodMonitor) OnChange(ctx context.Context, st store.RStore, _ store.ChangeSummary) error {
+func (m *PodMonitor) OnChange(ctx context.Context, st store.RStore, summary store.ChangeSummary) error {
+	// Runtime logs cannot change rollout status. Avoid walking every manifest on
+	// the high-frequency exact log-only notification path.
+	if summary.IsLogOnly() {
+		return nil
+	}
+
 	updates := m.diff(st)
 	for _, update := range updates {
 		ctx := store.WithManifestLogHandler(ctx, st, update.manifestName, spanIDForPod(update.manifestName, update.podID))
@@ -176,10 +181,21 @@ func newPodStatus(pod v1alpha1.Pod, manifestName model.ManifestName) podStatus {
 	return s
 }
 
-var podStatusAllowUnexported = cmp.AllowUnexported(podStatus{})
-
 func podStatusesEqual(a, b podStatus) bool {
-	return cmp.Equal(a, b, podStatusAllowUnexported)
+	return a.podID == b.podID &&
+		a.manifestName == b.manifestName &&
+		a.startTime.Equal(b.startTime) &&
+		podConditionsEqual(a.scheduled, b.scheduled) &&
+		podConditionsEqual(a.initialized, b.initialized) &&
+		podConditionsEqual(a.ready, b.ready)
+}
+
+func podConditionsEqual(a, b v1alpha1.PodCondition) bool {
+	return a.Type == b.Type &&
+		a.Status == b.Status &&
+		a.LastTransitionTime.Equal(&b.LastTransitionTime) &&
+		a.Reason == b.Reason &&
+		a.Message == b.Message
 }
 
 func spanIDForPod(mn model.ManifestName, podID k8s.PodID) logstore.SpanID {

--- a/internal/engine/k8srollout/podmonitor_test.go
+++ b/internal/engine/k8srollout/podmonitor_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -328,6 +329,16 @@ func TestPodStatusesEqual(t *testing.T) {
 			assert.Equal(t, tt.want, podStatusesEqual(base, candidate))
 		})
 	}
+}
+
+func TestPodStatusFieldCoverageGuard(t *testing.T) {
+	// podStatusesEqual and podConditionsEqual enumerate every field by hand
+	// instead of using reflection. If either count changes, update the
+	// comparison (and TestPodStatusesEqual) before updating the count, or the
+	// new field is silently ignored when deciding whether to log a rollout
+	// update.
+	assert.Equal(t, 6, reflect.TypeOf(podStatus{}).NumField())
+	assert.Equal(t, 5, reflect.TypeOf(v1alpha1.PodCondition{}).NumField())
 }
 
 func BenchmarkPodMonitorOnLogOnly(b *testing.B) {

--- a/internal/engine/k8srollout/podmonitor_test.go
+++ b/internal/engine/k8srollout/podmonitor_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/tilt-dev/tilt/internal/store"
 	"github.com/tilt-dev/tilt/internal/testutils/bufsync"
@@ -187,6 +188,190 @@ func TestJobCompletedAfterReady(t *testing.T) {
 	_ = f.pm.OnChange(f.ctx, f.store, store.LegacyChangeSummary())
 
 	assertSnapshot(t, f.out.String())
+}
+
+func TestMonitorChangeSummaryFiltering(t *testing.T) {
+	changedResource := store.NewChangeSet(types.NamespacedName{Name: "server"})
+	tests := []struct {
+		name          string
+		summary       store.ChangeSummary
+		wantProcessed bool
+	}{
+		{
+			name:          "exact log only skips",
+			summary:       store.ChangeSummary{Log: true},
+			wantProcessed: false,
+		},
+		{
+			name:          "log and legacy processes",
+			summary:       store.ChangeSummary{Log: true, Legacy: true},
+			wantProcessed: true,
+		},
+		{
+			name:          "log and UI resource processes",
+			summary:       store.ChangeSummary{Log: true, UIResources: changedResource},
+			wantProcessed: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := newPMFixture(t)
+			key := podManifest{pod: "cached-pod", manifest: "cached-manifest"}
+			cached := podStatus{podID: key.pod, manifestName: key.manifest}
+			f.pm.pods[key] = cached
+
+			err := f.pm.OnChange(f.ctx, f.store, tt.summary)
+			assert.NoError(t, err)
+
+			_, found := f.pm.pods[key]
+			assert.Equal(t, !tt.wantProcessed, found)
+		})
+	}
+}
+
+func TestMonitorMixedLogSummaryPrintsRealPodChange(t *testing.T) {
+	f := newPMFixture(t)
+	start := f.clock.Now()
+	p := v1alpha1.Pod{
+		Name:      "pod-id",
+		CreatedAt: apis.NewTime(start),
+		Conditions: []v1alpha1.PodCondition{
+			{
+				Type:               string(v1.PodScheduled),
+				Status:             string(v1.ConditionTrue),
+				LastTransitionTime: apis.NewTime(start.Add(time.Second)),
+			},
+		},
+	}
+	state := store.NewState()
+	state.UpsertManifestTarget(manifestutils.NewManifestTargetWithPod(
+		model.Manifest{Name: "server"}, p))
+	f.store.SetState(*state)
+
+	err := f.pm.OnChange(f.ctx, f.store, store.ChangeSummary{
+		Log:         true,
+		UIResources: store.NewChangeSet(types.NamespacedName{Name: "server"}),
+	})
+
+	assert.NoError(t, err)
+	assert.Contains(t, f.out.String(), "Tracking new pod rollout (pod-id)")
+}
+
+func TestPodStatusesEqual(t *testing.T) {
+	start := time.Date(2026, time.July, 10, 1, 2, 3, 4, time.UTC)
+	condition := func(conditionType, status, reason, message string, transition time.Time) v1alpha1.PodCondition {
+		return v1alpha1.PodCondition{
+			Type:               conditionType,
+			Status:             status,
+			LastTransitionTime: apis.NewTime(transition),
+			Reason:             reason,
+			Message:            message,
+		}
+	}
+	base := podStatus{
+		podID:        "pod-id",
+		manifestName: "server",
+		startTime:    start,
+		scheduled:    condition("PodScheduled", "True", "Scheduled", "scheduled", start.Add(time.Second)),
+		initialized:  condition("Initialized", "True", "Initialized", "initialized", start.Add(2*time.Second)),
+		ready:        condition("Ready", "False", "Starting", "starting", start.Add(3*time.Second)),
+	}
+
+	tests := []struct {
+		name   string
+		mutate func(*podStatus)
+		want   bool
+	}{
+		{name: "equal", mutate: func(*podStatus) {}, want: true},
+		{
+			name: "equal instants in different locations",
+			mutate: func(s *podStatus) {
+				location := time.FixedZone("offset", 2*60*60)
+				s.startTime = s.startTime.In(location)
+				s.scheduled.LastTransitionTime = apis.NewTime(s.scheduled.LastTransitionTime.Time.In(location))
+				s.initialized.LastTransitionTime = apis.NewTime(s.initialized.LastTransitionTime.Time.In(location))
+				s.ready.LastTransitionTime = apis.NewTime(s.ready.LastTransitionTime.Time.In(location))
+			},
+			want: true,
+		},
+		{name: "pod ID", mutate: func(s *podStatus) { s.podID = "other" }, want: false},
+		{name: "manifest name", mutate: func(s *podStatus) { s.manifestName = "other" }, want: false},
+		{name: "start time", mutate: func(s *podStatus) { s.startTime = s.startTime.Add(time.Second) }, want: false},
+		{name: "scheduled type", mutate: func(s *podStatus) { s.scheduled.Type = "Other" }, want: false},
+		{name: "scheduled status", mutate: func(s *podStatus) { s.scheduled.Status = "False" }, want: false},
+		{name: "scheduled time", mutate: func(s *podStatus) {
+			s.scheduled.LastTransitionTime = apis.NewTime(s.scheduled.LastTransitionTime.Add(time.Second))
+		}, want: false},
+		{name: "scheduled reason", mutate: func(s *podStatus) { s.scheduled.Reason = "Other" }, want: false},
+		{name: "scheduled message", mutate: func(s *podStatus) { s.scheduled.Message = "other" }, want: false},
+		{name: "initialized type", mutate: func(s *podStatus) { s.initialized.Type = "Other" }, want: false},
+		{name: "initialized status", mutate: func(s *podStatus) { s.initialized.Status = "False" }, want: false},
+		{name: "initialized time", mutate: func(s *podStatus) {
+			s.initialized.LastTransitionTime = apis.NewTime(s.initialized.LastTransitionTime.Add(time.Second))
+		}, want: false},
+		{name: "initialized reason", mutate: func(s *podStatus) { s.initialized.Reason = "Other" }, want: false},
+		{name: "initialized message", mutate: func(s *podStatus) { s.initialized.Message = "other" }, want: false},
+		{name: "ready type", mutate: func(s *podStatus) { s.ready.Type = "Other" }, want: false},
+		{name: "ready status", mutate: func(s *podStatus) { s.ready.Status = "True" }, want: false},
+		{name: "ready time", mutate: func(s *podStatus) {
+			s.ready.LastTransitionTime = apis.NewTime(s.ready.LastTransitionTime.Add(time.Second))
+		}, want: false},
+		{name: "ready reason", mutate: func(s *podStatus) { s.ready.Reason = "Other" }, want: false},
+		{name: "ready message", mutate: func(s *podStatus) { s.ready.Message = "other" }, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			candidate := base
+			tt.mutate(&candidate)
+			assert.Equal(t, tt.want, podStatusesEqual(base, candidate))
+		})
+	}
+}
+
+func BenchmarkPodMonitorOnLogOnly(b *testing.B) {
+	clock := clockwork.NewFakeClock()
+	pm := NewPodMonitor(clock)
+	st := store.NewTestingStore()
+	ctx := logger.WithLogger(context.Background(), logger.NewTestLogger(io.Discard))
+	state := store.NewState()
+	start := clock.Now()
+	for i := 0; i < 100; i++ {
+		name := fmt.Sprintf("server-%03d", i)
+		pod := v1alpha1.Pod{Name: name, CreatedAt: apis.NewTime(start)}
+		state.UpsertManifestTarget(manifestutils.NewManifestTargetWithPod(
+			model.Manifest{Name: model.ManifestName(name)}, pod))
+	}
+	st.SetState(*state)
+
+	// Populate the cache before timing so this measures the quiet steady-state
+	// work caused by a log-only notification.
+	_ = pm.OnChange(ctx, st, store.LegacyChangeSummary())
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = pm.OnChange(ctx, st, store.ChangeSummary{Log: true})
+	}
+}
+
+func BenchmarkPodStatusesEqual(b *testing.B) {
+	status := podStatus{
+		podID:        "pod-id",
+		manifestName: "server",
+		startTime:    time.Unix(1, 2),
+		ready: v1alpha1.PodCondition{
+			Type:               string(v1.PodReady),
+			Status:             string(v1.ConditionTrue),
+			LastTransitionTime: apis.NewTime(time.Unix(3, 4)),
+		},
+	}
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_ = podStatusesEqual(status, status)
+	}
 }
 
 type pmFixture struct {

--- a/internal/store/summary.go
+++ b/internal/store/summary.go
@@ -3,7 +3,6 @@ package store
 import (
 	"time"
 
-	"github.com/google/go-cmp/cmp"
 	"k8s.io/apimachinery/pkg/types"
 )
 
@@ -69,7 +68,16 @@ type ChangeSummary struct {
 }
 
 func (s ChangeSummary) IsLogOnly() bool {
-	return cmp.Equal(s, ChangeSummary{Log: true})
+	// Keep this equivalent to the exact value ChangeSummary{Log: true}.
+	// In particular, a log flag does not make a mixed summary log-only.
+	return s.Log &&
+		!s.Legacy &&
+		s.CmdSpecs.Changes == nil &&
+		s.UISessions.Changes == nil &&
+		s.UIResources.Changes == nil &&
+		s.UIButtons.Changes == nil &&
+		s.Clusters.Changes == nil &&
+		s.LastBackoff == 0
 }
 
 func (s *ChangeSummary) Add(other ChangeSummary) {

--- a/internal/store/summary.go
+++ b/internal/store/summary.go
@@ -86,6 +86,7 @@ func (s *ChangeSummary) Add(other ChangeSummary) {
 	s.CmdSpecs.AddAll(other.CmdSpecs)
 	s.UISessions.AddAll(other.UISessions)
 	s.UIResources.AddAll(other.UIResources)
+	s.UIButtons.AddAll(other.UIButtons)
 	s.Clusters.AddAll(other.Clusters)
 	if other.LastBackoff > s.LastBackoff {
 		s.LastBackoff = other.LastBackoff

--- a/internal/store/summary_test.go
+++ b/internal/store/summary_test.go
@@ -43,6 +43,32 @@ func TestChangeSummaryIsLogOnly(t *testing.T) {
 	}
 }
 
+func TestChangeSummaryAdd(t *testing.T) {
+	name := func(s string) types.NamespacedName { return types.NamespacedName{Name: s} }
+
+	t.Run("merges every field", func(t *testing.T) {
+		dst := ChangeSummary{}
+		src := ChangeSummary{
+			Legacy:      true,
+			Log:         true,
+			CmdSpecs:    NewChangeSet(name("cmd")),
+			UISessions:  NewChangeSet(name("session")),
+			UIResources: NewChangeSet(name("resource")),
+			UIButtons:   NewChangeSet(name("button")),
+			Clusters:    NewChangeSet(name("cluster")),
+			LastBackoff: time.Second,
+		}
+		dst.Add(src)
+		assert.Equal(t, src, dst)
+	})
+
+	t.Run("keeps larger backoff", func(t *testing.T) {
+		dst := ChangeSummary{LastBackoff: 2 * time.Second}
+		dst.Add(ChangeSummary{LastBackoff: time.Second})
+		assert.Equal(t, 2*time.Second, dst.LastBackoff)
+	})
+}
+
 func BenchmarkChangeSummaryIsLogOnly(b *testing.B) {
 	summary := ChangeSummary{Log: true}
 

--- a/internal/store/summary_test.go
+++ b/internal/store/summary_test.go
@@ -1,0 +1,53 @@
+package store
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func TestChangeSummaryIsLogOnly(t *testing.T) {
+	changed := NewChangeSet(types.NamespacedName{Name: "changed"})
+	emptyButAllocated := ChangeSet{Changes: make(map[types.NamespacedName]bool)}
+
+	tests := []struct {
+		name    string
+		summary ChangeSummary
+		want    bool
+	}{
+		{name: "exact log only", summary: ChangeSummary{Log: true}, want: true},
+		{name: "zero summary", summary: ChangeSummary{}, want: false},
+		{name: "legacy", summary: ChangeSummary{Log: true, Legacy: true}, want: false},
+		{name: "command specs", summary: ChangeSummary{Log: true, CmdSpecs: changed}, want: false},
+		{name: "UI sessions", summary: ChangeSummary{Log: true, UISessions: changed}, want: false},
+		{name: "UI resources", summary: ChangeSummary{Log: true, UIResources: changed}, want: false},
+		{name: "UI buttons", summary: ChangeSummary{Log: true, UIButtons: changed}, want: false},
+		{name: "clusters", summary: ChangeSummary{Log: true, Clusters: changed}, want: false},
+		{name: "last backoff", summary: ChangeSummary{Log: true, LastBackoff: time.Second}, want: false},
+
+		// cmp.Equal distinguishes a nil map from an allocated empty map. Keep that
+		// exact-value behavior while replacing reflection in the hot path.
+		{name: "allocated empty command specs", summary: ChangeSummary{Log: true, CmdSpecs: emptyButAllocated}, want: false},
+		{name: "allocated empty UI sessions", summary: ChangeSummary{Log: true, UISessions: emptyButAllocated}, want: false},
+		{name: "allocated empty UI resources", summary: ChangeSummary{Log: true, UIResources: emptyButAllocated}, want: false},
+		{name: "allocated empty UI buttons", summary: ChangeSummary{Log: true, UIButtons: emptyButAllocated}, want: false},
+		{name: "allocated empty clusters", summary: ChangeSummary{Log: true, Clusters: emptyButAllocated}, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.summary.IsLogOnly())
+		})
+	}
+}
+
+func BenchmarkChangeSummaryIsLogOnly(b *testing.B) {
+	summary := ChangeSummary{Log: true}
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_ = summary.IsLogOnly()
+	}
+}

--- a/internal/store/summary_test.go
+++ b/internal/store/summary_test.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"reflect"
 	"testing"
 	"time"
 
@@ -67,6 +68,14 @@ func TestChangeSummaryAdd(t *testing.T) {
 		dst.Add(ChangeSummary{LastBackoff: time.Second})
 		assert.Equal(t, 2*time.Second, dst.LastBackoff)
 	})
+}
+
+func TestChangeSummaryFieldCoverageGuard(t *testing.T) {
+	// IsLogOnly and Add enumerate every ChangeSummary field by hand instead of
+	// using reflection. If this count changes, update both methods (and their
+	// tests above) before updating the count, or the new field is silently
+	// ignored by log-only detection and summary merging.
+	assert.Equal(t, 8, reflect.TypeOf(ChangeSummary{}).NumField())
 }
 
 func BenchmarkChangeSummaryIsLogOnly(b *testing.B) {


### PR DESCRIPTION
## Summary

Under a sustained Kubernetes log storm, `PodMonitor` was spending a large
fraction of engine CPU and allocations on work that cannot affect rollout
status: every store notification (including exact log-only updates) walked
every manifest target and ran reflection-based pod status comparison.

This PR:

- Returns early from `PodMonitor.OnChange` for **exactly** log-only
  `ChangeSummary`s, matching the pattern already used by other store
  subscribers.
- Replaces `cmp.Equal` in `podStatusesEqual` with explicit field comparisons
  (same semantics, no reflection allocations).
- Adds `ChangeSummary.IsLogOnly` and fixes `ChangeSummary.Add` so `UIButtons`
  is merged like every other `ChangeSet` (a coalesced button change was
  previously droppable when mixed with a pending log-only summary).
- Adds field-count drift tests so hand-rolled enumerations fail closed when
  structs gain fields.

## Motivation

Profiled on a noisy log-only workload: `PodMonitor.diff` /
`podStatusesEqual` were ~18% cumulative CPU and ~17% cumulative allocations
in the engine. Runtime logs cannot change rollout state; re-diffing pods on
every log line is pure waste.

## Evidence

- Package tests for log-only skip, mixed summaries, field merge, and drift
  guards.
- Microbench: log-only `OnChange` ≈ 1.15ms / 6210 allocs → ≈ 5ns / 0 allocs.
- Hermetic log-only soak (k3d, clean tree including this series through
  `4c1d05bf6`): pass — hot path absent from steady-state profiles, memory
  under 2 GiB floor, rollout still observed, log rate healthy.

## Test plan

- [x] `go test ./internal/engine/k8srollout/ ./internal/store/`
- [ ] CI on this PR
- [ ] Manual: `tilt up` against a chatty workload still shows real pod
      restarts in resource logs; pure log spam does not re-churn rollout
      monitoring