### PR TITLE
logs: avoid no-op filter copies and clamp Compose log replay to tilt start

### DIFF
--- a/internal/controllers/core/dockercomposelogstream/reconciler.go
+++ b/internal/controllers/core/dockercomposelogstream/reconciler.go
@@ -152,6 +152,16 @@ func (r *Reconciler) manageLogWatch(ctx context.Context, nn types.NamespacedName
 	// the first log timestamps (also reported by Docker), so we pad it by a second to reduce the
 	// number of potentially duplicative logs
 	startWatchTime := containerState.StartedAt.Time.Add(-time.Second)
+	state := r.store.RLockState()
+	tiltStartTime := state.TiltStartTime
+	r.store.RUnlockState()
+
+	// Tilt retains about 2MB per log span, while a warm Compose container can hold GBs of json-file
+	// logs. Requesting that full history would flood the store's unbounded action queue only to discard
+	// it, so mirror the pod log stream invariant and only stream logs since Tilt started.
+	if !tiltStartTime.IsZero() && startWatchTime.Before(tiltStartTime) {
+		startWatchTime = tiltStartTime
+	}
 	if result.watch != nil {
 		if !result.watch.Done() {
 			// watcher is already running

--- a/internal/controllers/core/dockercomposelogstream/reconciler_test.go
+++ b/internal/controllers/core/dockercomposelogstream/reconciler_test.go
@@ -7,14 +7,89 @@ import (
 
 	typescontainer "github.com/moby/moby/api/types/container"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/tilt-dev/tilt/internal/container"
 	"github.com/tilt-dev/tilt/internal/controllers/fake"
 	"github.com/tilt-dev/tilt/internal/docker"
 	"github.com/tilt-dev/tilt/internal/dockercompose"
+	"github.com/tilt-dev/tilt/internal/store"
 	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
 )
+
+func TestContainerLogsSince(t *testing.T) {
+	startedAt := mustParseTime(t, "2021-09-08T19:58:01.483005100Z")
+	tiltStartTime := mustParseTime(t, "2026-07-11T03:30:00Z")
+
+	tests := []struct {
+		name          string
+		tiltStartTime time.Time
+		want          time.Time
+	}{
+		{
+			name:          "container started before Tilt",
+			tiltStartTime: tiltStartTime,
+			want:          tiltStartTime,
+		},
+		{
+			name:          "container started after Tilt",
+			tiltStartTime: startedAt.Add(-time.Minute),
+			want:          startedAt.Add(-time.Second),
+		},
+		{
+			name: "Tilt start time not initialized",
+			want: startedAt.Add(-time.Second),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := newFixture(t)
+			f.Store.WithState(func(state *store.EngineState) {
+				state.TiltStartTime = tt.tiltStartTime
+			})
+
+			containerID := "my-container-id"
+			output := make(chan string)
+			defer close(output)
+			f.dc.ContainerLogChans[containerID] = output
+			f.dc.Containers[containerID] = typescontainer.State{
+				Status:    "running",
+				Running:   true,
+				StartedAt: startedAt.Format(time.RFC3339Nano),
+			}
+			f.dcc.ContainerIDDefault = container.ID(containerID)
+
+			obj := v1alpha1.DockerComposeLogStream{
+				ObjectMeta: metav1.ObjectMeta{Name: "fe"},
+				Spec: v1alpha1.DockerComposeLogStreamSpec{
+					Service: "fe",
+					Project: v1alpha1.DockerComposeProject{YAML: "fake-yaml"},
+				},
+			}
+			f.Create(&obj)
+
+			require.Eventually(t, func() bool {
+				return len(f.dc.ContainerLogsRequestsSnapshot()) > 0
+			}, time.Second, 10*time.Millisecond)
+
+			requests := f.dc.ContainerLogsRequestsSnapshot()
+			require.Equal(t, containerID, requests[0].ContainerID)
+			got, err := time.Parse(time.RFC3339Nano, requests[0].Options.Since)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func mustParseTime(t *testing.T, value string) time.Time {
+	t.Helper()
+
+	parsed, err := time.Parse(time.RFC3339Nano, value)
+	require.NoError(t, err)
+	return parsed
+}
 
 // Make sure we stream logs correctly when
 // we're triggered by a project event.

--- a/internal/docker/fake_client.go
+++ b/internal/docker/fake_client.go
@@ -9,6 +9,7 @@ import (
 	"slices"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 	"unicode"
 
@@ -89,6 +90,11 @@ type ExecCall struct {
 	Cmd       model.Cmd
 }
 
+type ContainerLogsRequest struct {
+	ContainerID string
+	Options     client.ContainerLogsOptions
+}
+
 type FakeClient struct {
 	FakeEnv Env
 
@@ -126,8 +132,10 @@ type FakeClient struct {
 	Images map[string]typesimage.InspectResponse
 
 	// Containers returned by ContainerInspect
-	Containers        map[string]typescontainer.State
-	ContainerLogChans map[string]<-chan string
+	Containers            map[string]typescontainer.State
+	ContainerLogChans     map[string]<-chan string
+	ContainerLogsRequests []ContainerLogsRequest
+	containerLogsMu       sync.Mutex
 
 	// If true, ImageInspectWithRaw will always return an ImageInspect,
 	// even if one hasn't been explicitly pre-loaded.
@@ -192,6 +200,13 @@ func (c *FakeClient) SetExecError(err error) {
 }
 
 func (c *FakeClient) ContainerLogs(ctx context.Context, containerID string, options client.ContainerLogsOptions) (client.ContainerLogsResult, error) {
+	c.containerLogsMu.Lock()
+	c.ContainerLogsRequests = append(c.ContainerLogsRequests, ContainerLogsRequest{
+		ContainerID: containerID,
+		Options:     options,
+	})
+	c.containerLogsMu.Unlock()
+
 	output := c.ContainerLogChans[containerID]
 	reader, writer := io.Pipe()
 	go func() {
@@ -216,6 +231,13 @@ func (c *FakeClient) ContainerLogs(ctx context.Context, containerID string, opti
 		}
 	}()
 	return reader, nil
+}
+
+func (c *FakeClient) ContainerLogsRequestsSnapshot() []ContainerLogsRequest {
+	c.containerLogsMu.Lock()
+	defer c.containerLogsMu.Unlock()
+
+	return append([]ContainerLogsRequest(nil), c.ContainerLogsRequests...)
 }
 
 func (c *FakeClient) ContainerInspect(ctx context.Context, containerID string, options client.ContainerInspectOptions) (client.ContainerInspectResult, error) {

--- a/internal/hud/client/log_filter.go
+++ b/internal/hud/client/log_filter.go
@@ -150,8 +150,35 @@ func (f LogFilter) ApplyWithoutTail(lines []logstore.LogLine) []logstore.LogLine
 	return f.ApplyWithOptions(lines, false)
 }
 
+// matchesAllLines reports whether no per-line constraint is active, i.e.
+// MatchesAll is true for every possible line: no resource filter, no
+// build/runtime source restriction (those are the only two sources Matches
+// checks), no severe level filter, and no since bound. This is the default
+// `tilt up` filter, which runs on every store notification.
+func (f LogFilter) matchesAllLines() bool {
+	return len(f.resources) == 0 &&
+		f.source != FilterSourceRuntime &&
+		f.source != FilterSourceBuild &&
+		!f.level.AsSevereAs(logger.WarnLvl) &&
+		f.since.IsZero()
+}
+
 // ApplyWithOptions applies the filter with control over tail application.
+//
+// The result may share backing storage with the input; callers must not
+// mutate either afterwards.
 func (f LogFilter) ApplyWithOptions(lines []logstore.LogLine, applyTail bool) []logstore.LogLine {
+	if f.matchesAllLines() {
+		// Nothing can be filtered out, so don't pay to copy every line on
+		// every notification; the tail is a re-slice.
+		if applyTail && f.tail >= 0 && len(lines) > f.tail {
+			return lines[len(lines)-f.tail:]
+		}
+		return lines
+	}
+
+	// Grow-by-append beats presizing to len(lines) here: selective filters
+	// typically keep a small fraction of the input.
 	filtered := []logstore.LogLine{}
 	for _, line := range lines {
 		if f.MatchesAll(line) {

--- a/internal/hud/client/log_filter_bench_test.go
+++ b/internal/hud/client/log_filter_bench_test.go
@@ -1,0 +1,72 @@
+package client
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/tilt-dev/tilt/pkg/logger"
+	"github.com/tilt-dev/tilt/pkg/model"
+	"github.com/tilt-dev/tilt/pkg/model/logstore"
+)
+
+// The filter every default `tilt up` terminal stream runs with: no
+// constraint on any axis.
+func noopBenchFilter() LogFilter {
+	return NewLogFilter(FilterSourceAll, nil, FilterLevel(logger.NoneLvl),
+		FilterSince(time.Time{}), FilterTail(-1), false)
+}
+
+func benchFilterLines(n int) []logstore.LogLine {
+	ts := time.Unix(1594000000, 0)
+	lines := make([]logstore.LogLine, 0, n)
+	for i := 0; i < n; i++ {
+		mn := model.ManifestName(fmt.Sprintf("res-%03d", i%20))
+		lines = append(lines, logstore.LogLine{
+			Text:         fmt.Sprintf("log line %d with a typical payload\n", i),
+			SpanID:       logstore.SpanID(fmt.Sprintf("pod:default:%s", mn)),
+			ManifestName: mn,
+			Level:        logger.InfoLvl,
+			Time:         ts,
+		})
+	}
+	return lines
+}
+
+// The steady-state case: a no-op filter applied to each incremental batch
+// on every store notification.
+func BenchmarkLogFilterApplyNoop(b *testing.B) {
+	f := noopBenchFilter()
+	lines := benchFilterLines(50)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = f.Apply(lines)
+	}
+}
+
+// The initial-history case: a no-op filter over a large first batch.
+func BenchmarkLogFilterApplyNoopLarge(b *testing.B) {
+	f := noopBenchFilter()
+	lines := benchFilterLines(2000)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = f.Apply(lines)
+	}
+}
+
+// A real filter that keeps a subset (one resource out of twenty).
+func BenchmarkLogFilterApplyResourceFilter(b *testing.B) {
+	f := NewLogFilter(FilterSourceAll, FilterResources{"res-001"},
+		FilterLevel(logger.NoneLvl), FilterSince(time.Time{}), FilterTail(-1), false)
+	lines := benchFilterLines(2000)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = f.Apply(lines)
+	}
+}

--- a/internal/hud/client/log_filter_test.go
+++ b/internal/hud/client/log_filter_test.go
@@ -437,3 +437,67 @@ func TestLogFilterApplyWithSinceAndTail(t *testing.T) {
 	actual := filter.Apply(input)
 	assert.Equal(t, expected, actual)
 }
+
+// matchesAllLines gates the Apply fast path: it must be true only when no
+// per-line constraint is active. A false positive here would silently skip
+// real filtering.
+func TestLogFilterMatchesAllLines(t *testing.T) {
+	testCases := []struct {
+		description string
+		logFilter   LogFilter
+		expected    bool
+	}{
+		{
+			description: "zero-value filter constrains nothing",
+			logFilter:   LogFilter{},
+			expected:    true,
+		},
+		{
+			description: "default tilt up filter constrains nothing",
+			logFilter: NewLogFilter(FilterSourceAll, nil, FilterLevel(logger.NoneLvl),
+				FilterSince(time.Time{}), FilterTail(-1), false),
+			expected: true,
+		},
+		{
+			description: "tail is not a per-line constraint",
+			logFilter:   LogFilter{tail: 5},
+			expected:    true,
+		},
+		{
+			description: "resource filter is a constraint",
+			logFilter:   LogFilter{resources: FilterResources{"fe"}},
+			expected:    false,
+		},
+		{
+			description: "runtime source is a constraint",
+			logFilter:   LogFilter{source: FilterSourceRuntime},
+			expected:    false,
+		},
+		{
+			description: "build source is a constraint",
+			logFilter:   LogFilter{source: FilterSourceBuild},
+			expected:    false,
+		},
+		{
+			description: "warn level is a constraint",
+			logFilter:   LogFilter{level: logger.WarnLvl},
+			expected:    false,
+		},
+		{
+			description: "error level is a constraint",
+			logFilter:   LogFilter{level: logger.ErrorLvl},
+			expected:    false,
+		},
+		{
+			description: "since bound is a constraint",
+			logFilter:   LogFilter{since: time.Unix(1, 0)},
+			expected:    false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			assert.Equal(t, tc.expected, tc.logFilter.matchesAllLines())
+		})
+	}
+}

--- a/internal/hud/client/websocket_reader_test.go
+++ b/internal/hud/client/websocket_reader_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -24,18 +25,18 @@ func TestViewsHandled(t *testing.T) {
 	v := &proto_webview.View{Log: "hello world"}
 	f.sendView(v)
 	f.assertHandlerCallCount(1)
-	assert.Equal(t, "hello world", f.handler.lastViewLog)
+	assert.Equal(t, "hello world", f.handler.lastLog())
 
 	v = &proto_webview.View{Log: "goodbye world"}
 	f.sendView(v)
 	f.assertHandlerCallCount(2)
-	assert.Equal(t, "goodbye world", f.handler.lastViewLog)
+	assert.Equal(t, "goodbye world", f.handler.lastLog())
 }
 
 func TestHandlerErrorDoesntStopLoop(t *testing.T) {
 	f := newWebsocketReaderFixture(t)
 	f.start()
-	f.handler.nextErr = fmt.Errorf("aw nerts")
+	f.handler.setNextErr(fmt.Errorf("aw nerts"))
 
 	v := &proto_webview.View{Log: "hello world"}
 	f.sendView(v)
@@ -46,7 +47,7 @@ func TestHandlerErrorDoesntStopLoop(t *testing.T) {
 	v = &proto_webview.View{Log: "goodbye world"}
 	f.sendView(v)
 	f.assertHandlerCallCount(2)
-	assert.Equal(t, "goodbye world", f.handler.lastViewLog)
+	assert.Equal(t, "goodbye world", f.handler.lastLog())
 }
 
 func TestNonPersistentReaderExistsAfterHandling(t *testing.T) {
@@ -56,7 +57,7 @@ func TestNonPersistentReaderExistsAfterHandling(t *testing.T) {
 	v := &proto_webview.View{Log: "hello world"}
 	f.sendView(v)
 	f.assertHandlerCallCount(1)
-	assert.Equal(t, "hello world", f.handler.lastViewLog)
+	assert.Equal(t, "hello world", f.handler.lastLog())
 	f.assertDone()
 }
 
@@ -130,12 +131,13 @@ func (f *websocketReaderFixture) assertHandlerCallCount(n int) {
 	isCanceled := false
 
 	for {
-		if f.handler.callCount == n {
+		callCount := f.handler.callCount()
+		if callCount == n {
 			return
 		}
 		if isCanceled {
 			f.t.Fatalf("Timed out waiting for handler.callCount = %d (got: %d)",
-				n, f.handler.callCount)
+				n, callCount)
 		}
 
 		select {
@@ -166,13 +168,17 @@ func (f *websocketReaderFixture) assertDone() {
 }
 
 type fakeViewHandler struct {
-	callCount   int
+	mu          sync.Mutex
+	calls       int
 	lastViewLog string // use the Log field to differentiate the views we send, cuz why not
 	nextErr     error
 }
 
 func (fvh *fakeViewHandler) Handle(v *proto_webview.View) error {
-	fvh.callCount += 1
+	fvh.mu.Lock()
+	defer fvh.mu.Unlock()
+
+	fvh.calls += 1
 	if fvh.nextErr != nil {
 		err := fvh.nextErr
 		fvh.nextErr = nil
@@ -180,4 +186,25 @@ func (fvh *fakeViewHandler) Handle(v *proto_webview.View) error {
 	}
 	fvh.lastViewLog = v.Log
 	return nil
+}
+
+func (fvh *fakeViewHandler) callCount() int {
+	fvh.mu.Lock()
+	defer fvh.mu.Unlock()
+
+	return fvh.calls
+}
+
+func (fvh *fakeViewHandler) setNextErr(err error) {
+	fvh.mu.Lock()
+	defer fvh.mu.Unlock()
+
+	fvh.nextErr = err
+}
+
+func (fvh *fakeViewHandler) lastLog() string {
+	fvh.mu.Lock()
+	defer fvh.mu.Unlock()
+
+	return fvh.lastViewLog
 }


### PR DESCRIPTION
## Summary

Three small, related fixes on the log ingress / presentation path:

1. **Default log filter no longer copies every line.**
   The default `tilt up` terminal filter constrains nothing, but
   `ApplyWithOptions` still allocated a fresh `[]LogLine` on every batch.
   Constraint-free filters now return the input (tail as a re-slice). Selective
   filters keep grow-by-append (presizing regressed sparse filters in benches).
   Contract test ensures `matchesAllLines` cannot false-positive.

2. **Docker Compose log streams clamp `Since` to Tilt start.**
   Warm Compose containers previously replayed the full docker json-file
   backlog from container start into the store action queue. Kubernetes pod
   logs already stream from Tilt start; Compose now uses
   `max(container start − 1s, TiltStartTime)`. Live lines after `tilt up` are
   unchanged.

3. **Websocket reader test fixture is race-safe.**
   Test-only mutex around shared fake-handler state so
   `go test -race ./internal/hud/client/` passes (pre-existing race; unrelated
   to the filter change).

## Motivation

- Filter copy: largest optimizable allocator left in a log-storm profile after
  logstore work (~6% cumulative allocs / tens of MB flat on the no-op path).
- Compose replay: warm-restart against a multi-GB docker log backlog drove RSS
  into multi-GB within seconds and OOM under a memory cap, even though Tilt
  truncates retained spans to ~2MB — the damage is the transient replay.

## Evidence

- Filter unit + contract tests; benches: no-op 2000-line batch ≈ 170µs / 838KB
  → ≈ 3.5ns / 0 allocs.
- New reconciler test fails without the Compose `Since` clamp; fake Docker
  client records the requested window.
- Package tests pass with `-race` for the websocket fixture change.
- Compose warm-restart observation (local): multi-GB RSS / OOM without clamp →
  ~154–306MB over a 10‑minute soak with clamp.

## Test plan

- [x] `go test ./internal/hud/client/ ./internal/controllers/core/dockercomposelogstream/`
- [ ] `go test -race ./internal/hud/client/`
- [ ] CI on this PR
- [ ] Manual (Compose): restart Tilt against long-lived containers; confirm
      backlog is not fully replayed and new lines still stream

## Notes

If preferred, the race-only websocket commit can be split out; it is kept here
because it is the same package as the filter change and unblocks `-race` CI
locally.