### PR TITLE
cluster: failure thresholds should be a count, not a duration

### DIFF
--- a/internal/controllers/core/cluster/monitor.go
+++ b/internal/controllers/core/cluster/monitor.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"sync"
-	"time"
 
 	"github.com/jonboulle/clockwork"
 	"k8s.io/apimachinery/pkg/types"
@@ -97,19 +96,17 @@ func (c *clusterHealthMonitor) run(ctx context.Context, clusterNN types.Namespac
 
 	ticker := c.clock.NewTicker(clientHealthPollInterval)
 	defer ticker.Stop()
-	var unhealthySince time.Time
+
+	var failureCount int
 	for {
 		err := doKubernetesHealthCheck(ctx, conn.k8sClient)
 		if err != nil {
-			now := c.clock.Now()
-			if unhealthySince.IsZero() {
-				unhealthySince = now
-			}
-			if now.Sub(unhealthySince) >= clientHealthFailureGracePeriod {
+			failureCount++
+			if failureCount >= clientHealthFailureThreshold {
 				c.UpdateStatus(ctx, clusterNN, err.Error())
 			}
 		} else {
-			unhealthySince = time.Time{}
+			failureCount = 0
 			c.UpdateStatus(ctx, clusterNN, "")
 		}
 

--- a/internal/controllers/core/cluster/reconciler.go
+++ b/internal/controllers/core/cluster/reconciler.go
@@ -41,7 +41,7 @@ const (
 	clientHealthPollInterval = 15 * time.Second
 	// Like Kubernetes probes, require successive health check failures before turning
 	// a point-in-time control-plane error into a terminal CI result.
-	clientHealthFailureGracePeriod = 1 * time.Minute
+	clientHealthFailureThreshold = 4
 )
 
 type Reconciler struct {

--- a/internal/controllers/core/cluster/reconciler_test.go
+++ b/internal/controllers/core/cluster/reconciler_test.go
@@ -301,15 +301,21 @@ func TestKubernetesMonitorReportsSustainedFailure(t *testing.T) {
 	f.assertSteadyState(cluster)
 
 	f.k8sClient.ClusterHealthError = errors.New("fake cluster health error")
+
+	for i := 0; i < clientHealthFailureThreshold-1; i++ {
+		f.clock.Advance(clientHealthPollInterval)
+		requireClusterHealthCallCount(t, f.k8sClient, i+2)
+
+		f.MustGet(nn, cluster)
+		assert.Empty(t, cluster.Status.Error)
+	}
+
 	f.clock.Advance(clientHealthPollInterval)
-	requireClusterHealthCallCount(t, f.k8sClient, 2)
-
-	f.MustGet(nn, cluster)
-	assert.Empty(t, cluster.Status.Error)
-
-	f.clock.Advance(clientHealthFailureGracePeriod)
-	requireClusterHealthCallCount(t, f.k8sClient, 3)
-	<-f.requeues
+	select {
+	case <-f.requeues:
+	case <-time.After(time.Second):
+		t.Fatal("expected a requeue event")
+	}
 
 	f.MustGet(nn, cluster)
 	assert.Equal(t, "fake cluster health error", cluster.Status.Error)


### PR DESCRIPTION
two reasons:
- a count threshold is how probes are usually configured in the k8s ecosystem
- configuring it as a duration may have weird effects if the
  health check takes a long time

Signed-off-by: Nick Santos <nicholas.j.santos@gmail.com>
