### PR TITLE
web: show context lines for text-filtered logs, not just level-filtered ones

### DIFF
--- a/web/src/OverviewLogPane.test.tsx
+++ b/web/src/OverviewLogPane.test.tsx
@@ -149,21 +149,95 @@ describe("OverviewLogPane", () => {
   })
 
   describe("filters by term", () => {
-    it("displays log lines that match the specified filter term", () => {
+    it("displays matching log lines with surrounding context, like level filters do", () => {
       const termWithResults = createFilterTermState("line 5")
       const { container } = customRender(
         <BuildLogAndRunLog source="" level="" term={termWithResults} />
       )
 
-      expect(container.querySelectorAll(".LogLine")).toHaveLength(2)
+      expect(container.querySelectorAll(".LogLine")).toHaveLength(
+        2 * (1 + PROLOGUE_LENGTH)
+      )
       expect(screen.getAllByText(/line 5/)).toHaveLength(2)
       expect(screen.queryByText(/line 15/)).toBeNull()
+
+      const alerts = container.querySelectorAll(".is-endOfAlert")
+      expect(alerts).toHaveLength(2)
+      expect(alerts[alerts.length - 1]).toHaveTextContent("Vigoda pod line 5")
+      expect(container.querySelectorAll(".LogLine-alertNav")).toHaveLength(2)
     })
 
     it("displays zero log lines when no logs match the specified filter term", () => {
       const termWithResults = createFilterTermState("spaghetti")
       const { container } = customRender(
         <BuildLogAndRunLog source="" level="" term={termWithResults} />
+      )
+
+      expect(container.querySelectorAll(".LogLine")).toHaveLength(0)
+    })
+
+    it("does not repeat context for consecutive matches", () => {
+      let logStore = new LogStore()
+      let defaultFilter = {
+        source: FilterSource.all,
+        level: FilterLevel.all,
+        term: EMPTY_FILTER_TERM,
+      }
+      appendLines(
+        logStore,
+        "fe",
+        "no match 1\n",
+        "no match 2\n",
+        "hit line 1\n",
+        "hit line 2\n",
+        "hit line 3\n",
+        "no match 3\n"
+      )
+
+      const termWithResults = createFilterTermState("hit")
+      const { container } = customRender(
+        <LogStoreProvider value={logStore}>
+          <OverviewLogPane
+            manifestName="fe"
+            filterSet={{ ...defaultFilter, term: termWithResults }}
+          />
+        </LogStoreProvider>
+      )
+
+      expect(container.querySelectorAll(".LogLine")).toHaveLength(5)
+      expect(screen.queryByText(/no match 3/)).toBeNull()
+    })
+
+    it("shows a short prologue when the match is near the start of a span", () => {
+      let logStore = new LogStore()
+      let defaultFilter = {
+        source: FilterSource.all,
+        level: FilterLevel.all,
+        term: EMPTY_FILTER_TERM,
+      }
+      appendLines(logStore, "fe", "no match 1\n", "hit line\n")
+
+      const termWithResults = createFilterTermState("hit")
+      const { container } = customRender(
+        <LogStoreProvider value={logStore}>
+          <OverviewLogPane
+            manifestName="fe"
+            filterSet={{ ...defaultFilter, term: termWithResults }}
+          />
+        </LogStoreProvider>
+      )
+
+      expect(container.querySelectorAll(".LogLine")).toHaveLength(2)
+    })
+
+    it("combines with a level filter", () => {
+      const termWithResults = createFilterTermState("line 5")
+      const { container } = customRender(
+        <BuildLogAndRunLog
+          source=""
+          level={FilterLevel.warn}
+          term={termWithResults}
+        />
       )
 
       expect(container.querySelectorAll(".LogLine")).toHaveLength(0)

--- a/web/src/OverviewLogPane.tsx
+++ b/web/src/OverviewLogPane.tsx
@@ -589,8 +589,8 @@ export class OverviewLogComponent extends Component<OverviewLogComponentProps> {
 
     let isEndOfAlert =
       shouldDisplayPrologues &&
-      this.logDisplay.matchesLevelFilter(line) &&
-      (!entry.next || entry.next?.line.level !== line.level)
+      this.logDisplay.matchesPrologueFilter(line) &&
+      (!entry.next || !this.logDisplay.matchesPrologueFilter(entry.next.line))
     if (isEndOfAlert) {
       extraClasses.push("is-endOfAlert")
     }
@@ -598,9 +598,9 @@ export class OverviewLogComponent extends Component<OverviewLogComponentProps> {
     let isStartOfAlert =
       shouldDisplayPrologues &&
       !line.buildEvent &&
-      !this.logDisplay.matchesLevelFilter(line) &&
+      !this.logDisplay.matchesPrologueFilter(line) &&
       (!entry.prev ||
-        this.logDisplay.matchesLevelFilter(entry.prev.line) ||
+        this.logDisplay.matchesPrologueFilter(entry.prev.line) ||
         entry.prev.line.buildEvent)
     if (isStartOfAlert) {
       extraClasses.push("is-startOfAlert")

--- a/web/src/logs.ts
+++ b/web/src/logs.ts
@@ -71,7 +71,8 @@ export class LogDisplay {
   }
 
   shouldDisplayPrologues(): boolean {
-    return this.filterSet.level !== FilterLevel.all
+    const { level, term } = this.filterSet
+    return level !== FilterLevel.all || term.state === TermState.Parsed
   }
 
   matchesTermFilter(line: LogLine): boolean {
@@ -95,6 +96,11 @@ export class LogDisplay {
     return true
   }
 
+  // Whether a line is a "hit" that prologue context should lead up to.
+  matchesPrologueFilter(line: LogLine): boolean {
+    return this.matchesLevelFilter(line) && this.matchesTermFilter(line)
+  }
+
   matchesFilter(line: LogLine): boolean {
     if (line.buildEvent) {
       return true
@@ -108,14 +114,18 @@ export class LogDisplay {
       return false
     }
 
-    return this.matchesLevelFilter(line) && this.matchesTermFilter(line)
+    return this.matchesPrologueFilter(line)
   }
 
   trackPrologueLine(line: LogLine) {
     if (!this.prologuesBySpanId[line.spanId]) {
       this.prologuesBySpanId[line.spanId] = []
     }
-    this.prologuesBySpanId[line.spanId].push(line)
+    let spanLines = this.prologuesBySpanId[line.spanId]
+    spanLines.push(line)
+    if (spanLines.length > DISPLAY_LOG_PROLOGUE_LENGTH) {
+      spanLines.shift()
+    }
   }
 
   getAndClearPrologue(spanId: string): LogLine[] {


### PR DESCRIPTION
Disclaimer: Everything below the screenshot was written by claude.

We got this piece of feedback from an engineer:

<img width="1021" height="313" alt="image" src="https://github.com/user-attachments/assets/866f0cc6-9875-4bf4-822c-c68d1e1fdd0c" />


Fixes #6824.

Text search in the log pane currently shows only the bare matching lines, with no context — unlike level filters (Errors/Warnings), which already show a few lines of lead-in before each match via a rolling per-span buffer ("prologues").

This PR extends that existing mechanism to text search instead of building a new one.

## Changes

**`web/src/logs.ts`**
- `shouldDisplayPrologues()` now returns `true` for a parsed term filter as well as a level filter.
- Extracted `matchesPrologueFilter()` (level + term, no source) as the single "is this line a hit" predicate, shared by `OverviewLogPane`.
- `trackPrologueLine()` now caps the buffer at `DISPLAY_LOG_PROLOGUE_LENGTH` as lines come in, rather than growing it unboundedly and slicing only at match time. This didn't matter for level filters (matches are frequent), but a term search over a long, otherwise-unfiltered session could otherwise buffer arbitrarily many lines per span while waiting for a match.

**`web/src/OverviewLogPane.tsx`**
- `isStartOfAlert` / `isEndOfAlert` used to compare line levels to find a match group's boundary — which only worked because every line matching a level filter shares that exact level. A term filter's matches don't share anything so predictable, so both now compare match state (`matchesPrologueFilter`) instead. This works identically for level filters too.
- As a result, term-match groups now get the same divider/spacing and the same "… (more) …" link back to the unfiltered view that level filters already had.

**`web/src/OverviewLogPane.test.tsx`**
- Updated the term-filter test to assert the new (intended) behavior instead of the old bare-matches-only one.
- Added coverage for consecutive matches (no repeated context), a match near the start of a span (short prologue, no crash), and level+term filters combined.

## Testing

- `yarn test --watchAll=false` — full suite passes (363 tests).
- `yarn check` (prettier + tsc + eslint) — clean.
