### PR TITLE
hud/server: make apiserver config registration atomic

### DIFF
--- a/internal/hud/server/controller.go
+++ b/internal/hud/server/controller.go
@@ -203,37 +203,37 @@ func (s *HeadsUpServerController) addToAPIServerConfig() error {
 		return nil
 	}
 
-	var newConfig *clientcmdapi.Config
-	err := filelock.WithRLock(s.configAccess, func() error {
-		var e error
-		newConfig, e = s.configAccess.GetStartingConfig()
-		return e
-	})
-	if err != nil {
-		return err
-	}
-	newConfig = newConfig.DeepCopy()
-
-	clientConfig := s.apiServerConfig.GenericConfig.LoopbackClientConfig
 	if err := model.ValidateAPIServerName(s.apiServerName); err != nil {
 		return err
 	}
 
-	name := string(s.apiServerName)
-	newConfig.Contexts[name] = &clientcmdapi.Context{
-		Cluster:  name,
-		AuthInfo: name,
-	}
-	newConfig.AuthInfos[name] = &clientcmdapi.AuthInfo{
-		Token: clientConfig.BearerToken,
-	}
+	// Hold the exclusive lock across the entire read-modify-write so a
+	// concurrent Tilt process can't interleave its own update and lose
+	// this server's entry (or vice versa).
+	return filelock.WithLock(s.configAccess, func() error {
+		newConfig, err := s.configAccess.GetStartingConfig()
+		if err != nil {
+			return err
+		}
+		newConfig = newConfig.DeepCopy()
 
-	newConfig.Clusters[name] = &clientcmdapi.Cluster{
-		Server:                   clientConfig.Host,
-		CertificateAuthorityData: clientConfig.TLSClientConfig.CAData,
-	}
+		clientConfig := s.apiServerConfig.GenericConfig.LoopbackClientConfig
+		name := string(s.apiServerName)
+		newConfig.Contexts[name] = &clientcmdapi.Context{
+			Cluster:  name,
+			AuthInfo: name,
+		}
+		newConfig.AuthInfos[name] = &clientcmdapi.AuthInfo{
+			Token: clientConfig.BearerToken,
+		}
 
-	return s.modifyConfig(*newConfig)
+		newConfig.Clusters[name] = &clientcmdapi.Cluster{
+			Server:                   clientConfig.Host,
+			CertificateAuthorityData: clientConfig.TLSClientConfig.CAData,
+		}
+
+		return clientcmd.ModifyConfig(s.configAccess, *newConfig, true)
+	})
 }
 
 // Remove this API server's configs into the user settings directory.
@@ -244,31 +244,26 @@ func (s *HeadsUpServerController) removeFromAPIServerConfig() error {
 		return nil
 	}
 
-	var newConfig *clientcmdapi.Config
-	err := filelock.WithRLock(s.configAccess, func() error {
-		var e error
-		newConfig, e = s.configAccess.GetStartingConfig()
-		return e
-	})
-	if err != nil {
-		return err
-	}
-	newConfig = newConfig.DeepCopy()
 	if err := model.ValidateAPIServerName(s.apiServerName); err != nil {
 		return err
 	}
 
-	name := string(s.apiServerName)
-	delete(newConfig.Contexts, name)
-	delete(newConfig.AuthInfos, name)
-	delete(newConfig.Clusters, name)
-
-	return s.modifyConfig(*newConfig)
-}
-
-func (s *HeadsUpServerController) modifyConfig(config clientcmdapi.Config) error {
+	// Hold the exclusive lock across the entire read-modify-write so a
+	// concurrent Tilt process can't interleave its own update and lose
+	// this server's entry (or vice versa).
 	return filelock.WithLock(s.configAccess, func() error {
-		return clientcmd.ModifyConfig(s.configAccess, config, true)
+		newConfig, err := s.configAccess.GetStartingConfig()
+		if err != nil {
+			return err
+		}
+		newConfig = newConfig.DeepCopy()
+
+		name := string(s.apiServerName)
+		delete(newConfig.Contexts, name)
+		delete(newConfig.AuthInfos, name)
+		delete(newConfig.Clusters, name)
+
+		return clientcmd.ModifyConfig(s.configAccess, *newConfig, true)
 	})
 }
 

