### PR TITLE
Fix initial_sync being cancelled for syncing fall_back_on files

### DIFF
--- a/internal/controllers/core/liveupdate/reconciler.go
+++ b/internal/controllers/core/liveupdate/reconciler.go
@@ -774,7 +774,7 @@ func (r *Reconciler) maybeSync(ctx context.Context, lu *v1alpha1.LiveUpdate, mon
 		// Create a plan to update the container.
 		filesApplied := false
 		var oneUpdateStatus v1alpha1.LiveUpdateStatus
-		plan, failed := r.createLiveUpdatePlan(lu.Spec, filesChanged)
+		plan, failed := r.createLiveUpdatePlan(lu.Spec, filesChanged, isInitialSync)
 		if failed != nil {
 			// The plan told us to stop updating - this container is unrecoverable.
 			oneUpdateStatus.Failed = failed
@@ -873,7 +873,7 @@ func (r *Reconciler) maybeSync(ctx context.Context, lu *v1alpha1.LiveUpdate, mon
 	return status
 }
 
-func (r *Reconciler) createLiveUpdatePlan(spec v1alpha1.LiveUpdateSpec, filesChanged []string) (liveupdates.LiveUpdatePlan, *v1alpha1.LiveUpdateStateFailed) {
+func (r *Reconciler) createLiveUpdatePlan(spec v1alpha1.LiveUpdateSpec, filesChanged []string, isInitialSync bool) (liveupdates.LiveUpdatePlan, *v1alpha1.LiveUpdateStateFailed) {
 	plan, err := liveupdates.NewLiveUpdatePlan(spec, filesChanged)
 	if err != nil {
 		return plan, &v1alpha1.LiveUpdateStateFailed{
@@ -890,8 +890,9 @@ func (r *Reconciler) createLiveUpdatePlan(spec v1alpha1.LiveUpdateSpec, filesCha
 		}
 	}
 
-	// If any changed files match a FallBackOn file, fall back to next BuildAndDeployer
-	if len(plan.StopPaths) != 0 {
+	// A new container needs the complete sync contents, including FallBackOn files.
+	// Only subsequent changes to those files should fall back to the next BuildAndDeployer.
+	if !isInitialSync && len(plan.StopPaths) != 0 {
 		return plan, &v1alpha1.LiveUpdateStateFailed{
 			Reason:  "UpdateStopped",
 			Message: fmt.Sprintf("Detected change to stop file %q", plan.StopPaths[0]),

--- a/internal/controllers/core/liveupdate/reconciler_test.go
+++ b/internal/controllers/core/liveupdate/reconciler_test.go
@@ -1535,6 +1535,71 @@ func TestInitialSync_UsesSourceFileWatchIgnores(t *testing.T) {
 	assert.NotContains(t, names, "app/build/output.bin")
 }
 
+func TestInitialSync_SyncsStopPathsButLaterChangesStillStop(t *testing.T) {
+	f := newFixture(t)
+
+	tmpDir := t.TempDir()
+	srcDir := filepath.Join(tmpDir, "src")
+	privateDir := filepath.Join(srcDir, "private")
+	require.NoError(t, os.MkdirAll(privateDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(srcDir, "app.go"), []byte("package main"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(srcDir, ".env"), []byte("SECRET=value"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(privateDir, "secret.txt"), []byte("secret"), 0644))
+
+	f.setupFrontend()
+
+	var lu v1alpha1.LiveUpdate
+	f.MustGet(types.NamespacedName{Name: "frontend-liveupdate"}, &lu)
+	luUpdate := lu.DeepCopy()
+	luUpdate.Spec.BasePath = tmpDir
+	luUpdate.Spec.Syncs = []v1alpha1.LiveUpdateSync{
+		{LocalPath: "src", ContainerPath: "/app"},
+	}
+	luUpdate.Spec.StopPaths = []string{"src/.env", "src/private"}
+	luUpdate.Spec.InitialSync = &v1alpha1.LiveUpdateInitialSync{}
+	f.Update(luUpdate)
+
+	f.cu.Calls = nil
+	f.kdUpdateStatus("frontend-discovery", v1alpha1.KubernetesDiscoveryStatus{
+		Pods: []v1alpha1.Pod{
+			{
+				Name:      "pod-1",
+				Namespace: "default",
+				Phase:     "Running",
+				Containers: []v1alpha1.Container{
+					{
+						Name:  "main",
+						ID:    "container-1",
+						Image: "local-registry:12345/frontend-image:my-tag",
+						State: v1alpha1.ContainerState{
+							Running: &v1alpha1.ContainerStateRunning{},
+						},
+					},
+				},
+			},
+		},
+	})
+	f.MustReconcile(types.NamespacedName{Name: "frontend-liveupdate"})
+
+	require.Len(t, f.cu.Calls, 1)
+	names := tarEntryNames(t, f.cu.Calls[0])
+	assert.Contains(t, names, "app/app.go")
+	assert.Contains(t, names, "app/.env")
+	assert.Contains(t, names, "app/private/secret.txt")
+
+	f.MustGet(types.NamespacedName{Name: "frontend-liveupdate"}, &lu)
+	require.Len(t, lu.Status.Containers, 1)
+	stopChangeTime := metav1.MicroTime{Time: lu.Status.Containers[0].LastFileTimeSynced.Add(time.Second)}
+	f.addFileEvent("frontend-fw", filepath.Join(srcDir, ".env"), stopChangeTime)
+	f.MustReconcile(types.NamespacedName{Name: "frontend-liveupdate"})
+
+	f.MustGet(types.NamespacedName{Name: "frontend-liveupdate"}, &lu)
+	if assert.NotNil(t, lu.Status.Failed) {
+		assert.Equal(t, "UpdateStopped", lu.Status.Failed.Reason)
+	}
+	assert.Len(t, f.cu.Calls, 1, "stop path changes after initial sync must not be copied")
+}
+
 func TestInitialSync_MultipleSyncPaths(t *testing.T) {
 	f := newFixture(t)
 


### PR DESCRIPTION
Ran into an issue where `initial_sync` would silently fail due to files triggering `fall_back_on` and cancelling the file sync silently. Conceptually this shouldn't happen because `fall_back_on` is intended to fire when the user modifies a file while `initial_sync` is the system itself ensuring file state is the same between local and inside the pod.

context: in #6737 I introduced `initial_sync` which preemptively syncs all the watched files to the pod, the main use case is to ensure consistent file state between slightly outdated pre-built images and host machine file system.