### PR TITLE
dockercompose: small logs api tweaks

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -347,6 +347,7 @@ github.com/google/pprof v0.0.0-20260115054156-294ebfa9ad83 h1:z2ogiKUYzX5Is6zr/v
 github.com/google/pprof v0.0.0-20260115054156-294ebfa9ad83/go.mod h1:MxpfABSjhmINe3F1It9d+8exIHFvUqtLIRCdOGNXqiI=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
+github.com/google/subcommands v1.2.0 h1:vWQspBTo2nEqTUFita5/KeEWlUL8kQObDFbub/EN9oE=
 github.com/google/subcommands v1.2.0/go.mod h1:ZjhPrFU+Olkh9WazFPsl27BQ4UPiG37m3yTrtFlrHVk=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=

--- a/internal/cli/wire.go
+++ b/internal/cli/wire.go
@@ -113,6 +113,7 @@ var BaseWireSet = wire.NewSet(
 
 	build.ProvideClock,
 	provideClock,
+	model.ProvideStartTime,
 	provideLogSource,
 	provideLogResources,
 	provideLogLevel,

--- a/internal/cli/wire_gen.go
+++ b/internal/cli/wire_gen.go
@@ -141,7 +141,8 @@ func wireTiltfileResult(ctx context.Context, analytics2 *analytics.TiltAnalytics
 	env := localexec.DefaultEnv(webPort, webHost, kubeconfigPathOnce)
 	processExecer := localexec.NewProcessExecer(env)
 	defaults := _wireDefaultsValue
-	tiltfileLoader := tiltfile.ProvideTiltfileLoader(analytics2, plugin, versionPlugin, configPlugin, tiltextensionPlugin, cisettingsPlugin, dockerComposeClient, webHost, processExecer, defaults, product)
+	startTime := model.ProvideStartTime()
+	tiltfileLoader := tiltfile.ProvideTiltfileLoader(analytics2, plugin, versionPlugin, configPlugin, tiltextensionPlugin, cisettingsPlugin, dockerComposeClient, webHost, processExecer, defaults, product, startTime)
 	cliCmdTiltfileResultDeps := newTiltfileResultDeps(tiltfileLoader)
 	return cliCmdTiltfileResultDeps, nil
 }
@@ -203,7 +204,8 @@ func wireDockerPrune(ctx context.Context, analytics2 *analytics.TiltAnalytics, s
 	env := localexec.DefaultEnv(webPort, webHost, kubeconfigPathOnce)
 	processExecer := localexec.NewProcessExecer(env)
 	defaults := _wireDefaultsValue
-	tiltfileLoader := tiltfile.ProvideTiltfileLoader(analytics2, plugin, versionPlugin, configPlugin, tiltextensionPlugin, cisettingsPlugin, dockerComposeClient, webHost, processExecer, defaults, product)
+	startTime := model.ProvideStartTime()
+	tiltfileLoader := tiltfile.ProvideTiltfileLoader(analytics2, plugin, versionPlugin, configPlugin, tiltextensionPlugin, cisettingsPlugin, dockerComposeClient, webHost, processExecer, defaults, product, startTime)
 	cliDpDeps := newDPDeps(compositeClient, client, tiltfileLoader)
 	return cliDpDeps, nil
 }
@@ -320,7 +322,8 @@ func wireCmdUp(ctx context.Context, analytics3 *analytics.TiltAnalytics, cmdTags
 	localEnv := docker.ProvideLocalEnv(ctx, realClientCreator, kubeContext, product, clusterEnv)
 	dockerComposeClient := dockercompose.NewDockerComposeClient(localEnv)
 	defaults := _wireDefaultsValue
-	tiltfileLoader := tiltfile.ProvideTiltfileLoader(analytics3, plugin, versionPlugin, configPlugin, tiltextensionPlugin, cisettingsPlugin, dockerComposeClient, webHost, processExecer, defaults, product)
+	startTime := model.ProvideStartTime()
+	tiltfileLoader := tiltfile.ProvideTiltfileLoader(analytics3, plugin, versionPlugin, configPlugin, tiltextensionPlugin, cisettingsPlugin, dockerComposeClient, webHost, processExecer, defaults, product, startTime)
 	localClient := docker.ProvideLocalCli(ctx, localEnv)
 	clusterClient, err := docker.ProvideClusterCli(ctx, localEnv, clusterEnv, localClient)
 	if err != nil {
@@ -351,7 +354,7 @@ func wireCmdUp(ctx context.Context, analytics3 *analytics.TiltAnalytics, cmdTags
 	kubernetesClientFactory := _wireKubernetesClientFuncValue
 	clusterReconciler := cluster.NewReconciler(ctx, deferredClient, storeStore, clock, connectionManager, localEnv, dockerClientFactory, kubernetesClientFactory, websocketList, writer, kubeconfigPathOnce)
 	disableSubscriber := dockercomposeservice.NewDisableSubscriber(ctx, dockerComposeClient, clock)
-	dockercomposeserviceReconciler := dockercomposeservice.NewReconciler(deferredClient, dockerComposeClient, compositeClient, storeStore, scheme, disableSubscriber)
+	dockercomposeserviceReconciler := dockercomposeservice.NewReconciler(deferredClient, dockerComposeClient, compositeClient, storeStore, scheme, disableSubscriber, startTime)
 	imagemapReconciler := imagemap.NewReconciler(deferredClient, storeStore)
 	dockercomposelogstreamReconciler := dockercomposelogstream.NewReconciler(deferredClient, storeStore, dockerComposeClient, compositeClient)
 	sessionReconciler := session.NewReconciler(deferredClient, storeStore, clock)
@@ -545,7 +548,8 @@ func wireCmdCI(ctx context.Context, analytics3 *analytics.TiltAnalytics, subcomm
 	localEnv := docker.ProvideLocalEnv(ctx, realClientCreator, kubeContext, product, clusterEnv)
 	dockerComposeClient := dockercompose.NewDockerComposeClient(localEnv)
 	defaults := _wireDefaultsValue
-	tiltfileLoader := tiltfile.ProvideTiltfileLoader(analytics3, plugin, versionPlugin, configPlugin, tiltextensionPlugin, cisettingsPlugin, dockerComposeClient, webHost, processExecer, defaults, product)
+	startTime := model.ProvideStartTime()
+	tiltfileLoader := tiltfile.ProvideTiltfileLoader(analytics3, plugin, versionPlugin, configPlugin, tiltextensionPlugin, cisettingsPlugin, dockerComposeClient, webHost, processExecer, defaults, product, startTime)
 	localClient := docker.ProvideLocalCli(ctx, localEnv)
 	clusterClient, err := docker.ProvideClusterCli(ctx, localEnv, clusterEnv, localClient)
 	if err != nil {
@@ -576,7 +580,7 @@ func wireCmdCI(ctx context.Context, analytics3 *analytics.TiltAnalytics, subcomm
 	kubernetesClientFactory := _wireKubernetesClientFuncValue
 	clusterReconciler := cluster.NewReconciler(ctx, deferredClient, storeStore, clock, connectionManager, localEnv, dockerClientFactory, kubernetesClientFactory, websocketList, writer, kubeconfigPathOnce)
 	disableSubscriber := dockercomposeservice.NewDisableSubscriber(ctx, dockerComposeClient, clock)
-	dockercomposeserviceReconciler := dockercomposeservice.NewReconciler(deferredClient, dockerComposeClient, compositeClient, storeStore, scheme, disableSubscriber)
+	dockercomposeserviceReconciler := dockercomposeservice.NewReconciler(deferredClient, dockerComposeClient, compositeClient, storeStore, scheme, disableSubscriber, startTime)
 	imagemapReconciler := imagemap.NewReconciler(deferredClient, storeStore)
 	dockercomposelogstreamReconciler := dockercomposelogstream.NewReconciler(deferredClient, storeStore, dockerComposeClient, compositeClient)
 	sessionReconciler := session.NewReconciler(deferredClient, storeStore, clock)
@@ -766,7 +770,8 @@ func wireCmdUpdog(ctx context.Context, analytics3 *analytics.TiltAnalytics, cmdT
 	localEnv := docker.ProvideLocalEnv(ctx, realClientCreator, kubeContext, product, clusterEnv)
 	dockerComposeClient := dockercompose.NewDockerComposeClient(localEnv)
 	defaults := _wireDefaultsValue
-	tiltfileLoader := tiltfile.ProvideTiltfileLoader(analytics3, plugin, versionPlugin, configPlugin, tiltextensionPlugin, cisettingsPlugin, dockerComposeClient, webHost, processExecer, defaults, product)
+	startTime := model.ProvideStartTime()
+	tiltfileLoader := tiltfile.ProvideTiltfileLoader(analytics3, plugin, versionPlugin, configPlugin, tiltextensionPlugin, cisettingsPlugin, dockerComposeClient, webHost, processExecer, defaults, product, startTime)
 	localClient := docker.ProvideLocalCli(ctx, localEnv)
 	clusterClient, err := docker.ProvideClusterCli(ctx, localEnv, clusterEnv, localClient)
 	if err != nil {
@@ -797,7 +802,7 @@ func wireCmdUpdog(ctx context.Context, analytics3 *analytics.TiltAnalytics, cmdT
 	kubernetesClientFactory := _wireKubernetesClientFuncValue
 	clusterReconciler := cluster.NewReconciler(ctx, deferredClient, storeStore, clock, connectionManager, localEnv, dockerClientFactory, kubernetesClientFactory, websocketList, writer, kubeconfigPathOnce)
 	disableSubscriber := dockercomposeservice.NewDisableSubscriber(ctx, dockerComposeClient, clock)
-	dockercomposeserviceReconciler := dockercomposeservice.NewReconciler(deferredClient, dockerComposeClient, compositeClient, storeStore, scheme, disableSubscriber)
+	dockercomposeserviceReconciler := dockercomposeservice.NewReconciler(deferredClient, dockerComposeClient, compositeClient, storeStore, scheme, disableSubscriber, startTime)
 	imagemapReconciler := imagemap.NewReconciler(deferredClient, storeStore)
 	dockercomposelogstreamReconciler := dockercomposelogstream.NewReconciler(deferredClient, storeStore, dockerComposeClient, compositeClient)
 	sessionReconciler := session.NewReconciler(deferredClient, storeStore, clock)
@@ -1026,7 +1031,8 @@ func wireDownDeps(ctx context.Context, tiltAnalytics *analytics.TiltAnalytics, s
 	env := localexec.DefaultEnv(webPort, webHost, kubeconfigPathOnce)
 	processExecer := localexec.NewProcessExecer(env)
 	defaults := _wireDefaultsValue
-	tiltfileLoader := tiltfile.ProvideTiltfileLoader(tiltAnalytics, plugin, versionPlugin, configPlugin, tiltextensionPlugin, cisettingsPlugin, dockerComposeClient, webHost, processExecer, defaults, product)
+	startTime := model.ProvideStartTime()
+	tiltfileLoader := tiltfile.ProvideTiltfileLoader(tiltAnalytics, plugin, versionPlugin, configPlugin, tiltextensionPlugin, cisettingsPlugin, dockerComposeClient, webHost, processExecer, defaults, product, startTime)
 	downDeps := DownDeps{
 		tfl:              tiltfileLoader,
 		dcClient:         dockerComposeClient,
@@ -1149,8 +1155,7 @@ var K8sWireSet = wire.NewSet(k8s.ProvideClusterProduct, k8s.ProvideClusterName, 
 	ProvideNamespaceOverride)
 
 var BaseWireSet = wire.NewSet(
-	K8sWireSet, tiltfile.WireSet, git.ProvideGitRemote, localexec.DefaultEnv, localexec.NewProcessExecer, wire.Bind(new(localexec.Execer), new(*localexec.ProcessExecer)), docker.SwitchWireSet, dockercompose.NewDockerComposeClient, clockwork.NewRealClock, engine.DeployerWireSet, engine.NewBuildController, local.NewServerController, kubernetesdiscovery.NewContainerRestartDetector, k8swatch.NewServiceWatcher, k8swatch.NewEventWatchManager, uisession2.NewSubscriber, uiresource2.NewSubscriber, configs.NewConfigsController, configs.NewTriggerQueueSubscriber, telemetry.NewController, cloud.WireSet, cloudurl.ProvideAddress, k8srollout.NewPodMonitor, telemetry.NewStartTracker, session2.NewController, build.ProvideClock, provideClock,
-	provideLogSource,
+	K8sWireSet, tiltfile.WireSet, git.ProvideGitRemote, localexec.DefaultEnv, localexec.NewProcessExecer, wire.Bind(new(localexec.Execer), new(*localexec.ProcessExecer)), docker.SwitchWireSet, dockercompose.NewDockerComposeClient, clockwork.NewRealClock, engine.DeployerWireSet, engine.NewBuildController, local.NewServerController, kubernetesdiscovery.NewContainerRestartDetector, k8swatch.NewServiceWatcher, k8swatch.NewEventWatchManager, uisession2.NewSubscriber, uiresource2.NewSubscriber, configs.NewConfigsController, configs.NewTriggerQueueSubscriber, telemetry.NewController, cloud.WireSet, cloudurl.ProvideAddress, k8srollout.NewPodMonitor, telemetry.NewStartTracker, session2.NewController, build.ProvideClock, provideClock, model.ProvideStartTime, provideLogSource,
 	provideLogResources,
 	provideLogLevel,
 	provideLogSince,

--- a/internal/controllers/core/dockercomposelogstream/reconciler.go
+++ b/internal/controllers/core/dockercomposelogstream/reconciler.go
@@ -27,6 +27,11 @@ import (
 	"github.com/tilt-dev/tilt/pkg/model"
 )
 
+// Docker evidently records the container start time asynchronously, so it can actually be AFTER
+// the first log timestamps (also reported by Docker), so we pad it by a second to reduce the
+// number of potentially duplicative logs
+var logStartTimePadding = -time.Second
+
 type ContainerInfo struct {
 	ID    string
 	State *v1alpha1.DockerContainerState
@@ -151,17 +156,11 @@ func (r *Reconciler) manageLogWatch(ctx context.Context, nn types.NamespacedName
 	// Docker evidently records the container start time asynchronously, so it can actually be AFTER
 	// the first log timestamps (also reported by Docker), so we pad it by a second to reduce the
 	// number of potentially duplicative logs
-	startWatchTime := containerState.StartedAt.Time.Add(-time.Second)
-	state := r.store.RLockState()
-	tiltStartTime := state.TiltStartTime
-	r.store.RUnlockState()
-
-	// Tilt retains about 2MB per log span, while a warm Compose container can hold GBs of json-file
-	// logs. Requesting that full history would flood the store's unbounded action queue only to discard
-	// it, so mirror the pod log stream invariant and only stream logs since Tilt started.
-	if !tiltStartTime.IsZero() && startWatchTime.Before(tiltStartTime) {
-		startWatchTime = tiltStartTime
+	startWatchTime := containerState.StartedAt.Time.Add(logStartTimePadding)
+	if obj.Spec.SinceTime != nil && obj.Spec.SinceTime.Time.After(startWatchTime) {
+		startWatchTime = obj.Spec.SinceTime.Time.Add(logStartTimePadding)
 	}
+
 	if result.watch != nil {
 		if !result.watch.Done() {
 			// watcher is already running

--- a/internal/controllers/core/dockercomposelogstream/reconciler_test.go
+++ b/internal/controllers/core/dockercomposelogstream/reconciler_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/tilt-dev/tilt/internal/controllers/fake"
 	"github.com/tilt-dev/tilt/internal/docker"
 	"github.com/tilt-dev/tilt/internal/dockercompose"
-	"github.com/tilt-dev/tilt/internal/store"
 	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
 )
 
@@ -30,25 +29,22 @@ func TestContainerLogsSince(t *testing.T) {
 		{
 			name:          "container started before Tilt",
 			tiltStartTime: tiltStartTime,
-			want:          tiltStartTime,
+			want:          tiltStartTime.Add(logStartTimePadding),
 		},
 		{
 			name:          "container started after Tilt",
 			tiltStartTime: startedAt.Add(-time.Minute),
-			want:          startedAt.Add(-time.Second),
+			want:          startedAt.Add(logStartTimePadding),
 		},
 		{
 			name: "Tilt start time not initialized",
-			want: startedAt.Add(-time.Second),
+			want: startedAt.Add(logStartTimePadding),
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			f := newFixture(t)
-			f.Store.WithState(func(state *store.EngineState) {
-				state.TiltStartTime = tt.tiltStartTime
-			})
 
 			containerID := "my-container-id"
 			output := make(chan string)
@@ -64,8 +60,9 @@ func TestContainerLogsSince(t *testing.T) {
 			obj := v1alpha1.DockerComposeLogStream{
 				ObjectMeta: metav1.ObjectMeta{Name: "fe"},
 				Spec: v1alpha1.DockerComposeLogStreamSpec{
-					Service: "fe",
-					Project: v1alpha1.DockerComposeProject{YAML: "fake-yaml"},
+					Service:   "fe",
+					Project:   v1alpha1.DockerComposeProject{YAML: "fake-yaml"},
+					SinceTime: &metav1.Time{Time: tt.tiltStartTime},
 				},
 			}
 			f.Create(&obj)
@@ -78,7 +75,7 @@ func TestContainerLogsSince(t *testing.T) {
 			require.Equal(t, containerID, requests[0].ContainerID)
 			got, err := time.Parse(time.RFC3339Nano, requests[0].Options.Since)
 			require.NoError(t, err)
-			assert.Equal(t, tt.want, got)
+			assert.Equal(t, tt.want.UTC(), got.UTC())
 		})
 	}
 }

--- a/internal/controllers/core/dockercomposeservice/logs.go
+++ b/internal/controllers/core/dockercomposeservice/logs.go
@@ -106,6 +106,7 @@ func (r *Reconciler) toDesiredLogStream(obj *v1alpha1.DockerComposeService) (*v1
 		return nil, nil
 	}
 
+	sinceTime := metav1.Time(r.startTime)
 	desired := &v1alpha1.DockerComposeLogStream{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: obj.Name,
@@ -115,8 +116,9 @@ func (r *Reconciler) toDesiredLogStream(obj *v1alpha1.DockerComposeService) (*v1
 			},
 		},
 		Spec: v1alpha1.DockerComposeLogStreamSpec{
-			Service: obj.Spec.Service,
-			Project: obj.Spec.Project,
+			Service:   obj.Spec.Service,
+			Project:   obj.Spec.Project,
+			SinceTime: &sinceTime,
 		},
 	}
 

--- a/internal/controllers/core/dockercomposeservice/reconciler.go
+++ b/internal/controllers/core/dockercomposeservice/reconciler.go
@@ -43,6 +43,7 @@ type Reconciler struct {
 	indexer      *indexer.Indexer
 	requeuer     *indexer.Requeuer
 	disableQueue *DisableSubscriber
+	startTime    model.StartTime
 	mu           sync.Mutex
 
 	// Protected by the mutex.
@@ -71,6 +72,7 @@ func NewReconciler(
 	st store.RStore,
 	scheme *runtime.Scheme,
 	disableQueue *DisableSubscriber,
+	startTime model.StartTime,
 ) *Reconciler {
 	return &Reconciler{
 		ctrlClient:                     ctrlClient,
@@ -80,6 +82,7 @@ func NewReconciler(
 		st:                             st,
 		requeuer:                       indexer.NewRequeuer(),
 		disableQueue:                   disableQueue,
+		startTime:                      startTime,
 		results:                        make(map[types.NamespacedName]*Result),
 		resultsByServiceName:           make(map[string]*Result),
 		healthcheckOutputByServiceName: make(map[string]string),

--- a/internal/controllers/core/dockercomposeservice/reconciler_test.go
+++ b/internal/controllers/core/dockercomposeservice/reconciler_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/tilt-dev/tilt/internal/testutils/manifestbuilder"
 	"github.com/tilt-dev/tilt/internal/testutils/tempdir"
 	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
+	"github.com/tilt-dev/tilt/pkg/model"
 )
 
 func TestImageIndexing(t *testing.T) {
@@ -298,7 +299,7 @@ func newFixture(t *testing.T) *fixture {
 	dCli := docker.NewFakeClient()
 	clock := clockwork.NewFakeClock()
 	watcher := NewDisableSubscriber(cfb.Context(), dcCli, clock)
-	r := NewReconciler(cfb.Client, dcCli, dCli, cfb.Store, v1alpha1.NewScheme(), watcher)
+	r := NewReconciler(cfb.Client, dcCli, dCli, cfb.Store, v1alpha1.NewScheme(), watcher, model.ProvideStartTime())
 
 	return &fixture{
 		ControllerFixture: cfb.Build(r),

--- a/internal/engine/buildcontrol/wire.go
+++ b/internal/engine/buildcontrol/wire.go
@@ -32,6 +32,7 @@ import (
 	"github.com/tilt-dev/tilt/internal/store/liveupdates"
 	"github.com/tilt-dev/tilt/internal/tracer"
 	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
+	"github.com/tilt-dev/tilt/pkg/model"
 )
 
 var BaseWireSet = wire.NewSet(
@@ -99,6 +100,7 @@ func ProvideDockerComposeBuildAndDeployer(
 	wire.Build(
 		BaseWireSet,
 		dockercomposeservice.WireSet,
+		model.ProvideStartTime,
 		build.ProvideClock,
 		build.NewKINDLoader,
 		dockerimage.NewReconciler,

--- a/internal/engine/buildcontrol/wire_gen.go
+++ b/internal/engine/buildcontrol/wire_gen.go
@@ -31,6 +31,7 @@ import (
 	"github.com/tilt-dev/tilt/internal/store/liveupdates"
 	"github.com/tilt-dev/tilt/internal/tracer"
 	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
+	"github.com/tilt-dev/tilt/pkg/model"
 	"github.com/tilt-dev/wmclient/pkg/dirs"
 )
 
@@ -73,7 +74,8 @@ func ProvideDockerComposeBuildAndDeployer(ctx context.Context, dcCli dockercompo
 	reconciler := dockerimage.NewReconciler(ctrlclient, st, scheme, dCli, imageBuilder)
 	cmdimageReconciler := cmdimage.NewReconciler(ctrlclient, st, scheme, dCli, imageBuilder)
 	disableSubscriber := dockercomposeservice.NewDisableSubscriber(ctx, dcCli, clock)
-	dockercomposeserviceReconciler := dockercomposeservice.NewReconciler(ctrlclient, dcCli, dCli, st, scheme, disableSubscriber)
+	startTime := model.ProvideStartTime()
+	dockercomposeserviceReconciler := dockercomposeservice.NewReconciler(ctrlclient, dcCli, dCli, st, scheme, disableSubscriber, startTime)
 	dockerComposeBuildAndDeployer := NewDockerComposeBuildAndDeployer(reconciler, cmdimageReconciler, imageBuilder, dockercomposeserviceReconciler, buildClock, ctrlclient)
 	return dockerComposeBuildAndDeployer, nil
 }

--- a/internal/engine/upper_test.go
+++ b/internal/engine/upper_test.go
@@ -3273,7 +3273,7 @@ func newTestFixture(t *testing.T, options ...fixtureOptions) *testFixture {
 	ciSettingsPlugin := cisettings.NewPlugin(0)
 	realTFL := tiltfile.ProvideTiltfileLoader(ta,
 		k8sContextPlugin, versionPlugin, configPlugin, extPlugin, ciSettingsPlugin,
-		fakeDcc, "localhost", execer, feature.MainDefaults, env)
+		fakeDcc, "localhost", execer, feature.MainDefaults, env, model.ProvideStartTime())
 	tfl := tiltfile.NewFakeTiltfileLoader()
 	cc := configs.NewConfigsController(cdc)
 	tqs := configs.NewTriggerQueueSubscriber(cdc)
@@ -3320,7 +3320,7 @@ func newTestFixture(t *testing.T, options ...fixtureOptions) *testFixture {
 
 	kar := kubernetesapply.NewReconciler(cdc, kClient, sch, st, execer)
 	dcds := dockercomposeservice.NewDisableSubscriber(ctx, fakeDcc, clock)
-	dcr := dockercomposeservice.NewReconciler(cdc, fakeDcc, dockerClient, st, sch, dcds)
+	dcr := dockercomposeservice.NewReconciler(cdc, fakeDcc, dockerClient, st, sch, dcds, model.ProvideStartTime())
 
 	tfr := ctrltiltfile.NewReconciler(st, tfl, dockerClient, cdc, sch, engineMode, "", "", 0)
 	tbr := togglebutton.NewReconciler(cdc, sch)

--- a/internal/engine/wire.go
+++ b/internal/engine/wire.go
@@ -31,6 +31,7 @@ import (
 	"github.com/tilt-dev/tilt/internal/localexec"
 	"github.com/tilt-dev/tilt/internal/store"
 	"github.com/tilt-dev/tilt/internal/store/liveupdates"
+	"github.com/tilt-dev/tilt/pkg/model"
 )
 
 var DeployerBaseWireSet = wire.NewSet(
@@ -75,6 +76,7 @@ func provideFakeBuildAndDeployer(
 		dockerimage.NewReconciler,
 		cmdimage.NewReconciler,
 		dockercomposeservice.WireSet,
+		model.ProvideStartTime,
 		cmd.WireSet,
 		clockwork.NewRealClock,
 		provideFakeEnv,

--- a/internal/engine/wire_gen.go
+++ b/internal/engine/wire_gen.go
@@ -33,6 +33,7 @@ import (
 	"github.com/tilt-dev/tilt/internal/store/liveupdates"
 	"github.com/tilt-dev/tilt/internal/tracer"
 	"github.com/tilt-dev/tilt/pkg/apis/core/v1alpha1"
+	"github.com/tilt-dev/tilt/pkg/model"
 	"github.com/tilt-dev/wmclient/pkg/dirs"
 )
 
@@ -54,7 +55,8 @@ func provideFakeBuildAndDeployer(ctx context.Context, docker2 docker.Client, kCl
 	kubernetesapplyReconciler := kubernetesapply.NewReconciler(ctrlClient, kClient, scheme, st, execer)
 	imageBuildAndDeployer := buildcontrol.NewImageBuildAndDeployer(reconciler, cmdimageReconciler, imageBuilder, analytics2, clock, ctrlClient, kubernetesapplyReconciler)
 	disableSubscriber := dockercomposeservice.NewDisableSubscriber(ctx, dcc, clockworkClock)
-	dockercomposeserviceReconciler := dockercomposeservice.NewReconciler(ctrlClient, dcc, docker2, st, scheme, disableSubscriber)
+	startTime := model.ProvideStartTime()
+	dockercomposeserviceReconciler := dockercomposeservice.NewReconciler(ctrlClient, dcc, docker2, st, scheme, disableSubscriber, startTime)
 	dockerComposeBuildAndDeployer := buildcontrol.NewDockerComposeBuildAndDeployer(reconciler, cmdimageReconciler, imageBuilder, dockercomposeserviceReconciler, clock, ctrlClient)
 	localTargetBuildAndDeployer := buildcontrol.NewLocalTargetBuildAndDeployer(clock, ctrlClient, controller)
 	kubeContext := provideFakeKubeContext(env)

--- a/internal/hud/client/log_filter.go
+++ b/internal/hud/client/log_filter.go
@@ -17,6 +17,10 @@ const (
 	FilterSourceRuntime FilterSource = "runtime"
 )
 
+func (s FilterSource) MatchesAll() bool {
+	return s == FilterSourceAll || s == ""
+}
+
 func (s FilterSource) String() string { return string(s) }
 
 type FilterResources []model.ManifestName
@@ -157,8 +161,7 @@ func (f LogFilter) ApplyWithoutTail(lines []logstore.LogLine) []logstore.LogLine
 // `tilt up` filter, which runs on every store notification.
 func (f LogFilter) matchesAllLines() bool {
 	return len(f.resources) == 0 &&
-		f.source != FilterSourceRuntime &&
-		f.source != FilterSourceBuild &&
+		f.source.MatchesAll() &&
 		!f.level.AsSevereAs(logger.WarnLvl) &&
 		f.since.IsZero()
 }

--- a/internal/tiltfile/tiltfile.go
+++ b/internal/tiltfile/tiltfile.go
@@ -106,7 +106,8 @@ func ProvideTiltfileLoader(
 	webHost model.WebHost,
 	execer localexec.Execer,
 	fDefaults feature.Defaults,
-	env clusterid.Product) TiltfileLoader {
+	env clusterid.Product,
+	startTime model.StartTime) TiltfileLoader {
 	return tiltfileLoader{
 		analytics:        analytics,
 		k8sContextPlugin: k8sContextPlugin,
@@ -119,6 +120,7 @@ func ProvideTiltfileLoader(
 		execer:           execer,
 		fDefaults:        fDefaults,
 		env:              env,
+		startTime:        startTime,
 	}
 }
 
@@ -135,6 +137,7 @@ type tiltfileLoader struct {
 	ciSettingsPlugin cisettings.Plugin
 	fDefaults        feature.Defaults
 	env              clusterid.Product
+	startTime        model.StartTime
 }
 
 var _ TiltfileLoader = &tiltfileLoader{}
@@ -174,7 +177,7 @@ func (tfl tiltfileLoader) Load(ctx context.Context, tf *corev1alpha1.Tiltfile, p
 	tlr.Tiltignore = tiltignore
 
 	s := newTiltfileState(ctx, tfl.dcCli, tfl.webHost, tfl.execer, tfl.k8sContextPlugin, tfl.versionPlugin,
-		tfl.configPlugin, tfl.extensionPlugin, tfl.ciSettingsPlugin, feature.FromDefaults(tfl.fDefaults))
+		tfl.configPlugin, tfl.extensionPlugin, tfl.ciSettingsPlugin, feature.FromDefaults(tfl.fDefaults), tfl.startTime)
 
 	manifests, result, err := s.loadManifests(tf)
 

--- a/internal/tiltfile/tiltfile_state.go
+++ b/internal/tiltfile/tiltfile_state.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"github.com/looplab/tarjan"
 	"github.com/pkg/errors"
@@ -68,8 +67,6 @@ var unmatchedImageAllUnresourcedWarning = "No Kubernetes configs with images fou
 	"If you are using CRDs, add k8s_kind() to tell Tilt how to find images.\n" +
 	"https://docs.tilt.dev/api.html#api.k8s_kind"
 
-var pkgInitTime = time.Now()
-
 type resourceSet struct {
 	dc  []*dcResourceSet
 	k8s []*k8sResource
@@ -87,6 +84,7 @@ type tiltfileState struct {
 	extensionPlugin  *tiltextension.Plugin
 	ciSettingsPlugin cisettings.Plugin
 	features         feature.FeatureSet
+	startTime        model.StartTime
 
 	// added to during execution
 	buildIndex     *buildIndex
@@ -165,7 +163,8 @@ func newTiltfileState(
 	configPlugin *config.Plugin,
 	extensionPlugin *tiltextension.Plugin,
 	ciSettingsPlugin cisettings.Plugin,
-	features feature.FeatureSet) *tiltfileState {
+	features feature.FeatureSet,
+	startTime model.StartTime) *tiltfileState {
 	return &tiltfileState{
 		ctx:                       ctx,
 		dcCli:                     dcCli,
@@ -176,6 +175,7 @@ func newTiltfileState(
 		configPlugin:              configPlugin,
 		extensionPlugin:           extensionPlugin,
 		ciSettingsPlugin:          ciSettingsPlugin,
+		startTime:                 startTime,
 		buildIndex:                newBuildIndex(),
 		k8sObjectIndex:            tiltfile_k8s.NewState(),
 		k8sByName:                 make(map[string]*k8sResource),
@@ -1178,7 +1178,7 @@ func (s *tiltfileState) k8sDeployTarget(targetName model.TargetName, r *k8sResou
 		}
 	}
 
-	sinceTime := apis.NewTime(pkgInitTime)
+	sinceTime := metav1.Time(s.startTime)
 	applySpec := v1alpha1.KubernetesApplySpec{
 		Cluster:                         v1alpha1.ClusterNameDefault,
 		Timeout:                         metav1.Duration{Duration: updateSettings.K8sUpsertTimeout()},

--- a/internal/tiltfile/tiltfile_test.go
+++ b/internal/tiltfile/tiltfile_test.go
@@ -5849,7 +5849,7 @@ func (f *fixture) newTiltfileLoader() TiltfileLoader {
 	extPlugin := tiltextension.NewFakePlugin(extrr, extr)
 	ciSettingsPlugin := cisettings.NewPlugin(0)
 	return ProvideTiltfileLoader(f.ta, k8sContextPlugin, versionPlugin, configPlugin,
-		extPlugin, ciSettingsPlugin, dcc, f.webHost, execer, f.features, f.k8sEnv)
+		extPlugin, ciSettingsPlugin, dcc, f.webHost, execer, f.features, f.k8sEnv, model.ProvideStartTime())
 }
 
 func newFixture(t *testing.T) *fixture {

--- a/pkg/apis/core/v1alpha1/dockercomposelogstream_types.go
+++ b/pkg/apis/core/v1alpha1/dockercomposelogstream_types.go
@@ -61,6 +61,13 @@ type DockerComposeLogStreamSpec struct {
 	//
 	// Each service spec keeps its own copy of the project spec.
 	Project DockerComposeProject `json:"project" protobuf:"bytes,2,opt,name=project"`
+
+	// An RFC3339 timestamp from which to show logs. If this value
+	// precedes the time a container was started, only logs since the container start will be returned.
+	// If this value is in the future, no logs will be returned.
+	//
+	// +optional
+	SinceTime *metav1.Time `json:"sinceTime,omitempty" protobuf:"bytes,3,opt,name=sinceTime"`
 }
 
 var _ resource.Object = &DockerComposeLogStream{}

--- a/pkg/apis/core/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/core/v1alpha1/zz_generated.deepcopy.go
@@ -923,6 +923,10 @@ func (in *DockerComposeLogStreamList) DeepCopyObject() runtime.Object {
 func (in *DockerComposeLogStreamSpec) DeepCopyInto(out *DockerComposeLogStreamSpec) {
 	*out = *in
 	in.Project.DeepCopyInto(&out.Project)
+	if in.SinceTime != nil {
+		in, out := &in.SinceTime, &out.SinceTime
+		*out = (*in).DeepCopy()
+	}
 	return
 }
 

--- a/pkg/model/start_time.go
+++ b/pkg/model/start_time.go
@@ -1,0 +1,19 @@
+package model
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/tilt-dev/tilt/pkg/apis"
+)
+
+// StartTime is the time Tilt started. It's the single source of truth for the
+// "since" time on log streams (both Kubernetes pod logs and Docker Compose
+// logs), replacing per-package package-initialization timestamps. It's injected
+// via wire so there's exactly one value per Tilt process.
+type StartTime metav1.Time
+
+// ProvideStartTime captures the Tilt process start time once, at wire injection
+// time.
+func ProvideStartTime() StartTime {
+	return StartTime(apis.Now())
+}

--- a/pkg/openapi/zz_generated.openapi.go
+++ b/pkg/openapi/zz_generated.openapi.go
@@ -1846,12 +1846,18 @@ func schema_pkg_apis_core_v1alpha1_DockerComposeLogStreamSpec(ref common.Referen
 							Ref:         ref(v1alpha1.DockerComposeProject{}.OpenAPIModelName()),
 						},
 					},
+					"sinceTime": {
+						SchemaProps: spec.SchemaProps{
+							Description: "An RFC3339 timestamp from which to show logs. If this value precedes the time a container was started, only logs since the container start will be returned. If this value is in the future, no logs will be returned.",
+							Ref:         ref(v1.Time{}.OpenAPIModelName()),
+						},
+					},
 				},
 				Required: []string{"service", "project"},
 			},
 		},
 		Dependencies: []string{
-			v1alpha1.DockerComposeProject{}.OpenAPIModelName()},
+			v1alpha1.DockerComposeProject{}.OpenAPIModelName(), v1.Time{}.OpenAPIModelName()},
 	}
 }
 

--- a/web/src/core.d.ts
+++ b/web/src/core.d.ts
@@ -656,6 +656,13 @@ export interface DockerComposeLogStreamSpec {
    * Each service spec keeps its own copy of the project spec.
    */
   project: DockerComposeProject
+  /**
+   * An RFC3339 timestamp from which to show logs. If this value
+   * precedes the time a container was started, only logs since the container start will be returned.
+   * If this value is in the future, no logs will be returned.
+   * +optional
+   */
+  sinceTime?: string
 }
 /**
  * DockerComposeLogStreamStatus defines the observed state of DockerComposeLogStream


### PR DESCRIPTION
gets rid of global start-time constants
and threads start-time thru the api instead