### PR TITLE
fix: isolate installer archive extraction

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,6 +147,7 @@ cli-docs:
 
 test_install_version_check: install
 	NO_INSTALL=1 PATH="~/go/bin:$$PATH" scripts/install.sh
+	./scripts/install_test.sh
 
 shellcheck:
 	find ./scripts -type f -name '*.sh' -exec docker run --rm -it -e SHELLCHECK_OPTS="-e SC2001" -v $$(pwd):/mnt nlknguyen/alpine-shellcheck {} \;

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -13,17 +13,30 @@ BREW=$(command -v brew)
 set -e
 
 function copy_binary() {
+  local binary_path="${1:-tilt}"
   if [[ ":$PATH:" == *":$HOME/.local/bin:"* ]]; then
       if [ ! -d "$HOME/.local/bin" ]; then
         mkdir -p "$HOME/.local/bin"
       fi
-      mv tilt "$HOME/.local/bin/tilt"
+      mv "$binary_path" "$HOME/.local/bin/tilt"
   else
       echo "Installing Tilt to /usr/local/bin which is write protected"
       echo "If you'd prefer to install Tilt without sudo permissions, add \$HOME/.local/bin to your \$PATH and rerun the installer"
-      sudo mv tilt /usr/local/bin/tilt
+      sudo mv "$binary_path" /usr/local/bin/tilt
   fi
 }
+
+function install_from_archive() (
+  local url="$1"
+  local temp_dir
+  temp_dir=$(mktemp -d)
+  trap 'rm -rf "$temp_dir"' EXIT
+
+  set -o pipefail
+  set -x
+  curl -fsSL "$url" | tar -xzv -C "$temp_dir" tilt
+  copy_binary "$temp_dir/tilt"
+)
 
 function brew_install_or_upgrade() {
   set -x
@@ -62,9 +75,7 @@ function install_tilt() {
               armv7l)  ARCH=arm;;
               *)       ARCH=$(uname -m);;
           esac
-          set -x
-          curl -fsSL https://github.com/tilt-dev/tilt/releases/download/v$VERSION/tilt.$VERSION.linux.$ARCH.tar.gz | tar -xzv tilt
-          copy_binary
+          install_from_archive "https://github.com/tilt-dev/tilt/releases/download/v$VERSION/tilt.$VERSION.linux.$ARCH.tar.gz"
       fi
   elif [[ "$OSTYPE" == "darwin"* ]]; then
       if [[ "$BREW" != "" ]]; then
@@ -72,9 +83,7 @@ function install_tilt() {
       else
           # On macOS, "uname -m" reports "arm64" on ARM 64 bits machines
           ARCH=$(uname -m)
-          set -x
-          curl -fsSL https://github.com/tilt-dev/tilt/releases/download/v$VERSION/tilt.$VERSION.mac.$ARCH.tar.gz | tar -xzv tilt
-          copy_binary
+          install_from_archive "https://github.com/tilt-dev/tilt/releases/download/v$VERSION/tilt.$VERSION.mac.$ARCH.tar.gz"
       fi
   else
       set +x

--- a/scripts/install_test.sh
+++ b/scripts/install_test.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_PATH="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/install.sh}"
+TEST_ROOT=$(mktemp -d)
+trap 'rm -rf "$TEST_ROOT"' EXIT
+
+mkdir -p "$TEST_ROOT/archive" "$TEST_ROOT/mock-bin"
+printf '%s\n' \
+  '#!/bin/sh' \
+  'case "${1:-}" in' \
+  '  version) printf "%s\\n" "v0.37.7, built 2026-08-27" ;;' \
+  '  verify-install) ;;' \
+  'esac' > "$TEST_ROOT/archive/tilt"
+chmod +x "$TEST_ROOT/archive/tilt"
+tar -czf "$TEST_ROOT/tilt.tar.gz" -C "$TEST_ROOT/archive" tilt
+
+printf '%s\n' \
+  '#!/bin/sh' \
+  'set -eu' \
+  'if [ "${TILT_INSTALL_TEST_FAIL:-0}" = 1 ]; then' \
+  '  printf "%s" "not a tar archive"' \
+  'else' \
+  '  cat "$TILT_INSTALL_TEST_ARCHIVE"' \
+  'fi' > "$TEST_ROOT/mock-bin/curl"
+chmod +x "$TEST_ROOT/mock-bin/curl"
+
+run_install() {
+  local os_type="$1"
+  local fail_mode="$2"
+  local run_root="$TEST_ROOT/${os_type}-${fail_mode}"
+  local output="$run_root/output.log"
+  local status
+
+  mkdir -p "$run_root/home/.local/bin" "$run_root/tmp" "$run_root/work/tilt/existing"
+  printf '%s\n' keep > "$run_root/work/tilt/keep"
+
+  set +e
+  (
+    cd "$run_root/work"
+    HOME="$run_root/home" \
+      PATH="$run_root/home/.local/bin:$TEST_ROOT/mock-bin:/usr/bin:/bin" \
+      TMPDIR="$run_root/tmp" \
+      TILT_INSTALL_TEST_ARCHIVE="$TEST_ROOT/tilt.tar.gz" \
+      TILT_INSTALL_TEST_FAIL="$fail_mode" \
+      OSTYPE="$os_type" \
+      bash "$SCRIPT_PATH"
+  ) > "$output" 2>&1
+  status=$?
+  set -e
+
+  if [ "$fail_mode" = 0 ]; then
+    if [ "$status" -ne 0 ]; then
+      cat "$output"
+      return 1
+    fi
+    test -x "$run_root/home/.local/bin/tilt"
+    test -f "$run_root/work/tilt/keep"
+  elif [ "$status" -eq 0 ]; then
+    cat "$output"
+    return 1
+  fi
+
+  if find "$run_root/tmp" -mindepth 1 -maxdepth 1 -print -quit | grep -q .; then
+    printf 'installer temporary directory was not cleaned: %s\n' "$run_root/tmp"
+    return 1
+  fi
+}
+
+run_install linux-gnu 0
+run_install darwin 0
+run_install linux-gnu 1
+printf '%s\n' 'installer regression passed'


### PR DESCRIPTION
Fixes #6828.

## What changed
- Extract release archives in a unique temporary directory instead of the caller's working directory.
- Clean temporary files after successful and failed extraction.
- Add a regression test for Linux and macOS installer paths with an existing non-empty `tilt/` directory.

## Verification
- `./scripts/install_test.sh`
- `bash -n scripts/install.sh scripts/install_test.sh`
- `git diff --check`