### PR TITLE
dockerfile: prevent check directive parser panic

### DIFF
--- a/internal/dockerfile/ast.go
+++ b/internal/dockerfile/ast.go
@@ -10,6 +10,7 @@ import (
 	"github.com/docker/cli/opts"
 	"github.com/moby/buildkit/frontend/dockerfile/command"
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
+	"github.com/moby/buildkit/frontend/dockerfile/linter"
 	"github.com/moby/buildkit/frontend/dockerfile/parser"
 	"github.com/moby/buildkit/frontend/dockerfile/shell"
 	"github.com/pkg/errors"
@@ -40,12 +41,12 @@ func ParseAST(df Dockerfile) (AST, error) {
 	}, nil
 }
 
-func (a AST) extractBaseNameInFromCommand(node *parser.Node, shlex *shell.Lex, metaArgs []instructions.ArgCommand) string {
+func (a AST) extractBaseNameInFromCommand(node *parser.Node, shlex *shell.Lex, metaArgs []instructions.ArgCommand, lint *linter.Linter) string {
 	if node.Next == nil {
 		return ""
 	}
 
-	inst, err := instructions.ParseInstruction(node)
+	inst, err := instructions.ParseInstructionWithLinter(node, lint)
 	if err != nil {
 		return node.Next.Value // if there's a parsing error, fallback to the first arg
 	}
@@ -72,11 +73,12 @@ func (a AST) extractBaseNameInFromCommand(node *parser.Node, shlex *shell.Lex, m
 func (a AST) traverseImageRefs(visitor func(node *parser.Node, ref reference.Named) reference.Named, dockerfileArgs []instructions.ArgCommand) error {
 	metaArgs := append([]instructions.ArgCommand(nil), dockerfileArgs...)
 	shlex := shell.NewLex(a.result.EscapeToken)
+	lint := linter.New(&linter.Config{})
 
 	return a.Traverse(func(node *parser.Node) error {
 		switch strings.ToLower(node.Value) {
 		case command.Arg:
-			inst, err := instructions.ParseInstruction(node)
+			inst, err := instructions.ParseInstructionWithLinter(node, lint)
 			if err != nil {
 				return nil // ignore parsing error
 			}
@@ -90,7 +92,7 @@ func (a AST) traverseImageRefs(visitor func(node *parser.Node, ref reference.Nam
 			metaArgs = append([]instructions.ArgCommand{*argCmd}, metaArgs...)
 
 		case command.From:
-			baseName := a.extractBaseNameInFromCommand(node, shlex, metaArgs)
+			baseName := a.extractBaseNameInFromCommand(node, shlex, metaArgs, lint)
 			if baseName == "" {
 				return nil // ignore parsing error
 			}
@@ -109,7 +111,7 @@ func (a AST) traverseImageRefs(visitor func(node *parser.Node, ref reference.Nam
 				return nil
 			}
 
-			inst, err := instructions.ParseInstruction(node)
+			inst, err := instructions.ParseInstructionWithLinter(node, lint)
 			if err != nil {
 				return nil // ignore parsing error
 			}

--- a/internal/dockerfile/dockerfile_test.go
+++ b/internal/dockerfile/dockerfile_test.go
@@ -116,3 +116,15 @@ RUN --mount=type=cache,id=pip,target=/root/.cache/pip pip install python-dateuti
 		assert.Equal(t, "docker.io/library/python2-base", images[0].String())
 	}
 }
+
+func TestFindImagesWithCheckDirective(t *testing.T) {
+	df := Dockerfile(`
+# check=skip=SecretsUsedInArgOrEnv
+FROM alpine:3
+`)
+	images, err := df.FindImages(nil)
+	assert.NoError(t, err)
+	if assert.Len(t, images, 1) {
+		assert.Equal(t, "docker.io/library/alpine:3", images[0].String())
+	}
+}


### PR DESCRIPTION
## Summary

- initialize a BuildKit linter for typed Dockerfile instruction parsing
- reuse it across ARG, FROM, and COPY parsing without emitting lint warnings
- cover a `# check=` directive that previously caused a nil-pointer panic during image discovery

When BuildKit attaches a check directive to an instruction's preceding comments, `ParseInstruction` forwards a nil linter into `WithMergedConfigFromComments`. Passing an initialized linter preserves Tilt's existing best-effort parsing while allowing BuildKit to merge the directive configuration safely.

Fixes #6821.

## Testing

- `go test ./internal/dockerfile -run TestFindImagesWithCheckDirective -count=1`
- `go test ./internal/dockerfile -count=1`
- `git diff --check`
