### PR TITLE
web: collapse table columns instead of forcing horizontal scroll

### DIFF
--- a/web/src/OverviewTable.test.tsx
+++ b/web/src/OverviewTable.test.tsx
@@ -8,6 +8,7 @@ import Features, { FeaturesTestProvider, Flag } from "./feature"
 import { GroupByLabelView, TILTFILE_LABEL, UNLABELED_LABEL } from "./labels"
 import LogStore from "./LogStore"
 import OverviewTable, {
+  collapsedColumnsForWidth,
   labeledResourcesToTableCells,
   NoMatchesFound,
   OverviewGroup,
@@ -17,8 +18,14 @@ import OverviewTable, {
   ResourceTableHeaderSortTriangle,
   ResourceTableRow,
   TableGroupedByLabels,
+  TableWithoutGroups,
 } from "./OverviewTable"
-import { Name, RowValues, SelectionCheckbox } from "./OverviewTableColumns"
+import {
+  EXPANDER_COLUMN_ID,
+  Name,
+  RowValues,
+  SelectionCheckbox,
+} from "./OverviewTableColumns"
 import { ToggleTriggerModeTooltip } from "./OverviewTableTriggerModeToggle"
 import {
   DEFAULT_GROUP_STATE,
@@ -85,6 +92,32 @@ const findTableHeaderByName = (columnName: string, sortable = true): any => {
   const selector = sortable ? `Sort by ${columnName}` : columnName
   return screen.getAllByTitle(selector)[0]
 }
+
+const tableViewWithCollapsedColumns = (
+  view: TestDataView,
+  collapsedColumns: string[]
+) => (
+  <MemoryRouter
+    initialEntries={["/"]}
+    future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+  >
+    <SnackbarProvider>
+      <FeaturesTestProvider value={new Features({})}>
+        <ResourceGroupsContextProvider>
+          <ResourceListOptionsProvider>
+            <ResourceSelectionProvider>
+              <TableWithoutGroups
+                resources={view.uiResources}
+                buttons={view.uiButtons}
+                collapsedColumns={collapsedColumns}
+              />
+            </ResourceSelectionProvider>
+          </ResourceListOptionsProvider>
+        </ResourceGroupsContextProvider>
+      </FeaturesTestProvider>
+    </SnackbarProvider>
+  </MemoryRouter>
+)
 
 // End helpers
 
@@ -492,6 +525,7 @@ describe("overview table with groups", () => {
               <TableGroupedByLabels
                 resources={view.uiResources}
                 buttons={view.uiButtons}
+                collapsedColumns={[EXPANDER_COLUMN_ID]}
               />
             </ResourceSelectionProvider>
           </ResourceGroupsContextProvider>
@@ -925,6 +959,57 @@ it("renders the trigger mode column correctly", () => {
     ToggleTriggerModeTooltip.isAuto,
     ToggleTriggerModeTooltip.isManual,
   ])
+})
+
+describe("responsive columns", () => {
+  describe("collapsedColumnsForWidth", () => {
+    it("collapses only the expander when the table is wide", () => {
+      expect(collapsedColumnsForWidth(1400)).toEqual([EXPANDER_COLUMN_ID])
+    })
+
+    it("collapses columns right-to-left as the table narrows", () => {
+      expect(collapsedColumnsForWidth(1000)).toEqual([
+        "mode",
+        "endpoints",
+        "widgets",
+      ])
+    })
+
+    it("never collapses the selection or resource name columns", () => {
+      const collapsed = collapsedColumnsForWidth(1)
+      expect(collapsed).not.toContain("selection")
+      expect(collapsed).not.toContain("name")
+    })
+
+    it("assumes a full-size table before the first measurement", () => {
+      expect(collapsedColumnsForWidth(0)).toEqual([EXPANDER_COLUMN_ID])
+    })
+  })
+
+  it("moves collapsed columns into an expandable row detail", () => {
+    render(tableViewWithCollapsedColumns(nResourceView(2), ["podId", "mode"]))
+
+    // Collapsed columns are absent until a row is expanded
+    expect(screen.queryByText("Pod ID")).toBeNull()
+    expect(screen.queryByText("Mode")).toBeNull()
+
+    const expanders = screen.getAllByTitle(/^Show additional columns/)
+    expect(expanders).toHaveLength(2)
+
+    userEvent.click(expanders[0])
+
+    expect(screen.getByText("Pod ID")).toBeInTheDocument()
+    expect(screen.getByText("Mode")).toBeInTheDocument()
+  })
+
+  it("shows no expander when nothing is collapsed", () => {
+    render(
+      tableViewWithCollapsedColumns(nResourceView(2), [EXPANDER_COLUMN_ID])
+    )
+
+    expect(screen.queryAllByTitle(/^Show additional columns/)).toHaveLength(0)
+    expect(screen.getByText("Pod ID")).toBeInTheDocument()
+  })
 })
 
 function renderContainer(x: ReactElement) {

--- a/web/src/OverviewTable.tsx
+++ b/web/src/OverviewTable.tsx
@@ -13,12 +13,14 @@ import React, {
   useState,
 } from "react"
 import {
+  ColumnInstance,
   HeaderGroup,
   Row,
   SortingRule,
   TableHeaderProps,
   TableOptions,
   TableState,
+  useExpanded,
   usePagination,
   useSortBy,
   UseSortByState,
@@ -42,7 +44,9 @@ import {
 } from "./labels"
 import { LogAlertIndex, useLogAlertIndex } from "./LogStore"
 import {
+  COLUMN_COLLAPSE_BREAKPOINTS,
   COLUMNS,
+  EXPANDER_COLUMN_ID,
   ResourceTableHeaderTip,
   rowIsDisabled,
   RowValues,
@@ -78,6 +82,7 @@ import {
   UIResource,
   UIResourceStatus,
 } from "./types"
+import { useElementWidth } from "./useElementWidth"
 import type { View } from "./webview"
 
 export type OverviewTableProps = {
@@ -87,17 +92,20 @@ export type OverviewTableProps = {
 type TableWrapperProps = {
   resources?: UIResource[]
   buttons?: UIButton[]
+  collapsedColumns: string[]
 }
 
 type TableGroupProps = {
   label: string
   setGlobalSortBy: (id: string) => void
   focused: string
+  collapsedColumns: string[]
 } & TableOptions<RowValues>
 
 type TableProps = {
   setGlobalSortBy?: (id: string) => void
   focused: string
+  collapsedColumns: string[]
 } & TableOptions<RowValues>
 
 type ResourceTableHeadRowProps = {
@@ -125,9 +133,9 @@ const OverviewTableRoot = styled.section`
   padding-bottom: ${SizeUnit(1 / 2)};
   margin-left: auto;
   margin-right: auto;
-  /* Max and min width are based on fixed table layout and column widths */
+  /* Max width is based on fixed table layout and column widths. There's no min
+  width, since columns collapse into a detail panel as space runs out. */
   max-width: 2000px;
-  min-width: 1400px;
 
   @media screen and (max-width: 2200px) {
     margin-left: ${SizeUnit(1 / 2)};
@@ -225,6 +233,24 @@ const ResourceTableHeaderLabel = styled.div`
   user-select: none;
 `
 
+// Detail panel holding the columns that collapsed out of a narrow table
+const CollapsedColumnsDetail = styled.dl`
+  display: grid;
+  grid-template-columns: max-content minmax(0, 1fr);
+  gap: ${SizeUnit(1 / 4)} ${SizeUnit(1 / 2)};
+  margin: 0;
+  padding: ${SizeUnit(1 / 4)} 0 ${SizeUnit(1 / 2)} ${SizeUnit(1 / 2)};
+
+  dt {
+    color: ${Color.gray70};
+  }
+
+  dd {
+    margin: 0;
+    min-width: 0;
+  }
+`
+
 export const ResourceTableHeaderSortTriangle = styled.div`
   display: inline-block;
   margin-left: ${SizeUnit(0.25)};
@@ -308,6 +334,31 @@ export function TableNoMatchesFound(props: { resources?: UIResource[] }) {
   }
 
   return null
+}
+
+// If a column header is JSX, fall back on its id as a descriptive label
+// and capitalize for consistency.
+function columnDisplayName(column: ColumnInstance<RowValues>): string {
+  return typeof column.Header === "string"
+    ? column.Header
+    : `${column.id[0]?.toUpperCase()}${column.id?.slice(1)}`
+}
+
+// Which columns collapse into the per-row detail panel at a given table width.
+// When nothing collapses, the expander column hides itself, so the disclosure
+// control only appears when it has something to disclose.
+export function collapsedColumnsForWidth(tableWidth: number): string[] {
+  // Width is 0 before the first measurement; assume a full-size table so the
+  // first paint doesn't flash a collapsed layout.
+  if (tableWidth === 0) {
+    return [EXPANDER_COLUMN_ID]
+  }
+
+  const collapsed = COLUMN_COLLAPSE_BREAKPOINTS.filter(
+    ({ minTableWidth }) => tableWidth < minTableWidth
+  ).map(({ id }) => id)
+
+  return collapsed.length > 0 ? collapsed : [EXPANDER_COLUMN_ID]
 }
 
 const FIRST_SORT_STATE = false
@@ -623,7 +674,40 @@ function ShowMoreResourcesRow({
   )
 }
 
-function TableRow(props: { row: Row<RowValues>; focused: string }) {
+// Renders collapsed columns as label/value pairs. Cells come from `row.allCells`,
+// which includes hidden columns, so each column's Cell renderer is reused here.
+function CollapsedColumnsRow(props: { row: Row<RowValues>; colSpan: number }) {
+  const { row, colSpan } = props
+  const visibleIds = new Set(row.cells.map((cell) => cell.column.id))
+  const collapsedCells = row.allCells.filter(
+    (cell) => !visibleIds.has(cell.column.id)
+  )
+
+  if (collapsedCells.length === 0) {
+    return null
+  }
+
+  return (
+    <ResourceTableRow>
+      <ResourceTableData colSpan={colSpan}>
+        <CollapsedColumnsDetail>
+          {collapsedCells.map((cell) => (
+            <React.Fragment key={cell.column.id}>
+              <dt>{columnDisplayName(cell.column)}</dt>
+              <dd>{cell.render("Cell")}</dd>
+            </React.Fragment>
+          ))}
+        </CollapsedColumnsDetail>
+      </ResourceTableData>
+    </ResourceTableRow>
+  )
+}
+
+function TableRow(props: {
+  row: Row<RowValues>
+  focused: string
+  colSpan: number
+}) {
   let { row, focused } = props
   const { isSelected } = useResourceSelection()
   let isFocused = row.original.name == focused
@@ -640,22 +724,27 @@ function TableRow(props: { row: Row<RowValues>; focused: string }) {
   }, [isFocused, ref])
 
   return (
-    <ResourceTableRow
-      tabIndex={-1}
-      ref={ref}
-      {...row.getRowProps({
-        className: rowClasses,
-      })}
-    >
-      {row.cells.map((cell) => (
-        <ResourceTableData
-          {...cell.getCellProps()}
-          className={cell.column.isSorted ? "isSorted" : ""}
-        >
-          {cell.render("Cell")}
-        </ResourceTableData>
-      ))}
-    </ResourceTableRow>
+    <>
+      <ResourceTableRow
+        tabIndex={-1}
+        ref={ref}
+        {...row.getRowProps({
+          className: rowClasses,
+        })}
+      >
+        {row.cells.map((cell) => (
+          <ResourceTableData
+            {...cell.getCellProps()}
+            className={cell.column.isSorted ? "isSorted" : ""}
+          >
+            {cell.render("Cell")}
+          </ResourceTableData>
+        ))}
+      </ResourceTableRow>
+      {row.isExpanded && (
+        <CollapsedColumnsRow row={row} colSpan={props.colSpan} />
+      )}
+    </>
   )
 }
 
@@ -671,6 +760,8 @@ export function Table(props: TableProps) {
     rows, // Used to calculate the total number of rows
     page, // Used to render the rows for the current page
     prepareRow,
+    visibleColumns,
+    setHiddenColumns,
     state: { pageSize },
     setPageSize,
   } = useTable(
@@ -678,12 +769,23 @@ export function Table(props: TableProps) {
       columns: props.columns,
       data: props.data,
       autoResetSortBy: false,
+      autoResetExpanded: false,
+      autoResetHiddenColumns: false,
       useControlledState: props.useControlledState,
-      initialState: { pageSize: DEFAULT_RESOURCE_LIST_LIMIT },
+      initialState: {
+        pageSize: DEFAULT_RESOURCE_LIST_LIMIT,
+        hiddenColumns: props.collapsedColumns,
+      },
     },
     useSortBy,
+    useExpanded,
     usePagination
   )
+
+  // `collapsedColumns` is memoized by table width, so this only fires on resize.
+  useEffect(() => {
+    setHiddenColumns(props.collapsedColumns)
+  }, [setHiddenColumns, props.collapsedColumns])
 
   const showMoreOnClick = () => setPageSize(pageSize * RESOURCE_LIST_MULTIPLIER)
 
@@ -707,6 +809,7 @@ export function Table(props: TableProps) {
               key={row.original.name}
               row={row}
               focused={props.focused}
+              colSpan={visibleColumns.length}
             />
           )
         })}
@@ -714,7 +817,7 @@ export function Table(props: TableProps) {
           itemCount={rows.length}
           pageSize={pageSize}
           onClick={showMoreOnClick}
-          colSpan={props.columns.length}
+          colSpan={visibleColumns.length}
         />
       </tbody>
     </ResourceTable>
@@ -755,6 +858,7 @@ function TableGroup(props: TableGroupProps) {
 export function TableGroupedByLabels({
   resources,
   buttons,
+  collapsedColumns,
 }: TableWrapperProps) {
   const features = useFeatures()
   const logAlertIndex = useLogAlertIndex()
@@ -801,6 +905,7 @@ export function TableGroupedByLabels({
           useControlledState={useControlledState}
           setGlobalSortBy={setGlobalSortBy}
           focused={focused}
+          collapsedColumns={collapsedColumns}
         />
       ))}
       <TableGroup
@@ -810,6 +915,7 @@ export function TableGroupedByLabels({
         useControlledState={useControlledState}
         setGlobalSortBy={setGlobalSortBy}
         focused={focused}
+        collapsedColumns={collapsedColumns}
       />
       <TableGroup
         label={TILTFILE_LABEL}
@@ -818,6 +924,7 @@ export function TableGroupedByLabels({
         useControlledState={useControlledState}
         setGlobalSortBy={setGlobalSortBy}
         focused={focused}
+        collapsedColumns={collapsedColumns}
       />
       <OverviewTableKeyboardShortcuts
         focused={focused}
@@ -828,7 +935,11 @@ export function TableGroupedByLabels({
   )
 }
 
-export function TableWithoutGroups({ resources, buttons }: TableWrapperProps) {
+export function TableWithoutGroups({
+  resources,
+  buttons,
+  collapsedColumns,
+}: TableWrapperProps) {
   const features = useFeatures()
   const logAlertIndex = useLogAlertIndex()
   const data = useMemo(() => {
@@ -846,7 +957,12 @@ export function TableWithoutGroups({ resources, buttons }: TableWrapperProps) {
 
   return (
     <TableWithoutGroupsRoot>
-      <Table columns={COLUMNS} data={data} focused={focused} />
+      <Table
+        columns={COLUMNS}
+        data={data}
+        focused={focused}
+        collapsedColumns={collapsedColumns}
+      />
       <OverviewTableKeyboardShortcuts
         focused={focused}
         setFocused={setFocused}
@@ -856,7 +972,9 @@ export function TableWithoutGroups({ resources, buttons }: TableWrapperProps) {
   )
 }
 
-function OverviewTableContent(props: OverviewTableProps) {
+function OverviewTableContent(
+  props: OverviewTableProps & { collapsedColumns: string[] }
+) {
   const features = useFeatures()
   const labelsEnabled = features.isEnabled(Flag.Labels)
   const resourcesHaveLabels =
@@ -883,6 +1001,7 @@ function OverviewTableContent(props: OverviewTableProps) {
       <TableGroupedByLabels
         resources={resourcesToDisplay}
         buttons={props.view.uiButtons}
+        collapsedColumns={props.collapsedColumns}
       />
     )
   } else {
@@ -902,6 +1021,7 @@ function OverviewTableContent(props: OverviewTableProps) {
           }
           resources={resourcesToDisplay}
           buttons={props.view.uiButtons}
+          collapsedColumns={props.collapsedColumns}
         />
       </>
     )
@@ -909,9 +1029,16 @@ function OverviewTableContent(props: OverviewTableProps) {
 }
 
 export default function OverviewTable(props: OverviewTableProps) {
+  const rootRef = useRef<HTMLElement | null>(null)
+  const tableWidth = useElementWidth(rootRef)
+  const collapsedColumns = useMemo(
+    () => collapsedColumnsForWidth(tableWidth),
+    [tableWidth]
+  )
+
   return (
-    <OverviewTableRoot aria-label="Resources overview">
-      <OverviewTableContent {...props} />
+    <OverviewTableRoot ref={rootRef} aria-label="Resources overview">
+      <OverviewTableContent {...props} collapsedColumns={collapsedColumns} />
     </OverviewTableRoot>
   )
 }

--- a/web/src/OverviewTableColumns.tsx
+++ b/web/src/OverviewTableColumns.tsx
@@ -142,6 +142,9 @@ const PodIdInput = styled.input`
   border-radius: 2px;
   padding: ${SizeUnit(0.1)} ${SizeUnit(0.2)};
   width: 100px;
+  /* Flex items won't shrink past their intrinsic size by default, which pushes
+  the copy button outside the cell when the column is narrow. */
+  min-width: 0;
   text-overflow: ellipsis;
   overflow: auto;
 
@@ -608,6 +611,64 @@ export function ResourceTableHeaderTip(props: { id?: string }) {
   )
 }
 
+export const EXPANDER_COLUMN_ID = "expander"
+
+// Columns collapse into a per-row detail panel as the table narrows, dropping
+// right-to-left so the leftmost columns survive longest. The selection checkbox
+// and resource name never collapse, so they have no entry here. Each
+// `minTableWidth` is the table width at or above which the column stays visible.
+export const COLUMN_COLLAPSE_BREAKPOINTS: ReadonlyArray<{
+  id: string
+  minTableWidth: number
+}> = [
+  { id: "mode", minTableWidth: 1350 },
+  { id: "endpoints", minTableWidth: 1190 },
+  { id: "widgets", minTableWidth: 1040 },
+  { id: "podId", minTableWidth: 890 },
+  { id: "status", minTableWidth: 730 },
+  { id: "resourceTypeLabel", minTableWidth: 580 },
+  { id: "lastDeployTime", minTableWidth: 500 },
+  { id: "trigger", minTableWidth: 430 },
+  { id: "starred", minTableWidth: 380 },
+]
+
+const ExpanderButton = styled.button`
+  ${mixinResetButtonStyle};
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+  padding: ${SizeUnit(1 / 4)};
+`
+
+const ExpanderTriangle = styled.div`
+  width: 0;
+  height: 0;
+  border-top: 5px solid transparent;
+  border-bottom: 5px solid transparent;
+  border-left: 6px solid ${Color.gray70};
+
+  &.is-expanded {
+    transform: rotate(90deg);
+  }
+`
+
+function TableExpanderColumn({ row }: CellProps<RowValues>) {
+  const label = `${row.isExpanded ? "Hide" : "Show"} additional columns for ${
+    row.original.name
+  }`
+
+  return (
+    <ExpanderButton
+      {...row.getToggleRowExpandedProps()}
+      aria-expanded={row.isExpanded}
+      aria-label={label}
+      title={label}
+    >
+      <ExpanderTriangle className={row.isExpanded ? "is-expanded" : ""} />
+    </ExpanderButton>
+  )
+}
+
 // https://react-table.tanstack.com/docs/api/useTable#column-options
 // The docs on this are not very clear!
 // `accessor` should return a primitive, and that primitive is used for sorting and filtering
@@ -615,6 +676,13 @@ export function ResourceTableHeaderTip(props: { id?: string }) {
 // best evidence I've (Matt) found: https://github.com/tannerlinsley/react-table/discussions/2429#discussioncomment-25582
 //   (from the author)
 export const COLUMNS: Column<RowValues>[] = [
+  {
+    Header: "",
+    id: EXPANDER_COLUMN_ID,
+    disableSortBy: true,
+    width: "30px",
+    Cell: TableExpanderColumn,
+  },
   {
     Header: (props) => <ResourceSelectionHeader {...props} />,
     id: "selection",
@@ -646,7 +714,9 @@ export const COLUMNS: Column<RowValues>[] = [
     Header: "Resource Name",
     accessor: "name",
     Cell: TableNameColumn,
-    width: "400px",
+    // Proportional so the name column gives space back as the table narrows,
+    // rather than reserving a fixed width and collapsing other columns early.
+    width: "25%",
   },
   {
     Header: "Type",
@@ -655,6 +725,9 @@ export const COLUMNS: Column<RowValues>[] = [
   },
   {
     Header: "Status",
+    // Named explicitly because react-table otherwise ids function accessors by
+    // their Header string.
+    id: "status",
     accessor: (row) => statusSortKey(row),
     Cell: TableStatusColumn,
     width: "auto",

--- a/web/src/OverviewTablePane.tsx
+++ b/web/src/OverviewTablePane.tsx
@@ -37,9 +37,9 @@ const OverviewTableMenu = styled.section`
   align-items: center;
   margin-left: auto;
   margin-right: auto;
-  /* Max and min width are based on fixed table layout and column widths */
+  /* Max width matches the table below, which has no min width. */
   max-width: 2000px;
-  min-width: 1400px;
+  flex-wrap: wrap;
 
   @media screen and (max-width: 2200px) {
     margin-left: ${SizeUnit(1 / 2)};

--- a/web/src/react-table-config.d.ts
+++ b/web/src/react-table-config.d.ts
@@ -1,6 +1,11 @@
 // From https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/react-table
 
 import {
+  UseExpandedHooks,
+  UseExpandedInstanceProps,
+  UseExpandedOptions,
+  UseExpandedRowProps,
+  UseExpandedState,
   UsePaginationInstanceProps,
   UsePaginationOptions,
   UsePaginationState,
@@ -17,8 +22,8 @@ declare module "react-table" {
 
   export interface TableOptions<D extends Record<string, unknown>>
     extends UseSortByOptions<D>,
-      UsePaginationOptions<D> {
-    // UseExpandedOptions<D>,
+      UsePaginationOptions<D>,
+      UseExpandedOptions<D> {
     // UseFiltersOptions<D>,
     // UseGlobalFiltersOptions<D>,
     // UseGroupByOptions<D>,
@@ -33,8 +38,8 @@ declare module "react-table" {
 
   export interface Hooks<
     D extends Record<string, unknown> = Record<string, unknown>
-  > extends UseSortByHooks<D> {
-    // UseExpandedHooks<D>,
+  > extends UseSortByHooks<D>,
+      UseExpandedHooks<D> {
     // UseGroupByHooks<D>,
     // UseRowSelectHooks<D>,
     // UseSortByHooks<D>
@@ -43,9 +48,9 @@ declare module "react-table" {
   export interface TableInstance<
     D extends Record<string, unknown> = Record<string, unknown>
   > extends UseSortByInstanceProps<D>,
-      UsePaginationInstanceProps<D> {
+      UsePaginationInstanceProps<D>,
+      UseExpandedInstanceProps<D> {
     // UseColumnOrderInstanceProps<D>,
-    // UseExpandedInstanceProps<D>,
     // UseFiltersInstanceProps<D>,
     // UseGlobalFiltersInstanceProps<D>,
     // UseGroupByInstanceProps<D>,
@@ -57,9 +62,9 @@ declare module "react-table" {
   export interface TableState<
     D extends Record<string, unknown> = Record<string, unknown>
   > extends UseSortByState<D>,
-      UsePaginationState<D> {
+      UsePaginationState<D>,
+      UseExpandedState<D> {
     // UseColumnOrderState<D>,
-    // UseExpandedState<D>,
     // UseFiltersState<D>,
     // UseGlobalFiltersState<D>,
     // UseGroupByState<D>,
@@ -89,9 +94,11 @@ declare module "react-table" {
   //   extends UseGroupByCellProps<D>,
   //     UseRowStateCellProps<D> {}
 
-  // export interface Row<D extends Record<string, unknown> = Record<string, unknown>>
-  //   extends UseExpandedRowProps<D>,
-  //     UseGroupByRowProps<D>,
-  //     UseRowSelectRowProps<D>,
-  //     UseRowStateRowProps<D> {}
+  export interface Row<
+    D extends Record<string, unknown> = Record<string, unknown>
+  > extends UseExpandedRowProps<D> {
+    //     UseGroupByRowProps<D>,
+    //     UseRowSelectRowProps<D>,
+    //     UseRowStateRowProps<D>
+  }
 }

--- a/web/src/useElementWidth.ts
+++ b/web/src/useElementWidth.ts
@@ -1,0 +1,43 @@
+import { RefObject, useEffect, useState } from "react"
+
+// Tracks an element's rendered width. The viewport isn't a good proxy for the
+// space the table actually has, since it shares the page with a collapsible
+// sidebar. Returns 0 until the first measurement.
+export function useElementWidth(ref: RefObject<HTMLElement | null>): number {
+  const [width, setWidth] = useState(0)
+
+  useEffect(() => {
+    const element = ref.current
+    if (!element) {
+      return
+    }
+
+    // jsdom has no ResizeObserver, so tests get a single static measurement.
+    if (typeof ResizeObserver === "undefined") {
+      setWidth(element.getBoundingClientRect().width)
+      return
+    }
+
+    // Setting state here re-enters the observer, since collapsing a column
+    // resizes the table. The browser reports that as a ResizeObserver loop
+    // error, so hand the measurement off to the next frame.
+    let frame = 0
+    const observer = new ResizeObserver((entries) => {
+      const entry = entries[0]
+      if (entry) {
+        const nextWidth = entry.contentRect.width
+        cancelAnimationFrame(frame)
+        frame = requestAnimationFrame(() => setWidth(nextWidth))
+      }
+    })
+
+    observer.observe(element)
+
+    return () => {
+      cancelAnimationFrame(frame)
+      observer.disconnect()
+    }
+  }, [ref])
+
+  return width
+}


### PR DESCRIPTION
Note: the code and tests were created with generative AI assistance to background solving an annoyance I keep running into at work.

I use a tiling window manager so it comes up frequently for me, but I imagine folks with laptop screens and the sidebar open or with vertical side monitors also run into it.

The resources table has a hard `min-width: 1400px`, and anything less than that results is a scrollbar. The top bar for the page _is_ responsive. The mix of those things makes my brain constantly forget I need to scroll horizontally to see/interact with things.

This change makes the columns responsively collapse into a per-row detail panel as the resources table narrows, dropping right to left. The selection checkbox and resource name never collapse.

I'll note that the breakpoint values for when to collapse given columns are hand-tuned, I couldn't think of a good way to make them more intelligent without an extra layout pass.

Screenshots of before and after:

<details>
<summary>Before Screenshots</summary>
<img width="1445" height="684" alt="before-full" src="https://github.com/user-attachments/assets/ac1f489e-42c1-498d-b52f-2c009b1b51cb" />
<img width="945" height="673" alt="before-small-scrolled" src="https://github.com/user-attachments/assets/b3d281b6-5217-4c00-b166-ea16538a5cac" />
<img width="945" height="673" alt="before-small" src="https://github.com/user-attachments/assets/d15ab21d-a879-4370-9ed2-33f37c8b3236" />
<img width="626" height="673" alt="before-smaller-scrolled" src="https://github.com/user-attachments/assets/8623b4e7-0a6c-4cc9-a157-6c5ddc7db514" />
<img width="626" height="673" alt="before-smaller" src="https://github.com/user-attachments/assets/55213571-630d-40cf-af27-53180ee76066" />
</details>

<details>
<summary>After Screenshots</summary>
<img width="906" height="905" alt="after-collapsed" src="https://github.com/user-attachments/assets/3516d469-29a3-48fb-b798-3c85c46fbb8b" />
<img width="668" height="813" alt="after-expanded-smaller" src="https://github.com/user-attachments/assets/415283f8-8cbe-48dd-8f21-6da9cb4a4661" />
<img width="906" height="850" alt="after-expanded" src="https://github.com/user-attachments/assets/257a4085-829c-4fa7-ae0c-e901c669ec86" />
</details>