--- a/internal/hud/server/controller_test.go
+++ b/internal/hud/server/controller_test.go
@@ -1,0 +1,102 @@
+package server
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	genericapiserver "k8s.io/apiserver/pkg/server"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+
+	"github.com/tilt-dev/wmclient/pkg/dirs"
+
+	"github.com/tilt-dev/tilt/internal/filelock"
+	"github.com/tilt-dev/tilt/internal/testutils/tempdir"
+	"github.com/tilt-dev/tilt/pkg/model"
+)
+
+// Concurrent Tilt processes share the same config file
+// (~/.tilt-dev/config). Registration and removal must be atomic
+// read-modify-write operations; otherwise one process can write a stale
+// snapshot that discards another process's entry, and clients later fail
+// with "No tilt apiserver found".
+func TestConcurrentAPIServerConfigUpdates(t *testing.T) {
+	f := tempdir.NewTempDirFixture(t)
+	configAccess := ProvideConfigAccess(dirs.NewTiltDevDirAt(f.Path()))
+
+	const count = 8
+	controllers := make([]*HeadsUpServerController, count)
+	for i := range controllers {
+		controllers[i] = newConfigOnlyController(
+			configAccess, model.APIServerName(fmt.Sprintf("tilt-%d", 10000+i)))
+	}
+
+	var wg sync.WaitGroup
+	for _, c := range controllers {
+		wg.Add(1)
+		go func(c *HeadsUpServerController) {
+			defer wg.Done()
+			assert.NoError(t, c.addToAPIServerConfig())
+		}(c)
+	}
+	wg.Wait()
+
+	config := readConfigForTest(t, configAccess)
+	for _, c := range controllers {
+		name := string(c.apiServerName)
+		if assert.Contains(t, config.Contexts, name) {
+			assert.Contains(t, config.AuthInfos, name)
+			assert.Contains(t, config.Clusters, name)
+		}
+	}
+
+	for _, c := range controllers {
+		wg.Add(1)
+		go func(c *HeadsUpServerController) {
+			defer wg.Done()
+			assert.NoError(t, c.removeFromAPIServerConfig())
+		}(c)
+	}
+	wg.Wait()
+
+	config = readConfigForTest(t, configAccess)
+	assert.Empty(t, config.Contexts)
+	assert.Empty(t, config.AuthInfos)
+	assert.Empty(t, config.Clusters)
+}
+
+// newConfigOnlyController builds the minimal controller needed to
+// exercise config registration, without starting any servers.
+func newConfigOnlyController(configAccess clientcmd.ConfigAccess, name model.APIServerName) *HeadsUpServerController {
+	apiServerConfig := &APIServerConfig{
+		GenericConfig: &genericapiserver.RecommendedConfig{
+			Config: genericapiserver.Config{
+				LoopbackClientConfig: &rest.Config{
+					Host:        fmt.Sprintf("http://localhost/%s", name),
+					BearerToken: string(name),
+				},
+			},
+		},
+	}
+	return &HeadsUpServerController{
+		configAccess:    configAccess,
+		apiServerName:   name,
+		apiServerConfig: apiServerConfig,
+	}
+}
+
+func readConfigForTest(t testing.TB, configAccess clientcmd.ConfigAccess) *clientcmdapi.Config {
+	t.Helper()
+	var config *clientcmdapi.Config
+	err := filelock.WithRLock(configAccess, func() error {
+		var e error
+		config, e = configAccess.GetStartingConfig()
+		return e
+	})
+	require.NoError(t, err)
+	return config
+}


### PR DESCRIPTION
Fixes #6814.

`addToAPIServerConfig` and `removeFromAPIServerConfig` read the shared config under a **read** lock, released it, mutated an in-memory copy, and later wrote the full snapshot back under a separate **write** lock. The write lock serializes writers but doesn't protect the whole transaction, so two Tilt processes can read the same base snapshot and the later writer discards the earlier one's registration or removal.

The result is a CLI command failing with `No tilt apiserver found: tilt-<port>` against a server that is still running and healthy — the entry was simply dropped from the config by an unrelated Tilt process.

This holds the exclusive lock across the entire read-modify-write in both functions, so concurrent processes serialize on the full transaction. `modifyConfig` was only used by these two callers and is inlined into them; `ValidateAPIServerName` now runs before the read, so an invalid name no longer takes the lock or touches the file.

No deadlock risk from the nested `clientcmd.ModifyConfig` call: `internal/filelock`'s `init()` sets `clientcmd.UseModifyConfigLock = false`, so `ModifyConfig` doesn't take a lock of its own.

### Testing

`TestConcurrentAPIServerConfigUpdates` registers and then deregisters 8 controllers concurrently against one config file. It **fails on master** — an entry survives after every removal, the lost-update — and passes with the fix. Clean under `-race -count=10`.

Also run: `make shorttest` (full suite; the only failures are the pre-existing `TestKustomizeFlags`/`TestKustomizeBin`, which fail identically on unmodified `master` because `kustomize` isn't on my PATH), `go vet`, `goimports -local github.com/tilt-dev`, and `golangci-lint` (0 issues).

### Notes for reviewers

- **Mixed versions still race.** The lock is advisory and only helps processes running this code, so an older `tilt` binary alongside a fixed one can still clobber the config.
- **Slightly longer exclusive hold.** The read moves from a shared lock to the exclusive one, so two concurrent startups serialize where they previously read in parallel. The file is small, so this should be immaterial — flagging it as a real behavior change.
- I verified on macOS only; Windows semantics look equivalent (`LockFileEx` exclusive per handle) but I haven't run it there.
