### PR TITLE
logstore: cut allocation churn on the incremental log hot path

### DIFF
--- a/pkg/model/logstore/logline.go
+++ b/pkg/model/logstore/logline.go
@@ -26,6 +26,9 @@ type LogLine struct {
 	Time time.Time
 }
 
+// Accumulates the segments of one line. A single builder is reused across
+// all lines of a toLogLines call (start/reset recycle the segment buffer),
+// so it must not retain segment state past reset.
 type logLineBuilder struct {
 	span        *Span
 	segments    []LogSegment
@@ -34,12 +37,24 @@ type logLineBuilder struct {
 	needsTrailingNewline bool
 }
 
-func newLogLineBuilder(span *Span, segment LogSegment, isFirstLine bool) *logLineBuilder {
-	return &logLineBuilder{
-		span:        span,
-		segments:    []LogSegment{segment},
-		isFirstLine: isFirstLine,
-	}
+// Begins a new line, reusing the segment buffer of any previously consumed
+// line.
+func (b *logLineBuilder) start(span *Span, segment LogSegment, isFirstLine bool) {
+	b.span = span
+	b.segments = append(b.segments[:0], segment)
+	b.isFirstLine = isFirstLine
+	b.needsTrailingNewline = false
+}
+
+// An active builder holds at least the segment that started its line.
+func (b *logLineBuilder) active() bool {
+	return len(b.segments) > 0
+}
+
+func (b *logLineBuilder) reset() {
+	b.span = nil
+	b.segments = b.segments[:0]
+	b.needsTrailingNewline = false
 }
 
 func (b *logLineBuilder) addSegment(segment LogSegment) {
@@ -54,21 +69,21 @@ func (b *logLineBuilder) isComplete() bool {
 	return b.lastSegment().IsComplete()
 }
 
-func (b *logLineBuilder) build(options logOptions) []LogLine {
-	result := []LogLine{}
-
+// Appends the built line(s) onto result rather than returning a fresh
+// slice, so the per-line cost is only the line text itself.
+func (b *logLineBuilder) appendTo(result []LogLine, options logOptions) []LogLine {
 	segment := b.segments[0]
 	buildEvent := segment.Fields[logger.FieldNameBuildEvent]
 	if buildEvent == "init" {
 		result = append(result, b.buildSpaceLine(options))
 	}
 
-	result = append(result, b.buildMainLine(options))
-	return result
+	return append(result, b.buildMainLine(options))
 }
 
 func (b *logLineBuilder) buildSpaceLine(options logOptions) LogLine {
 	sb := strings.Builder{}
+	sb.Grow(sourcePrefixReserveLen + 1)
 	span := b.span
 	segment := b.segments[0]
 	spanID := segment.SpanID
@@ -76,7 +91,7 @@ func (b *logLineBuilder) buildSpaceLine(options logOptions) LogLine {
 	if options.showManifestPrefix && span.ManifestName != "" {
 		shouldSkip := options.skipFirstLineManifestPrefix && b.isFirstLine
 		if !shouldSkip {
-			sb.WriteString(SourcePrefix(span.ManifestName))
+			appendSourcePrefix(&sb, span.ManifestName)
 		}
 	}
 	sb.WriteString("\n")
@@ -99,11 +114,19 @@ func (b *logLineBuilder) buildMainLine(options logOptions) LogLine {
 	progressID := segment.Fields[logger.FieldNameProgressID]
 	progressMustPrint := segment.Fields[logger.FieldNameProgressMustPrint] == "1"
 
+	// Reserve for the worst case (prefix + anchor marker + text + trailing
+	// newline) so each line's text is built in a single allocation.
+	textLen := 0
+	for _, seg := range b.segments {
+		textLen += len(seg.Text)
+	}
 	sb := strings.Builder{}
+	sb.Grow(textLen + sourcePrefixReserveLen + len("WARNING: ") + 1)
+
 	if options.showManifestPrefix && span.ManifestName != "" {
 		shouldSkip := options.skipFirstLineManifestPrefix && b.isFirstLine
 		if !shouldSkip {
-			sb.WriteString(SourcePrefix(span.ManifestName))
+			appendSourcePrefix(&sb, span.ManifestName)
 		}
 	}
 

--- a/pkg/model/logstore/logstore.go
+++ b/pkg/model/logstore/logstore.go
@@ -1,6 +1,7 @@
 package logstore
 
 import (
+	"bytes"
 	"fmt"
 	"sort"
 	"strings"
@@ -79,7 +80,13 @@ func (l LogSegment) String() string {
 }
 
 func segmentsFromBytes(spanID SpanID, time time.Time, level logger.Level, fields logger.Fields, bs []byte) []LogSegment {
-	segments := []LogSegment{}
+	// One segment per newline, plus one more for a trailing partial line.
+	// Sizing up front keeps a multi-line write to a single allocation.
+	segmentCount := bytes.Count(bs, []byte{newlineByte})
+	if len(bs) == 0 || bs[len(bs)-1] != newlineByte {
+		segmentCount++
+	}
+	segments := make([]LogSegment, 0, segmentCount)
 	lastBreak := 0
 	for i, b := range bs {
 		if b == newlineByte {
@@ -348,7 +355,7 @@ func (s *LogStore) tailHelper(n int, spans map[SpanID]*Span, showManifestPrefix 
 		startedSpans[spanID] = true
 	}
 
-	tempStore := &LogStore{spans: s.cloneSpanMap(), segments: newSegments}
+	tempStore := &LogStore{spans: s.cloneSpanMapForSegments(newSegments), segments: newSegments}
 	tempStore.recomputeDerivedValues()
 	return tempStore.toLogString(logOptions{
 		spans:              tempStore.spans,
@@ -356,10 +363,21 @@ func (s *LogStore) tailHelper(n int, spans map[SpanID]*Span, showManifestPrefix 
 	})
 }
 
-func (s *LogStore) cloneSpanMap() map[SpanID]*Span {
-	newSpans := make(map[SpanID]*Span, len(s.spans))
-	for spanID, span := range s.spans {
-		newSpans[spanID] = span.Clone()
+// Clone only the spans referenced by the given segments.
+//
+// Temp stores built from a segment window only need those spans:
+// recomputeDerivedValues rebuilds every derived index from the segments and
+// deletes unreferenced spans anyway, so cloning the full map is pure waste
+// when the store holds many more spans than the window touches.
+func (s *LogStore) cloneSpanMapForSegments(segments []LogSegment) map[SpanID]*Span {
+	newSpans := make(map[SpanID]*Span)
+	for _, segment := range segments {
+		if _, ok := newSpans[segment.SpanID]; ok {
+			continue
+		}
+		if span, ok := s.spans[segment.SpanID]; ok {
+			newSpans[segment.SpanID] = span.Clone()
+		}
 	}
 	return newSpans
 }
@@ -448,6 +466,12 @@ func (s *LogStore) ContinuingLinesWithOptions(checkpoint Checkpoint, opts LineOp
 	isSameSpanContinuation := false
 	isDifferentSpan := false
 	checkpointIndex := s.checkpointToIndex(checkpoint)
+	if checkpointIndex >= len(s.segments) {
+		// Nothing new since the checkpoint. Subscribers are notified for every
+		// store change, so this is the common case for non-log changes and must
+		// not pay for span cloning below.
+		return nil
+	}
 	precedingIndexToPrint := s.prevIndexMatchingManifests(checkpointIndex, opts.ManifestNames)
 	nextIndexToPrint := s.nextIndexMatchingManifests(checkpointIndex, opts.ManifestNames)
 	var precedingSegment = LogSegment{}
@@ -470,12 +494,9 @@ func (s *LogStore) ContinuingLinesWithOptions(checkpoint Checkpoint, opts LineOp
 		}
 	}
 
-	// --> if checkpointIndex == len(s.segments)
-	// nothing new to print, return!
-
 	tempSegments := s.segments[checkpointIndex:]
 	tempLogStore := &LogStore{
-		spans:    s.cloneSpanMap(),
+		spans:    s.cloneSpanMapForSegments(tempSegments),
 		segments: tempSegments,
 	}
 	tempLogStore.recomputeDerivedValues()
@@ -508,13 +529,6 @@ func (s *LogStore) ContinuingLinesWithOptions(checkpoint Checkpoint, opts LineOp
 }
 
 func (s *LogStore) ToLogList(fromCheckpoint Checkpoint) (*webview.LogList, error) {
-	spans := make(map[string]*webview.LogSpan, len(s.spans))
-	for spanID, span := range s.spans {
-		spans[string(spanID)] = &webview.LogSpan{
-			ManifestName: span.ManifestName.String(),
-		}
-	}
-
 	startIndex := s.checkpointToIndex(fromCheckpoint)
 	if startIndex >= len(s.segments) {
 		// No logs to send down.
@@ -524,9 +538,22 @@ func (s *LogStore) ToLogList(fromCheckpoint Checkpoint) (*webview.LogList, error
 		}, nil
 	}
 
+	// Only send the spans referenced by the segments in this update. Both the
+	// web UI and the tilt logs client resolve each segment against the spans of
+	// the update that carried it (the web UI additionally accumulates spans
+	// across updates), so re-sending every span in the store on each
+	// incremental update is pure overhead.
+	spans := make(map[string]*webview.LogSpan)
 	segments := make([]*webview.LogSegment, 0, len(s.segments)-startIndex)
 	for i := startIndex; i < len(s.segments); i++ {
 		segment := s.segments[i]
+		if _, ok := spans[string(segment.SpanID)]; !ok {
+			if span, ok := s.spans[segment.SpanID]; ok {
+				spans[string(segment.SpanID)] = &webview.LogSpan{
+					ManifestName: span.ManifestName.String(),
+				}
+			}
+		}
 		segments = append(segments, &webview.LogSegment{
 			SpanId: string(segment.SpanID),
 			Level:  webview.LogLevel(segment.Level.Name()),

--- a/pkg/model/logstore/logstore.go
+++ b/pkg/model/logstore/logstore.go
@@ -113,7 +113,12 @@ func segmentsFromBytes(spanID SpanID, time time.Time, level logger.Level, fields
 }
 
 func linesToString(lines []LogLine) string {
+	total := 0
+	for _, line := range lines {
+		total += len(line.Text)
+	}
 	sb := strings.Builder{}
+	sb.Grow(total)
 	for _, line := range lines {
 		sb.WriteString(line.Text)
 	}
@@ -442,12 +447,7 @@ func (s *LogStore) ContinuingString(checkpoint Checkpoint) string {
 }
 
 func (s *LogStore) ContinuingStringWithOptions(checkpoint Checkpoint, opts LineOptions) string {
-	lines := s.ContinuingLinesWithOptions(checkpoint, opts)
-	sb := strings.Builder{}
-	for _, line := range lines {
-		sb.WriteString(line.Text)
-	}
-	return sb.String()
+	return linesToString(s.ContinuingLinesWithOptions(checkpoint, opts))
 }
 
 func (s *LogStore) IsLastSegmentUncompleted() bool {
@@ -694,17 +694,6 @@ func (s *LogStore) toLogString(options logOptions) string {
 
 // Returns a sequence of lines, including trailing newlines.
 func (s *LogStore) toLogLines(options logOptions) []LogLine {
-	result := []LogLine{}
-	var lineBuilder *logLineBuilder
-
-	var consumeLineBuilder = func() {
-		if lineBuilder == nil {
-			return
-		}
-		result = append(result, lineBuilder.build(options)...)
-		lineBuilder = nil
-	}
-
 	// We want to print the log line-by-line, but we don't actually store the logs
 	// line-by-line. We store them as segments.
 	//
@@ -722,6 +711,34 @@ func (s *LogStore) toLogLines(options logOptions) []LogLine {
 		return nil
 	}
 
+	// Every line-starting segment in the window yields one line, so size the
+	// result up front. (A rare "init" build event adds an extra space line,
+	// absorbed by append's growth.)
+	lineCount := 0
+	for i := startIndex; i <= lastIndex; i++ {
+		segment := s.segments[i]
+		if !segment.StartsLine() {
+			continue
+		}
+		if _, ok := options.spans[segment.SpanID]; !ok {
+			continue
+		}
+		lineCount++
+	}
+
+	result := make([]LogLine, 0, lineCount)
+
+	// One builder is reused for every line; consume flushes it into result
+	// and recycles its segment buffer.
+	lineBuilder := logLineBuilder{}
+	var consumeLineBuilder = func() {
+		if !lineBuilder.active() {
+			return
+		}
+		result = lineBuilder.appendTo(result, options)
+		lineBuilder.reset()
+	}
+
 	isFirstLine := true
 	for i := startIndex; i <= lastIndex; i++ {
 		segment := s.segments[i]
@@ -737,12 +754,12 @@ func (s *LogStore) toLogLines(options logOptions) []LogLine {
 
 		// If the last segment never completed, print a newline now, so that the
 		// logs from different sources don't blend together.
-		if lineBuilder != nil {
+		if lineBuilder.active() {
 			lineBuilder.needsTrailingNewline = true
 			consumeLineBuilder()
 		}
 
-		lineBuilder = newLogLineBuilder(span, segment, isFirstLine)
+		lineBuilder.start(span, segment, isFirstLine)
 		isFirstLine = false
 
 		// If this segment is not complete, run ahead and try to complete it.

--- a/pkg/model/logstore/logstore_bench_test.go
+++ b/pkg/model/logstore/logstore_bench_test.go
@@ -80,6 +80,19 @@ func BenchmarkToLogListIncremental(b *testing.B) {
 	}
 }
 
+// A full render of the whole store, as on initial web page load or a
+// `tilt logs` snapshot: every line goes through the line-builder path with
+// manifest prefixes.
+func BenchmarkStringFullStore(b *testing.B) {
+	s := benchStore(10)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = s.String()
+	}
+}
+
 // Log ingestion: one complete line per event, with the default byte cap so
 // amortized truncation stays part of the measured cost.
 func BenchmarkAppendSingleLine(b *testing.B) {

--- a/pkg/model/logstore/logstore_bench_test.go
+++ b/pkg/model/logstore/logstore_bench_test.go
@@ -1,0 +1,109 @@
+package logstore
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/tilt-dev/tilt/pkg/model"
+)
+
+// Shaped like a busy dev session: many spans (one per pod/build), with new
+// logs arriving on only a few of them between subscriber notifications.
+const benchSpanCount = 200
+
+func benchSpanName(i int) model.ManifestName {
+	return model.ManifestName(fmt.Sprintf("span-%03d", i))
+}
+
+// benchStore builds a store with benchSpanCount spans, each holding
+// linesPerSpan complete lines. The byte cap is raised so results measure the
+// hot path, not truncation policy.
+func benchStore(linesPerSpan int) *LogStore {
+	s := NewLogStore()
+	s.maxLogLengthInBytes = 500 * 1000 * 1000
+	ts := time.Unix(1594000000, 0)
+	for line := 0; line < linesPerSpan; line++ {
+		for span := 0; span < benchSpanCount; span++ {
+			name := benchSpanName(span)
+			s.Append(newTestLogEvent(name, ts, fmt.Sprintf("line %d for span %s\n", line, name)), nil)
+		}
+	}
+	return s
+}
+
+// The common steady-state notification: a handful of new lines on one span
+// since the subscriber's last checkpoint.
+func BenchmarkContinuingLinesIncremental(b *testing.B) {
+	s := benchStore(10)
+	checkpoint := s.Checkpoint()
+	ts := time.Unix(1594000100, 0)
+	for i := 0; i < 5; i++ {
+		s.Append(newTestLogEvent(benchSpanName(0), ts, fmt.Sprintf("new line %d\n", i)), nil)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = s.ContinuingLines(checkpoint)
+	}
+}
+
+// A notification that added no logs (e.g. a pure state change): the
+// subscriber asks for continuing lines and gets nothing.
+func BenchmarkContinuingLinesNoNewLogs(b *testing.B) {
+	s := benchStore(10)
+	checkpoint := s.Checkpoint()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = s.ContinuingLines(checkpoint)
+	}
+}
+
+// The websocket incremental update path: a small batch of new segments
+// serialized for the browser or a tilt logs client.
+func BenchmarkToLogListIncremental(b *testing.B) {
+	s := benchStore(10)
+	checkpoint := s.Checkpoint()
+	ts := time.Unix(1594000100, 0)
+	for i := 0; i < 5; i++ {
+		s.Append(newTestLogEvent(benchSpanName(0), ts, fmt.Sprintf("new line %d\n", i)), nil)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = s.ToLogList(checkpoint)
+	}
+}
+
+// Log ingestion: one complete line per event, with the default byte cap so
+// amortized truncation stays part of the measured cost.
+func BenchmarkAppendSingleLine(b *testing.B) {
+	s := NewLogStore()
+	ts := time.Unix(1594000000, 0)
+	event := newTestLogEvent("server", ts, "a fairly typical log line with some payload attached\n")
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		s.Append(event, nil)
+	}
+}
+
+// A multi-line write, e.g. a build log chunk arriving in one event.
+func BenchmarkAppendMultiLine(b *testing.B) {
+	s := NewLogStore()
+	ts := time.Unix(1594000000, 0)
+	msg := strings.Repeat("a build output line with some detail in it\n", 100)
+	event := newTestLogEvent("build", ts, msg)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		s.Append(event, nil)
+	}
+}

--- a/pkg/model/logstore/logstore_test.go
+++ b/pkg/model/logstore/logstore_test.go
@@ -362,6 +362,42 @@ func TestLogIncremental(t *testing.T) {
 	assert.Equal(t, int32(-1), list.ToCheckpoint)
 }
 
+func TestContinuingLinesNoNewLogs(t *testing.T) {
+	l := NewLogStore()
+	l.Append(newTestLogEvent("fe", time.Now(), "line\n"), nil)
+	checkpoint := l.Checkpoint()
+
+	assert.Empty(t, l.ContinuingLines(checkpoint))
+	assert.Empty(t, l.ContinuingLinesWithOptions(checkpoint, LineOptions{
+		ManifestNames: model.ManifestNameSet{"fe": true},
+	}))
+}
+
+func TestLogIncrementalSpansScopedToSegments(t *testing.T) {
+	l := NewLogStore()
+	l.Append(newTestLogEvent("fe", time.Now(), "fe line\n"), nil)
+	l.Append(newTestLogEvent("back", time.Now(), "back line\n"), nil)
+	checkpoint := l.Checkpoint()
+	l.Append(newTestLogEvent("back", time.Now(), "back line 2\n"), nil)
+
+	// The full list carries every span its segments reference.
+	full, err := l.ToLogList(0)
+	assert.NoError(t, err)
+	assert.Equal(t, 2, len(full.Spans))
+
+	// An incremental update carries only the spans its segments reference.
+	// Every segment's span must ride in the same update: the tilt logs client
+	// resolves segments against the spans of the update that carried them.
+	list, err := l.ToLogList(checkpoint)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(list.Segments))
+	assert.Equal(t, 1, len(list.Spans))
+	for _, seg := range list.Segments {
+		_, ok := list.Spans[seg.SpanId]
+		assert.True(t, ok, "segment span %q missing from update", seg.SpanId)
+	}
+}
+
 func TestWarnings(t *testing.T) {
 	l := NewLogStore()
 	l.Append(testLogEvent{

--- a/pkg/model/logstore/prefix.go
+++ b/pkg/model/logstore/prefix.go
@@ -1,22 +1,46 @@
 package logstore
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/tilt-dev/tilt/pkg/model"
 )
 
+// Manifest names are right-aligned into a column this many bytes wide;
+// longer names are truncated with an ellipsis.
+const sourcePrefixMaxNameLen = 13
+
+const sourcePrefixSeparator = " │ "
+const sourcePrefixEllipsis = "…"
+
+// The most bytes appendSourcePrefix can write, for pre-sizing builders.
+const sourcePrefixReserveLen = sourcePrefixMaxNameLen +
+	len(sourcePrefixSeparator) + len(sourcePrefixEllipsis)
+
+// Writes SourcePrefix(n) into sb without allocating intermediate strings.
+// This runs once per rendered log line, so it must not allocate.
+func appendSourcePrefix(sb *strings.Builder, n model.ManifestName) {
+	if n == "" || n == model.MainTiltfileManifestName {
+		return
+	}
+	if len(n) > sourcePrefixMaxNameLen {
+		sb.WriteString(string(n[:sourcePrefixMaxNameLen-1]))
+		sb.WriteString(sourcePrefixEllipsis)
+	} else {
+		for i := len(n); i < sourcePrefixMaxNameLen; i++ {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(string(n))
+	}
+	sb.WriteString(sourcePrefixSeparator)
+}
+
 func SourcePrefix(n model.ManifestName) string {
 	if n == "" || n == model.MainTiltfileManifestName {
 		return ""
 	}
-	max := 13
-	spaces := ""
-	if len(n) > max {
-		n = n[:max-1] + "…"
-	} else {
-		spaces = strings.Repeat(" ", max-len(n))
-	}
-	return fmt.Sprintf("%s%s │ ", spaces, n)
+	sb := strings.Builder{}
+	sb.Grow(sourcePrefixReserveLen)
+	appendSourcePrefix(&sb, n)
+	return sb.String()
 }

--- a/pkg/model/logstore/prefix_test.go
+++ b/pkg/model/logstore/prefix_test.go
@@ -1,0 +1,36 @@
+package logstore
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/tilt-dev/tilt/pkg/model"
+)
+
+// Characterization of the prefix format: right-aligned in a 13-byte column,
+// long names truncated with an ellipsis. appendSourcePrefix must stay
+// byte-for-byte identical to SourcePrefix.
+func TestSourcePrefix(t *testing.T) {
+	cases := []struct {
+		name     model.ManifestName
+		expected string
+	}{
+		{"", ""},
+		{model.MainTiltfileManifestName, ""},
+		{"fe", "           fe │ "},
+		{"exactly-13-ch", "exactly-13-ch │ "},
+		{"a-name-that-is-too-long", "a-name-that-… │ "},
+	}
+
+	for _, c := range cases {
+		t.Run(string(c.name), func(t *testing.T) {
+			assert.Equal(t, c.expected, SourcePrefix(c.name))
+
+			sb := strings.Builder{}
+			appendSourcePrefix(&sb, c.name)
+			assert.Equal(t, c.expected, sb.String())
+		})
+	}
+}


### PR DESCRIPTION
## Summary

After reducing subscriber work on log-only notifications, logstore was still
a major source of steady-state GC under a multi-span log storm:

- empty checkpoint windows still cloned span maps
- incremental `ToLogList` re-sent every span
- `toLogLines` allocated heavily per rendered line

This PR:

- Returns early from `ContinuingLinesWithOptions` when the checkpoint window
  is empty.
- Clones only spans referenced by the checkpoint window (drops full
  `cloneSpanMap` for that path).
- Scopes incremental `ToLogList` span payloads to segments actually sent
  (safe for `tilt logs` and the web client; covered by
  `TestLogIncrementalSpansScopedToSegments`).
- Preallocates segments from newline counts; reuses a single line builder
  and cuts per-line prefix/builder churn in `toLogLines` / prefix helpers.

## Motivation

On a ~200-span session shape after the PodMonitor skip, span cloning and
line materialization dominated remaining engine alloc profiles during
steady log ingress.

## Evidence

- Unit tests for scoped incremental spans and prefix characterization.
- New benches in `logstore_bench_test.go` (empty window, narrow window,
  full-store render, continuing lines).
- Reported microbench deltas (same shapes as in commit messages), e.g.
  full-store render ≈ 950µs / 16k allocs → ≈ 305µs / 2k allocs.
- Hermetic log-only soak floors green with log rate within the ≥80% baseline
  band while validating the firehose path.

## Test plan

- [x] `go test ./pkg/model/logstore/`
- [ ] CI on this PR
- [ ] Optional: `go test -bench=. ./pkg/model/logstore/` if reviewing numbers